### PR TITLE
Support rebalancing Deployments across Clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/google/go-cmp v0.3.0
 	github.com/muesli/reflow v0.1.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -60,6 +60,18 @@ type ClusterStatus struct {
 	SyncedResources []string `json:"syncedResources,omitempty"`
 }
 
+// IsReady returns true if the cluster's status indicates it's Ready.
+func (c *Cluster) IsReady() bool {
+	for _, cond := range c.Status.Conditions {
+		if cond.Type == ClusterConditionReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// SetConditionReady sets the Ready-type condition to report the given status,
+// reason, and message.
 func (cs *ClusterStatus) SetConditionReady(status corev1.ConditionStatus, reason, message string) {
 	for idx, cond := range cs.Conditions {
 		if cond.Type == ClusterConditionReady {

--- a/pkg/reconciler/deployment/daemonset.go
+++ b/pkg/reconciler/deployment/daemonset.go
@@ -1,0 +1,159 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clusterlisters "github.com/kcp-dev/kcp/pkg/client/listers/cluster/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
+)
+
+type daemonSetReconciler struct {
+	kubeClient    kubernetes.Interface
+	lister        appsv1lister.DaemonSetLister
+	clusterLister clusterlisters.ClusterLister
+}
+
+func (c daemonSetReconciler) reconcile(ctx context.Context, daemonSet *appsv1.DaemonSet) error {
+	log.Println("reconciling", daemonSet.Name)
+
+	if daemonSet.Labels == nil {
+		daemonSet.Labels = map[string]string{}
+	}
+
+	// If we're reconciling a root, make its current leafs match the
+	// desired replicated state.
+	if daemonSet.Labels[clusterLabel] == "" {
+		root := daemonSet
+
+		// Get all leafs belonging to the root.
+		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, root.Name))
+		if err != nil {
+			return err
+		}
+		leafs, err := c.lister.List(sel)
+		if err != nil {
+			return err
+		}
+
+		// Get all clusters.
+		cls, err := c.clusterLister.List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		// Filter out un-ready clusters.
+		cls = filterClusters(cls)
+
+		// If there's no viable clusters, the root cannot progress.
+		if len(cls) == 0 {
+			root.Status.Conditions = []appsv1.DaemonSetCondition{{
+				Type:    appsv1.DaemonSetConditionType("Ready"),
+				Status:  corev1.ConditionFalse,
+				Reason:  "NoRegisteredClusters",
+				Message: "kcp has no clusters registered to receive DaemonSets",
+			}}
+			// Delete all leafs.
+			for _, l := range leafs {
+				if err := c.kubeClient.AppsV1().DaemonSets(root.Namespace).Delete(ctx, l.Name, metav1.DeleteOptions{}); err != nil {
+					return err
+				}
+				log.Printf("deleted leaf %q", l.Name)
+			}
+			return nil
+		}
+
+		return c.applyLeafs(ctx, daemonSet, leafs, cls)
+	}
+
+	// TODO: aggregate status.
+	return nil
+}
+
+func (c daemonSetReconciler) applyLeafs(ctx context.Context, root *appsv1.DaemonSet, leafs []*appsv1.DaemonSet, cls []*v1alpha1.Cluster) error {
+	// currentLeafs indexes existing leafs by name, and stores
+	// whether that leaf was updated during this reconciliation.
+	// Any leafs that aren't updated are assumed to be orphaned, and will
+	// be deleted (e.g., they belong to an un-ready cluster).
+	currentLeafs := map[string]bool{}
+	for _, l := range leafs {
+		currentLeafs[l.Name] = false
+	}
+
+	// Create a DaemonSet for each cluster.
+	for _, cl := range cls {
+		vd := root.DeepCopy()
+
+		// TODO: munge cluster name
+		vd.Name = fmt.Sprintf("%s--%s", root.Name, cl.Name)
+		if vd.Labels == nil {
+			vd.Labels = map[string]string{}
+		}
+		vd.Labels[clusterLabel] = cl.Name
+		vd.Labels[ownedByLabel] = root.Name
+
+		// Set OwnerReference so deleting the root deletes all leafs.
+		vd.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+			UID:        root.UID,
+			Name:       root.Name,
+		}}
+
+		// TODO: munge namespace
+		vd.SetResourceVersion("")
+
+		if _, found := currentLeafs[vd.Name]; found {
+			// Update a leaf.
+			if _, err := c.kubeClient.AppsV1().DaemonSets(root.Namespace).Update(ctx, vd, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+			// This leaf was updated, and should not be deleted.
+			currentLeafs[vd.Name] = true
+			log.Printf("updated leaf %q", vd.Name)
+		} else {
+			// Create a leaf.
+			// This handles the N -> N+1 scale-up scenario.
+			if _, err := c.kubeClient.AppsV1().DaemonSets(root.Namespace).Create(ctx, vd, metav1.CreateOptions{}); err != nil {
+				return err
+			}
+			log.Printf("created leaf %q", vd.Name)
+		}
+	}
+
+	for n, updated := range currentLeafs {
+		if !updated {
+			// Delete any other leafs that we didn't update; these
+			// might have belonged to deleted/un-ready clusters.
+			// This handles the N -> N-1 scale-down scenario.
+			if err := c.kubeClient.AppsV1().DaemonSets(root.Namespace).Delete(ctx, n, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+			log.Printf("deleted leaf %q", n)
+		}
+	}
+
+	return nil
+}
+
+// aggregateStatus aggregates the statuses of the leafs into the root object's status.
+//
+// Any changes to root are expected to be persisted outside this method's
+// scope.
+func (c daemonSetReconciler) aggregateStatus(ctx context.Context, root *appsv1.DaemonSet, leafs []*appsv1.DaemonSet) error {
+	// Cheat and set the root .status.conditions to the first leaf's .status.conditions.
+	// TODO: do better.
+	if len(leafs) > 0 {
+		root.Status.Conditions = leafs[0].Status.Conditions
+	}
+
+	// Update the root's status.
+	_, err := c.kubeClient.AppsV1().DaemonSets(root.Namespace).UpdateStatus(ctx, root, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/reconciler/deployment/daemonset_test.go
+++ b/pkg/reconciler/deployment/daemonset_test.go
@@ -1,0 +1,458 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clusterfake "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/fake"
+	clusterinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReconcileDaemonSets(t *testing.T) {
+	for _, c := range []struct {
+		desc string
+
+		// the state of existing daemonsets and clusters, before reconciling.
+		root     *appsv1.DaemonSet
+		leafs    []runtime.Object
+		clusters []runtime.Object
+
+		// the state of root and leaf daemonsets after reconciling.
+		wantRoot  *appsv1.DaemonSet
+		wantLeafs []appsv1.DaemonSet
+	}{{
+		desc: "no clusters, no leafs",
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs:    nil, // no leafs yet.
+		clusters: nil, // no clusters.
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			Status: appsv1.DaemonSetStatus{
+				Conditions: []appsv1.DaemonSetCondition{{
+					Type:    appsv1.DaemonSetConditionType("Ready"),
+					Status:  corev1.ConditionFalse,
+					Reason:  "NoRegisteredClusters",
+					Message: "kcp has no clusters registered to receive DaemonSets",
+				}},
+			},
+		},
+		wantLeafs: nil, // no leafs to create.
+	}, {
+		desc: "no ready clusters, delete all leafs",
+		// This case simulates what happens when the only cluster becomes unready.
+		// It had previously been assigned a leaf, so that leaf should now be deleted.
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs: []runtime.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:    v1alpha1.ClusterConditionReady,
+						Status:  corev1.ConditionFalse, // cluster is not ready.
+						Reason:  "MismatchedTypes",
+						Message: "CRD puller determined this cluster can't talk daemonsets",
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			Status: appsv1.DaemonSetStatus{
+				Conditions: []appsv1.DaemonSetCondition{{
+					Type:    appsv1.DaemonSetConditionType("Ready"),
+					Status:  corev1.ConditionFalse,
+					Reason:  "NoRegisteredClusters",
+					Message: "kcp has no clusters registered to receive DaemonSets",
+				}},
+			},
+		},
+		wantLeafs: nil, // leaf was deleted.
+	}, {
+		desc: "one cluster, no leafs",
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs: nil, // no leafs yet.
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		wantLeafs: []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}},
+	}, {
+		desc: "one cluster, leaf exists",
+		// The assignment of the leaf to the only cluster is already stable, so no changes should be made.
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs: []runtime.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		wantLeafs: []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}},
+	}, {
+		desc: "two clusters, one leaf",
+		// This simulates when a single cluster with a leaf assigned is joined by a second cluster.
+		// The existing leaf should have its replicas updated, and another leaf is created.
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs: []runtime.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		wantLeafs: []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-2",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-2",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}},
+	}, {
+		desc: "two clusters, three leafs",
+		// This simulates when a third cluster is deleted, and its replicas are rebalanced among two remaining clusters.
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs: []runtime.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-2",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-2",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-3",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-3",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		wantLeafs: []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-2",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-2",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}},
+	}, {
+		desc: "three clusters",
+		// This demonstrates uneven balancing of replicas across leafs.
+		// A set of two leafs each with 5 replicas is split into 3 leafs with 4/3/3 replicas.
+		root: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		leafs: []runtime.Object{
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+			&appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-2",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-2",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-3"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		},
+		wantLeafs: []appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-2",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-2",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-3",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-3",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "DaemonSet", Name: "root"}},
+			},
+			Spec: appsv1.DaemonSetSpec{MinReadySeconds: 7},
+		}},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			kubeClient := fake.NewSimpleClientset(c.leafs...)
+			clusterClient := clusterfake.NewSimpleClientset(c.clusters...)
+			sif := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod)
+			csif := clusterinformers.NewSharedInformerFactoryWithOptions(clusterClient, resyncPeriod)
+			ctrl := daemonSetReconciler{
+				kubeClient:    kubeClient,
+				lister:        sif.Apps().V1().DaemonSets().Lister(),
+				clusterLister: csif.Cluster().V1alpha1().Clusters().Lister(),
+			}
+			for _, d := range c.leafs {
+				sif.Apps().V1().DaemonSets().Informer().GetIndexer().Add(d)
+			}
+			for _, c := range c.clusters {
+				csif.Cluster().V1alpha1().Clusters().Informer().GetIndexer().Add(c)
+			}
+
+			// Reconcile the root daemonset.
+			if err := ctrl.reconcile(ctx, c.root); err != nil {
+				t.Fatalf("applyLeafs: %v", err)
+			}
+
+			// Check that root state is expected.
+			if d := cmp.Diff(c.wantRoot, c.root); d != "" {
+				t.Errorf("Root diff: (-want,+got)\n%s", d)
+			}
+			// Check that leafs state is expected.
+			ls, err := kubeClient.AppsV1().DaemonSets("").List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Listing daemonsets: %v", err)
+			}
+			if d := cmp.Diff(c.wantLeafs, ls.Items); d != "" {
+				t.Errorf("Leafs diff: (-want,+got)\n%s", d)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/deployment/deployment.go
+++ b/pkg/reconciler/deployment/deployment.go
@@ -3,14 +3,15 @@ package deployment
 import (
 	"context"
 	"fmt"
+	"log"
+	"sort"
 	"time"
 
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
 )
 
@@ -23,9 +24,17 @@ const (
 func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deployment) error {
 	klog.Infof("reconciling deployment %q", deployment.Name)
 
-	if deployment.Labels == nil || deployment.Labels[clusterLabel] == "" {
-		// This is a root deployment; get its leafs.
-		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, deployment.Name))
+	if deployment.Labels == nil {
+		deployment.Labels = map[string]string{}
+	}
+
+	// If we're reconciling a root, make its current leafs match the
+	// desired split state.
+	if deployment.Labels[clusterLabel] == "" {
+		root := deployment
+
+		// Get all leafs belonging to the root.
+		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, root.Name))
 		if err != nil {
 			return err
 		}
@@ -34,128 +43,127 @@ func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deploymen
 			return err
 		}
 
-		if len(leafs) == 0 {
-			if err := c.createLeafs(ctx, deployment); err != nil {
-				return err
-			}
-		}
-
-	} else {
-		rootDeploymentName := deployment.Labels[ownedByLabel]
-		// A leaf deployment was updated; get others and aggregate status.
-		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, rootDeploymentName))
+		// Get all clusters.
+		cls, err := c.clusterLister.List(labels.Everything())
 		if err != nil {
 			return err
 		}
-		others, err := c.lister.List(sel)
-		if err != nil {
-			return err
-		}
+		// Filter out un-ready clusters.
+		cls = filterClusters(cls)
 
-		var rootDeployment *appsv1.Deployment
-
-		rootIf, exists, err := c.indexer.Get(&appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   deployment.Namespace,
-				Name:        rootDeploymentName,
-				ClusterName: deployment.GetClusterName(),
-			},
-		})
-		if err != nil {
-			return err
-		}
-		if !exists {
-			return fmt.Errorf("Root deployment not found: %s", rootDeploymentName)
-		}
-
-		rootDeployment = rootIf.(*appsv1.Deployment)
-
-		// Aggregate .status from all leafs.
-
-		rootDeployment = rootDeployment.DeepCopy()
-		rootDeployment.Status.Replicas = 0
-		rootDeployment.Status.UpdatedReplicas = 0
-		rootDeployment.Status.ReadyReplicas = 0
-		rootDeployment.Status.AvailableReplicas = 0
-		rootDeployment.Status.UnavailableReplicas = 0
-		for _, o := range others {
-			rootDeployment.Status.Replicas += o.Status.Replicas
-			rootDeployment.Status.UpdatedReplicas += o.Status.UpdatedReplicas
-			rootDeployment.Status.ReadyReplicas += o.Status.ReadyReplicas
-			rootDeployment.Status.AvailableReplicas += o.Status.AvailableReplicas
-			rootDeployment.Status.UnavailableReplicas += o.Status.UnavailableReplicas
-		}
-
-		// Cheat and set the root .status.conditions to the first leaf's .status.conditions.
-		// TODO: do better.
-		if len(others) > 0 {
-			rootDeployment.Status.Conditions = others[0].Status.Conditions
-		}
-
-		if _, err := c.client.Deployments(rootDeployment.Namespace).UpdateStatus(ctx, rootDeployment, metav1.UpdateOptions{}); err != nil {
-			if errors.IsConflict(err) {
-				key, err := cache.MetaNamespaceKeyFunc(deployment)
-				if err != nil {
+		// If there's no viable clusters, the root cannot progress.
+		if len(cls) == 0 {
+			root.Status.Conditions = []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentProgressing,
+				Status:  corev1.ConditionFalse,
+				Reason:  "NoRegisteredClusters",
+				Message: "kcp has no clusters registered to receive Deployments",
+			}}
+			// Delete all leafs.
+			for _, l := range leafs {
+				if err := c.kubeClient.AppsV1().Deployments(root.Namespace).Delete(ctx, l.Name, metav1.DeleteOptions{}); err != nil {
 					return err
 				}
-				c.queue.AddRateLimited(key)
-				return nil
+				log.Printf("deleted leaf %q", l.Name)
 			}
-			return err
+			return nil
 		}
+
+		return c.applyLeafs(ctx, root, leafs, cls)
 	}
 
-	return nil
-}
-
-func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) error {
-	cls, err := c.clusterLister.List(labels.Everything())
+	// If we're reconciling a leaf, get all other leafs belonging to the
+	// same root, and aggregate their status into the root's status.
+	rootName := deployment.Labels[ownedByLabel]
+	sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, rootName))
+	if err != nil {
+		return err
+	}
+	leafs, err := c.lister.List(sel)
 	if err != nil {
 		return err
 	}
 
-	if len(cls) == 0 {
-		root.Status.Conditions = []appsv1.DeploymentCondition{{
-			Type:    appsv1.DeploymentProgressing,
-			Status:  corev1.ConditionFalse,
-			Reason:  "NoRegisteredClusters",
-			Message: "kcp has no clusters registered to receive Deployments",
-		}}
-		return nil
+	// Get the root.
+	rootIf, exists, err := c.indexer.Get(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   deployment.Namespace,
+			Name:        rootName,
+			ClusterName: deployment.GetClusterName(),
+		},
+	})
+	if err != nil {
+		return err
 	}
+	if !exists {
+		return fmt.Errorf("root deployment not found: %s", rootName)
+	}
+	root := rootIf.(*appsv1.Deployment)
 
-	if len(cls) == 1 {
-		// nothing to split, just label Deployment for the only cluster.
-		if root.Labels == nil {
-			root.Labels = map[string]string{}
+	return c.aggregateStatus(ctx, root, leafs)
+}
+
+// filterClusters filters Cluster objects and only returns those that are
+// Ready.
+//
+// TODO: consider other cluster traits here, like scheduling constraints.
+func filterClusters(cls []*v1alpha1.Cluster) []*v1alpha1.Cluster {
+	var out []*v1alpha1.Cluster
+	for _, cl := range cls {
+		if cl.IsReady() {
+			out = append(out, cl)
 		}
+	}
+	// Sort for reproducibility.
+	// TODO: This biases more replicas toward lexigraphically earlier named
+	// clusters, come up with something else that's better and stable.
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
 
-		// TODO: munge cluster name
-		root.Labels[clusterLabel] = cls[0].Name
-		return nil
+// applyLeafs applies the desired state of leaf deployments, based on the
+// number of ready clusters and desired root deployment replicas.
+//
+// Leaf deployments will be:
+// - created for clusters that don't already have a leaf.
+// - updated for clusters that already have a leaf (e.g., to take into account
+//   new replica counts assigned to that leaf, as other leafs are
+//   created/deleted)
+// - deleted if they are for clusters that are deleted or become un-ready
+//
+// Any changes to root are expected to be persisted outside this method's
+// scope.
+func (c *Controller) applyLeafs(ctx context.Context, root *appsv1.Deployment, leafs []*appsv1.Deployment, cls []*v1alpha1.Cluster) error {
+	// currentLeafs indexes existing leaf deployments by name, and stores
+	// whether that leaf was updated during this reconciliation.
+	// Any leafs that aren't updated are assumed to be orphaned, and will
+	// be deleted (e.g., they belong to an un-ready cluster).
+	currentLeafs := map[string]bool{}
+	for _, l := range leafs {
+		currentLeafs[l.Name] = false
 	}
 
-	// If there are >1 Clusters, create a virtual Deployment labeled/named for each Cluster with a subset of replicas requested.
-	// TODO: assign replicas unevenly based on load/scheduling.
-	replicasEach := *root.Spec.Replicas / int32(len(cls))
-	rest := *root.Spec.Replicas % int32(len(cls))
-	for index, cl := range cls {
+	// Reassign replicas across available deployments.
+	// Try to make this as even as possible, so that no cluster as 2+ more
+	// replicas than any other.
+	each := make([]int32, len(cls))
+	for i := 0; i < int(*root.Spec.Replicas); i++ {
+		each[i%len(cls)]++
+	}
+
+	for idx, cl := range cls {
 		vd := root.DeepCopy()
 
 		// TODO: munge cluster name
 		vd.Name = fmt.Sprintf("%s--%s", root.Name, cl.Name)
-
 		if vd.Labels == nil {
 			vd.Labels = map[string]string{}
 		}
 		vd.Labels[clusterLabel] = cl.Name
 		vd.Labels[ownedByLabel] = root.Name
 
-		replicasToSet := replicasEach
-		if index == 0 {
-			replicasToSet += rest
-		}
-		vd.Spec.Replicas = &replicasToSet
+		// Set replica count.
+		vd.Spec.Replicas = &each[idx]
 
 		// Set OwnerReference so deleting the Deployment deletes all virtual deployments.
 		vd.OwnerReferences = []metav1.OwnerReference{{
@@ -167,11 +175,66 @@ func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) e
 
 		// TODO: munge namespace
 		vd.SetResourceVersion("")
-		if _, err := c.kubeClient.AppsV1().Deployments(root.Namespace).Create(ctx, vd, metav1.CreateOptions{}); err != nil {
-			return err
+
+		if _, found := currentLeafs[vd.Name]; found {
+			// Update a leaf.
+			if _, err := c.kubeClient.AppsV1().Deployments(root.Namespace).Update(ctx, vd, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+			// This leaf was updated, and should not be deleted.
+			currentLeafs[vd.Name] = true
+			klog.Infof("updated child deployment %q", vd.Name)
+		} else {
+			// Create a leaf.
+			// This handles the N -> N+1 scale-up scenario.
+			if _, err := c.kubeClient.AppsV1().Deployments(root.Namespace).Create(ctx, vd, metav1.CreateOptions{}); err != nil {
+				return err
+			}
+			klog.Infof("created child deployment %q", vd.Name)
 		}
-		klog.Infof("created child deployment %q", vd.Name)
+	}
+
+	for n, updated := range currentLeafs {
+		if !updated {
+			// Delete any other leafs that we didn't update; these
+			// might have belonged to deleted/un-ready clusters.
+			// This handles the N -> N-1 scale-down scenario.
+			if err := c.kubeClient.AppsV1().Deployments(root.Namespace).Delete(ctx, n, metav1.DeleteOptions{}); err != nil {
+				return err
+			}
+			klog.Infof("deleted child deployment %q", n)
+		}
 	}
 
 	return nil
+}
+
+// aggregateStatus aggregates the statuses of the leafs into the root object's status.
+//
+// Any changes to root are expected to be persisted outside this method's
+// scope.
+func (c Controller) aggregateStatus(ctx context.Context, root *appsv1.Deployment, leafs []*appsv1.Deployment) error {
+	// Aggregate .status from all leafs.
+	root.Status.Replicas = 0
+	root.Status.UpdatedReplicas = 0
+	root.Status.ReadyReplicas = 0
+	root.Status.AvailableReplicas = 0
+	root.Status.UnavailableReplicas = 0
+	for _, o := range leafs {
+		root.Status.Replicas += o.Status.Replicas
+		root.Status.UpdatedReplicas += o.Status.UpdatedReplicas
+		root.Status.ReadyReplicas += o.Status.ReadyReplicas
+		root.Status.AvailableReplicas += o.Status.AvailableReplicas
+		root.Status.UnavailableReplicas += o.Status.UnavailableReplicas
+	}
+
+	// Cheat and set the root .status.conditions to the first leaf's .status.conditions.
+	// TODO: do better.
+	if len(leafs) > 0 {
+		root.Status.Conditions = leafs[0].Status.Conditions
+	}
+
+	// Update the root's status.
+	_, err := c.kubeClient.AppsV1().Deployments(root.Namespace).UpdateStatus(ctx, root, metav1.UpdateOptions{})
+	return err
 }

--- a/pkg/reconciler/deployment/deployment_test.go
+++ b/pkg/reconciler/deployment/deployment_test.go
@@ -1,0 +1,461 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clusterfake "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/fake"
+	clusterinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func ptr(i int32) *int32 { return &i }
+
+func TestReconcileDeployments(t *testing.T) {
+	for _, c := range []struct {
+		desc string
+
+		// the state of existing deployments and clusters, before reconciling.
+		root     *appsv1.Deployment
+		leafs    []runtime.Object
+		clusters []runtime.Object
+
+		// the state of root and leaf deployments after reconciling.
+		wantRoot  *appsv1.Deployment
+		wantLeafs []appsv1.Deployment
+	}{{
+		desc: "no clusters, no leafs",
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		leafs:    nil, // no leafs yet.
+		clusters: nil, // no clusters.
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{{
+					Type:    appsv1.DeploymentProgressing,
+					Status:  corev1.ConditionFalse,
+					Reason:  "NoRegisteredClusters",
+					Message: "kcp has no clusters registered to receive Deployments",
+				}},
+			},
+		},
+		wantLeafs: nil, // no leafs to create.
+	}, {
+		desc: "no ready clusters, delete all leafs",
+		// This case simulates what happens when the only cluster becomes unready.
+		// It had previously been assigned a leaf, so that leaf should now be deleted.
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		leafs: []runtime.Object{
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(10)},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:    v1alpha1.ClusterConditionReady,
+						Status:  corev1.ConditionFalse, // cluster is not ready.
+						Reason:  "MismatchedTypes",
+						Message: "CRD puller determined this cluster can't talk deployments",
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+			Status: appsv1.DeploymentStatus{
+				Conditions: []appsv1.DeploymentCondition{{
+					Type:    appsv1.DeploymentProgressing,
+					Status:  corev1.ConditionFalse,
+					Reason:  "NoRegisteredClusters",
+					Message: "kcp has no clusters registered to receive Deployments",
+				}},
+			},
+		},
+		wantLeafs: nil, // leaf was deleted.
+	}, {
+		desc: "one cluster, no leafs",
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		leafs: nil, // no leafs yet.
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		wantLeafs: []appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(10)},
+		}},
+	}, {
+		desc: "one cluster, leaf exists",
+		// The assignment of the leaf to the only cluster is already stable, so no changes should be made.
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		leafs: []runtime.Object{
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(10)},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		wantLeafs: []appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(10)},
+		}},
+	}, {
+		desc: "two clusters, one leaf",
+		// This simulates when a single cluster with a leaf assigned is joined by a second cluster.
+		// The existing leaf should have its replicas updated, and another leaf is created.
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		leafs: []runtime.Object{
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(10)},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		wantLeafs: []appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(5)},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-2",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-2",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(5)},
+		}},
+	}, {
+		desc: "two clusters, three leafs",
+		// This simulates when a third cluster is deleted, and its replicas are rebalanced among two remaining clusters.
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		leafs: []runtime.Object{
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(4)},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-2",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-2",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(3)},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-3",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-3",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(3)},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(10)},
+		},
+		wantLeafs: []appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(5)},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-2",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-2",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(5)},
+		}},
+	}, {
+		desc: "three clusters, uneven rebalance",
+		// This demonstrates uneven balancing of replicas across leafs.
+		// A set of two leafs together carrying 11 replicas (6+5) is
+		// split into 3 leafs carrying (4+4+3) replicas.
+		root: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(11)},
+		},
+		leafs: []runtime.Object{
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(6)},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-2",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-2",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{Replicas: ptr(5)},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-3"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       appsv1.DeploymentSpec{Replicas: ptr(11)},
+		},
+		wantLeafs: []appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(4)}, // the first leaf gets an extra replica.
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-2",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-2",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(4)}, // the second leaf also gets an extra replica.
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-3",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-3",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "root"}},
+			},
+			Spec: appsv1.DeploymentSpec{Replicas: ptr(3)},
+		}},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			kubeClient := fake.NewSimpleClientset(c.leafs...)
+			clusterClient := clusterfake.NewSimpleClientset(c.clusters...)
+			sif := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod)
+			csif := clusterinformers.NewSharedInformerFactoryWithOptions(clusterClient, resyncPeriod)
+			ctrl := Controller{
+				kubeClient:    kubeClient,
+				lister:        sif.Apps().V1().Deployments().Lister(),
+				clusterLister: csif.Cluster().V1alpha1().Clusters().Lister(),
+			}
+			for _, d := range c.leafs {
+				sif.Apps().V1().Deployments().Informer().GetIndexer().Add(d)
+			}
+			for _, c := range c.clusters {
+				csif.Cluster().V1alpha1().Clusters().Informer().GetIndexer().Add(c)
+			}
+
+			// Reconcile the root deployment.
+			if err := ctrl.reconcile(ctx, c.root); err != nil {
+				t.Fatalf("applyLeafs: %V", err)
+			}
+
+			// Check that root state is expected.
+			if d := cmp.Diff(c.wantRoot, c.root); d != "" {
+				t.Errorf("Root diff: (-want,+got)\n%s", d)
+			}
+			// Check that leafs state is expected.
+			ls, err := kubeClient.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Listing deployments: %v", err)
+			}
+			if d := cmp.Diff(c.wantLeafs, ls.Items); d != "" {
+				t.Errorf("Leafs diff: (-want,+got)\n%s", d)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/deployment/pod.go
+++ b/pkg/reconciler/deployment/pod.go
@@ -1,0 +1,172 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clusterlisters "github.com/kcp-dev/kcp/pkg/client/listers/cluster/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+var randInt func(int) int = rand.Intn
+
+type podReconciler struct {
+	kubeClient    kubernetes.Interface
+	lister        corev1lister.PodLister
+	clusterLister clusterlisters.ClusterLister
+	indexer       cache.Indexer
+}
+
+func (c podReconciler) reconcile(ctx context.Context, pod *corev1.Pod) error {
+	log.Println("reconciling", pod.Name)
+
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+
+	// If we're reconciling a root, make its current leafs match the
+	// desired assigned state.
+	if pod.Labels[clusterLabel] == "" {
+		root := pod
+
+		// Get all leafs belonging to the root.
+		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, root.Name))
+		if err != nil {
+			return err
+		}
+		leafs, err := c.lister.List(sel)
+		if err != nil {
+			return err
+		}
+
+		// Get all clusters.
+		cls, err := c.clusterLister.List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		// Filter out un-ready clusters.
+		cls = filterClusters(cls)
+
+		// If there's no viable clusters, the root cannot progress.
+		if len(cls) == 0 {
+			root.Status.Conditions = []corev1.PodCondition{{
+				Type:    corev1.PodReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  "NoRegisteredClusters",
+				Message: "kcp has no clusters registered to receive Pods",
+			}}
+			// Delete all leafs.
+			for _, l := range leafs {
+				if err := c.kubeClient.CoreV1().Pods(root.Namespace).Delete(ctx, l.Name, metav1.DeleteOptions{}); err != nil {
+					return err
+				}
+				log.Printf("deleted leaf %q", l.Name)
+			}
+			return nil
+		}
+
+		return c.applyLeafs(ctx, pod, leafs, cls)
+	}
+
+	// If we're reconciling a leaf, get all other leafs belonging to the
+	// same root, and aggregate their status into the root's status.
+	rootName := pod.Labels[ownedByLabel]
+	sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, rootName))
+	if err != nil {
+		return err
+	}
+	leafs, err := c.lister.List(sel)
+	if err != nil {
+		return err
+	}
+
+	// Get the root.
+	rootIf, exists, err := c.indexer.Get(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   pod.Namespace,
+			Name:        rootName,
+			ClusterName: pod.GetClusterName(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("root not found: %s", rootName)
+	}
+	root := rootIf.(*corev1.Pod)
+
+	return c.aggregateStatus(ctx, root, leafs)
+}
+
+func (c podReconciler) applyLeafs(ctx context.Context, root *corev1.Pod, leafs []*corev1.Pod, cls []*v1alpha1.Cluster) error {
+	switch len(leafs) {
+	case 0: // Create a copy on some cluster (at random).
+
+		cl := cls[randInt(len(cls))]
+
+		vd := root.DeepCopy()
+
+		// TODO: munge cluster name
+		vd.Name = fmt.Sprintf("%s--%s", root.Name, cl.Name)
+		if vd.Labels == nil {
+			vd.Labels = map[string]string{}
+		}
+		vd.Labels[clusterLabel] = cl.Name
+		vd.Labels[ownedByLabel] = root.Name
+
+		// Set OwnerReference so deleting the root deletes all leafs.
+		vd.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			UID:        root.UID,
+			Name:       root.Name,
+		}}
+
+		// TODO: munge namespace
+		vd.SetResourceVersion("")
+
+		// Create a leaf.
+		if _, err := c.kubeClient.CoreV1().Pods(root.Namespace).Create(ctx, vd, metav1.CreateOptions{}); err != nil {
+			return err
+		}
+
+	case 1: // Update the existing copy.
+		l := leafs[0].DeepCopy()
+		l.Spec = root.Spec
+		// TODO: update status?
+		if _, err := c.kubeClient.CoreV1().Pods(root.Namespace).Update(ctx, l, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	default:
+		// Uh oh.
+	}
+
+	return nil
+}
+
+// aggregateStatus aggregates the statuses of the leafs into the root object's status.
+//
+// Any changes to root are expected to be persisted outside this method's
+// scope.
+func (c podReconciler) aggregateStatus(ctx context.Context, root *corev1.Pod, leafs []*corev1.Pod) error {
+	if len(leafs) != 1 {
+		// uh oh.
+	}
+
+	// The status of the root is the status of the leaf.
+	root.Status = leafs[0].Status
+
+	// Update the root's status.
+	_, err := c.kubeClient.CoreV1().Pods(root.Namespace).UpdateStatus(ctx, root, metav1.UpdateOptions{})
+	return err
+}

--- a/pkg/reconciler/deployment/pod_test.go
+++ b/pkg/reconciler/deployment/pod_test.go
@@ -1,0 +1,319 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clusterfake "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/fake"
+	clusterinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func init() {
+	randInt = func(int) int { return 0 }
+}
+
+func TestReconcilePod(t *testing.T) {
+	for _, c := range []struct {
+		desc string
+
+		// the state of existing root, leafs and clusters, before reconciling.
+		root     *corev1.Pod
+		leafs    []runtime.Object
+		clusters []runtime.Object
+
+		// the state of root and leafs after reconciling.
+		wantRoot  *corev1.Pod
+		wantLeafs []corev1.Pod
+	}{{
+		desc: "no clusters, no leafs",
+		root: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		leafs:    nil, // no leafs yet.
+		clusters: nil, // no clusters.
+		wantRoot: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{
+					Type:    corev1.PodReady,
+					Status:  corev1.ConditionFalse,
+					Reason:  "NoRegisteredClusters",
+					Message: "kcp has no clusters registered to receive Pods",
+				}},
+			},
+		},
+		wantLeafs: nil, // no leafs to create.
+	}, {
+		desc: "no ready clusters, delete all leafs",
+		// This case simulates what happens when the only cluster becomes unready.
+		// It had previously been assigned a leaf, so that leaf should now be deleted.
+		root: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		leafs: []runtime.Object{
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster",
+						"kcp.dev/owned-by": "root",
+					},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:    v1alpha1.ClusterConditionReady,
+						Status:  corev1.ConditionFalse, // cluster is not ready.
+						Reason:  "MismatchedTypes",
+						Message: "CRD puller determined this cluster can't talk Pods",
+					}},
+				},
+			},
+		},
+		wantRoot: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{{
+					Type:    corev1.PodReady,
+					Status:  corev1.ConditionFalse,
+					Reason:  "NoRegisteredClusters",
+					Message: "kcp has no clusters registered to receive Pods",
+				}},
+			},
+		},
+		wantLeafs: nil, // leaf was deleted.
+	}, {
+		desc: "one cluster, no leafs",
+		root: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		leafs: nil, // no leafs yet.
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		wantLeafs: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: "root"}},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		}},
+	}, {
+		desc: "one cluster, leaf exists",
+		// The assignment of the leaf to the only cluster is already stable, so no changes should be made.
+		root: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		leafs: []runtime.Object{
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster",
+						"kcp.dev/owned-by": "root",
+					},
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: "root"}},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		wantLeafs: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: "root"}},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		}},
+	}, {
+		desc: "two clusters, one leaf",
+		// This simulates when a single cluster with a leaf assigned is joined by a second cluster.
+		// The existing leaf is stable, no new leafs should be needed.
+		root: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		leafs: []runtime.Object{
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "root--cluster-1",
+					Labels: map[string]string{
+						"kcp.dev/cluster":  "cluster-1",
+						"kcp.dev/owned-by": "root",
+					},
+					OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: "root"}},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+			},
+		},
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		wantLeafs: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: "root"}},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		}},
+	}, {
+		desc: "two clusters, no leafs",
+		// This simulates when a new unassigned root joins with two candidate clusters available.
+		// Reconciling will choose one at random (deterministic for testing) and put a leaf copy there.
+		root: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		leafs: nil, // no leafs yet.
+		clusters: []runtime.Object{
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-1"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+			&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster-2"},
+				Status: v1alpha1.ClusterStatus{
+					Conditions: []v1alpha1.Condition{{
+						Type:   v1alpha1.ClusterConditionReady,
+						Status: corev1.ConditionTrue,
+					}},
+				},
+			},
+		},
+		wantRoot: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "root", Labels: map[string]string{}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		},
+		wantLeafs: []corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "root--cluster-1",
+				Labels: map[string]string{
+					"kcp.dev/cluster":  "cluster-1",
+					"kcp.dev/owned-by": "root",
+				},
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: "root"}},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "my-image"}}},
+		}},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			kubeClient := fake.NewSimpleClientset(c.leafs...)
+			clusterClient := clusterfake.NewSimpleClientset(c.clusters...)
+			sif := informers.NewSharedInformerFactoryWithOptions(kubeClient, resyncPeriod)
+			csif := clusterinformers.NewSharedInformerFactoryWithOptions(clusterClient, resyncPeriod)
+			ctrl := podReconciler{
+				kubeClient:    kubeClient,
+				lister:        sif.Core().V1().Pods().Lister(),
+				clusterLister: csif.Cluster().V1alpha1().Clusters().Lister(),
+			}
+			for _, d := range c.leafs {
+				sif.Core().V1().Pods().Informer().GetIndexer().Add(d)
+			}
+			for _, c := range c.clusters {
+				csif.Cluster().V1alpha1().Clusters().Informer().GetIndexer().Add(c)
+			}
+
+			// Reconcile the root.
+			if err := ctrl.reconcile(ctx, c.root); err != nil {
+				t.Fatalf("applyLeafs: %v", err)
+			}
+
+			// Check that root state is expected.
+			if d := cmp.Diff(c.wantRoot, c.root); d != "" {
+				t.Errorf("Root diff: (-want,+got)\n%s", d)
+			}
+			// Check that leafs state is expected.
+			ls, err := kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Fatalf("Listing: %v", err)
+			}
+			if d := cmp.Diff(c.wantLeafs, ls.Items); d != "" {
+				t.Errorf("Leafs diff: (-want,+got)\n%s", d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Instead of only creating leaf Deployments, also update and delete
existing leafs. This means that as Clusters are added and become Ready,
Deployments' replicas will be rebalanced across ready clusters, and as
they get deleted or become un-Ready, they'll rebalance across ready
clusters.

This is incomplete: cluster creations/deletions/changes won't trigger
root deployment reconciliations as of this change.

This also adds unit tests and configures CI to run tests.

(Also fix some lint errors and style nits)

edit: This PR has also grown to include DaemonSet and Pod scheduling, _not hooked up to any controller_, to demonstrate how they'd work in unit tests. These are examples of different scheduling strategies we'd like to generalize and apply to other arbitrary types.