### PR TITLE
Fixes "resources_to_sync" flag as it was type mismatched when parsing the flags.

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -93,7 +93,7 @@ func ConfigFromFlags(flags *pflag.FlagSet) *Config {
 func AddConfigFlags(flags *pflag.FlagSet) {
 	flags.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
 	flags.String("syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
-	flags.StringArray("resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
+	flags.StringSlice("resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
 	flags.Bool("install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
 	flags.Bool("pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
 	flags.Bool("push_mode", false, "If true, run syncer for each cluster from inside cluster controller")


### PR DESCRIPTION
The var resources_to_sync was not being used as when trying to parse it, it was parsed as type `StringSlice` while being defined as `StringArray`.


``` 
	resourcesToSync, err := flags.GetStringSlice("resources_to_sync")
	if err == nil {
		cfg.ResourcesToSync = resourcesToSync
	}
```

I changed the var definition instead that the parsing as with StringSlice we can define multiple resources separated by commas and/or by adding extra `resouce_to_sync` flags.:

```
--resources_to_sync=deployments.apps --resources_to_sync=ingresses.networking.k8s.io,ingressclasses.networking.k8s.io
```