### PR TITLE
Avoid pruning metadata fields that are inside spec (Fix for issue #43)

### DIFF
--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -413,6 +413,12 @@ var knownPackages map[string]map[string]apiextensionsv1.JSONSchemaProps = map[st
 		// generate validation for it.
 		"ObjectMeta": apiextensionsv1.JSONSchemaProps{
 			Type: "object",
+
+			// CHANGE vs the OperatorSDK code:
+			// Add `x-preserve-unknown-fields: true` here since it is necessary when metadata is not at the top-level
+			// (for example in Deployment spec.template.metadata), in order not to prune unknown fields and avoid
+			// emptying metadata
+			XPreserveUnknownFields: boolPtr(true),
 		},
 		"Time": apiextensionsv1.JSONSchemaProps{
 			Type:   "string",


### PR DESCRIPTION
Avoid pruning metadata fields that are inside spec

This fixes issue #43.
The problem was that the `ObjectMeta` hard-coded Schema was not defining the `x-preserve-unknown-fields` openapi extension.
So when creating a custom reosurce whose schema contains a field of this type inside its Spec, the content of the metadata map was systematically pruned.
