### PR TITLE
Add status sync and other demo fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .kcp
-kcp
-
-cluster-controller
-deployment-splitter
-syncer
-contrib/demo/clusters/kind/us-east1*
-contrib/demo/clusters/kind/us-west1*
+/bin/kcp
+/bin/cluster-controller
+/bin/deployment-splitter
+/bin/syncer
+contrib/demo/clusters/kind/us-east1.yaml
+contrib/demo/clusters/kind/us-east1.kubeconfig
+contrib/demo/clusters/kind/us-west1.yaml
+contrib/demo/clusters/kind/us-west1.kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 .kcp
-/bin/kcp
-/bin/cluster-controller
-/bin/deployment-splitter
-/bin/syncer
 contrib/demo/clusters/kind/us-east1.yaml
 contrib/demo/clusters/kind/us-east1.kubeconfig
 contrib/demo/clusters/kind/us-west1.yaml

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -64,11 +64,11 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	specSyncer, err, _ := syncer.NewSpecSyncer(fromConfig, toConfig, syncedResourceTypes, *clusterID)
+	specSyncer, err := syncer.NewSpecSyncer(fromConfig, toConfig, syncedResourceTypes, *clusterID)
 	if err != nil {
 		klog.Fatal(err)
 	}
-	statusSyncer, err, _ := syncer.NewStatusSyncer(fromConfig, toConfig, syncedResourceTypes, *clusterID)
+	statusSyncer, err := syncer.NewStatusSyncer(fromConfig, toConfig, syncedResourceTypes, *clusterID)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -64,13 +64,19 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	s, err := syncer.New(fromConfig, toConfig, syncedResourceTypes, *clusterID)
+	specSyncer, err, _ := syncer.NewSpecSyncer(fromConfig, toConfig, syncedResourceTypes, *clusterID)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	statusSyncer, err, _ := syncer.NewStatusSyncer(fromConfig, toConfig, syncedResourceTypes, *clusterID)
 	if err != nil {
 		klog.Fatal(err)
 	}
 
-	s.Start(numThreads)
+	specSyncer.Start(numThreads)
+	statusSyncer.Start(numThreads)
 	klog.Infoln("Starting workers")
-	<-s.Done()
+	<-specSyncer.Done()
+	<-statusSyncer.Done()
 	klog.Infoln("Stopping workers")
 }

--- a/contrib/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demo/clusters/kind/createKindClusters.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
+#!/bin/bash -e
 
 DEMO_ROOT="$(dirname "${BASH_SOURCE}")/../.."
 
-rm -f ${DEMO_ROOT}/clusters/kind/us-east1-kubeconfig
 kind create cluster --config ${DEMO_ROOT}/clusters/kind/us-east1.config --kubeconfig ${DEMO_ROOT}/clusters/kind/us-east1.kubeconfig
 sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-east1.kubeconfig | cat ${DEMO_ROOT}/clusters/us-east1.yaml - > ${DEMO_ROOT}/clusters/kind/us-east1.yaml
 
-rm -f ${DEMO_ROOT}/clusters/kind/us-west1-kubeconfig
 kind create cluster --config ${DEMO_ROOT}/clusters/kind/us-west1.config --kubeconfig ${DEMO_ROOT}/clusters/kind/us-west1.kubeconfig
 sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-west1.kubeconfig | cat ${DEMO_ROOT}/clusters/us-west1.yaml - > ${DEMO_ROOT}/clusters/kind/us-west1.yaml

--- a/contrib/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demo/clusters/kind/createKindClusters.sh
@@ -2,8 +2,10 @@
 
 DEMO_ROOT="$(dirname "${BASH_SOURCE}")/../.."
 
-kind create cluster --name us-east1 --kubeconfig ${DEMO_ROOT}/clusters/kind/us-east1-kubeconfig
-sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-east1-kubeconfig | cat ${DEMO_ROOT}/clusters/us-east1.yaml - > ${DEMO_ROOT}/clusters/kind/us-east1.yaml
+rm -f ${DEMO_ROOT}/clusters/kind/us-east1-kubeconfig
+kind create cluster --config ${DEMO_ROOT}/clusters/kind/us-east1.config --kubeconfig ${DEMO_ROOT}/clusters/kind/us-east1.kubeconfig
+sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-east1.kubeconfig | cat ${DEMO_ROOT}/clusters/us-east1.yaml - > ${DEMO_ROOT}/clusters/kind/us-east1.yaml
 
-kind create cluster --name us-west1 --kubeconfig ${DEMO_ROOT}/clusters/kind/us-west1-kubeconfig
-sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-west1-kubeconfig | cat ${DEMO_ROOT}/clusters/us-west1.yaml - > ${DEMO_ROOT}/clusters/kind/us-west1.yaml
+rm -f ${DEMO_ROOT}/clusters/kind/us-west1-kubeconfig
+kind create cluster --config ${DEMO_ROOT}/clusters/kind/us-west1.config --kubeconfig ${DEMO_ROOT}/clusters/kind/us-west1.kubeconfig
+sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-west1.kubeconfig | cat ${DEMO_ROOT}/clusters/us-west1.yaml - > ${DEMO_ROOT}/clusters/kind/us-west1.yaml

--- a/contrib/demo/clusters/kind/us-east1.config
+++ b/contrib/demo/clusters/kind/us-east1.config
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: us-east1
+networking:
+  apiServerAddress: "127.0.0.1"

--- a/contrib/demo/clusters/kind/us-west1.config
+++ b/contrib/demo/clusters/kind/us-west1.config
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: us-west1
+networking:
+  apiServerAddress: "127.0.0.1"

--- a/contrib/demo/script
+++ b/contrib/demo/script
@@ -61,7 +61,8 @@ pe "head -n 15 ${CLUSTERS_DIR}/us-east1.yaml"
 pe "kubectl apply -f ${CLUSTERS_DIR}/us-east1.yaml"
 
 kubectl wait crd/deployments.apps --for condition=established &>/dev/null
-sleep 2
+kubectl wait apiservices/v1.apps --for condition=available &>/dev/null
+pause 5
 
 pe "kubectl api-resources"
 

--- a/contrib/demo/startKcpForDemo.sh
+++ b/contrib/demo/startKcpForDemo.sh
@@ -13,21 +13,28 @@ KCP_ROOT="$(cd ${DEMO_ROOT}/../.. && pwd)"
 
 KUBECONFIG=${KCP_ROOT}/.kcp/data/admin.kubeconfig
 
-echo "Starting KCP"
+echo "Starting KCP server ..."
 (cd ${KCP_ROOT} && exec ./bin/kcp start) &> kcp.log &
 KCP_PID=$!
+echo "KCP server started: $KCP_PID" 
 
-sleep 5
+echo "Waiting for KCP server to be up and running..." 
+sleep 10
 
-echo "Starting Cluster Controller"
+echo ""
+echo "Starting Cluster Controller..."
 ${KCP_ROOT}/bin/cluster-controller -push_mode=true -pull_mode=false -kubeconfig=${KUBECONFIG} deployments &> cluster-controller.log &
 CC_PID=$!
+echo "Cluster Controller started: $CC_PID" 
 
+echo ""
 echo "Starting Deployment Splitter"
 ${KCP_ROOT}/bin/deployment-splitter -kubeconfig=${KCP_ROOT}/.kcp/data/admin.kubeconfig &> deployment-splitter.log &
 SPLIT_PID=$!
+echo "Deployment Splitter started: $SPLIT_PID" 
 
-echo "Use ctrl-C to stop them"
+echo ""
+echo "Use ctrl-C to stop all components"
 echo ""
 
 tail -f cluster-controller.log deployment-splitter.log  &

--- a/contrib/kcp.code-workspace
+++ b/contrib/kcp.code-workspace
@@ -68,6 +68,16 @@
 				"args": ["--kubeconfig=${env:HOME}/.kube/config", "pods", "clusters"]
 			},
 			{
+				"name": "Launch cluster controller - push mode",
+				"type": "go",
+				"request": "launch",
+				"mode": "debug",
+				"program": "${workspaceFolder:kcp}/cmd/cluster-controller",
+				"env": { "GOMOD": "${workspaceFolder:kcp}/go.mod", },
+				"cwd": "${workspaceFolder:kcp}",
+				"args": ["-push_mode=true", "-pull_mode=false", "-kubeconfig=${workspaceFolder:kcp}/.kcp/data/admin.kubeconfig"],
+			},
+			{
 				"name": "Launch cluster controller",
 				"type": "go",
 				"request": "launch",

--- a/pkg/reconciler/deployment/deployment.go
+++ b/pkg/reconciler/deployment/deployment.go
@@ -92,14 +92,13 @@ func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deploymen
 			rootDeployment.Status.Conditions = others[0].Status.Conditions
 		}
 
-		_, err = c.client.Deployments(rootDeployment.Namespace).UpdateStatus(ctx, rootDeployment, metav1.UpdateOptions{})
-		if err != nil {
+		if _, err := c.client.Deployments(rootDeployment.Namespace).UpdateStatus(ctx, rootDeployment, metav1.UpdateOptions{}); err != nil {
 			if errors.IsConflict(err) {
 				key, err := cache.MetaNamespaceKeyFunc(deployment)
 				if err != nil {
 					return err
 				}
-				c.queue.AddAfter(key, 2*time.Second)
+				c.queue.AddRateLimited(key)
 				return nil
 			}
 			return err

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -1,0 +1,124 @@
+package syncer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+
+func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, clusterID string) (*Controller, error, bool) {
+	return New(from, to, upsertIntoDownstream, deleteFromDownstream, func(c *Controller, gvr schema.GroupVersionResource) cache.ResourceEventHandlerFuncs{
+		return cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { c.AddToQueue(gvr, obj) },
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				oldUnstrob, isOldObjUnstructured := oldObj.(*unstructured.Unstructured)
+				newUnstrob, isNewObjUnstructured := newObj.(*unstructured.Unstructured)
+				if isOldObjUnstructured && isNewObjUnstructured {
+					if ! equality.Semantic.DeepEqual(oldUnstrob.GetAnnotations(), newUnstrob.GetAnnotations()) {
+						c.AddToQueue(gvr, newObj)
+					}
+					if ! equality.Semantic.DeepEqual(oldUnstrob.GetLabels(), newUnstrob.GetLabels()) {
+						c.AddToQueue(gvr, newObj)
+					}
+	
+					oldObjKeys := sets.StringKeySet(oldUnstrob.UnstructuredContent())
+					newObjKeys := sets.StringKeySet(newUnstrob.UnstructuredContent())
+					for _, key := range oldObjKeys.Union(newObjKeys).UnsortedList() {
+						if key == "metadata" || key == "status" {
+							continue
+						}
+						if ! equality.Semantic.DeepEqual(oldUnstrob.UnstructuredContent()[key], newUnstrob.UnstructuredContent()[key]) {
+							c.AddToQueue(gvr, newObj)
+						}
+					} 
+
+				}
+			},
+			DeleteFunc: func(obj interface{}) { c.AddToQueue(gvr, obj) },
+		}
+	}, syncedResourceTypes, clusterID)
+}
+
+func (c *Controller) ensureNamespaceExists(namespace string) error {
+	namespaces := c.toClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	})
+	newNamespace := &unstructured.Unstructured{}
+	newNamespace.SetAPIVersion("v1")
+	newNamespace.SetKind("Namespace")
+	newNamespace.SetName(namespace)
+	if _, err := namespaces.Create(context.TODO(), newNamespace, metav1.CreateOptions{}); err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			klog.Infof("Error while creating namespace %s: %v", namespace, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func deleteFromDownstream(c *Controller, ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) error {
+	// TODO: get UID of just-deleted object and pass it as a precondition on this delete.
+	// This would avoid races where an object is deleted and another object with the same name is created immediately after.
+
+	return c.getClient(gvr, namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+func upsertIntoDownstream(c *Controller, ctx context.Context, gvr schema.GroupVersionResource, namespace string, unstrob *unstructured.Unstructured) error {
+	if err := c.ensureNamespaceExists(namespace); err != nil {
+		klog.Error(err)
+		return err
+	}
+
+	client := c.getClient(gvr, namespace)
+
+	unstrob = unstrob.DeepCopy()
+
+	// Attempt to create the object; if the object already exists, update it.
+	unstrob.SetUID("")
+	unstrob.SetResourceVersion("")
+	
+	ownedByLabel := unstrob.GetLabels()["kcp.dev/owned-by"]
+	var ownerReferences []metav1.OwnerReference
+	for _, reference := range unstrob.GetOwnerReferences() {
+		if reference.Name == ownedByLabel {
+			continue
+		}
+		ownerReferences = append(ownerReferences, reference)
+	}
+	unstrob.SetOwnerReferences(ownerReferences)
+
+	if _, err := client.Create(ctx, unstrob, metav1.CreateOptions{}); err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			klog.Error("Creating resource %s/%s: %v", namespace, unstrob.GetName(), err)
+			return err
+		}
+
+		existing, err := client.Get(ctx, unstrob.GetName(), metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Getting resource %s/%s: %v", namespace, unstrob.GetName(), err)
+			return err
+		}
+		klog.Infof("Object %s/%s already exists: update it", gvr.Resource, unstrob.GetName())
+
+		unstrob.SetResourceVersion(existing.GetResourceVersion())
+		if _, err := client.Update(ctx, unstrob, metav1.UpdateOptions{}); err != nil {
+			klog.Errorf("Updating resource %s/%s: %v", namespace, unstrob.GetName(), err)
+			return err
+		}
+	} else {
+		klog.Infof("Created object %s/%s", gvr.Resource, unstrob.GetName())
+	}
+
+	return nil
+}

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -1,0 +1,58 @@
+package syncer
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+
+func NewStatusSyncer(from, to *rest.Config, syncedResourceTypes []string, clusterID string) (*Controller, error, bool) {
+	return New(from, to, updateStatusInUpstream, nil, func(c *Controller, gvr schema.GroupVersionResource) cache.ResourceEventHandlerFuncs{
+		return cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, obj interface{}) {
+				oldUnstrob, isOldObjUnstructured := oldObj.(*unstructured.Unstructured)
+				newUnstrob, isNewObjUnstructured := obj.(*unstructured.Unstructured)
+				if isOldObjUnstructured && isNewObjUnstructured && oldUnstrob != nil && newUnstrob != nil {
+					if newStatus, statusExists := newUnstrob.UnstructuredContent()["status"]; statusExists {
+						oldStatus := oldUnstrob.UnstructuredContent()["status"]
+						areEqual := equality.Semantic.DeepEqual(oldStatus, newStatus)
+						if ! areEqual {
+							c.AddToQueue(gvr, obj)
+						}
+					}
+				}
+			},
+		}
+	}, syncedResourceTypes, clusterID)
+}
+
+func updateStatusInUpstream(c *Controller, ctx context.Context, gvr schema.GroupVersionResource, namespace string, unstrob *unstructured.Unstructured) error {
+	client := c.getClient(gvr, namespace)
+
+	unstrob = unstrob.DeepCopy()
+
+	// Attempt to create the object; if the object already exists, update it.
+	unstrob.SetUID("")
+	unstrob.SetResourceVersion("")
+
+	existing, err := client.Get(ctx, unstrob.GetName(), metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Getting resource %s/%s: %v", namespace, unstrob.GetName(), err)
+		return err
+	}
+
+	unstrob.SetResourceVersion(existing.GetResourceVersion())
+	if _, err := client.UpdateStatus(ctx, unstrob, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Updating status of resource %s/%s: %v", namespace, unstrob.GetName(), err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/util/errors/retryable.go
+++ b/pkg/util/errors/retryable.go
@@ -1,0 +1,19 @@
+package errors
+
+type RetryableError struct {
+	err error
+}
+
+// Error implements the Error interface.
+func (e *RetryableError) Error() string {
+	return e.err.Error()
+}
+
+func NewRetryableError(err error) error {
+	return &RetryableError{err}
+}
+
+func IsRetryable(err error) bool {
+	_, isRetryable := err.(*RetryableError)
+	return isRetryable
+}


### PR DESCRIPTION
This PR completes the remaining required implementation parts to have the Demo fully working as expected.
Main it:
- adds the synchronization of the object status from the physical clusters back to KCP.
- fixes a race condition that allowed ignoring the synchronization of an object when the corresponding API resource was not published and available in KCP soon enough.

It is paired with upcoming PRs in the [KCP Kubernetes feature branch](https://github.com/kcp-dev/kubernetes), but still can be compiled and run well without them.  