### PR TITLE
Fix cluster controller

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,5 +1,6 @@
 apiVersion: cluster.example.dev/v1alpha1
 kind: Cluster
 metadata:
-  name: kind
+  name: my-cluster
 spec:
+  kubeconfig: hello # invalid


### PR DESCRIPTION
Previously, Cluster objects were enqueued in the workqueue and then cast
as strings when processing the queue, leading to a panic.

Instead, enqueue the string key of the Cluster, which we can cast as
string and lookup in the index when processing.