### PR TITLE
More fixes on the Syncer

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -28,9 +28,11 @@ const (
 )
 
 var (
-	kubeconfig   = flag.String("from", "", "Kubeconfig file for -from cluster")
-	toKubeconfig = flag.String("to", "", "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used")
-	clusterID    = flag.String("cluster", "", "ID of this cluster")
+	fromKubeconfig = flag.String("from_kubeconfig", "", "Kubeconfig file for -from cluster")
+	fromContext    = flag.String("from_context", "", "Context to use in the Kubeconfig file for -from cluster, instead of the current context")
+	toKubeconfig   = flag.String("to_kubeconfig", "", "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used")
+	toContext      = flag.String("to_context", "", "Context to use in the Kubeconfig file for -to cluster, instead of the current context")
+	clusterID      = flag.String("cluster", "", "ID of this cluster")
 )
 
 func main() {
@@ -38,10 +40,19 @@ func main() {
 	syncedResourceTypes := flag.Args()
 
 	// Create a client to dynamically watch "from".
-	fromConfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+
+	var fromOverrides clientcmd.ConfigOverrides
+	if *fromContext != "" {
+		fromOverrides.CurrentContext = *fromContext
+	}
+
+	fromConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: *fromKubeconfig},
+		&fromOverrides).ClientConfig()
 	if err != nil {
 		klog.Fatal(err)
 	}
+
 	fromClient := dynamic.NewForConfigOrDie(fromConfig)
 	fromDSIF := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fromClient, resyncPeriod, metav1.NamespaceAll, func(o *metav1.ListOptions) {
 		o.LabelSelector = fmt.Sprintf("cluster = %s", *clusterID)
@@ -49,7 +60,17 @@ func main() {
 
 	var toConfig *rest.Config
 	if *toKubeconfig != "" {
-		toConfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfig) // rest.InClusterConfig()
+		var toOverrides clientcmd.ConfigOverrides
+		if *toContext != "" {
+			toOverrides.CurrentContext = *toContext
+		}
+
+		toConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: *toKubeconfig},
+			&toOverrides).ClientConfig()
+		if err != nil {
+			klog.Fatal(err)
+		}
 	} else {
 		toConfig, err = rest.InClusterConfig()
 	}

--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -6,6 +6,8 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -29,7 +31,7 @@ func syncerConfigMapName(logicalCluster string) string {
 // installSyncer installs the syncer image on the target cluster.
 //
 // It takes the syncer image name to run, and the kubeconfig of the kcp
-func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage, kubeconfig, clusterID, logicalCluster string, resourcesToSync []string) error {
+func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage, kubeconfig, clusterID, logicalCluster string, apiGroups, resourcesToSync []string) error {
 	// Create Namespace
 	if _, err := client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -49,9 +51,68 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 		return err
 	}
 
-	// TODO: Create or Update ClusterRole
+	// Create or Update ClusterRole
 
-	// TODO: Create ClusterRoleBinding
+	var resourcesWithStatus []string
+	resourcesWithStatus = append(resourcesWithStatus, resourcesToSync...)
+	for _, resourceToSync := range resourcesToSync {
+		resourcesWithStatus = append(resourcesWithStatus, resourceToSync+"/status")
+	}
+
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: syncerSAName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"create"},
+				APIGroups: []string{""},
+				Resources: []string{"namespaces"},
+			},
+			{
+				Verbs:     []string{"create", "update", "get"},
+				Resources: resourcesWithStatus,
+				APIGroups: apiGroups,
+			},
+		},
+	}
+	if _, err := client.RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{}); err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+		existing, err := client.RbacV1().ClusterRoles().Get(ctx, clusterRole.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if !equality.Semantic.DeepEqual(existing.Rules, clusterRole.Rules) {
+			clusterRole.ResourceVersion = existing.ResourceVersion
+			if _, err := client.RbacV1().ClusterRoles().Update(ctx, clusterRole, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Create ClusterRoleBinding
+
+	if _, err := client.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: syncerSAName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      syncerSAName,
+				Namespace: syncerNS,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     syncerSAName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}, metav1.CreateOptions{}); err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
 
 	// Populate a ConfigMap with the kubeconfig to reach the kcp, to be
 	// mounted into the syncer's Pod.
@@ -76,7 +137,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 
 	args := []string{
 		"-cluster", clusterID,
-		"-kubeconfig", "/kcp/kubeconfig",
+		"-from", "/kcp/kubeconfig",
 	}
 	args = append(args, resourcesToSync...)
 
@@ -131,6 +192,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 							},
 						},
 					}},
+					ServiceAccountName: syncerSAName,
 				},
 			},
 		},

--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -137,7 +137,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 
 	args := []string{
 		"-cluster", clusterID,
-		"-from", "/kcp/kubeconfig",
+		"-from_kubeconfig", "/kcp/kubeconfig",
 	}
 	args = append(args, resourcesToSync...)
 


### PR DESCRIPTION
- Make the syncer correctly point to the `to` cluster (with the option of passing a kubeconfig for it)
- Only try to synchronize the resource types that have effectively been been imported by the cluster controller
- Create the required rbac rules to enable the syncer service account to create the synced objects in the `to` cluster.
- Fix the syncer reconcile loop and add more detailed logs.
