### PR TITLE
Schedule namespaces and all resources in them to clusters

### DIFF
--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gvk
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+)
+
+// GVKTranslator translates a given GroupVersionKind into a
+// GroupVersionResource, using a RESTMapper.
+type GVKTranslator struct {
+	m *restmapper.DeferredDiscoveryRESTMapper
+}
+
+// NewGVKTranslator returns a GVKTranslator that can translate a given
+// GroupVersionKind into the corresponding GroupVersionResource, using a
+// RESTMapper.
+func NewGVKTranslator(cfg *rest.Config) *GVKTranslator {
+	return &GVKTranslator{m: restmapper.NewDeferredDiscoveryRESTMapper(
+		memory.NewMemCacheClient(
+			discovery.NewDiscoveryClientForConfigOrDie(cfg)))}
+}
+
+// Get returns the corresponding GroupVersionResource for the given
+// GroupVersionKind.
+func (t *GVKTranslator) Get(gvk *schema.GroupVersionKind) (*schema.GroupVersionResource, error) {
+	m, err := t.m.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	return &m.Resource, nil
+}

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/multierr"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+const (
+	resyncPeriod   = 10 * time.Hour
+	pollTypesEvery = time.Minute
+)
+
+// DynamicDiscoverySharedInformerFactory is a SharedInformerFactory that
+// dynamically discovers new types and begins informing on them.
+type DynamicDiscoverySharedInformerFactory struct {
+	disco      *discovery.DiscoveryClient
+	dsif       dynamicinformer.DynamicSharedInformerFactory
+	handler    GVREventHandler
+	filterFunc func(interface{}) bool
+
+	mu   sync.Mutex // guards gvrs
+	gvrs sets.String
+}
+
+// IndexerFor returns the indexer for the given type GVR.
+func (d *DynamicDiscoverySharedInformerFactory) IndexerFor(gvr schema.GroupVersionResource) cache.Indexer {
+	return d.dsif.ForResource(gvr).Informer().GetIndexer()
+}
+
+// Listers returns a map of per-resource-type listers for all types that are
+// known by this informer factory, and that are synced.
+//
+// If any informers aren't synced, their GVRs are returned so that they can be
+// checked and processed later.
+func (d *DynamicDiscoverySharedInformerFactory) Listers() (listers map[schema.GroupVersionResource]cache.GenericLister, notSynced []schema.GroupVersionResource) {
+	listers = map[schema.GroupVersionResource]cache.GenericLister{}
+
+	for _, gvrstr := range d.gvrs.UnsortedList() {
+		gvr, _ := schema.ParseResourceArg(gvrstr)
+		if gvr == nil {
+			klog.Errorf("parsing GVR string %q", gvrstr)
+			continue
+		}
+
+		if !d.dsif.ForResource(*gvr).Informer().HasSynced() {
+			notSynced = append(notSynced, *gvr)
+			continue
+		}
+
+		listers[*gvr] = d.dsif.ForResource(*gvr).Lister()
+	}
+	return listers, notSynced
+}
+
+// NewDynamicDiscoverySharedInformerFactory returns a factory for shared
+// informers that discovers new types and informs on updates to resources of
+// those types.
+func NewDynamicDiscoverySharedInformerFactory(
+	disco *discovery.DiscoveryClient,
+	dynClient dynamic.Interface,
+	filterFunc func(obj interface{}) bool,
+	handler GVREventHandler) DynamicDiscoverySharedInformerFactory {
+	dsif := dynamicinformer.NewDynamicSharedInformerFactory(dynClient, resyncPeriod)
+	return DynamicDiscoverySharedInformerFactory{
+		disco:      disco,
+		dsif:       dsif,
+		handler:    handler,
+		filterFunc: filterFunc,
+		gvrs:       sets.NewString(),
+	}
+}
+
+// GVREventHandler is an event handler that includes the GroupVersionResource
+// of the resource being handled.
+type GVREventHandler interface {
+	OnAdd(gvr schema.GroupVersionResource, obj interface{})
+	OnUpdate(gvr schema.GroupVersionResource, oldObj, newObj interface{})
+	OnDelete(gvr schema.GroupVersionResource, obj interface{})
+}
+
+type GVREventHandlerFuncs struct {
+	AddFunc    func(gvr schema.GroupVersionResource, obj interface{})
+	UpdateFunc func(gvr schema.GroupVersionResource, oldObj, newObj interface{})
+	DeleteFunc func(gvr schema.GroupVersionResource, obj interface{})
+}
+
+func (g GVREventHandlerFuncs) OnAdd(gvr schema.GroupVersionResource, obj interface{}) {
+	if g.AddFunc != nil {
+		g.AddFunc(gvr, obj)
+	}
+}
+func (g GVREventHandlerFuncs) OnUpdate(gvr schema.GroupVersionResource, oldObj, newObj interface{}) {
+	if g.UpdateFunc != nil {
+		g.UpdateFunc(gvr, oldObj, newObj)
+	}
+}
+func (g GVREventHandlerFuncs) OnDelete(gvr schema.GroupVersionResource, obj interface{}) {
+	if g.DeleteFunc != nil {
+		g.DeleteFunc(gvr, obj)
+	}
+}
+
+func (d *DynamicDiscoverySharedInformerFactory) Start(ctx context.Context) {
+	// Immediately discover types and start informing.
+	// TODO: Feed any failure to discover types into /readyz, instead of
+	// panicking.
+	if err := d.discoverTypes(ctx); err != nil {
+		klog.Fatalf("Error discovering initial types: %v", err)
+	}
+
+	// Poll for new types in the background.
+	ticker := time.NewTicker(pollTypesEvery)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				if err := d.discoverTypes(ctx); err != nil {
+					klog.Errorf("Error discovering types: %v", err)
+				}
+			}
+		}
+	}()
+}
+
+func (d *DynamicDiscoverySharedInformerFactory) discoverTypes(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	latest := sets.NewString()
+	rs, err := d.disco.ServerPreferredResources()
+	if err != nil {
+		return err
+	}
+	for _, r := range rs {
+		gv, err := schema.ParseGroupVersion(r.GroupVersion)
+		if err != nil {
+			return err
+		}
+		for _, ai := range r.APIResources {
+			if strings.Contains(ai.Name, "/") {
+				// foo/status, pods/exec, namespace/finalize, etc.
+				continue
+			}
+			if !ai.Namespaced {
+				// Ignore cluster-scoped things.
+				continue
+			}
+			if !sets.NewString([]string(ai.Verbs)...).HasAll("list", "watch") {
+				klog.V(2).Infof("resource %s.%s %s is not list+watchable: %v", gv.Group, gv.Version, ai.Name, ai.Verbs)
+				continue
+			}
+
+			latest.Insert(strings.Join([]string{ai.Name, gv.Version, gv.Group}, "."))
+		}
+	}
+
+	// Set up informers for any new types that have been discovered.
+	// TODO: Stop informers for types we no longer have.
+	newGVRs := latest.Difference(d.gvrs)
+	var merr error
+	for _, gvrstr := range newGVRs.UnsortedList() {
+		gvr, _ := schema.ParseResourceArg(gvrstr)
+		if gvr == nil {
+			multierr.AppendInto(&merr, fmt.Errorf("parsing GVR string %q: %w", gvrstr, err))
+			continue
+		}
+
+		inf := d.dsif.ForResource(*gvr).Informer()
+		inf.AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: d.filterFunc,
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc:    func(obj interface{}) { d.handler.OnAdd(*gvr, obj) },
+				UpdateFunc: func(oldObj, newObj interface{}) { d.handler.OnUpdate(*gvr, oldObj, newObj) },
+				DeleteFunc: func(obj interface{}) { d.handler.OnDelete(*gvr, obj) },
+			},
+		})
+		go inf.Run(ctx.Done())
+	}
+	if merr != nil {
+		return merr
+	}
+
+	d.gvrs = latest
+	return nil
+}

--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -1,0 +1,415 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	clusterinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/cluster/v1alpha1"
+	clusterlisters "github.com/kcp-dev/kcp/pkg/client/listers/cluster/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/gvk"
+	"github.com/kcp-dev/kcp/pkg/informer"
+)
+
+const controllerName = "namespace-scheduler"
+
+// NewController returns a new Controller which schedules namespaced resources to a Cluster.
+func NewController(
+	dynClient dynamic.Interface,
+	disco *discovery.DiscoveryClient,
+	clusterInformer clusterinformer.ClusterInformer,
+	clusterLister clusterlisters.ClusterLister,
+	namespaceInformer coreinformers.NamespaceInformer,
+	namespaceLister corelisters.NamespaceLister,
+	namespaceClient coreclient.NamespaceInterface,
+	gvkTrans *gvk.GVKTranslator,
+) *Controller {
+
+	resourceQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	gvrQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	namespaceQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	clusterQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	c := &Controller{
+		resourceQueue:  resourceQueue,
+		gvrQueue:       gvrQueue,
+		namespaceQueue: namespaceQueue,
+		clusterQueue:   clusterQueue,
+
+		dynClient:       dynClient,
+		clusterLister:   clusterLister,
+		namespaceLister: namespaceLister,
+		namespaceClient: namespaceClient,
+		gvkTrans:        gvkTrans,
+
+		syncChecks: []cache.InformerSynced{
+			namespaceInformer.Informer().HasSynced,
+			clusterInformer.Informer().HasSynced,
+		},
+	}
+	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueCluster(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueCluster(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueueCluster(obj) },
+	})
+	namespaceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: filterNamespace,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { c.enqueueNamespace(obj) },
+			UpdateFunc: func(_, obj interface{}) { c.enqueueNamespace(obj) },
+			DeleteFunc: nil, // Nothing to do.
+		},
+	})
+	c.ddsif = informer.NewDynamicDiscoverySharedInformerFactory(disco, dynClient,
+		filterResource,
+		informer.GVREventHandlerFuncs{
+			AddFunc:    func(gvr schema.GroupVersionResource, obj interface{}) { c.enqueueResource(gvr, obj) },
+			UpdateFunc: func(gvr schema.GroupVersionResource, _, obj interface{}) { c.enqueueResource(gvr, obj) },
+			DeleteFunc: nil, // Nothing to do.
+		})
+
+	return c
+}
+
+type Controller struct {
+	resourceQueue  workqueue.RateLimitingInterface
+	gvrQueue       workqueue.RateLimitingInterface
+	namespaceQueue workqueue.RateLimitingInterface
+	clusterQueue   workqueue.RateLimitingInterface
+
+	dynClient       dynamic.Interface
+	clusterLister   clusterlisters.ClusterLister
+	namespaceLister corelisters.NamespaceLister
+	namespaceClient coreclient.NamespaceInterface
+	ddsif           informer.DynamicDiscoverySharedInformerFactory
+	gvkTrans        *gvk.GVKTranslator
+
+	syncChecks []cache.InformerSynced
+}
+
+func filterResource(obj interface{}) bool {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return false
+	}
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return false
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
+	if clusterName != "admin" {
+		klog.V(2).Infof("Skipping update for non-admin cluster %q", clusterName)
+		return false
+	}
+
+	current, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		klog.V(2).Infof("Object was not Unstructured: %T", obj)
+		return false
+	}
+
+	if namespaceBlocklist.Has(current.GetNamespace()) {
+		klog.V(2).Infof("Skipping syncing namespace %q", current.GetNamespace())
+		return false
+	}
+	return true
+}
+
+func filterNamespace(obj interface{}) bool {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return false
+	}
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return false
+	}
+	clusterName, name := clusters.SplitClusterAwareKey(clusterAwareName)
+	if clusterName != "admin" {
+		klog.Infof("Skipping update for non-admin cluster %q", clusterName)
+		return false
+	}
+	if namespaceBlocklist.Has(name) {
+		klog.V(2).Infof("Skipping syncing namespace %q", name)
+		return false
+	}
+	return true
+}
+
+func (c *Controller) enqueueResource(gvr schema.GroupVersionResource, obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	gvrstr := strings.Join([]string{gvr.Resource, gvr.Version, gvr.Group}, ".")
+	c.resourceQueue.Add(gvrstr + "::" + key)
+}
+
+func (c *Controller) enqueueGVR(gvr schema.GroupVersionResource) {
+	gvrstr := strings.Join([]string{gvr.Resource, gvr.Version, gvr.Group}, ".")
+	c.gvrQueue.Add(gvrstr)
+}
+
+func (c *Controller) enqueueNamespace(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	c.namespaceQueue.Add(key)
+}
+
+func (c *Controller) enqueueCluster(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	c.clusterQueue.Add(key)
+}
+
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.resourceQueue.ShutDown()
+	defer c.gvrQueue.ShutDown()
+	defer c.namespaceQueue.ShutDown()
+	defer c.clusterQueue.ShutDown()
+
+	klog.Info("Starting Namespace scheduler")
+	defer klog.Info("Shutting down Namespace scheduler")
+
+	if !cache.WaitForNamedCacheSync("namespace-scheduler", ctx.Done(), c.syncChecks...) {
+		klog.Warning("Failed to wait for caches to sync")
+		return
+	}
+
+	c.ddsif.Start(ctx)
+
+	for i := 0; i < numThreads; i++ {
+		go wait.Until(func() { c.startResourceWorker(ctx) }, time.Second, ctx.Done())
+		go wait.Until(func() { c.startGVRWorker(ctx) }, time.Second, ctx.Done())
+		go wait.Until(func() { c.startNamespaceWorker(ctx) }, time.Second, ctx.Done())
+		go wait.Until(func() { c.startClusterWorker(ctx) }, time.Second, ctx.Done())
+	}
+	<-ctx.Done()
+}
+
+func (c *Controller) startResourceWorker(ctx context.Context) {
+	for c.processNextResource(ctx) {
+	}
+}
+func (c *Controller) startGVRWorker(ctx context.Context) {
+	for c.processNextGVR(ctx) {
+	}
+}
+func (c *Controller) startNamespaceWorker(ctx context.Context) {
+	for c.processNextNamespace(ctx) {
+	}
+}
+func (c *Controller) startClusterWorker(ctx context.Context) {
+	for c.processNextCluster(ctx) {
+	}
+}
+
+func (c *Controller) processNextResource(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.resourceQueue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.resourceQueue.Done(key)
+
+	if err := c.processResource(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.resourceQueue.AddRateLimited(key)
+		return true
+	}
+	c.resourceQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processNextGVR(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.gvrQueue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.resourceQueue.Done(key)
+
+	if err := c.processGVR(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.gvrQueue.AddRateLimited(key)
+		return true
+	}
+	c.gvrQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processNextNamespace(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.namespaceQueue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.namespaceQueue.Done(key)
+
+	if err := c.processNamespace(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.namespaceQueue.AddRateLimited(key)
+		return true
+	}
+	c.namespaceQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processNextCluster(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.clusterQueue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.clusterQueue.Done(key)
+
+	if err := c.processCluster(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.clusterQueue.AddRateLimited(key)
+		return true
+	}
+	c.clusterQueue.Forget(key)
+	return true
+}
+
+// key is gvr::KEY
+func (c *Controller) processResource(ctx context.Context, key string) error {
+	parts := strings.SplitN(key, "::", 2)
+	if len(parts) != 2 {
+		klog.Errorf("Error parsing key %q; dropping", key)
+		return nil
+	}
+	gvrstr := parts[0]
+	gvr, _ := schema.ParseResourceArg(gvrstr)
+	if gvr == nil {
+		klog.Errorf("Error parsing GVR %q; dropping", gvrstr)
+		return nil
+	}
+	key = parts[1]
+
+	obj, exists, err := c.ddsif.IndexerFor(*gvr).GetByKey(key)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		klog.Infof("object %q does not exist", key)
+		return nil
+	}
+	unstr, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		klog.Errorf("object was not Unstructured, dropping: %T", obj)
+		return nil
+	}
+	unstr = unstr.DeepCopy()
+
+	// Get logical cluster name.
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("failed to split key %q, dropping: %v", key, err)
+		return nil
+	}
+	lclusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
+	return c.reconcileResource(ctx, lclusterName, unstr, gvr)
+}
+
+func (c *Controller) processGVR(ctx context.Context, gvrstr string) error {
+	gvr, _ := schema.ParseResourceArg(gvrstr)
+	if gvr == nil {
+		klog.Errorf("Error parsing GVR %q; dropping", gvrstr)
+		return nil
+	}
+	return c.reconcileGVR(ctx, *gvr)
+}
+
+// namespaceBlocklist holds a set of namespaces that should never be synced from kcp to physical clusters.
+var namespaceBlocklist = sets.NewString("kube-system", "kube-public", "kube-node-lease")
+
+func (c *Controller) processNamespace(ctx context.Context, key string) error {
+	ns, err := c.namespaceLister.Get(key)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// Get logical cluster name.
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.Errorf("failed to split key %q, dropping: %v", key, err)
+		return nil
+	}
+	lclusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
+
+	return c.reconcileNamespace(ctx, lclusterName, ns.DeepCopy())
+}
+
+func (c *Controller) processCluster(ctx context.Context, key string) error {
+	cluster, err := c.clusterLister.Get(key)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return c.observeCluster(ctx, cluster.DeepCopy())
+}

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+)
+
+const clusterLabel = "kcp.dev/cluster"
+
+// reconcileResource is responsible for setting the cluster for a resource of
+// any type, to match the cluster where its namespace is assigned.
+func (c *Controller) reconcileResource(ctx context.Context, lclusterName string, unstr *unstructured.Unstructured, gvr *schema.GroupVersionResource) error {
+	klog.Infof("Reconciling %s %s/%s", gvr.String(), unstr.GetNamespace(), unstr.GetName())
+
+	// If the resource is not namespaced (incl if the resource is itself a
+	// namespace), ignore it.
+	if unstr.GetNamespace() == "" {
+		klog.Infof("%s %s had no namespace; ignoring", gvr.String(), unstr.GetName())
+		return nil
+	}
+
+	// Align the resource's assigned cluster with the namespace's assigned
+	// cluster.
+	// First, get the namespace object (from the cached lister).
+	ns, err := c.namespaceLister.Get(clusters.ToClusterAwareKey(lclusterName, unstr.GetNamespace()))
+	if err != nil {
+		return err
+	}
+
+	lbls := unstr.GetLabels()
+	if lbls == nil {
+		lbls = map[string]string{}
+	}
+
+	old, new := lbls[clusterLabel], ns.Labels[clusterLabel]
+	if old == new {
+		// Already assigned to the right cluster.
+		return nil
+	}
+
+	// Update the resource's assignment.
+	klog.Infof("Patching to update cluster assignment for %s %s/%s: %q -> %q", gvr, ns.Name, unstr.GetName(), old, new)
+	if _, err := c.dynClient.Resource(*gvr).Namespace(ns.Name).Patch(ctx, unstr.GetName(), types.MergePatchType, clusterLabelPatchBytes(new), metav1.PatchOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) reconcileGVR(ctx context.Context, gvr schema.GroupVersionResource) error {
+	// Update all resources in the namespace with the cluster assignment.
+	listers, _ := c.ddsif.Listers()
+	lister, found := listers[gvr]
+	if !found {
+		return fmt.Errorf("Informer for %s is not synced; re-enqueueing", gvr)
+	}
+
+	// Enqueue workqueue items to reconcile every resource of this type, in
+	// all namespaces.
+	objs, err := lister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		c.enqueueResource(gvr, obj)
+	}
+	return nil
+}
+
+// reconcileNamespace is responsible for assigning a namespace to a cluster, if
+// it does not already have one.
+//
+// After assigning (or if it's already assigned), this also updates all
+// resources in the namespace to be assigned to the namespace's cluster.
+func (c *Controller) reconcileNamespace(ctx context.Context, lclusterName string, ns *corev1.Namespace) error {
+	klog.Infof("Reconciling Namespace %s", ns.Name)
+
+	if ns.Labels == nil {
+		ns.Labels = map[string]string{}
+	}
+
+	clusterName := ns.Labels[clusterLabel]
+	if clusterName == "" {
+		// Namespace is not assigned to a cluster; assign one.
+		// First, list all clusters.
+		cls, err := c.clusterLister.List(labels.Everything())
+		if err != nil {
+			return err
+		}
+
+		// TODO: Filter out un-Ready clusters so a namespace doesn't
+		// get assigned to an un-Ready cluster.
+
+		if len(cls) == 0 {
+			// TODO set status, on namespace and all resources in namespace.
+			return fmt.Errorf("no clusters")
+		}
+
+		// Select a cluster at random.
+		cl := cls[rand.Intn(len(cls))]
+		old, new := "", cl.Name
+
+		// Patch the namespace.
+		klog.Infof("Patching to update cluster assignment for namespace %s: %q -> %q", ns.Name, old, new)
+		if _, err := c.namespaceClient.Patch(ctx, ns.Name, types.MergePatchType, clusterLabelPatchBytes(new), metav1.PatchOptions{}); err != nil {
+			return err
+		}
+	}
+
+	// Check if the cluster reports as Ready.
+	cl, err := c.clusterLister.Get(clusters.ToClusterAwareKey(lclusterName, clusterName))
+	if err != nil {
+		return err
+	}
+	if !cl.Status.Conditions.HasReady() {
+		klog.Infof("Cluster %q is not reporting as ready", cl.Name)
+
+		// TODO: reassign this namespace to another Ready cluster at random.
+	}
+
+	// Update all resources in the namespace with the cluster assignment.
+	//
+	// TODO: This will happen any time a namespace update is observed,
+	// including updates that don't affect cluster assignment (e.g.,
+	// annotation). This will be especially painful at startup, since all
+	// resources are already enqueued and reconciled separately. Add some
+	// logic to filter out un-interesting updates, and consider only
+	// enqueueing items here if they're not already enqueued.
+	listers, notSynced := c.ddsif.Listers()
+	for gvr, lister := range listers {
+		objs, err := lister.ByNamespace(ns.Name).List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		for _, obj := range objs {
+			c.enqueueResource(gvr, obj)
+		}
+	}
+	// For all types whose informer hasn't synced yet, enqueue a workqueue
+	// item to check that GVR again later (reconcileGVR, above).
+	for _, gvr := range notSynced {
+		klog.Infof("Informer for %s is not synced; re-enqueueing", gvr)
+		c.enqueueGVR(gvr)
+	}
+
+	return nil
+}
+
+// clusterLabelPatchBytes returns JSON patch bytes expressing an operation to
+// add or replace the cluster assignment label to the given value.
+func clusterLabelPatchBytes(val string) []byte {
+	return []byte(fmt.Sprintf(`
+{
+  "metadata":{
+    "labels":{
+      "kcp.dev/cluster": %q
+    }
+  }
+}`, val))
+}
+
+// observeCluster is responsible for watching to see if the Cluster is happy;
+// if it's not, any namespace assigned to that cluster will be unassigned.
+//
+// After the namespace is unassigned, it will be picked up by
+// reconcileNamespace above and assigned to another happy cluster if one can be
+// found.
+func (c *Controller) observeCluster(ctx context.Context, cl *v1alpha1.Cluster) error {
+	klog.Infof("Observing Cluster %s", cl.Name)
+
+	if cl.Status.Conditions.HasReady() {
+		// Cluster's happy, nothing to do.
+		return nil
+	}
+
+	// TODO: If the Cluster reports as unhealthy, enqueue work items to
+	// reconcile every namespace assigned to that cluster. This, along with
+	// the above TODO, will reassign the namespace to a ready cluster.
+
+	return nil
+}

--- a/pkg/reconciler/namespace/namespace_test.go
+++ b/pkg/reconciler/namespace/namespace_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clusterfake "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/fake"
+	"github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+)
+
+const lcluster = "my-logical-cluster"
+
+// TODO:
+// - a namespace is unassigned, no clusters; error.
+// - a cluster becomes unhappy, unassign its namespaces.
+// - test that a namespace's resources are also assigned when a namespace gets assigned.
+
+func TestReconcileResource(t *testing.T) {
+	targetCluster := "target-cluster"
+	nsName := "my-namespace"
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		desc            string
+		assignedCluster string
+		wantPatch       bool
+	}{{
+		desc:            "deployment assigned to different cluster",
+		assignedCluster: "some-other-cluster",
+		wantPatch:       true,
+	}, {
+		desc:            "deployment not assigned",
+		assignedCluster: "",
+		wantPatch:       true,
+	}, {
+		desc:            "deployment assigned to correct cluster",
+		assignedCluster: targetCluster,
+		wantPatch:       false,
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						ClusterName: lcluster,
+						Name:        nsName,
+						Labels: map[string]string{
+							clusterLabel: targetCluster,
+						},
+					},
+				},
+			)
+			nsif := informers.NewSharedInformerFactory(clientset, time.Second)
+			nsif.Core().V1().Namespaces().Informer() // This is needed to get the informer to start listening.
+			nsif.Start(ctx.Done())
+			t.Logf("cache synced: %+v", nsif.WaitForCacheSync(ctx.Done()))
+
+			d := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: lcluster,
+					Namespace:   nsName,
+					Name:        "my-deployment",
+					Labels: map[string]string{
+						clusterLabel: tc.assignedCluster,
+					},
+				},
+				Spec: appsv1.DeploymentSpec{},
+			}
+			rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(d)
+			if err != nil {
+				t.Fatalf("ToUnstructured: %v", err)
+			}
+			unstr := &unstructured.Unstructured{Object: rawMap}
+			sch := runtime.NewScheme()
+			if err := appsv1.AddToScheme(sch); err != nil {
+				t.Fatal(err)
+			}
+			dynClient := dynfake.NewSimpleDynamicClient(sch, runtime.Object(d))
+			gvr := &schema.GroupVersionResource{
+				Group:    "apps",
+				Version:  "v1",
+				Resource: "deployments",
+			}
+
+			c := &Controller{
+				namespaceLister: nsif.Core().V1().Namespaces().Lister(),
+				dynClient:       dynClient,
+			}
+
+			// Reconcile the Deployment and see that its labels
+			// were patched as expected.
+			if err := c.reconcileResource(ctx, lcluster, unstr, gvr); err != nil {
+				// TODO: This should be a t.Fatal, but this fails because the
+				// dynamic client fails to find the Deployment by GVR.  For
+				// now, just t.Logf the failure and check that we got the patch
+				// we expected.
+				t.Logf("reconcileResource: %v", err)
+			}
+			wantActions := []k8stesting.Action{}
+			if tc.wantPatch {
+				wantActions = append(wantActions, k8stesting.NewPatchAction(*gvr, nsName, d.Name, types.MergePatchType, clusterLabelPatchBytes(targetCluster)))
+			}
+			if diff := cmp.Diff(wantActions, dynClient.Actions()); diff != "" {
+				t.Fatalf("Unexpected actions: (-got,+want): %s", diff)
+			}
+
+			// TODO: Get the deployment back out and see that its label was updated.
+		})
+	}
+}
+
+func TestReconcileNamespace(t *testing.T) {
+	targetCluster := "target-cluster"
+	nsName := "my-namespace"
+
+	gvr := &schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		desc            string
+		assignedCluster string
+		wantPatch       bool
+	}{{
+		desc:            "namespace not assigned",
+		assignedCluster: "",
+		wantPatch:       true,
+	}, {
+		desc:            "namespace assigned",
+		assignedCluster: targetCluster,
+		wantPatch:       false,
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: lcluster,
+					Name:        nsName,
+					Labels: map[string]string{
+						clusterLabel: tc.assignedCluster,
+					},
+				},
+			}
+			clientset := fake.NewSimpleClientset(ns)
+
+			clusterClient := clusterfake.NewSimpleClientset(&v1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: targetCluster,
+				},
+			})
+			csif := externalversions.NewSharedInformerFactory(clusterClient, time.Second)
+			csif.Cluster().V1alpha1().Clusters().Informer() // This is needed to get the informer to start listening.
+			csif.Start(ctx.Done())
+			t.Logf("cache synced: %+v", csif.WaitForCacheSync(ctx.Done()))
+
+			c := &Controller{
+				clusterLister:   csif.Cluster().V1alpha1().Clusters().Lister(),
+				namespaceClient: clientset.CoreV1().Namespaces(),
+			}
+
+			// Reconcile the Namespace and see that its labels were
+			// patched as expected.
+			if err := c.reconcileNamespace(ctx, lcluster, ns); err != nil {
+				// TODO: This should be a t.Fatal, but this fails because the
+				// dynamic client fails to find the Deployment by GVR.  For
+				// now, just t.Logf the failure and check that we got the patch
+				// we expected.
+				t.Logf("reconcileNamespace: %v", err)
+			}
+			wantActions := []k8stesting.Action{}
+			if tc.wantPatch {
+				wantActions = append(wantActions, k8stesting.NewPatchAction(*gvr, "", nsName, types.MergePatchType, clusterLabelPatchBytes(targetCluster)))
+			}
+			if diff := cmp.Diff(wantActions, clientset.Actions()); diff != "" {
+				t.Fatalf("Unexpected actions: (-got,+want): %s", diff)
+			}
+
+			// TODO: Get the deployment back out and see that its label was updated.
+		})
+	}
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -37,6 +37,7 @@ func DefaultConfig() *Config {
 		InstallClusterController:   false,
 		ClusterControllerOptions:   cluster.DefaultOptions(),
 		InstallWorkspaceController: false,
+		InstallNamespaceScheduler:  false,
 		KubeConfigPath:             "admin.kubeconfig",
 		Listen:                     ":6443",
 		RootDirectory:              ".kcp",
@@ -57,6 +58,7 @@ type Config struct {
 	InstallClusterController   bool
 	ClusterControllerOptions   *cluster.Options
 	InstallWorkspaceController bool
+	InstallNamespaceScheduler  bool
 	KubeConfigPath             string
 	Listen                     string
 	RootDirectory              string
@@ -70,6 +72,7 @@ func BindOptions(c *Config, fs *pflag.FlagSet) *Config {
 	fs.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
 	fs.BoolVar(&c.InstallClusterController, "install_cluster_controller", c.InstallClusterController, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
 	fs.BoolVar(&c.InstallWorkspaceController, "install_workspace_controller", c.InstallWorkspaceController, "Registers the workspace custom resource, and the related controller to allow scheduling workspaces to shards")
+	fs.BoolVar(&c.InstallNamespaceScheduler, "install_namespace_scheduler", c.InstallNamespaceScheduler, "Registers the namespace scheduler to allow scheduling namespaces and resource to physical clusters")
 	fs.StringVar(&c.Listen, "listen", c.Listen, "Address:port to bind to")
 	fs.StringSliceVar(&c.EtcdClientInfo.Endpoints, "etcd-servers", c.EtcdClientInfo.Endpoints, "List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
 	fs.StringVar(&c.EtcdClientInfo.KeyFile, "etcd-keyfile", c.EtcdClientInfo.KeyFile, "TLS key file used to secure etcd communication.")

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	clusterv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+const clusterLabel = "kcp.dev/cluster"
+
+func TestNamespaceScheduler(t *testing.T) {
+	// TODO(jasonhall): Make tests pass.
+	t.Skip("Tests currently don't pass")
+
+	var testCases = []struct {
+		name string
+		work func(ctx context.Context, t framework.TestingTInterface, kubeClient kubernetes.Interface, client clientset.Interface, watcher watch.Interface)
+	}{
+		{
+			name: "create a namespace without clusters, expect it to be unschedulable",
+			work: func(ctx context.Context, t framework.TestingTInterface, kubeClient kubernetes.Interface, client clientset.Interface, watcher watch.Interface) {
+				namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create namespace: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(namespace), 5*time.Second); err != nil {
+					t.Errorf("did not see workspace created: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, unschedulableMatcher(), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+			},
+		},
+		{
+			name: "add a cluster after a namespace is unschedulable, expect it to be scheduled",
+			work: func(ctx context.Context, t framework.TestingTInterface, kubeClient kubernetes.Interface, client clientset.Interface, watcher watch.Interface) {
+				namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create namespace: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(namespace), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace created: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, unschedulableMatcher(), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+				bostonCluster, err := client.ClusterV1alpha1().Clusters().Create(ctx, &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create cluster: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(bostonCluster.Name), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+			},
+		},
+		{
+			name: "create a namespace with a cluster, expect it to be scheduled",
+			work: func(ctx context.Context, t framework.TestingTInterface, kubeClient kubernetes.Interface, client clientset.Interface, watcher watch.Interface) {
+				bostonCluster, err := client.ClusterV1alpha1().Clusters().Create(ctx, &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create first cluster: %v", err)
+					return
+				}
+				namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create namespace: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(namespace), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace created: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(bostonCluster.Name), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+			},
+		},
+		{
+			name: "delete a cluster that a namespace is scheduled to, expect it to move to another cluster",
+			work: func(ctx context.Context, t framework.TestingTInterface, kubeClient kubernetes.Interface, client clientset.Interface, watcher watch.Interface) {
+				bostonCluster, err := client.ClusterV1alpha1().Clusters().Create(ctx, &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create first cluster: %v", err)
+					return
+				}
+				atlantaCluster, err := client.ClusterV1alpha1().Clusters().Create(ctx, &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "atlanta"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create second cluster: %v", err)
+					return
+				}
+				namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create namespace: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(namespace), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace created: %v", err)
+					return
+				}
+				namespace, err = expectNextEvent(watcher, watch.Modified, scheduledAnywhereMatcher(), 5*time.Second)
+				if err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+				var otherCluster string
+				for _, name := range []string{bostonCluster.Name, atlantaCluster.Name} {
+					if name != namespace.Labels[clusterLabel] {
+						otherCluster = name
+						break
+					}
+				}
+				if err := client.ClusterV1alpha1().Clusters().Delete(ctx, namespace.Labels[clusterLabel], metav1.DeleteOptions{}); err != nil {
+					t.Errorf("failed to delete cluster: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(otherCluster), 5*time.Second); err != nil {
+					t.Errorf("did not see workspace updated: %v", err)
+					return
+				}
+			},
+		},
+		{
+			name: "delete all clusters, expect namespace to be unschedulable",
+			work: func(ctx context.Context, t framework.TestingTInterface, kubeClient kubernetes.Interface, client clientset.Interface, watcher watch.Interface) {
+				bostonCluster, err := client.ClusterV1alpha1().Clusters().Create(ctx, &clusterv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create first cluster: %v", err)
+					return
+				}
+				namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				if err != nil {
+					t.Errorf("failed to create namespace: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(namespace), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace created: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(bostonCluster.Name), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+				if err := client.ClusterV1alpha1().Clusters().Delete(ctx, bostonCluster.Name, metav1.DeleteOptions{}); err != nil {
+					t.Errorf("failed to delete cluster: %v", err)
+					return
+				}
+				if _, err := expectNextEvent(watcher, watch.Modified, unschedulableMatcher(), 5*time.Second); err != nil {
+					t.Errorf("did not see namespace updated: %v", err)
+					return
+				}
+			},
+		},
+	}
+	const serverName = "main"
+	for i := range testCases {
+		testCase := testCases[i]
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+			ctx := context.Background()
+			if deadline, ok := t.Deadline(); ok {
+				withDeadline, cancel := context.WithDeadline(ctx, deadline)
+				t.Cleanup(cancel)
+				ctx = withDeadline
+			}
+			if len(servers) != 1 {
+				t.Errorf("incorrect number of servers: %d", len(servers))
+				return
+			}
+			server := servers[serverName]
+			cfg, err := server.Config()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			clusterName, err := detectClusterName(cfg, ctx)
+			if err != nil {
+				t.Errorf("failed to detect cluster name: %v", err)
+				return
+			}
+			kubeClient, err := kubernetes.NewClusterForConfig(cfg)
+			if err != nil {
+				t.Errorf("failed to construct client for server: %v", err)
+				return
+			}
+			client := kubeClient.Cluster(clusterName)
+			watcher, err := client.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{})
+			if err != nil {
+				t.Errorf("failed to watch namespaces: %v", err)
+				return
+			}
+
+			clients, err := clientset.NewClusterForConfig(cfg)
+			if err != nil {
+				t.Errorf("failed to construct client for server: %v", err)
+				return
+			}
+			clusterClient := clients.Cluster(clusterName)
+
+			testCase.work(ctx, t, client, clusterClient, watcher)
+		}, framework.KcpConfig{
+			Name: "main",
+			Args: []string{"--install_cluster_controller", "--install_workspace_controller", "--install_namespace_scheduler"},
+		})
+	}
+}
+
+// TODO: we need to undo the prefixing and get normal sharding behavior in soon ... ?
+func detectClusterName(cfg *rest.Config, ctx context.Context) (string, error) {
+	crdClient, err := apiextensionsclientset.NewClusterForConfig(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to construct client for server: %w", err)
+	}
+	crds, err := crdClient.Cluster("*").ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list crds: %w", err)
+	}
+	if len(crds.Items) == 0 {
+		return "", errors.New("found no crds, cannot detect cluster name")
+	}
+	for _, crd := range crds.Items {
+		if crd.ObjectMeta.Name == "workspaces.tenancy.kcp.dev" {
+			return crd.ObjectMeta.ClusterName, nil
+		}
+	}
+	return "", errors.New("detected no admin cluster")
+}
+
+func exactMatcher(expected *corev1.Namespace) matcher {
+	return func(object *corev1.Namespace) error {
+		if !apiequality.Semantic.DeepEqual(expected, object) {
+			return fmt.Errorf("incorrect object: %v", cmp.Diff(expected, object))
+		}
+		return nil
+	}
+}
+
+func unschedulableMatcher() matcher {
+	return func(object *corev1.Namespace) error {
+		if !isNamespaceUnschedulable(object) {
+			return fmt.Errorf("expected an unschedulable namespace, got status.conditions: %#v", object.Status.Conditions)
+		}
+		return nil
+	}
+}
+
+func scheduledMatcher(target string) matcher {
+	return func(object *corev1.Namespace) error {
+		if isNamespaceUnschedulable(object) {
+			return fmt.Errorf("expected a scheduled workspace, got status.conditions: %#v", object.Status.Conditions)
+		}
+		if object.Labels[clusterLabel] != target {
+			return fmt.Errorf("expected namespace assignment to be %q, got %q", target, object.Labels[clusterLabel])
+		}
+		return nil
+	}
+}
+
+func scheduledAnywhereMatcher() matcher {
+	return func(object *corev1.Namespace) error {
+		if isNamespaceUnschedulable(object) {
+			return fmt.Errorf("expected a scheduled workspace, got status.conditions: %#v", object.Status.Conditions)
+		}
+		return nil
+	}
+}
+
+type matcher func(object *corev1.Namespace) error
+
+func expectNextEvent(w watch.Interface, expectType watch.EventType, matcher matcher, duration time.Duration) (*corev1.Namespace, error) {
+	event, err := nextEvent(w, duration)
+	if err != nil {
+		return nil, err
+	}
+	if expectType != event.Type {
+		return nil, fmt.Errorf("got incorrect watch event type: %v != %v\n", expectType, event.Type)
+	}
+	workspace, ok := event.Object.(*corev1.Namespace)
+	if !ok {
+		return nil, fmt.Errorf("got %T, not a Workspace", event.Object)
+	}
+	if err := matcher(workspace); err != nil {
+		return workspace, err
+	}
+	return workspace, nil
+}
+
+func nextEvent(w watch.Interface, duration time.Duration) (watch.Event, error) {
+	stopTimer := time.NewTimer(duration)
+	defer stopTimer.Stop()
+	select {
+	case event, ok := <-w.ResultChan():
+		if !ok {
+			return watch.Event{}, errors.New("watch closed unexpectedly")
+		}
+		return event, nil
+	case <-stopTimer.C:
+		return watch.Event{}, errors.New("timed out waiting for event")
+	}
+}
+
+const conditionTypeUnschedulable = "Unschedulable"
+
+func isNamespaceUnschedulable(ns *corev1.Namespace) bool {
+	for _, cond := range ns.Status.Conditions {
+		if cond.Type == conditionTypeUnschedulable {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This does not yet include:

- syncer transforming namespace names when applying to physical clusters (probably in another more syncer-focused PR)