### PR TITLE
Generalize createKindClusters.sh to create multiple clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .kcp
-contrib/demo/clusters/kind/*.yaml
+contrib/demo/clusters/*.yaml
 contrib/demo/clusters/kind/*.kubeconfig
+contrib/demo/clusters/kind/*.config
 *.log
 coverage.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .kcp
 contrib/demo/clusters/*.yaml
-contrib/demo/clusters/kind/*.kubeconfig
-contrib/demo/clusters/kind/*.config
 *.log
 coverage.*

--- a/contrib/demo/apiNegotiation
+++ b/contrib/demo/apiNegotiation
@@ -4,7 +4,7 @@ DEMO_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 . ${DEMO_DIR}/demo-magic
 
 ROOT_DIR="$( cd ${DEMO_DIR}/../.. && pwd)"
-CLUSTERS_DIR=${CLUSTERS_DIR:-${DEMO_DIR}/clusters/kind}
+CLUSTERS_DIR=${CLUSTERS_DIR:-${DEMO_DIR}/clusters}
 
 TYPE_SPEED=30
 #PROMPT_AFTER=1

--- a/contrib/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demo/clusters/kind/createKindClusters.sh
@@ -1,9 +1,35 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -euxo pipefail
 
 DEMO_ROOT="$(dirname "${BASH_SOURCE}")/../.."
 
-kind create cluster --config ${DEMO_ROOT}/clusters/kind/us-east1.config --kubeconfig ${DEMO_ROOT}/clusters/kind/us-east1.kubeconfig
-sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-east1.kubeconfig | cat ${DEMO_ROOT}/clusters/us-east1.yaml - > ${DEMO_ROOT}/clusters/kind/us-east1.yaml
+clusters="$@"
+if [[ $# -eq 0 ]]; then
+  clusters="us-east1 us-west1"
+fi
 
-kind create cluster --config ${DEMO_ROOT}/clusters/kind/us-west1.config --kubeconfig ${DEMO_ROOT}/clusters/kind/us-west1.kubeconfig
-sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/us-west1.kubeconfig | cat ${DEMO_ROOT}/clusters/us-west1.yaml - > ${DEMO_ROOT}/clusters/kind/us-west1.yaml
+for name in ${clusters}; do
+  if [[ ! -f ${DEMO_ROOT}/clusters/kind/${name}.config ]]; then
+    cat > ${DEMO_ROOT}/clusters/kind/${name}.config << EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ${name}
+networking:
+  apiServerAddress: "127.0.0.1"
+EOF
+  fi
+
+  kind delete cluster --name=${name} || true
+  kind create cluster --config ${DEMO_ROOT}/clusters/kind/${name}.config --kubeconfig ${DEMO_ROOT}/clusters/kind/${name}.kubeconfig
+
+  cat > ${DEMO_ROOT}/clusters/${name}.yaml << EOF
+apiVersion: cluster.example.dev/v1alpha1
+kind: Cluster
+metadata:
+  name: ${name}
+spec:
+  kubeconfig: |
+EOF
+  sed -e 's/^/    /' ${DEMO_ROOT}/clusters/kind/${name}.kubeconfig >> ${DEMO_ROOT}/clusters/${name}.yaml
+done

--- a/contrib/demo/clusters/kind/us-east1.config
+++ b/contrib/demo/clusters/kind/us-east1.config
@@ -1,5 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-name: us-east1
-networking:
-  apiServerAddress: "127.0.0.1"

--- a/contrib/demo/clusters/kind/us-west1.config
+++ b/contrib/demo/clusters/kind/us-west1.config
@@ -1,8 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-name: us-west1
-networking:
-  apiServerAddress: "127.0.0.1"
-nodes:
-- role: control-plane
-  image: kindest/node:v1.15.12

--- a/contrib/demo/clusters/us-east1.yaml
+++ b/contrib/demo/clusters/us-east1.yaml
@@ -1,6 +1,0 @@
-apiVersion: cluster.example.dev/v1alpha1
-kind: Cluster
-metadata:
-  name: us-east1
-spec:
-  kubeconfig: |

--- a/contrib/demo/clusters/us-west1.yaml
+++ b/contrib/demo/clusters/us-west1.yaml
@@ -1,6 +1,0 @@
-apiVersion: cluster.example.dev/v1alpha1
-kind: Cluster
-metadata:
-  name: us-west1
-spec:
-  kubeconfig: |

--- a/contrib/demo/kubecon
+++ b/contrib/demo/kubecon
@@ -4,7 +4,7 @@ DEMO_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 . ${DEMO_DIR}/demo-magic
 
 ROOT_DIR="$( cd ${DEMO_DIR}/../.. && pwd)"
-CLUSTERS_DIR=${CLUSTERS_DIR:-${DEMO_DIR}/clusters/kind}
+CLUSTERS_DIR=${CLUSTERS_DIR:-${DEMO_DIR}/clusters}
 
 TYPE_SPEED=30
 #PROMPT_AFTER=1


### PR DESCRIPTION
When given no args, it creates a us-east1 and us-west1 cluster as
before. When given args, it creates clusters with those names. KinD
configs, kubeconfigs and Cluster CRD YAMLs are generated and gitignored
to avoid churn and potentially leaking sensitive information.