### PR TITLE
Fix errors in the syncer when an object is deleted...

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -38,6 +38,9 @@ var (
 func main() {
 	flag.Parse()
 	syncedResourceTypes := flag.Args()
+	if len(syncedResourceTypes) == 0 {
+		syncedResourceTypes = []string{"pods", "deployments"}
+	}
 
 	// Create a client to dynamically watch "from".
 


### PR DESCRIPTION
... and add `pods` and `deployments` as default resource types to be synced
in order to be consistent with preivous behavior and other commands.
