### PR TITLE
Use `go:embed` to embed KCP CRDs

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,12 @@
+package kcp
+
+import "embed"
+
+// This file should ONLY be used to define variables with the content of data files
+// accessible from the root of the source code, that should be embedded inside
+// GO code through go:embed annotations
+// It is required to define this file at the root of the module since
+// go:embed cannot reference files in parent directories relatively to the current package.
+
+//go:embed config
+var ConfigDir embed.FS


### PR DESCRIPTION
This allows registering KCP CRDs (located inside the `config` folder) at KCP start, whatever be the current directory in which KCP is started.