### PR TITLE
Add 'listen' CLI option

### DIFF
--- a/pkg/utils/net/net.go
+++ b/pkg/utils/net/net.go
@@ -1,0 +1,26 @@
+package net
+
+import (
+	"net"
+	"strconv"
+)
+
+// SplitAddrPort splits the given address into its IP address and port parts.
+// It works with both IPv4 and IPv6 addresses.
+func SplitAddrPort(addr string) (net.IP, int, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	if addr := net.ParseIP(host); addr != nil {
+		return addr, portInt, nil
+	}
+
+	return net.IPv4zero, portInt, nil
+}

--- a/pkg/utils/net/net_test.go
+++ b/pkg/utils/net/net_test.go
@@ -1,0 +1,68 @@
+package net
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestSplitAddrPort(t *testing.T) {
+	var testCases = []struct {
+		addr         string
+		expectedAddr net.IP
+		expectedPort int
+		expectedErr  error
+	}{
+		{
+			addr:         "127.0.0.1:8080",
+			expectedAddr: net.ParseIP("127.0.0.1"),
+			expectedPort: 8080,
+		},
+		{
+			addr:         ":8080",
+			expectedAddr: net.IPv4zero,
+			expectedPort: 8080,
+		},
+		{
+			addr:         "[::1]:8080",
+			expectedAddr: net.ParseIP("::1"),
+			expectedPort: 8080,
+		},
+		{
+			addr:         "[2001:db8:1f70::999:de8:7648:6e8]:8080",
+			expectedAddr: net.ParseIP("2001:db8:1f70::999:de8:7648:6e8"),
+			expectedPort: 8080,
+		},
+		{
+			addr:         "[::]:8080",
+			expectedAddr: net.IPv6zero,
+			expectedPort: 8080,
+		},
+		{
+			addr:        "127.0.0.1",
+			expectedErr: &net.AddrError{Err: "missing port in address", Addr: "127.0.0.1"},
+		},
+	}
+
+	for i, tc := range testCases {
+		actualAddr, actualPort, err := SplitAddrPort(tc.addr)
+		if err != nil {
+			if tc.expectedErr != nil {
+				if !reflect.DeepEqual(tc.expectedErr, err) {
+					t.Fatalf("test case %d. errors mismatch. expected: %s, actual: %s", i, tc.expectedErr, err)
+				}
+				continue
+			}
+
+			t.Fatalf("test case %d. unexpected error: %v", i, err)
+		}
+
+		if tc.expectedAddr.String() != actualAddr.String() {
+			t.Errorf("test case %d. addresses mismatch. expected: %s, actual: %s", i, tc.expectedAddr, actualAddr)
+		}
+
+		if tc.expectedPort != actualPort {
+			t.Errorf("test case %d. ports mismatch. expected: %d, actual: %d", i, tc.expectedPort, actualPort)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a `--listen-at` option to kcp. The assigned value (ipv4, ipv6) 
is used as the bind address of the generic API server.

Test result:

```sh
# default
$ bin/kcp start
Connected to etcd 12037351334381611957 default
...
I0507 21:05:10.039034 1775924 secure_serving.go:178] Serving securely on [::]:6443

# if port only, bind to 0.0.0.0
$ bin/kcp start --listen-at=:56443
Connected to etcd 12037351334381611957 default
....
I0507 21:06:51.444359 1776675 secure_serving.go:178] Serving securely on [::]:56443

# ipv6
$ bin/kcp start --listen-at="[::1]:56443"
Connected to etcd 12037351334381611957 default
...
I0507 21:07:39.962650 1777011 secure_serving.go:178] Serving securely on [::1]:56443

# ipv4
$ bin/kcp start --listen-at="127.0.0.1:56443"
Connected to etcd 12037351334381611957 default
...
I0507 21:09:05.210727 1777849 secure_serving.go:178] Serving securely on 127.0.0.1:56443
```

Fixes https://github.com/kcp-dev/kcp/issues/15.

Signed-off-by: Ivan Sim <isim@redhat.com>