### PR TITLE
add cmd/deployment-splitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 kcp
 
 cluster-controller
+deployment-splitter
+syncer

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build:
 	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/kcp ./cmd/kcp
 	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/syncer ./cmd/syncer
 	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/cluster-controller ./cmd/cluster-controller
+	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/deployment-splitter ./cmd/deployment-splitter
 .PHONY: build
 
 vendor:

--- a/cmd/deployment-splitter/README.md
+++ b/cmd/deployment-splitter/README.md
@@ -1,0 +1,41 @@
+# Deployment Splitter
+
+The Deployment Splitter is responsible for watching `kcp` for [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) resources and creating corresponding child Deployments, one for each Cluster `kcp` knows about.
+
+The underlying real clusters will react to the creation of these child Deployments by syncing them, creating Pods, and updating status, at which point the Deployment Splitter will react by aggregating that status back up to the root Deployment.
+
+## Running
+
+Run `kcp`
+
+```
+make
+bin/kcp start
+export KUBECONFIG=.kcp/data/admin.kubeconfig
+kubectl config use-context admin
+```
+
+Run Cluster Controller
+
+```
+kubectl apply -f config/cluster.example.dev_clusters.yaml
+bin/cluster-controller --kubeconfig=.kcp/data/admin.kubeconfig
+```
+
+Run Deployment Splitter
+
+```
+kubectl apply -f contrib/crds/apps/apps_deployments.yaml
+bin/deployment-splitter --kubeconfig=.kcp/data/admin.kubeconfig
+```
+
+## TODO
+
+Deployment Splitter is definitely _not_ a scheduler. It's not smart. We could make it smart?
+
+- react to clusters being added/deleted and becoming unavailable by rebalancing replicas across children
+- balance replicas across children based on advertised capabilities (which can change over time), observed load, etc.
+- recreate deleted child deployments
+- react to root deployments being scaled up/down
+
+These features and more are already supported by other projects, such as [Karmada](https://github.com/karmada-io/karmada) and [kubefed](https://github.com/kubernetes-retired/federation).

--- a/cmd/deployment-splitter/main.go
+++ b/cmd/deployment-splitter/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/kcp-dev/kcp/pkg/reconciler/deployment"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const numThreads = 2
+
+var kubeconfig = flag.String("kubeconfig", "", "Path to kubeconfig")
+
+func main() {
+	flag.Parse()
+
+	r, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	deployment.NewController(r).Start(numThreads)
+}

--- a/pkg/reconciler/deployment/controller.go
+++ b/pkg/reconciler/deployment/controller.go
@@ -1,0 +1,145 @@
+package deployment
+
+import (
+	"context"
+	"log"
+	"time"
+
+	clusterclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	clusterlisters "github.com/kcp-dev/kcp/pkg/client/listers/cluster/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const resyncPeriod = 10 * time.Hour
+
+// NewController returns a new Controller which splits new Deployment objects
+// into N virtual Deployments labeled for each Cluster that exists at the time
+// the Deployment is created.
+func NewController(cfg *rest.Config) *Controller {
+	client := appsv1client.NewForConfigOrDie(cfg)
+	kubeClient := kubernetes.NewForConfigOrDie(cfg)
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	sif := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod)
+	sif.Apps().V1().Deployments().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { queue.AddRateLimited(obj) },
+		UpdateFunc: func(_, obj interface{}) { queue.AddRateLimited(obj) },
+	})
+	stopCh := make(chan struct{}) // TODO: hook this up to SIGTERM/SIGINT
+	sif.WaitForCacheSync(stopCh)
+	sif.Start(stopCh)
+
+	csif := externalversions.NewSharedInformerFactoryWithOptions(clusterclient.NewForConfigOrDie(cfg), resyncPeriod)
+	csif.WaitForCacheSync(stopCh)
+	csif.Start(stopCh)
+
+	return &Controller{
+		queue:         queue,
+		client:        client,
+		indexer:       sif.Apps().V1().Deployments().Informer().GetIndexer(),
+		lister:        sif.Apps().V1().Deployments().Lister(),
+		clusterLister: csif.Cluster().V1alpha1().Clusters().Lister(),
+		stopCh:        stopCh,
+	}
+}
+
+type Controller struct {
+	queue         workqueue.RateLimitingInterface
+	client        *appsv1client.AppsV1Client
+	indexer       cache.Indexer
+	lister        appsv1lister.DeploymentLister
+	clusterLister clusterlisters.ClusterLister
+	kubeClient    kubernetes.Interface
+	stopCh        chan struct{}
+}
+
+func (c *Controller) Start(numThreads int) {
+	defer c.queue.ShutDown()
+	for i := 0; i < numThreads; i++ {
+		go wait.Until(c.startWorker, time.Second, c.stopCh)
+	}
+	log.Println("Starting workers")
+	<-c.stopCh
+	log.Println("Stopping workers")
+}
+
+func (c *Controller) startWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	err := c.process(key)
+	c.handleErr(err, key)
+	return true
+}
+
+func (c *Controller) handleErr(err error, key string) {
+	// Reconcile worked, nothing else to do for this workqueue item.
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	// Re-enqueue up to 5 times.
+	num := c.queue.NumRequeues(key)
+	if num < 5 {
+		log.Printf("Error reconciling key %q, retrying... (#%d): %v", key, num, err)
+		c.queue.AddRateLimited(key)
+		return
+	}
+
+	// Give up and report error elsewhere.
+	c.queue.Forget(key)
+	runtime.HandleError(err)
+	log.Printf("Dropping key %q after failed retries: %v", key, err)
+}
+
+func (c *Controller) process(key string) error {
+	obj, exists, err := c.indexer.GetByKey(key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		log.Printf("Object with key %q was deleted", key)
+		return nil
+	}
+	current := obj.(*appsv1.Deployment)
+	previous := current.DeepCopy()
+
+	ctx := context.TODO()
+	if err := c.reconcile(ctx, current); err != nil {
+		return err
+	}
+
+	// If the object being reconciled changed as a result, update it.
+	if !equality.Semantic.DeepEqual(previous.Status, current.Status) {
+		_, uerr := c.client.Deployments(current.Namespace).UpdateStatus(ctx, current, metav1.UpdateOptions{})
+		return uerr
+	}
+
+	return err
+}

--- a/pkg/reconciler/deployment/deployment.go
+++ b/pkg/reconciler/deployment/deployment.go
@@ -1,0 +1,132 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	clusterLabel = "cluster"
+	ownedByLabel = "owned-by"
+	pollInterval = time.Minute
+)
+
+func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deployment) error {
+	log.Println("reconciling deployment", deployment.Name)
+
+	if deployment.Labels == nil || deployment.Labels[clusterLabel] == "" {
+		// This is a root deployment; get its leafs.
+		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, deployment.Labels[deployment.Name]))
+		if err != nil {
+			return err
+		}
+		leafs, err := c.lister.List(sel)
+		if err != nil {
+			return err
+		}
+
+		if len(leafs) == 0 {
+			if err := c.createLeafs(ctx, deployment); err != nil {
+				return err
+			}
+		}
+
+	} else {
+		// A leaf deployment was updated; get others and aggregate status.
+		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, deployment.Labels[ownedByLabel]))
+		if err != nil {
+			return err
+		}
+		others, err := c.lister.List(sel)
+		if err != nil {
+			return err
+		}
+
+		// Aggregate .status from all leafs.
+		deployment.Status.Replicas = 0
+		deployment.Status.ReadyReplicas = 0
+		deployment.Status.AvailableReplicas = 0
+		deployment.Status.UnavailableReplicas = 0
+		for _, o := range others {
+			deployment.Status.Replicas += o.Status.Replicas
+			deployment.Status.ReadyReplicas += o.Status.ReadyReplicas
+			deployment.Status.AvailableReplicas += o.Status.AvailableReplicas
+			deployment.Status.UnavailableReplicas += o.Status.UnavailableReplicas
+
+		}
+
+		// Cheat and set the root .status.conditions to the first leaf's .status.conditions.
+		// TODO: do better.
+		deployment.Status.Conditions = others[0].Status.Conditions
+	}
+
+	return nil
+}
+
+func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) error {
+	cls, err := c.clusterLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	if len(cls) == 0 {
+		root.Status.Conditions = []appsv1.DeploymentCondition{{
+			Type:    appsv1.DeploymentProgressing,
+			Status:  corev1.ConditionFalse,
+			Reason:  "NoRegisteredClusters",
+			Message: "kcp has no clusters registered to receive Deployments",
+		}}
+		return nil
+	}
+
+	if len(cls) == 1 {
+		// nothing to split, just label Deployment for the only cluster.
+		if root.Labels == nil {
+			root.Labels = map[string]string{}
+		}
+
+		// TODO: munge cluster name
+		root.Labels[clusterLabel] = cls[0].Name
+		return nil
+	}
+
+	// If there are >1 Clusters, create a virtual Deployment labeled/named for each Cluster with a subset of replicas requested.
+	// TODO: assign replicas unevenly based on load/scheduling.
+	replicasEach := *root.Spec.Replicas / int32(len(cls))
+	for _, cl := range cls {
+		vd := root.DeepCopy()
+
+		// TODO: munge cluster name
+		vd.Name = fmt.Sprintf("%s--%s", root.Name, cl.Name)
+
+		if vd.Labels == nil {
+			vd.Labels = map[string]string{}
+		}
+		vd.Labels[clusterLabel] = cl.Name
+		vd.Labels[ownedByLabel] = root.Name
+
+		vd.Spec.Replicas = &replicasEach
+
+		// Set OwnerReference so deleting the Deployment deletes all virtual deployments.
+		vd.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			UID:        root.UID,
+		}}
+
+		// TODO: munge namespace
+		if _, err := c.kubeClient.AppsV1().Deployments(root.Namespace).Create(ctx, vd, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+		log.Printf("created child deployment %q", vd.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- watches deployments (virtual and real)
  - creates N virtual deployments if a real deployment has no children (where N = # of clusters)
  - aggregates virtual deployment status up into real deployment status when children update


WIP: This doesn't work right now