### PR TITLE
Pipe kcp's kubeconfig from cluster controller to syncer

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,13 +11,6 @@ KUBECONFIG=.kcp/data/admin.kubeconfig
 kubectl api-resources
 ```
 
-The kubeconfig configures two contexts, `user` (the default) and `admin`.
-Switch the default context to `admin` with the following command:
-
-```
-kubectl config use-context admin
-```
-
 # Build and run Cluster Controller
 
 First, be sure to define the Cluster CRD type:
@@ -36,7 +29,6 @@ go run ./cmd/cluster-controller \
 ```
 
 `ko publish` requires the `KO_DOCKER_REPO` env var to be set to the container image registry to push the image to (e.g., `KO_DOCKER_REPO=quay.io/my-user`).
-If you're using [KinD](https://kind.sigs.k8s.io), you can set `KO_DOCKER_REPO=kind.local` to publish to your local KinD cluster.
 
 # Test the registration of a Physical Cluster
 

--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
 
 	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
@@ -23,5 +24,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	cluster.NewController(r, *syncerImage).Start(numThreads)
+	kubeconfigBytes, err := ioutil.ReadFile(*kubeconfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	cluster.NewController(r, *syncerImage, string(kubeconfigBytes)).Start(numThreads)
 }

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -34,8 +35,7 @@ func main() {
 	flag.Parse()
 
 	// Create a client to dynamically watch "from".
-	//fromConfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
-	fromConfig, err := rest.InClusterConfig()
+	fromConfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -64,17 +64,9 @@ func main() {
 
 	// Get all types the upstream API server knows about.
 	// TODO: watch this and learn about new types, or forget about old ones.
-	/*
-		gvrstrs, err := getAllGVRs(fromConfig)
-		if err != nil {
-			log.Fatal(err)
-		}
-	*/
-	// TODO: For now, only care about:
-	gvrstrs := []string{
-		".v1.namespaces",
-		".v1.pods",
-		".v1.deployments",
+	gvrstrs, err := getAllGVRs(fromConfig)
+	if err != nil {
+		log.Fatal(err)
 	}
 	for _, gvrstr := range gvrstrs {
 		gvr, _ := schema.ParseResourceArg(gvrstr)


### PR DESCRIPTION
This passes the kubeconfig provided to the cluster controller at its startup, pointing to the kcp, down to the syncer so that when it starts it can reach back out to the kcp to begin syncing.

It also passes the unique cluster name to the syncer's `-cluster` flag, which controls how it filters objects it requests from the kcp to only get those intended for its cluster.