### PR TITLE
Treat the 'single cluster' case the same as 'multiple clusters' in deployment-splitter

### DIFF
--- a/pkg/reconciler/deployment/deployment.go
+++ b/pkg/reconciler/deployment/deployment.go
@@ -122,18 +122,7 @@ func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) e
 		return nil
 	}
 
-	if len(cls) == 1 {
-		// nothing to split, just label Deployment for the only cluster.
-		if root.Labels == nil {
-			root.Labels = map[string]string{}
-		}
-
-		// TODO: munge cluster name
-		root.Labels[clusterLabel] = cls[0].Name
-		return nil
-	}
-
-	// If there are >1 Clusters, create a virtual Deployment labeled/named for each Cluster with a subset of replicas requested.
+	// If there are Cluster(s), create a virtual Deployment labeled/named for each Cluster with a subset of replicas requested.
 	// TODO: assign replicas unevenly based on load/scheduling.
 	replicasEach := *root.Spec.Replicas / int32(len(cls))
 	rest := *root.Spec.Replicas % int32(len(cls))


### PR DESCRIPTION
This PR tries to fix an issue as follows.

In the implementation of deployment-splitter, if there is only one cluster, current logic is to directly convert the root Deployment into a virtual deployment.

Consequently, the virtual deployment becomes an 'orphan', with no root Deployment. Thus in the following reconciliation cycles, errors are generated by
https://github.com/kcp-dev/kcp/blob/e0096fefde31a6c4c3e309693205f1568886aa2b/pkg/reconciler/deployment/deployment.go#L66
Finally the controller runs out of retries, and following logic, which  updates status of the root Deployment, never gets a chance to run.