### PR TITLE
Make the API server an importable package

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -2,41 +2,12 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"errors"
-	"flag"
 	"fmt"
-	"io/ioutil"
-	"net"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strconv"
-
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
-	"github.com/kcp-dev/kcp/pkg/etcd"
-	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
-	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
+	"github.com/kcp-dev/kcp/pkg/server"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	genericapiserver "k8s.io/apiserver/pkg/server"
-	"k8s.io/apiserver/pkg/storage/storagebackend"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/kubernetes/pkg/genericcontrolplane"
-	"k8s.io/kubernetes/pkg/genericcontrolplane/clientutils"
-	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
-)
-
-var (
-	syncerImage                         string
-	resourcesToSync                     []string
-	installClusterController            bool
-	pullMode, pushMode, autoPublishAPIs bool
-	listen                              string
-	etcdClientInfo                      etcd.ClientInfo
+	"os"
+	"os/signal"
 )
 
 func main() {
@@ -75,222 +46,14 @@ func main() {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			//flag.CommandLine.Lookup("v").Value.Set("9")
 
-			dir := filepath.Join(".", ".kcp")
-			if fi, err := os.Stat(dir); err != nil {
-				if !os.IsNotExist(err) {
-					return err
-				}
-				if err := os.Mkdir(dir, 0755); err != nil {
-					return err
-				}
-			} else {
-				if !fi.IsDir() {
-					return fmt.Errorf("%q is a file, please delete or select another location", dir)
-				}
-			}
-			s := &etcd.Server{
-				Dir: filepath.Join(dir, "data"),
-			}
-			ctx := context.TODO()
-
-			runFunc := func(cfg etcd.ClientInfo) error {
-				c, err := clientv3.New(clientv3.Config{
-					Endpoints: cfg.Endpoints,
-					TLS:       cfg.TLS,
-				})
-				if err != nil {
-					return err
-				}
-				defer c.Close()
-				r, err := c.Cluster.MemberList(context.Background())
-				if err != nil {
-					return err
-				}
-				for _, member := range r.Members {
-					fmt.Fprintf(os.Stderr, "Connected to etcd %d %s\n", member.GetID(), member.GetName())
-				}
-
-				serverOptions := options.NewServerRunOptions()
-				host, port, err := net.SplitHostPort(listen)
-				if err != nil {
-					return fmt.Errorf("--listen must be of format host:port: %w", err)
-				}
-
-				if host != "" {
-					serverOptions.SecureServing.BindAddress = net.ParseIP(host)
-				}
-				if port != "" {
-					p, err := strconv.Atoi(port)
-					if err != nil {
-						return err
-					}
-					serverOptions.SecureServing.BindPort = p
-				}
-
-				serverOptions.SecureServing.ServerCert.CertDirectory = s.Dir
-				serverOptions.Etcd.StorageConfig.Transport = storagebackend.TransportConfig{
-					ServerList:    cfg.Endpoints,
-					CertFile:      cfg.CertFile,
-					KeyFile:       cfg.KeyFile,
-					TrustedCAFile: cfg.TrustedCAFile,
-				}
-				cpOptions, err := genericcontrolplane.Complete(serverOptions)
-				if err != nil {
-					return err
-				}
-
-				server, err := genericcontrolplane.CreateServerChain(cpOptions, ctx.Done())
-				if err != nil {
-					return err
-				}
-
-				var clientConfig clientcmdapi.Config
-				clientConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-					"loopback": {Token: server.LoopbackClientConfig.BearerToken},
-				}
-				clientConfig.Clusters = map[string]*clientcmdapi.Cluster{
-					// admin is the virtual cluster running by default
-					"admin": {
-						Server:                   server.LoopbackClientConfig.Host,
-						CertificateAuthorityData: server.LoopbackClientConfig.CAData,
-						TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
-					},
-					// user is a virtual cluster that is lazily instantiated
-					"user": {
-						Server:                   server.LoopbackClientConfig.Host + "/clusters/user",
-						CertificateAuthorityData: server.LoopbackClientConfig.CAData,
-						TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
-					},
-				}
-				clientConfig.Contexts = map[string]*clientcmdapi.Context{
-					"admin": {Cluster: "admin", AuthInfo: "loopback"},
-					"user":  {Cluster: "user", AuthInfo: "loopback"},
-				}
-				clientConfig.CurrentContext = "admin"
-				if err := clientcmd.WriteToFile(clientConfig, filepath.Join(s.Dir, "admin.kubeconfig")); err != nil {
-					return err
-				}
-
-				if installClusterController {
-					if err := server.AddPostStartHook("Install Cluster Controller", func(context genericapiserver.PostStartHookContext) error {
-						// Register the `clusters` CRD in both the admin and user logical clusters
-						for contextName := range clientConfig.Contexts {
-							logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
-							if err != nil {
-								return err
-							}
-							if err := cluster.RegisterCRDs(logicalClusterConfig); err != nil {
-								return err
-							}
-						}
-						adminConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, "admin", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
-						if err != nil {
-							return err
-						}
-
-						kubeconfig := clientConfig.DeepCopy()
-						for _, cluster := range kubeconfig.Clusters {
-							hostURL, err := url.Parse(cluster.Server)
-							if err != nil {
-								return err
-							}
-							hostURL.Host = server.ExternalAddress
-							cluster.Server = hostURL.String()
-						}
-
-						if pullMode && pushMode {
-							return errors.New("can't set --push_mode and --pull_mode")
-						}
-						syncerMode := cluster.SyncerModeNone
-						if pullMode {
-							syncerMode = cluster.SyncerModePull
-						}
-						if pushMode {
-							syncerMode = cluster.SyncerModePush
-						}
-
-						clientutils.EnableMultiCluster(adminConfig, nil, "clusters", "customresourcedefinitions", "apiresourceimports", "negotiatedapiresources")
-						clusterController, err := cluster.NewController(
-							adminConfig,
-							syncerImage,
-							*kubeconfig,
-							resourcesToSync,
-							syncerMode,
-						)
-						if err != nil {
-							return err
-						}
-						clusterController.Start(2)
-
-						apiresourceController, err := apiresource.NewController(
-							adminConfig,
-							autoPublishAPIs,
-						)
-						if err != nil {
-							return err
-						}
-						apiresourceController.Start(2)
-
-						return nil
-					}); err != nil {
-						return err
-					}
-				}
-
-				prepared := server.PrepareRun()
-
-				return prepared.Run(ctx.Done())
-			}
-
-			if len(etcdClientInfo.Endpoints) == 0 {
-				// No etcd servers specified so create one in-process:
-				return s.Run(runFunc)
-			}
-
-			etcdClientInfo.TLS = &tls.Config{
-				InsecureSkipVerify: true,
-			}
-
-			if len(etcdClientInfo.CertFile) > 0 && len(etcdClientInfo.KeyFile) > 0 {
-				cert, err := tls.LoadX509KeyPair(etcdClientInfo.CertFile, etcdClientInfo.KeyFile)
-				if err != nil {
-					return fmt.Errorf("failed to load x509 keypair: %s", err)
-				}
-				etcdClientInfo.TLS.Certificates = []tls.Certificate{cert}
-			}
-
-			if len(etcdClientInfo.TrustedCAFile) > 0 {
-				if caCert, err := ioutil.ReadFile(etcdClientInfo.TrustedCAFile); err != nil {
-					return fmt.Errorf("failed to read ca file: %s", err)
-				} else {
-					caPool := x509.NewCertPool()
-					caPool.AppendCertsFromPEM(caCert)
-					etcdClientInfo.TLS.RootCAs = caPool
-					etcdClientInfo.TLS.InsecureSkipVerify = false
-				}
-			}
-
-			return runFunc(etcdClientInfo)
+			// Setup signal handler for a cleaner shutdown
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
+			defer cancel()
+			srv := server.NewServer(server.ConfigFromFlags(cmd.Flags()))
+			return srv.Run(ctx)
 		},
 	}
-	startCmd.Flags().AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
-	startCmd.Flags().StringVar(&syncerImage, "syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
-	startCmd.Flags().StringArrayVar(&resourcesToSync, "resources_to_sync", []string{"pods", "deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
-	startCmd.Flags().BoolVar(&installClusterController, "install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
-	startCmd.Flags().BoolVar(&pullMode, "pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
-	startCmd.Flags().BoolVar(&pushMode, "push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
-	startCmd.Flags().StringVar(&listen, "listen", ":6443", "Address:port to bind to")
-	startCmd.Flags().BoolVar(&autoPublishAPIs, "auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
-
-	startCmd.Flags().StringSliceVar(&etcdClientInfo.Endpoints, "etcd-servers", etcdClientInfo.Endpoints,
-		"List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
-	startCmd.Flags().StringVar(&etcdClientInfo.KeyFile, "etcd-keyfile", etcdClientInfo.KeyFile,
-		"TLS key file used to secure etcd communication.")
-	startCmd.Flags().StringVar(&etcdClientInfo.CertFile, "etcd-certfile", etcdClientInfo.CertFile,
-		"TLS certification file used to secure etcd communication.")
-	startCmd.Flags().StringVar(&etcdClientInfo.TrustedCAFile, "etcd-cafile", etcdClientInfo.TrustedCAFile,
-		"TLS Certificate Authority file used to secure etcd communication.")
-
+	server.AddConfigFlags(startCmd.Flags())
 	cmd.AddCommand(startCmd)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,0 +1,110 @@
+package server
+
+import (
+	"flag"
+	"github.com/kcp-dev/kcp/pkg/etcd"
+	"github.com/spf13/pflag"
+	"path/filepath"
+)
+
+// Config determines the behavior of the KCP server.
+type Config struct {
+	AutoPublishAPIs          bool
+	EtcdClientInfo           etcd.ClientInfo
+	EtcdDirectory            string
+	InstallClusterController bool
+	KubeConfigPath           string
+	Listen                   string
+	PullMode                 bool
+	PushMode                 bool
+	ResourcesToSync          []string
+	RootDirectory            string
+	SyncerImage              string
+}
+
+// DefaultConfig returns a configuration with default values.
+func DefaultConfig() *Config {
+	return &Config{
+		AutoPublishAPIs:          false,
+		EtcdClientInfo:           etcd.ClientInfo{},
+		EtcdDirectory:            "data",
+		InstallClusterController: false,
+		KubeConfigPath:           filepath.Join("data", "admin.kubeconfig"),
+		Listen:                   ":6443",
+		PullMode:                 false,
+		PushMode:                 false,
+		ResourcesToSync:          []string{"pods", "deployments.apps"},
+		RootDirectory:            ".kcp",
+		SyncerImage:              "quay.io/kcp-dev/kcp-syncer",
+	}
+}
+
+// ConfigFromFlags returns a default configuration with config values set from the provided flag set
+func ConfigFromFlags(flags *pflag.FlagSet) *Config {
+	cfg := DefaultConfig()
+	listen, err := flags.GetString("listen")
+	if err == nil {
+		cfg.Listen = listen
+	}
+	syncerImage, err := flags.GetString("syncer_image")
+	if err == nil {
+		cfg.SyncerImage = syncerImage
+	}
+	resourcesToSync, err := flags.GetStringSlice("resources_to_sync")
+	if err == nil {
+		cfg.ResourcesToSync = resourcesToSync
+	}
+	installClusterController, err := flags.GetBool("install_cluster_controller")
+	if err == nil {
+		cfg.InstallClusterController = installClusterController
+	}
+	pullMode, err := flags.GetBool("pull_mode")
+	if err == nil {
+		cfg.PullMode = pullMode
+	}
+	pushMode, err := flags.GetBool("push_mode")
+	if err == nil {
+		cfg.PushMode = pushMode
+	}
+	autoPublishAPIs, err := flags.GetBool("auto_publish_apis")
+	if err == nil {
+		cfg.AutoPublishAPIs = autoPublishAPIs
+	}
+	etcdServers, err := flags.GetStringSlice("etcd-servers")
+	if err == nil {
+		cfg.EtcdClientInfo.Endpoints = etcdServers
+	}
+	etcdKeyFile, err := flags.GetString("etcd-keyfile")
+	if err == nil {
+		cfg.EtcdClientInfo.KeyFile = etcdKeyFile
+	}
+	etcdCertFile, err := flags.GetString("etcd-certfile")
+	if err == nil {
+		cfg.EtcdClientInfo.CertFile = etcdCertFile
+	}
+	etcdTrustedCAFile, err := flags.GetString("etcd-cafile")
+	if err == nil {
+		cfg.EtcdClientInfo.TrustedCAFile = etcdTrustedCAFile
+	}
+	return cfg
+}
+
+// AddConfigFlags adds all the config flags to the provided flag set
+func AddConfigFlags(flags *pflag.FlagSet) {
+	flags.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
+	flags.String("syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
+	flags.StringArray("resources_to_sync", []string{"pods", "deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
+	flags.Bool("install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
+	flags.Bool("pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
+	flags.Bool("push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
+	flags.String("listen", ":6443", "Address:port to bind to")
+	flags.Bool("auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
+	flags.StringSlice("etcd-servers", []string{},
+		"List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
+	flags.String("etcd-keyfile", "",
+		"TLS key file used to secure etcd communication.")
+	flags.String("etcd-certfile", "",
+		"TLS certification file used to secure etcd communication.")
+	flags.String("etcd-cafile", "",
+		"TLS Certificate Authority file used to secure etcd communication.")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,301 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"github.com/kcp-dev/kcp/pkg/etcd"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"io/ioutil"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/pkg/genericcontrolplane"
+	"k8s.io/kubernetes/pkg/genericcontrolplane/clientutils"
+	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// Server manages the configuration and kcp api-server. It allows callers to easily use kcp
+// as a library rather than as a single binary. Using its constructor function, you can easily
+// setup a new api-server and start it:
+//
+//   srv := server.NewServer(server.DefaultConfig())
+//   srv.Run(ctx)
+//
+// You may optionally provide PostStartHookFunc and PreShutdownHookFunc hooks before starting
+// the server that should be passed to the api-server itself. These hooks have access to a
+// restclient.Config which allows you to easily create a client.
+//
+//   srv.AddPostStartHook("my-hook", func(context genericapiserver.PostStartHookContext) error {
+//       client := clientset.NewForConfigOrDie(context.LoopbackClientConfig)
+//   })
+type Server struct {
+	cfg              *Config
+	postStartHooks   []postStartHookEntry
+	preShutdownHooks []preShutdownHookEntry
+}
+
+// postStartHookEntry groups a PostStartHookFunc with a name. We're not storing these hooks
+// in a map and are instead letting the underlying api server perform the hook validation,
+// such as checking for multiple PostStartHookFunc with the same name
+type postStartHookEntry struct {
+	name string
+	hook genericapiserver.PostStartHookFunc
+}
+
+// preShutdownHookEntry fills the same purpose as postStartHookEntry except that it handles
+// the PreShutdownHookFunc
+type preShutdownHookEntry struct {
+	name string
+	hook genericapiserver.PreShutdownHookFunc
+}
+
+// Run starts the KCP api-server. This function blocks until the api-server stops or an error.
+func (s *Server) Run(ctx context.Context) error {
+	dir := filepath.Join(".", s.cfg.RootDirectory)
+	if len(s.cfg.RootDirectory) != 0 {
+		if fi, err := os.Stat(dir); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			if err := os.Mkdir(dir, 0755); err != nil {
+				return err
+			}
+		} else {
+			if !fi.IsDir() {
+				return fmt.Errorf("%q is a file, please delete or select another location", dir)
+			}
+		}
+	}
+	es := &etcd.Server{
+		Dir: filepath.Join(dir, s.cfg.EtcdDirectory),
+	}
+
+	runFunc := func(cfg etcd.ClientInfo) error {
+		c, err := clientv3.New(clientv3.Config{
+			Endpoints: cfg.Endpoints,
+			TLS:       cfg.TLS,
+		})
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		r, err := c.Cluster.MemberList(context.Background())
+		if err != nil {
+			return err
+		}
+		for _, member := range r.Members {
+			fmt.Fprintf(os.Stderr, "Connected to etcd %d %s\n", member.GetID(), member.GetName())
+		}
+
+		serverOptions := options.NewServerRunOptions()
+		host, port, err := net.SplitHostPort(s.cfg.Listen)
+		if err != nil {
+			return fmt.Errorf("--listen must be of format host:port: %w", err)
+		}
+
+		if host != "" {
+			serverOptions.SecureServing.BindAddress = net.ParseIP(host)
+		}
+		if port != "" {
+			p, err := strconv.Atoi(port)
+			if err != nil {
+				return err
+			}
+			serverOptions.SecureServing.BindPort = p
+		}
+
+		serverOptions.SecureServing.ServerCert.CertDirectory = es.Dir
+		serverOptions.Etcd.StorageConfig.Transport = storagebackend.TransportConfig{
+			ServerList:    cfg.Endpoints,
+			CertFile:      cfg.CertFile,
+			KeyFile:       cfg.KeyFile,
+			TrustedCAFile: cfg.TrustedCAFile,
+		}
+		cpOptions, err := genericcontrolplane.Complete(serverOptions)
+		if err != nil {
+			return err
+		}
+
+		server, err := genericcontrolplane.CreateServerChain(cpOptions, ctx.Done())
+		if err != nil {
+			return err
+		}
+
+		var clientConfig clientcmdapi.Config
+		clientConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
+			"loopback": {Token: server.LoopbackClientConfig.BearerToken},
+		}
+		clientConfig.Clusters = map[string]*clientcmdapi.Cluster{
+			// admin is the virtual cluster running by default
+			"admin": {
+				Server:                   server.LoopbackClientConfig.Host,
+				CertificateAuthorityData: server.LoopbackClientConfig.CAData,
+				TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
+			},
+			// user is a virtual cluster that is lazily instantiated
+			"user": {
+				Server:                   server.LoopbackClientConfig.Host + "/clusters/user",
+				CertificateAuthorityData: server.LoopbackClientConfig.CAData,
+				TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
+			},
+		}
+		clientConfig.Contexts = map[string]*clientcmdapi.Context{
+			"admin": {Cluster: "admin", AuthInfo: "loopback"},
+			"user":  {Cluster: "user", AuthInfo: "loopback"},
+		}
+		clientConfig.CurrentContext = "admin"
+		if err := clientcmd.WriteToFile(clientConfig, filepath.Join(s.cfg.RootDirectory, s.cfg.KubeConfigPath)); err != nil {
+			return err
+		}
+
+		// Add our custom hooks to the underlying api server
+		for _, entry := range s.postStartHooks {
+			err := server.AddPostStartHook(entry.name, entry.hook)
+			if err != nil {
+				return err
+			}
+		}
+		for _, entry := range s.preShutdownHooks {
+			err := server.AddPreShutdownHook(entry.name, entry.hook)
+			if err != nil {
+				return err
+			}
+		}
+
+		if s.cfg.InstallClusterController {
+			if err := server.AddPostStartHook("Install Cluster Controller", func(context genericapiserver.PostStartHookContext) error {
+				// Register the `clusters` CRD in both the admin and user logical clusters
+				for contextName := range clientConfig.Contexts {
+					logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+					if err != nil {
+						return err
+					}
+					if err := cluster.RegisterCRDs(logicalClusterConfig); err != nil {
+						return err
+					}
+				}
+				adminConfig, err := clientcmd.NewNonInteractiveClientConfig(clientConfig, "admin", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+				if err != nil {
+					return err
+				}
+
+				kubeconfig := clientConfig.DeepCopy()
+				for _, cluster := range kubeconfig.Clusters {
+					hostURL, err := url.Parse(cluster.Server)
+					if err != nil {
+						return err
+					}
+					hostURL.Host = server.ExternalAddress
+					cluster.Server = hostURL.String()
+				}
+
+				if s.cfg.PullMode && s.cfg.PushMode {
+					return errors.New("can't set --push_mode and --pull_mode")
+				}
+				syncerMode := cluster.SyncerModeNone
+				if s.cfg.PullMode {
+					syncerMode = cluster.SyncerModePull
+				}
+				if s.cfg.PushMode {
+					syncerMode = cluster.SyncerModePush
+				}
+
+				clientutils.EnableMultiCluster(adminConfig, nil, "clusters", "customresourcedefinitions", "apiresourceimports", "negotiatedapiresources")
+				clusterController, err := cluster.NewController(
+					adminConfig,
+					s.cfg.SyncerImage,
+					*kubeconfig,
+					s.cfg.ResourcesToSync,
+					syncerMode,
+				)
+				if err != nil {
+					return err
+				}
+				clusterController.Start(2)
+
+				apiresourceController, err := apiresource.NewController(
+					adminConfig,
+					s.cfg.AutoPublishAPIs,
+				)
+				if err != nil {
+					return err
+				}
+				apiresourceController.Start(2)
+
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+
+		prepared := server.PrepareRun()
+
+		return prepared.Run(ctx.Done())
+	}
+
+	if len(s.cfg.EtcdClientInfo.Endpoints) == 0 {
+		// No etcd servers specified so create one in-process:
+		return es.Run(runFunc)
+	}
+
+	s.cfg.EtcdClientInfo.TLS = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	if len(s.cfg.EtcdClientInfo.CertFile) > 0 && len(s.cfg.EtcdClientInfo.KeyFile) > 0 {
+		cert, err := tls.LoadX509KeyPair(s.cfg.EtcdClientInfo.CertFile, s.cfg.EtcdClientInfo.KeyFile)
+		if err != nil {
+			return fmt.Errorf("failed to load x509 keypair: %s", err)
+		}
+		s.cfg.EtcdClientInfo.TLS.Certificates = []tls.Certificate{cert}
+	}
+
+	if len(s.cfg.EtcdClientInfo.TrustedCAFile) > 0 {
+		if caCert, err := ioutil.ReadFile(s.cfg.EtcdClientInfo.TrustedCAFile); err != nil {
+			return fmt.Errorf("failed to read ca file: %s", err)
+		} else {
+			caPool := x509.NewCertPool()
+			caPool.AppendCertsFromPEM(caCert)
+			s.cfg.EtcdClientInfo.TLS.RootCAs = caPool
+			s.cfg.EtcdClientInfo.TLS.InsecureSkipVerify = false
+		}
+	}
+
+	return runFunc(s.cfg.EtcdClientInfo)
+}
+
+// AddPostStartHook allows you to add a PostStartHook that gets passed to the underlying genericapiserver implementation.
+func (s *Server) AddPostStartHook(name string, hook genericapiserver.PostStartHookFunc) {
+	// you could potentially add duplicate or invalid post start hooks here, but we'll let
+	// the genericapiserver implementation do its own validation during startup.
+	s.postStartHooks = append(s.postStartHooks, postStartHookEntry{
+		name: name,
+		hook: hook,
+	})
+}
+
+// AddPreShutdownHook allows you to add a PreShutdownHookFunc that gets passed to the underlying genericapiserver implementation.
+func (s *Server) AddPreShutdownHook(name string, hook genericapiserver.PreShutdownHookFunc) {
+	// you could potentially add duplicate or invalid post start hooks here, but we'll let
+	// the genericapiserver implementation do its own validation during startup.
+	s.preShutdownHooks = append(s.preShutdownHooks, preShutdownHookEntry{
+		name: name,
+		hook: hook,
+	})
+}
+
+// NewServer creates a new instance of Server which manages the KCP api-server.
+func NewServer(cfg *Config) *Server {
+	return &Server{cfg: cfg}
+}


### PR DESCRIPTION
I sent a [Slack message](https://kubernetes.slack.com/archives/C021U8WSAFK/p1630021405002500) indicating that it would be useful if the KCP project could be structured in a way that we could easily combine both the KCP API server and our own custom controllers into a single binary. Currently, the KCP API server is constructed in the `cmd/kcp/kcp.go` file and is configured only with command line flags which is not conducive to importing into your own projects.

This PR aims to address a few things
* Moves the core construction of the API server to a new package (`pkg/server`) and replaces all the construction code in `cmd/kcp/kcp.go` with an implementation of the new API server package.
* Adds the ability to customize the API server by either passing a `*pflag.FlagSet` or a struct with all the configuration values you want.
* Adds default config constructor for quickly initializing an API server config based on the defaults this project uses currently
* Adds the ability to register custom `PostStartHookFunc`s and `PreShutdownHookFunc`s that get passed to the API server. This will be useful when registering custom controllers, where the controller will need access to the client config for connecting to the API server.