### PR TITLE
Add unit test for pkg/syncer/statussyncer.go

### DIFF
--- a/pkg/syncer/statussyncer_test.go
+++ b/pkg/syncer/statussyncer_test.go
@@ -1,0 +1,84 @@
+package syncer
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestDeepEqualStatus(t *testing.T) {
+	for _, c := range []struct {
+		desc     string
+		old, new *unstructured.Unstructured
+		want     bool
+	}{{
+		desc: "both objects have same status",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		want: true,
+	}, {
+		desc: "both objects have status; different",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "no",
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "one object doesn't have status",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"status": map[string]string{
+					"cool": "yes",
+				},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]string{},
+			},
+		},
+		want: false,
+	}, {
+		desc: "both objects don't have status",
+		old: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]string{},
+			},
+		},
+		new: &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]string{},
+			},
+		},
+		want: true,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := deepEqualStatus(c.old, c.new)
+			if got != c.want {
+				t.Fatalf("got %t, want %t", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This behavior was changed in https://github.com/kcp-dev/kcp/pull/199 without a corresponding unit test, because there were no unit tests.

Pre-#199, the fourth unit test case would have returned `false`, and now returns `true`.