### PR TITLE
Condition of cluster not set correct, lead to create infinited syncer

### DIFF
--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,6 +52,28 @@ type ClusterSpec struct {
 // ClusterStatus communicates the observed state of the Cluster (from the controller).
 type ClusterStatus struct {
 	Conditions Conditions `json:"conditions,omitempty"`
+}
+
+func (cs *ClusterStatus) SetConditionReady(status corev1.ConditionStatus, reason, message string) {
+	for idx, cond := range cs.Conditions {
+		if cond.Type == ClusterConditionReady {
+			cs.Conditions[idx] = Condition{
+				Type:               ClusterConditionReady,
+				Status:             status,
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: cond.LastTransitionTime,
+			}
+			return
+		}
+	}
+	cs.Conditions = append(cs.Conditions, Condition{
+		Type:               ClusterConditionReady,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	})
 }
 
 // ClusterList is a list of Cluster resources

--- a/pkg/apis/cluster/v1alpha1/conditions.go
+++ b/pkg/apis/cluster/v1alpha1/conditions.go
@@ -32,28 +32,6 @@ func (c Conditions) HasReady() bool {
 	return false
 }
 
-func (c Conditions) SetReady(status corev1.ConditionStatus, reason, message string) {
-	for idx, cond := range c {
-		if cond.Type == ClusterConditionReady {
-			c[idx] = Condition{
-				Type:               ClusterConditionReady,
-				Status:             status,
-				Reason:             reason,
-				Message:            message,
-				LastTransitionTime: metav1.Now(),
-			}
-			return
-		}
-	}
-	c = append(c, Condition{
-		Type:               ClusterConditionReady,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	})
-}
-
 type ConditionType string
 
 const (


### PR DESCRIPTION
The original implements for updating `cluster.status.conditions` is not correct.
The 
```
func (c Conditions) SetReady(status corev1.ConditionStatus, reason, message string) {
	for idx, cond := range c {
		if cond.Type == ClusterConditionReady {
			c[idx] = Condition{
				Type:               ClusterConditionReady,
				Status:             status,
				Reason:             reason,
				Message:            message,
				LastTransitionTime: metav1.Now(),
			}
			return
		}
	}
	c = append(c, Condition{
		Type:               ClusterConditionReady,
		Status:             status,
		Reason:             reason,
		Message:            message,
		LastTransitionTime: metav1.Now(),
	})
}
```

can not modify the outer `cluster.status.conditions` with the `append`.
In `push` node, that's lead to every reconcile will try to create new `syncer` in the controller, since the condition is not set as `ready` in previously reconcile.
