### PR TITLE
Avoid infinite loop when delete cluster with push mode

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -15,10 +15,10 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 )
@@ -165,6 +165,7 @@ func (c *Controller) startWorker() {
 		select {
 		case <-c.stopCh:
 			log.Println("stopping syncer worker")
+			return
 		default:
 			c.processNextWorkItem()
 		}


### PR DESCRIPTION
Will get these message loop infinite like this:
```
2021-05-17 18:38:27.763163 I | stopping syncer worker
2021-05-17 18:38:27.763169 I | stopping syncer worker
2021-05-17 18:38:27.763177 I | stopping syncer worker
2021-05-17 18:38:27.763183 I | stopping syncer worker
2021-05-17 18:38:27.763189 I | stopping syncer worker
2021-05-17 18:38:27.763195 I | stopping syncer worker
2021-05-17 18:38:27.763201 I | stopping syncer worker
2021-05-17 18:38:27.763207 I | stopping syncer worker
2021-05-17 18:38:27.763213 I | stopping syncer worker
2021-05-17 18:38:27.763219 I | stopping syncer worker
2021-05-17 18:38:27.763223 I | stopping syncer worker
2021-05-17 18:38:27.763226 I | stopping syncer worker
2021-05-17 18:38:27.763232 I | stopping syncer worker
2021-05-17 18:38:27.763239 I | stopping syncer worker
2021-05-17 18:38:27.763242 I | stopping syncer worker
2021-05-17 18:38:27.763249 I | stopping syncer worker
2021-05-17 18:38:27.763256 I | stopping syncer worker
2021-05-17 18:38:27.763262 I | stopping syncer worker
2021-05-17 18:38:27.763268 I | stopping syncer worker
```