### PR TITLE
Fix enqueueing in deployment splitter

### DIFF
--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -80,7 +80,7 @@ func (c *Controller) enqueue(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	c.queue.Add(key)
+	c.queue.AddRateLimited(key)
 }
 
 func (c *Controller) Start(numThreads int) {


### PR DESCRIPTION
Enqueue the object's key instead of the full object, so that when we process the item we don't panic trying to interpret the object as the key.

This is consistent with cluster-controller, and other controllers in general.