### PR TITLE
Reconcile a whole deployment not only its status

### DIFF
--- a/pkg/reconciler/deployment/controller.go
+++ b/pkg/reconciler/deployment/controller.go
@@ -150,8 +150,8 @@ func (c *Controller) process(key string) error {
 	}
 
 	// If the object being reconciled changed as a result, update it.
-	if !equality.Semantic.DeepEqual(previous.Status, current.Status) {
-		_, uerr := c.client.Deployments(current.Namespace).UpdateStatus(ctx, current, metav1.UpdateOptions{})
+	if !equality.Semantic.DeepEqual(previous, current) {
+		_, uerr := c.client.Deployments(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
 		return uerr
 	}
 


### PR DESCRIPTION
When you have a single downstream cluster, the `deployment-splitter` adds a `cluster: your-downstream` label to the fetched deployment struct `root` internally. But currently `pkg/reconciler/deployment/controller.go` only detects a diff in the `Status` field, so the `cluster` label cannot be included.

Instead of the `controller.go` as this PR, alternately we can update the deployment in `pkg/reconciler/deployment/deployment.go` like the following: Which is better?

```go
if len(cls) == 1 {
	// nothing to split, just label Deployment for the only cluster.
	if root.Labels == nil {
		root.Labels = map[string]string{}
	}

	// TODO: munge cluster name
	root.Labels[clusterLabel] = cls[0].Name
	if _, err := c.kubeClient.AppsV1().Deployments(root.Namespace).Update(ctx, vd, metav1.UpdateOptions{}); err != nil {
		return err
	}
        return nil
}
```

fixes #63 