### PR TITLE
Fix flag typo in startKcpAndClusterController.sh

### DIFF
--- a/contrib/demo/startKcpAndClusterController.sh
+++ b/contrib/demo/startKcpAndClusterController.sh
@@ -20,7 +20,7 @@ KCP_PID=$!
 sleep 5
 
 echo "Starting Cluster Controller"
-${KCP_ROOT}/bin/cluster-controller -pull_model=false -kubeconfig=${KUBECONFIG} deployments &> cluster-controller.log &
+${KCP_ROOT}/bin/cluster-controller -pull_mode=false -kubeconfig=${KUBECONFIG} deployments &> cluster-controller.log &
 CC_PID=$!
 
 echo "Use ctrl-C to stop them"


### PR DESCRIPTION
fix typo in demo script.

```bash
$ ./startKcpAndClusterController.sh
Starting KCP
Starting Cluster Controller
Use ctrl-C to stop them

flag provided but not defined: -pull_model
Usage of /Users/aigarash/Developments/src/github.com/kcp-dev/kcp/bin/cluster-controller:
...
```