### PR TITLE
Make group not required, to support core types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ contrib/demo/clusters/kind/us-east1.yaml
 contrib/demo/clusters/kind/us-east1.kubeconfig
 contrib/demo/clusters/kind/us-west1.yaml
 contrib/demo/clusters/kind/us-west1.kubeconfig
+*.log

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,7 @@ all: build
 .PHONY: all
 
 build:
-	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/kcp ./cmd/kcp
-	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/syncer ./cmd/syncer
-	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/cluster-controller ./cmd/cluster-controller
-	go build -ldflags "-X k8s.io/client-go/pkg/version.gitVersion=$$(git describe --abbrev=8 --dirty --always)" -o bin/deployment-splitter ./cmd/deployment-splitter
+	go build -o bin ./cmd/...
 .PHONY: build
 
 vendor:

--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -47,6 +47,7 @@ func main() {
 	if len(resourcesToSync) == 0 {
 		resourcesToSync = []string{"pods", "deployments.apps"}
 	}
+	klog.Infof("Syncing resources: %v", resourcesToSync)
 
 	if *pullMode && *pushMode {
 		klog.Fatal("can't set --push_mode and --pull_mode")

--- a/config/apiresource.kcp.dev_apiresourceimports.yaml
+++ b/config/apiresource.kcp.dev_apiresourceimports.yaml
@@ -101,7 +101,6 @@ spec:
                   version:
                     type: string
                 required:
-                - group
                 - version
                 type: object
               kind:

--- a/config/apiresource.kcp.dev_negotiatedapiresources.yaml
+++ b/config/apiresource.kcp.dev_negotiatedapiresources.yaml
@@ -97,7 +97,6 @@ spec:
                   version:
                     type: string
                 required:
-                - group
                 - version
                 type: object
               kind:

--- a/contrib/demo/startKcpForDemo.sh
+++ b/contrib/demo/startKcpForDemo.sh
@@ -7,6 +7,8 @@ cleanup() {
   kill $KCP_PID $CC_PID $SPLIT_PID $TAIL_PID
 }
 
+make build
+
 CURRENT_DIR="$(pwd)"
 DEMO_ROOT="$(dirname "${BASH_SOURCE}")"
 KCP_ROOT="$(cd ${DEMO_ROOT}/../.. && pwd)"
@@ -20,6 +22,9 @@ echo "KCP server started: $KCP_PID"
 
 echo "Waiting for KCP server to be up and running..." 
 sleep 10
+
+echo "Applying CRDs..."
+kubectl apply -f config/
 
 echo ""
 echo "Starting Cluster Controller..."

--- a/pkg/apis/apiresource/v1alpha1/common_types.go
+++ b/pkg/apis/apiresource/v1alpha1/common_types.go
@@ -25,6 +25,7 @@ import (
 )
 
 const APIVersionAnnotation = "apiresource.kcp.dev/apiVersion"
+
 type ColumnDefinition struct {
 	metav1.TableColumnDefinition `json:",inline"`
 
@@ -100,6 +101,7 @@ func (sr *SubResources) ImportFromCRDVersion(crdVersion *apiextensionsv1.CustomR
 }
 
 type GroupVersion struct {
+	// +optional
 	Group   string `json:"group"`
 	Version string `json:"version"`
 }


### PR DESCRIPTION
Also:
- gitignore `*.log` files created by demo scripts
- rewrite `make build` for brevity
- log resources that cluster controller will sync
- rebuild and apply CRDs in demo script