### PR TITLE
Do not try to sync status when status field is empty or nil in both objects

### DIFF
--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -19,11 +19,10 @@ func deepEqualStatus(oldObj, newObj interface{}) bool {
 		return false
 	}
 
-	if newStatus, statusExists := newUnstrob.UnstructuredContent()["status"]; statusExists {
-		oldStatus := oldUnstrob.UnstructuredContent()["status"]
-		return equality.Semantic.DeepEqual(oldStatus, newStatus)
-	}
-	return false
+	newStatus := newUnstrob.UnstructuredContent()["status"]
+	oldStatus := oldUnstrob.UnstructuredContent()["status"]
+
+	return equality.Semantic.DeepEqual(oldStatus, newStatus)
 }
 
 func NewStatusSyncer(from, to *rest.Config, syncedResourceTypes []string, clusterID string) (*Controller, error) {


### PR DESCRIPTION
Currently `deepEqualStatus` returns true when the status is empty/nil in both objects. This is causing reconciling to happen needlessly for objects with an empty status, and triggers errors in objects that do not have a status (e.g., a ConfigMap).