### PR TITLE
Fix path to the dev_cluster.yaml in demo script

### DIFF
--- a/contrib/demo/script
+++ b/contrib/demo/script
@@ -53,7 +53,7 @@ clear
 
 pe "kubectl config use-context admin"
 
-pe "kubectl apply -f config/cluster.example.dev_clusters.yaml"
+pe "kubectl apply -f ${ROOT_DIR}/config/cluster.example.dev_clusters.yaml"
 
 pe "head -n 15 ${CLUSTERS_DIR}/us-west1.yaml"
 pe "kubectl apply -f ${CLUSTERS_DIR}/us-west1.yaml"


### PR DESCRIPTION
Fixed the path to the `cluster.example.dev_clusters.yaml` in demo script so that it can be executed from the non-repository root directory.