### PR TITLE
Update the KCP command line to CRD-tenancy changes, and include the cluster controller.

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/controlplane/clientutils"
 )
 
 const numThreads = 2
@@ -13,6 +14,7 @@ const numThreads = 2
 var (
 	kubeconfigPath  = flag.String("kubeconfig", "", "Path to kubeconfig")
 	syncerImage = flag.String("syncer_image", "", "Syncer image to install on clusters")
+	pullModel = flag.Bool("pull_model", true, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
 )
 
 func main() {
@@ -26,11 +28,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	kubeconfig, err := configLoader.RawConfig() 
+	clientutils.EnableMultiCluster(r, nil, "clusters", "customresourcedefinitions")
+	kubeconfig, err := configLoader.RawConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	cluster.NewController(r, *syncerImage, kubeconfig).Start(numThreads)
+	resourcesToSync := flag.Args()
+	if len(resourcesToSync) == 0 {
+		resourcesToSync = []string{"pods", "deployments"}
+	}
+
+	cluster.NewController(r, *syncerImage, kubeconfig, resourcesToSync, *pullModel).Start(numThreads)
 }

--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -12,9 +12,9 @@ import (
 const numThreads = 2
 
 var (
-	kubeconfigPath  = flag.String("kubeconfig", "", "Path to kubeconfig")
-	syncerImage = flag.String("syncer_image", "", "Syncer image to install on clusters")
-	pullModel = flag.Bool("pull_model", true, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
+	kubeconfigPath = flag.String("kubeconfig", "", "Path to kubeconfig")
+	syncerImage    = flag.String("syncer_image", "", "Syncer image to install on clusters")
+	pullModel      = flag.Bool("pull_model", true, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
 )
 
 func main() {

--- a/cmd/crd-puller/pull-crds.go
+++ b/cmd/crd-puller/pull-crds.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	crdpuller "github.com/kcp-dev/kcp/pkg/crdpuller"
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
+	crdpuller "github.com/kcp-dev/kcp/pkg/crdpuller"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
@@ -22,7 +22,7 @@ func main() {
 		Short:      "Pull CRDs from a Kubernetes cluster",
 		Long: help.Doc(`
 					Pull CRDs from a Kubernetes cluster
-					Based on a kubeconfig file, it uses dicovery API and the OpenAPI v2
+					Based on a kubeconfig file, it uses discovery API and the OpenAPI v2
 					model on the cluster to build CRDs for a list of api resource names.
 				`),
 		Example: "",

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -11,13 +12,16 @@ import (
 	"github.com/spf13/pflag"
 	"go.etcd.io/etcd/clientv3"
 
-	"github.com/kcp-dev/kcp/pkg/etcd"
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
+	"github.com/kcp-dev/kcp/pkg/etcd"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
 
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/controlplane"
+	"k8s.io/kubernetes/pkg/controlplane/clientutils"
 	"k8s.io/kubernetes/pkg/controlplane/options"
 )
 
@@ -42,6 +46,7 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	var syncerImage *string
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the control plane process",
@@ -111,24 +116,23 @@ func main() {
 					return err
 				}
 
-				prepared := server.PrepareRun()
-
 				var clientConfig clientcmdapi.Config
 				clientConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-					"loopback": {Token: prepared.LoopbackClientConfig.BearerToken},
+					"loopback": {Token: server.LoopbackClientConfig.BearerToken},
 				}
 				clientConfig.Clusters = map[string]*clientcmdapi.Cluster{
 					// admin is the virtual cluster running by default
 					"admin": {
-						Server:                   prepared.LoopbackClientConfig.Host,
-						CertificateAuthorityData: prepared.LoopbackClientConfig.CAData,
-						TLSServerName:            prepared.LoopbackClientConfig.TLSClientConfig.ServerName,
+						Server:                   server.LoopbackClientConfig.Host,
+						CertificateAuthorityData: server.LoopbackClientConfig.CAData,
+						TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
+
 					},
 					// user is a virtual cluster that is lazily instantiated
 					"user": {
-						Server:                   prepared.LoopbackClientConfig.Host + "/clusters/user",
-						CertificateAuthorityData: prepared.LoopbackClientConfig.CAData,
-						TLSServerName:            prepared.LoopbackClientConfig.TLSClientConfig.ServerName,
+						Server:                   server.LoopbackClientConfig.Host + "/clusters/user",
+						CertificateAuthorityData: server.LoopbackClientConfig.CAData,
+						TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
 					},
 				}
 				clientConfig.Contexts = map[string]*clientcmdapi.Context{
@@ -140,11 +144,49 @@ func main() {
 					return err
 				}
 
+				server.AddPostStartHook("Install Cluster Controller", func(context genericapiserver.PostStartHookContext) error {
+					// Register the `clusters` CRD in both the admin and user logical clusters
+					
+					for contextName, _ := range clientConfig.Contexts {
+						logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+						if err != nil {
+							return err
+						}
+						cluster.RegisterClusterCRD(logicalClusterConfig)
+					}
+					adminConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, "admin", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+					if err != nil {
+						return err
+					}
+
+					kubeconfig := clientConfig.DeepCopy()
+					for _, cluster := range kubeconfig.Clusters {
+						hostURL, err := url.Parse(cluster.Server)
+						if err != nil {
+							return err
+						}
+						hostURL.Host = server.ExternalAddress
+						cluster.Server = hostURL.String()
+					}
+
+					clientutils.EnableMultiCluster(adminConfig, nil, "clusters", "customresourcedefinitions")
+					clusterController := cluster.NewController(
+						adminConfig,
+						*syncerImage,
+						*kubeconfig,
+					)
+					clusterController.Start(2)
+					return nil
+				})
+
+				prepared := server.PrepareRun()
+
 				return prepared.Run(ctx.Done())
 			})
 		},
 	}
 	startCmd.Flags().AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
+	syncerImage = startCmd.Flags().String("syncer-image", "quay.io/dfestal/kcp-syncer", "syncer-image is the reference of a container image that containers th syncer and will be used by the syncer POD in registered physical clusters.")
 	cmd.AddCommand(startCmd)
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -19,7 +19,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/controlplane"
 	"k8s.io/kubernetes/pkg/controlplane/options"
-	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
 )
 
 func main() {
@@ -107,18 +106,12 @@ func main() {
 					return err
 				}
 
-				var server  *aggregatorapiserver.APIAggregator
-				server, err = controlplane.CreateServerChain(cpOptions, ctx.Done())
+				server, err := controlplane.CreateServerChain(cpOptions, ctx.Done())
 				if err != nil {
 					return err
 				}
 
-				preparedAggregator, err := server.PrepareRun()
-				if err != nil {
-					return err
-				}
-
-				prepared := server.GenericAPIServer
+				prepared := server.PrepareRun()
 
 				var clientConfig clientcmdapi.Config
 				clientConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
@@ -147,7 +140,7 @@ func main() {
 					return err
 				}
 
-				return preparedAggregator.Run(ctx.Done())
+				return prepared.Run(ctx.Done())
 			})
 		},
 	}

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -25,6 +25,13 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/options"
 )
 
+var (
+	syncerImage string
+	resourcesToSync []string
+	installClusterController bool
+	pullModel bool
+)
+
 func main() {
 	help.FitTerminal()
 	cmd := &cobra.Command{
@@ -46,7 +53,6 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	var syncerImage *string
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the control plane process",
@@ -61,7 +67,7 @@ func main() {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			//flag.CommandLine.Lookup("v").Value.Set("9")
-
+			
 			dir := filepath.Join(".", ".kcp")
 			if fi, err := os.Stat(dir); err != nil {
 				if !os.IsNotExist(err) {
@@ -126,7 +132,6 @@ func main() {
 						Server:                   server.LoopbackClientConfig.Host,
 						CertificateAuthorityData: server.LoopbackClientConfig.CAData,
 						TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
-
 					},
 					// user is a virtual cluster that is lazily instantiated
 					"user": {
@@ -144,40 +149,43 @@ func main() {
 					return err
 				}
 
-				server.AddPostStartHook("Install Cluster Controller", func(context genericapiserver.PostStartHookContext) error {
-					// Register the `clusters` CRD in both the admin and user logical clusters
-					
-					for contextName, _ := range clientConfig.Contexts {
-						logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+				if installClusterController {
+					server.AddPostStartHook("Install Cluster Controller", func(context genericapiserver.PostStartHookContext) error {
+						// Register the `clusters` CRD in both the admin and user logical clusters
+						for contextName, _ := range clientConfig.Contexts {
+							logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+							if err != nil {
+								return err
+							}
+							cluster.RegisterClusterCRD(logicalClusterConfig)
+						}
+						adminConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, "admin", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
 						if err != nil {
 							return err
 						}
-						cluster.RegisterClusterCRD(logicalClusterConfig)
-					}
-					adminConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, "admin", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
-					if err != nil {
-						return err
-					}
 
-					kubeconfig := clientConfig.DeepCopy()
-					for _, cluster := range kubeconfig.Clusters {
-						hostURL, err := url.Parse(cluster.Server)
-						if err != nil {
-							return err
+						kubeconfig := clientConfig.DeepCopy()
+						for _, cluster := range kubeconfig.Clusters {
+							hostURL, err := url.Parse(cluster.Server)
+							if err != nil {
+								return err
+							}
+							hostURL.Host = server.ExternalAddress
+							cluster.Server = hostURL.String()
 						}
-						hostURL.Host = server.ExternalAddress
-						cluster.Server = hostURL.String()
-					}
 
-					clientutils.EnableMultiCluster(adminConfig, nil, "clusters", "customresourcedefinitions")
-					clusterController := cluster.NewController(
-						adminConfig,
-						*syncerImage,
-						*kubeconfig,
-					)
-					clusterController.Start(2)
-					return nil
-				})
+						clientutils.EnableMultiCluster(adminConfig, nil, "clusters", "customresourcedefinitions")
+						clusterController := cluster.NewController(
+							adminConfig,
+							syncerImage,
+							*kubeconfig,
+							resourcesToSync,
+							pullModel,
+						)
+						clusterController.Start(2)
+						return nil
+					})
+				}
 
 				prepared := server.PrepareRun()
 
@@ -186,7 +194,10 @@ func main() {
 		},
 	}
 	startCmd.Flags().AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
-	syncerImage = startCmd.Flags().String("syncer-image", "quay.io/dfestal/kcp-syncer", "syncer-image is the reference of a container image that containers th syncer and will be used by the syncer POD in registered physical clusters.")
+	startCmd.Flags().StringVar(&syncerImage, "syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
+	startCmd.Flags().StringArrayVar(&resourcesToSync, "resources_to_sync", []string{"pods", "deployments"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
+	startCmd.Flags().BoolVar(&installClusterController, "install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
+	startCmd.Flags().BoolVar(&pullModel, "pull_model", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
 	cmd.AddCommand(startCmd)
 
 	if err := cmd.Execute(); err != nil {

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	syncerImage string
-	resourcesToSync []string
+	syncerImage              string
+	resourcesToSync          []string
 	installClusterController bool
-	pullModel bool
+	pullModel                bool
 )
 
 func main() {
@@ -67,7 +67,7 @@ func main() {
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			//flag.CommandLine.Lookup("v").Value.Set("9")
-			
+
 			dir := filepath.Join(".", ".kcp")
 			if fi, err := os.Stat(dir); err != nil {
 				if !os.IsNotExist(err) {
@@ -152,7 +152,7 @@ func main() {
 				if installClusterController {
 					server.AddPostStartHook("Install Cluster Controller", func(context genericapiserver.PostStartHookContext) error {
 						// Register the `clusters` CRD in both the admin and user logical clusters
-						for contextName, _ := range clientConfig.Contexts {
+						for contextName := range clientConfig.Contexts {
 							logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
 							if err != nil {
 								return err

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
+	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.0.0
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 	k8s.io/kubernetes v0.0.0

--- a/go.mod
+++ b/go.mod
@@ -16,33 +16,32 @@ require (
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
 	k8s.io/klog v1.0.0
-	k8s.io/kube-aggregator v0.0.0
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 	k8s.io/kubernetes v0.0.0
 	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (
-	k8s.io/api => github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/apiextensions-apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/apimachinery => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/cli-runtime => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/client-go => github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/cloud-provider => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/cluster-bootstrap => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/code-generator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/cri-api => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/csi-translation-lib => github.com/kcp-dev/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kube-aggregator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kube-controller-manager => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kube-proxy => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kube-scheduler => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kubectl => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kubelet => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/kubernetes => github.com/kcp-dev/kubernetes v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/legacy-cloud-providers => github.com/kcp-dev/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/metrics => github.com/kcp-dev/kubernetes/staging/src/k8s.io/metrics v0.0.0-20210407134426-21a4a5279bda
-	k8s.io/sample-apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20210407134426-21a4a5279bda
+	k8s.io/api => github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20210504234152-98ac86830031
+	k8s.io/apiextensions-apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20210504234152-98ac86830031
+	k8s.io/apimachinery => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20210504234152-98ac86830031
+	k8s.io/apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20210504234152-98ac86830031
+	k8s.io/cli-runtime => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cli-runtime v0.0.0-20210504234152-98ac86830031
+	k8s.io/client-go => github.com/kcp-dev/kubernetes/staging/src/k8s.io/client-go v0.0.0-20210504234152-98ac86830031
+	k8s.io/cloud-provider => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20210504234152-98ac86830031
+	k8s.io/cluster-bootstrap => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20210504234152-98ac86830031
+	k8s.io/code-generator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20210504234152-98ac86830031
+	k8s.io/component-base => github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20210504234152-98ac86830031
+	k8s.io/cri-api => github.com/kcp-dev/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20210504234152-98ac86830031
+	k8s.io/csi-translation-lib => github.com/kcp-dev/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20210504234152-98ac86830031
+	k8s.io/kube-aggregator => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20210504234152-98ac86830031
+	k8s.io/kube-controller-manager => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20210504234152-98ac86830031
+	k8s.io/kube-proxy => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20210504234152-98ac86830031
+	k8s.io/kube-scheduler => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20210504234152-98ac86830031
+	k8s.io/kubectl => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20210504234152-98ac86830031
+	k8s.io/kubelet => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20210504234152-98ac86830031
+	k8s.io/kubernetes => github.com/kcp-dev/kubernetes v0.0.0-20210504234152-98ac86830031
+	k8s.io/legacy-cloud-providers => github.com/kcp-dev/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20210504234152-98ac86830031
+	k8s.io/metrics => github.com/kcp-dev/kubernetes/staging/src/k8s.io/metrics v0.0.0-20210504234152-98ac86830031
+	k8s.io/sample-apiserver => github.com/kcp-dev/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20210504234152-98ac86830031
 )

--- a/pkg/cmd/help/doc.go
+++ b/pkg/cmd/help/doc.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/muesli/reflow/wordwrap"
 	"github.com/MakeNowJust/heredoc"
+	"github.com/muesli/reflow/wordwrap"
 	"github.com/spf13/cobra"
 	terminal "github.com/wayneashleyberry/terminal-dimensions"
 )
@@ -28,4 +28,3 @@ func FitTerminal() {
 		return strings.TrimRightFunc(wordwrap.String(s, int(w)), unicode.IsSpace)
 	})
 }
-

--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -56,7 +56,7 @@ func NewSchemaPuller(config *rest.Config) (SchemaPuller, error) {
 
 	return &schemaPuller{
 		discoveryClient: discoveryClient,
-		crdClient: crdClient,
+		crdClient:       crdClient,
 		models:          models,
 	}, nil
 }
@@ -70,7 +70,7 @@ func (sp *schemaPuller) PullCRDs(context context.Context, resourceNames ...strin
 		return nil, err
 	}
 
-	apiResourceNames := map[schema.GroupVersion]sets.String {}
+	apiResourceNames := map[schema.GroupVersion]sets.String{}
 	for _, apiResourcesList := range apiResourcesLists {
 		gv, err := schema.ParseGroupVersion(apiResourcesList.GroupVersion)
 		if err != nil {
@@ -81,7 +81,7 @@ func (sp *schemaPuller) PullCRDs(context context.Context, resourceNames ...strin
 		for _, apiResource := range apiResourcesList.APIResources {
 			apiResourceNames[gv].Insert(apiResource.Name)
 		}
-		 
+
 	}
 
 	apiResourcesLists, err = sp.discoveryClient.ServerPreferredResources()
@@ -120,9 +120,9 @@ func (sp *schemaPuller) PullCRDs(context context.Context, resourceNames ...strin
 				crd, err := sp.crdClient.CustomResourceDefinitions().Get(context, CRDName, metav1.GetOptions{})
 				if err == nil {
 					crds[apiResource.Name] = &apiextensionsv1.CustomResourceDefinition{
-						TypeMeta: typeMeta,
+						TypeMeta:   typeMeta,
 						ObjectMeta: objectMeta,
-						Spec: crd.Spec,
+						Spec:       crd.Spec,
 					}
 					continue
 				} else {
@@ -160,9 +160,9 @@ func (sp *schemaPuller) PullCRDs(context context.Context, resourceNames ...strin
 					}
 					return false
 				}
-		
+
 				statusSubResource := &apiextensionsv1.CustomResourceSubresourceStatus{}
-				if ! hasSubResource("status") {
+				if !hasSubResource("status") {
 					statusSubResource = nil
 				}
 
@@ -170,12 +170,12 @@ func (sp *schemaPuller) PullCRDs(context context.Context, resourceNames ...strin
 					SpecReplicasPath:   ".spec.replicas",
 					StatusReplicasPath: ".status.replicas",
 				}
-				if ! hasSubResource("scale") {
+				if !hasSubResource("scale") {
 					scaleSubResource = nil
 				}
- 
+
 				crd = &apiextensionsv1.CustomResourceDefinition{
-					TypeMeta: typeMeta,
+					TypeMeta:   typeMeta,
 					ObjectMeta: objectMeta,
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: gv.Group,
@@ -223,9 +223,9 @@ type SchemaConverter struct {
 var _ proto.SchemaVisitorArbitrary = (*SchemaConverter)(nil)
 
 func (sc *SchemaConverter) setupDescription(schema proto.Schema) {
-	schemaDescription := schema.GetDescription() 
+	schemaDescription := schema.GetDescription()
 	inheritedDescription := sc.description
-	subSchemaDescription := "" 
+	subSchemaDescription := ""
 
 	switch typed := schema.(type) {
 	case *proto.Arbitrary:
@@ -260,7 +260,7 @@ func (sc *SchemaConverter) VisitArbitrary(a *proto.Arbitrary) {
 }
 
 func (sc *SchemaConverter) VisitArray(a *proto.Array) {
-	sc.setupDescription(a)	
+	sc.setupDescription(a)
 	sc.schemaProps.Type = "array"
 	if len(a.Extensions) > 0 {
 		var kind *proto.Kind = nil
@@ -323,7 +323,7 @@ func (sc *SchemaConverter) VisitArray(a *proto.Array) {
 	}
 }
 func (sc *SchemaConverter) VisitMap(m *proto.Map) {
-	sc.setupDescription(m)	
+	sc.setupDescription(m)
 	subtypeSchemaProps := apiextensionsv1.JSONSchemaProps{}
 	m.SubType.Accept(&SchemaConverter{
 		schemaProps: &subtypeSchemaProps,
@@ -399,7 +399,7 @@ func boolPtr(b bool) *bool {
 // map in `controller-tools `, and used to hard-code the OpenAPI V3 schema for a number
 // of well-known Kubernetes types:
 // https://github.com/kubernetes-sigs/controller-tools/blob/v0.5.0/pkg/crd/known_types.go#L26
-var knownPackages map[string]map[string]apiextensionsv1.JSONSchemaProps = map[string]map[string]apiextensionsv1.JSONSchemaProps {
+var knownPackages map[string]map[string]apiextensionsv1.JSONSchemaProps = map[string]map[string]apiextensionsv1.JSONSchemaProps{
 	"k8s.io/api/core/v1": {
 		// Explicit defaulting for the corev1.Protocol type in lieu of https://github.com/kubernetes/enhancements/pull/1928
 		"Protocol": apiextensionsv1.JSONSchemaProps{
@@ -486,7 +486,7 @@ var knownPackages map[string]map[string]apiextensionsv1.JSONSchemaProps = map[st
 var knownSchemas map[string]apiextensionsv1.JSONSchemaProps
 
 func init() {
-	knownSchemas = map[string]apiextensionsv1.JSONSchemaProps {}
+	knownSchemas = map[string]apiextensionsv1.JSONSchemaProps{}
 	for pkgName, schemas := range knownPackages {
 		for typeName, schema := range schemas {
 			schemaName := util.ToRESTFriendlyName(pkgName + "." + typeName)

--- a/pkg/reconciler/cluster/cluster.go
+++ b/pkg/reconciler/cluster/cluster.go
@@ -13,13 +13,17 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 )
 
 const pollInterval = time.Minute
 
 func (c *Controller) reconcile(ctx context.Context, cluster *v1alpha1.Cluster) error {
 	log.Println("reconciling cluster", cluster.Name)
+
+	logicalCluster := cluster.GetClusterName()
 
 	// Get client from kubeconfig
 	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
@@ -58,6 +62,7 @@ func (c *Controller) reconcile(ctx context.Context, cluster *v1alpha1.Cluster) e
 	}
 
 	for resourceName, pulledCrd := range crds {
+		pulledCrd.SetClusterName(logicalCluster)
 		clusterCrd, err := c.crdClient.CustomResourceDefinitions().Create(ctx, pulledCrd, v1.CreateOptions{})
 		if errors.IsAlreadyExists(err) {
 			clusterCrd, err = c.crdClient.CustomResourceDefinitions().Get(ctx, pulledCrd.Name, v1.GetOptions{})
@@ -76,7 +81,21 @@ func (c *Controller) reconcile(ctx context.Context, cluster *v1alpha1.Cluster) e
 	}
 
 	if !cluster.Status.Conditions.HasReady() {
-		if err := installSyncer(ctx, client, c.syncerImage, c.kubeconfig, cluster.Name); err != nil {
+		kubeConfig := c.kubeconfig.DeepCopy()
+		if _, exists := kubeConfig.Contexts[logicalCluster]; !exists {
+			log.Printf("error installing syncer: no context with the name of the expected cluster: %s", logicalCluster)
+			cluster.Status.Conditions.SetReady(corev1.ConditionFalse,
+				"ErrorInstallingSyncer",
+				fmt.Sprintf("Error installing syncer: no context with the name of the expected cluster: %s", logicalCluster))
+			return nil // Don't retry.
+		}
+
+		kubeConfig.CurrentContext = logicalCluster
+		bytes, err := clientcmd.Write(*kubeConfig)
+		if err == nil {
+			err = installSyncer(ctx, client, c.syncerImage, string(bytes), cluster.Name, logicalCluster)
+		}
+		if err != nil {
 			log.Printf("error installing syncer: %v", err)
 			cluster.Status.Conditions.SetReady(corev1.ConditionFalse,
 				"ErrorInstallingSyncer",
@@ -89,7 +108,7 @@ func (c *Controller) reconcile(ctx context.Context, cluster *v1alpha1.Cluster) e
 			"SyncerInstalling",
 			"Installing syncer on cluster")
 	} else {
-		if err := healthcheckSyncer(ctx, client); err != nil {
+		if err := healthcheckSyncer(ctx, client, logicalCluster); err != nil {
 			log.Println("syncer not yet ready")
 			cluster.Status.Conditions.SetReady(corev1.ConditionFalse,
 				"SyncerNotReady",
@@ -103,6 +122,11 @@ func (c *Controller) reconcile(ctx context.Context, cluster *v1alpha1.Cluster) e
 	}
 
 	// Enqueue another check later
-	c.queue.AddAfter(cluster, pollInterval)
+	key, err := cache.MetaNamespaceKeyFunc(cluster)
+	if err != nil {
+		klog.Error(err)
+	} else {
+		c.queue.AddAfter(key, pollInterval)
+	}
 	return nil
 }

--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -39,21 +39,21 @@ func NewController(cfg *rest.Config, syncerImage string, kubeconfig clientcmdapi
 	crdClient := apiextensionsv1client.NewForConfigOrDie(cfg)
 
 	c := &Controller{
-		queue:       queue,
-		client:      client,
-		crdClient:   crdClient,
-		syncerImage: syncerImage,
-		kubeconfig:  kubeconfig,
-		stopCh:      stopCh,
+		queue:           queue,
+		client:          client,
+		crdClient:       crdClient,
+		syncerImage:     syncerImage,
+		kubeconfig:      kubeconfig,
+		stopCh:          stopCh,
 		resourcesToSync: resourcesToSync,
-		pullModel: pullModel,
+		pullModel:       pullModel,
 	}
 
 	sif := externalversions.NewSharedInformerFactoryWithOptions(clusterclient.NewForConfigOrDie(cfg), resyncPeriod)
 	sif.Cluster().V1alpha1().Clusters().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueue(obj) },
 		UpdateFunc: func(_, obj interface{}) { c.enqueue(obj) },
-		DeleteFunc: func(obj interface{})  { c.deletedCluster(obj) },
+		DeleteFunc: func(obj interface{}) { c.deletedCluster(obj) },
 	})
 	c.indexer = sif.Cluster().V1alpha1().Clusters().Informer().GetIndexer()
 	sif.WaitForCacheSync(stopCh)
@@ -63,15 +63,15 @@ func NewController(cfg *rest.Config, syncerImage string, kubeconfig clientcmdapi
 }
 
 type Controller struct {
-	queue       workqueue.RateLimitingInterface
-	client      clusterv1alpha1.ClusterV1alpha1Interface
-	indexer     cache.Indexer
-	crdClient   apiextensionsv1client.ApiextensionsV1Interface
-	syncerImage string
-	kubeconfig  clientcmdapi.Config
-	stopCh      chan struct{}
+	queue           workqueue.RateLimitingInterface
+	client          clusterv1alpha1.ClusterV1alpha1Interface
+	indexer         cache.Indexer
+	crdClient       apiextensionsv1client.ApiextensionsV1Interface
+	syncerImage     string
+	kubeconfig      clientcmdapi.Config
+	stopCh          chan struct{}
 	resourcesToSync []string
-	pullModel   bool
+	pullModel       bool
 }
 
 func (c *Controller) enqueue(obj interface{}) {
@@ -145,7 +145,7 @@ func (c *Controller) process(key string) error {
 
 	if !exists {
 		log.Printf("Object with key %q was deleted", key)
-		return nil		
+		return nil
 	}
 	current := obj.(*v1alpha1.Cluster)
 	previous := current.DeepCopy()
@@ -186,12 +186,11 @@ func (c *Controller) deletedCluster(obj interface{}) {
 	c.cleanup(ctx, castObj)
 }
 
-
 func RegisterClusterCRD(cfg *rest.Config) error {
 	bytes, err := ioutil.ReadFile("config/cluster.example.dev_clusters.yaml")
-	
+
 	crdClient := apiextensionsv1client.NewForConfigOrDie(cfg)
-	
+
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 	err = yaml.Unmarshal(bytes, crd)
 	if err != nil {

--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -31,7 +31,7 @@ const resyncPeriod = 10 * time.Hour
 // server it reaches using the REST client.
 //
 // When new Clusters are found, the syncer will be run there using the given image.
-func NewController(cfg *rest.Config, syncerImage string, kubeconfig clientcmdapi.Config) *Controller {
+func NewController(cfg *rest.Config, syncerImage string, kubeconfig clientcmdapi.Config, resourcesToSync []string, pullModel bool) *Controller {
 	client := clusterv1alpha1.NewForConfigOrDie(cfg)
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	stopCh := make(chan struct{}) // TODO: hook this up to SIGTERM/SIGINT
@@ -45,6 +45,8 @@ func NewController(cfg *rest.Config, syncerImage string, kubeconfig clientcmdapi
 		syncerImage: syncerImage,
 		kubeconfig:  kubeconfig,
 		stopCh:      stopCh,
+		resourcesToSync: resourcesToSync,
+		pullModel: pullModel,
 	}
 
 	sif := externalversions.NewSharedInformerFactoryWithOptions(clusterclient.NewForConfigOrDie(cfg), resyncPeriod)
@@ -68,6 +70,8 @@ type Controller struct {
 	syncerImage string
 	kubeconfig  clientcmdapi.Config
 	stopCh      chan struct{}
+	resourcesToSync []string
+	pullModel   bool
 }
 
 func (c *Controller) enqueue(obj interface{}) {

--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -142,6 +142,18 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 	return nil
 }
 
+// uninstallSyncer uninstalls the syncer image from the target cluster.
+func uninstallSyncer(ctx context.Context, client kubernetes.Interface, logicalCluster string) {
+	if err := client.CoreV1().ConfigMaps(syncerNS).Delete(ctx, syncerConfigMapName(logicalCluster), metav1.DeleteOptions{}); err != nil {
+		klog.Error(err)
+	}
+
+	if err := client.AppsV1().Deployments(syncerNS).Delete(ctx, syncerWorkloadName(logicalCluster), metav1.DeleteOptions{}); err != nil {
+		klog.Error(err)
+	}
+}
+
+
 func healthcheckSyncer(ctx context.Context, client kubernetes.Interface, logicalCluster string) error {
 	pods, err := client.CoreV1().Pods(syncerNS).List(ctx, metav1.ListOptions{LabelSelector: "app=" + syncerConfigMapName(logicalCluster) })
 	if err != nil {

--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -5,21 +5,31 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 )
 
 const (
 	syncerNS      = "syncer-system"
 	syncerSAName  = "syncer"
-	syncerPodName = "syncer"
+	syncerPrefix = "syncer"
 )
+
+func syncerWorkloadName(logicalCluster string) string {
+	return syncerPrefix + "-from-" + logicalCluster
+}
+
+func syncerConfigMapName(logicalCluster string) string {
+	return "kubeconfig-for-" + logicalCluster
+}
 
 // installSyncer installs the syncer image on the target cluster.
 //
 // It takes the syncer image name to run, and the kubeconfig of the kcp
-func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage, kubeconfig, clusterID string) error {
+func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage, kubeconfig, clusterID, logicalCluster string) error {
 	// Create Namespace
 	if _, err := client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -45,57 +55,84 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 
 	// Populate a ConfigMap with the kubeconfig to reach the kcp, to be
 	// mounted into the syncer's Pod.
-	if _, err := client.CoreV1().ConfigMaps(syncerNS).Create(ctx, &corev1.ConfigMap{
+	configMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: syncerNS,
-			Name:      "kubeconfig",
+			Name:      syncerConfigMapName(logicalCluster),
 		},
 		Data: map[string]string{
 			"kubeconfig": kubeconfig,
 		},
-	}, metav1.CreateOptions{}); err != nil && !k8serrors.IsAlreadyExists(err) {
-		return err
+	}
+	if _, err := client.CoreV1().ConfigMaps(syncerNS).Create(ctx, &configMap, metav1.CreateOptions{}); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			if _, err := client.CoreV1().ConfigMaps(syncerNS).Update(ctx, &configMap, metav1.UpdateOptions{}); err != nil {
+			}
+		} else {
+			return err
+		}
 	}
 
+	var one int32 = 1
 	// Create or Update Pod
-	pod := &corev1.Pod{
+	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: syncerNS,
-			Name:      syncerPodName,
+			Name:      syncerWorkloadName(logicalCluster),
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "syncer",
-				Image: syncerImage,
-				Args: []string{
-					"-cluster", clusterID,
-					"-kubeconfig", "/kcp/kubeconfig",
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector {
+				MatchLabels: map[string]string{
+					"app": syncerWorkloadName(logicalCluster),
 				},
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "kubeconfig",
-					MountPath: "/kcp",
-					ReadOnly:  true,
-				}},
-			}},
-			Volumes: []corev1.Volume{{
-				Name: "kubeconfig",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "kubeconfig",
-						},
-						Items: []corev1.KeyToPath{{
-							Key: "kubeconfig", Path: "kubeconfig",
-						}},
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Template: corev1.PodTemplateSpec {
+				ObjectMeta: metav1.ObjectMeta {
+					Labels: map[string]string{
+						"app": syncerWorkloadName(logicalCluster),
 					},
 				},
-			}},
-		},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "syncer",
+						Image: syncerImage,
+						Args: []string{
+							"-cluster", clusterID,
+							"-kubeconfig", "/kcp/kubeconfig",
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "kubeconfig",
+							MountPath: "/kcp",
+							ReadOnly:  true,
+						}},
+						TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "kubeconfig",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: syncerConfigMapName(logicalCluster),
+								},
+								Items: []corev1.KeyToPath{{
+									Key: "kubeconfig", Path: "kubeconfig",
+								}},
+							},
+						},
+					}},
+				},
+			},
+		},		
 	}
-	if _, err := client.CoreV1().Pods(syncerNS).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+	if _, err := client.AppsV1().Deployments(syncerNS).Create(ctx, deployment, metav1.CreateOptions{}); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			// Update Pod
-			if _, err := client.CoreV1().Pods(syncerNS).Update(ctx, pod, metav1.UpdateOptions{}); err != nil {
+			// Update Deployment
+			if _, err := client.AppsV1().Deployments(syncerNS).Update(ctx, deployment, metav1.UpdateOptions{}); err != nil {
+				klog.Error(err)
 				return err
 			}
 		} else {
@@ -105,13 +142,20 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 	return nil
 }
 
-func healthcheckSyncer(ctx context.Context, client kubernetes.Interface) error {
-	pod, err := client.CoreV1().Pods(syncerNS).Get(ctx, syncerPodName, metav1.GetOptions{})
+func healthcheckSyncer(ctx context.Context, client kubernetes.Interface, logicalCluster string) error {
+	pods, err := client.CoreV1().Pods(syncerNS).List(ctx, metav1.ListOptions{LabelSelector: "app=" + syncerConfigMapName(logicalCluster) })
 	if err != nil {
 		return err
 	}
-	if pod.Status.Phase == corev1.PodRunning {
-		return nil
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("Syncer pod not ready: not syncer pod found")
 	}
-	return fmt.Errorf("Syncer pod not ready: %s", pod.Status.Phase)
+	if len(pods.Items) > 1 {
+		return fmt.Errorf("Syncer pod not ready: there should be only 1 syncer pod")
+	}
+	pod := pods.Items[0]
+	if pod.Status.Phase != corev1.PodRunning {
+		return fmt.Errorf("Syncer pod not ready: %s", pod.Status.Phase)
+	}
+	return nil
 }

--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -110,7 +110,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 					Containers: []corev1.Container{{
 						Name:  "syncer",
 						Image: syncerImage,
-						Args: args,
+						Args:  args,
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "kubeconfig",
 							MountPath: "/kcp",


### PR DESCRIPTION
This PR accomodates the CRD tenancy hacks made on the `kubernetes` side in commit https://github.com/kcp-dev/kubernetes/commit/816623327aac1a22360e9d31d589cf11af8bc1ef

It also enables CRD tenancy support in the cluster controller and adds the ability to optionally integrate the cluster-controller, as well as the syncer deployment, directly inside the kcp command line.
When the corresponding flag is enabled, kcp will fetch CRDs from registered physical clusters, install them into KCP, and the corresponding logical clusters will be able to see them.