### PR TITLE
Refactor server run

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -114,8 +114,8 @@ func main() {
 	crdSharedInformerFactory.Start(ctx.Done())
 	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
 
-	clusterController.Start(numThreads, ctx.Done())
-	apiresourceController.Start(2, ctx.Done())
+	clusterController.Start(ctx, numThreads)
+	apiresourceController.Start(ctx, 2)
 
 	<-ctx.Done()
 }

--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -1,20 +1,30 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"os/signal"
-	"syscall"
+	"time"
 
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	typedapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/genericcontrolplane/clientutils"
 
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	typedapiresource "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/apiresource/v1alpha1"
+	typedcluster "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/cluster/v1alpha1"
+	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
 )
 
 const numThreads = 2
+const resyncPeriod = 10 * time.Hour
 
 var (
 	kubeconfigPath  = flag.String("kubeconfig", "", "Path to kubeconfig")
@@ -25,8 +35,9 @@ var (
 )
 
 func main() {
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	// Setup signal handler for a cleaner shutdown
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
+	defer cancel()
 
 	flag.Parse()
 
@@ -61,27 +72,50 @@ func main() {
 		syncerMode = cluster.SyncerModePush
 	}
 
-	clusterController, err := cluster.NewController(r, *syncerImage, kubeconfig, resourcesToSync, syncerMode)
-	if err != nil {
-		klog.Fatal(err)
-	}
-	clusterController.Start(numThreads)
+	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(kcpclient.NewForConfigOrDie(r), resyncPeriod)
+	crdSharedInformerFactory := crdexternalversions.NewSharedInformerFactoryWithOptions(apiextensionsclient.NewForConfigOrDie(r), resyncPeriod)
 
-	apiresourceController, err := apiresource.NewController(
-		r,
-		*autoPublishAPIs,
+	apiResourceClient := typedapiresource.NewForConfigOrDie(r)
+	crdClient := typedapiextensions.NewForConfigOrDie(r)
+	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(r)
+	clusterClient := typedcluster.NewForConfigOrDie(r)
+
+	clusterController, err := cluster.NewController(
+		crdClient,
+		discoveryClient,
+		clusterClient,
+		kcpSharedInformerFactory.Cluster().V1alpha1().Clusters(),
+		apiResourceClient,
+		kcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
+		*syncerImage,
+		kubeconfig,
+		resourcesToSync,
+		syncerMode,
 	)
 	if err != nil {
 		klog.Fatal(err)
 	}
-	apiresourceController.Start(2)
 
-	go func() {
-		<-sigs
-		clusterController.Stop()
-		apiresourceController.Stop()
-	}()
+	apiresourceController, err := apiresource.NewController(
+		apiResourceClient,
+		crdClient,
+		*autoPublishAPIs,
+		kcpSharedInformerFactory.Apiresource().V1alpha1().NegotiatedAPIResources(),
+		kcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
+		crdSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+	)
+	if err != nil {
+		klog.Fatal(err)
+	}
 
-	<-clusterController.Done()
-	<-apiresourceController.Done()
+	kcpSharedInformerFactory.Start(ctx.Done())
+	kcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+	crdSharedInformerFactory.Start(ctx.Done())
+	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+	clusterController.Start(numThreads, ctx.Done())
+	apiresourceController.Start(2, ctx.Done())
+
+	<-ctx.Done()
 }

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/server/v3/embed"
+
 	"k8s.io/klog"
 )
 

--- a/pkg/reconciler/apiresource/negotiation.go
+++ b/pkg/reconciler/apiresource/negotiation.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"reflect"
 
-	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	crdhelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -218,7 +217,7 @@ func (c *Controller) enforceCRDToNegotiatedAPIResource(ctx context.Context, clus
 				Type:   apiresourcev1alpha1.Enforced,
 				Status: metav1.ConditionTrue,
 			})
-			if _, err := c.apiresourceClient.NegotiatedAPIResources().UpdateStatus(ctx, negotiatedAPIResource, metav1.UpdateOptions{}); err != nil {
+			if _, err := c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().UpdateStatus(ctx, negotiatedAPIResource, metav1.UpdateOptions{}); err != nil {
 				klog.Errorf("Error updating NegotiatedAPIResource status: %v", err)
 				return err
 			}
@@ -226,7 +225,7 @@ func (c *Controller) enforceCRDToNegotiatedAPIResource(ctx context.Context, clus
 			if err := negotiatedAPIResource.Spec.CommonAPIResourceSpec.SetSchema(version.Schema.OpenAPIV3Schema); err != nil {
 				return err
 			}
-			if _, err := c.apiresourceClient.NegotiatedAPIResources().Update(ctx, negotiatedAPIResource, metav1.UpdateOptions{}); err != nil {
+			if _, err := c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().Update(ctx, negotiatedAPIResource, metav1.UpdateOptions{}); err != nil {
 				klog.Errorf("Error updating NegotiatedAPIResource: %v", err)
 				return err
 			}
@@ -282,7 +281,7 @@ func (c *Controller) updatePublishingStatusOnNegotiatedAPIResources(ctx context.
 		for _, obj := range objects {
 			negotiatedAPIResource := obj.(*apiresourcev1alpha1.NegotiatedAPIResource).DeepCopy()
 			c.setPublishingStatusOnNegotiatedAPIResource(ctx, clusterName, gvr, negotiatedAPIResource, crd)
-			_, err := c.apiresourceClient.NegotiatedAPIResources().UpdateStatus(ctx, negotiatedAPIResource, metav1.UpdateOptions{})
+			_, err := c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().UpdateStatus(ctx, negotiatedAPIResource, metav1.UpdateOptions{})
 			if err != nil {
 				klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 				return err
@@ -323,7 +322,7 @@ func (c *Controller) deleteNegotiatedAPIResource(ctx context.Context, clusterNam
 		}
 
 		toDelete := objs[0].(*apiresourcev1alpha1.NegotiatedAPIResource)
-		err = c.apiresourceClient.NegotiatedAPIResources().Delete(ctx, toDelete.Name, metav1.DeleteOptions{})
+		err = c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().Delete(ctx, toDelete.Name, metav1.DeleteOptions{})
 		if err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
@@ -545,7 +544,7 @@ func (c *Controller) ensureAPIResourceCompatibility(ctx context.Context, cluster
 				return err
 			}
 			apiResourceImport.SetResourceVersion(lastOne.GetResourceVersion())
-			if _, err := c.apiresourceClient.APIResourceImports().UpdateStatus(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
+			if _, err := c.kcpClient.ApiresourceV1alpha1().APIResourceImports().UpdateStatus(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
 				klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 				return err
 			}
@@ -553,9 +552,9 @@ func (c *Controller) ensureAPIResourceCompatibility(ctx context.Context, cluster
 		})
 	}
 	if negotiatedAPIResource == nil {
-		existing, err := c.apiresourceClient.NegotiatedAPIResources().Create(ctx, newNegotiatedAPIResource, metav1.CreateOptions{})
+		existing, err := c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().Create(ctx, newNegotiatedAPIResource, metav1.CreateOptions{})
 		if k8serrors.IsAlreadyExists(err) {
-			existing, err = c.apiresourceClient.NegotiatedAPIResources().Get(ctx, newNegotiatedAPIResource.Name, metav1.GetOptions{})
+			existing, err = c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().Get(ctx, newNegotiatedAPIResource.Name, metav1.GetOptions{})
 		}
 		if err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
@@ -563,14 +562,14 @@ func (c *Controller) ensureAPIResourceCompatibility(ctx context.Context, cluster
 		}
 		if len(newNegotiatedAPIResource.Status.Conditions) > 0 {
 			existing.Status = newNegotiatedAPIResource.Status
-			_, err = c.apiresourceClient.NegotiatedAPIResources().UpdateStatus(ctx, existing, metav1.UpdateOptions{})
+			_, err = c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().UpdateStatus(ctx, existing, metav1.UpdateOptions{})
 			if err != nil {
 				klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 				return err
 			}
 		}
 	} else if updatedNegotiatedSchema {
-		if _, err := c.apiresourceClient.NegotiatedAPIResources().Update(ctx, newNegotiatedAPIResource, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().Update(ctx, newNegotiatedAPIResource, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
 		}
@@ -711,14 +710,14 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 		// Of course here we're simply adding already-known resources of existing physical clusters as CRDs in KCP.
 		// But to please this Kubernetes approval requirement, let's add the required annotation in imported CRDs
 		// with one of the KCP PRs that hacked Kubernetes CRD support for KCP.
-		if apihelpers.IsProtectedCommunityGroup(gvr.Group) {
+		if crdhelpers.IsProtectedCommunityGroup(gvr.Group) {
 			if cr.ObjectMeta.Annotations == nil {
 				cr.ObjectMeta.Annotations = map[string]string{}
 			}
 			cr.ObjectMeta.Annotations["api-approved.kubernetes.io"] = "https://github.com/kcp-dev/kubernetes/pull/4"
 		}
 
-		if _, err := c.crdClient.CustomResourceDefinitions().Create(ctx, cr, metav1.CreateOptions{}); err != nil {
+		if _, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, cr, metav1.CreateOptions{}); err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
 		}
@@ -768,7 +767,7 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 				NegotiatedAPIResourceAsOwnerReference(negotiatedApiResource))
 		}
 
-		if _, err := c.crdClient.CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
 		}
@@ -781,7 +780,7 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 		Type:   apiresourcev1alpha1.Submitted,
 		Status: metav1.ConditionTrue,
 	})
-	if _, err := c.apiresourceClient.NegotiatedAPIResources().UpdateStatus(ctx, negotiatedApiResource, metav1.UpdateOptions{}); err != nil {
+	if _, err := c.kcpClient.ApiresourceV1alpha1().NegotiatedAPIResources().UpdateStatus(ctx, negotiatedApiResource, metav1.UpdateOptions{}); err != nil {
 		klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 		return err
 	}
@@ -804,7 +803,7 @@ func (c *Controller) updateStatusOnRelatedAPIResourceImports(ctx context.Context
 				Type:   apiresourcev1alpha1.Available,
 				Status: publishedCondition.Status,
 			})
-			if _, err := c.apiresourceClient.APIResourceImports().UpdateStatus(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
+			if _, err := c.kcpClient.ApiresourceV1alpha1().APIResourceImports().UpdateStatus(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
 				klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 				return err
 			}
@@ -826,7 +825,7 @@ func (c *Controller) cleanupNegotiatedAPIResource(ctx context.Context, clusterNa
 		apiResourceImport := obj.(*apiresourcev1alpha1.APIResourceImport).DeepCopy()
 		apiResourceImport.RemoveCondition(apiresourcev1alpha1.Available)
 		apiResourceImport.RemoveCondition(apiresourcev1alpha1.Compatible)
-		if _, err := c.apiresourceClient.APIResourceImports().UpdateStatus(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.kcpClient.ApiresourceV1alpha1().APIResourceImports().UpdateStatus(ctx, apiResourceImport, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
 		}
@@ -886,7 +885,7 @@ func (c *Controller) cleanupNegotiatedAPIResource(ctx context.Context, clusterNa
 		return nil
 	}
 	if len(cleanedVersions) == 0 {
-		if err := c.crdClient.CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil {
+		if err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
 		}
@@ -894,7 +893,7 @@ func (c *Controller) cleanupNegotiatedAPIResource(ctx context.Context, clusterNa
 		crd = crd.DeepCopy()
 		crd.Spec.Versions = cleanedVersions
 		crd.OwnerReferences = cleanedOwnerReferences
-		if _, err := c.crdClient.CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.apiExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
 			klog.Errorf("Error in %s: %v", runtime.GetCaller(), err)
 			return err
 		}

--- a/pkg/reconciler/apiresource/negotiation.go
+++ b/pkg/reconciler/apiresource/negotiation.go
@@ -36,8 +36,8 @@ import (
 	"github.com/kcp-dev/kcp/pkg/schemacompat"
 )
 
-func (c *Controller) process(key queueElement) error {
-	ctx := request.WithCluster(context.TODO(), request.Cluster{Name: key.clusterName})
+func (c *Controller) process(ctx context.Context, key queueElement) error {
+	ctx = request.WithCluster(ctx, request.Cluster{Name: key.clusterName})
 
 	switch key.theType {
 	case customResourceDefinitionType:

--- a/pkg/reconciler/cluster/apiimporter.go
+++ b/pkg/reconciler/cluster/apiimporter.go
@@ -67,7 +67,7 @@ func (i *APIImporter) Stop() {
 	}
 	for _, obj := range objs {
 		apiResourceImportToDelete := obj.(*apiresourcev1alpha1.APIResourceImport)
-		err := i.c.apiResourceClient.APIResourceImports().Delete(request.WithCluster(context.Background(), request.Cluster{Name: i.logicalClusterName}), apiResourceImportToDelete.Name, metav1.DeleteOptions{})
+		err := i.c.kcpClient.ApiresourceV1alpha1().APIResourceImports().Delete(request.WithCluster(context.Background(), request.Cluster{Name: i.logicalClusterName}), apiResourceImportToDelete.Name, metav1.DeleteOptions{})
 		if err != nil {
 			klog.Errorf("error deleting APIResourceImport %s: %v", apiResourceImportToDelete.Name, err)
 		}
@@ -105,7 +105,7 @@ func (i *APIImporter) ImportAPIs() {
 				klog.Errorf("Error setting schema: %v", err)
 				continue
 			}
-			if _, err := i.c.apiResourceClient.APIResourceImports().Update(i.context, apiResourceImport, metav1.UpdateOptions{}); err != nil {
+			if _, err := i.c.kcpClient.ApiresourceV1alpha1().APIResourceImports().Update(i.context, apiResourceImport, metav1.UpdateOptions{}); err != nil {
 				klog.Errorf("error updating APIResourceImport %s: %v", apiResourceImport.Name, err)
 				continue
 			}
@@ -175,7 +175,7 @@ func (i *APIImporter) ImportAPIs() {
 				klog.Errorf("Error setting schema: %v", err)
 				continue
 			}
-			if _, err := i.c.apiResourceClient.APIResourceImports().Create(i.context, apiResourceImport, metav1.CreateOptions{}); err != nil {
+			if _, err := i.c.kcpClient.ApiresourceV1alpha1().APIResourceImports().Create(i.context, apiResourceImport, metav1.CreateOptions{}); err != nil {
 				klog.Errorf("error creating APIResourceImport %s: %v", apiResourceImport.Name, err)
 				continue
 			}
@@ -197,7 +197,7 @@ func (i *APIImporter) ImportAPIs() {
 		}
 		if len(objs) == 1 {
 			apiResourceImportToRemove := objs[0].(*apiresourcev1alpha1.APIResourceImport)
-			err := i.c.apiResourceClient.APIResourceImports().Delete(i.context, apiResourceImportToRemove.Name, metav1.DeleteOptions{})
+			err := i.c.kcpClient.ApiresourceV1alpha1().APIResourceImports().Delete(i.context, apiResourceImportToRemove.Name, metav1.DeleteOptions{})
 			if err != nil {
 				klog.Errorf("error deleting APIResourceImport %s: %v", apiResourceImportToRemove.Name, err)
 				continue

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -324,8 +324,8 @@ func (s *Server) Run(ctx context.Context) error {
 			kcpSharedInformerFactory.WaitForCacheSync(context.StopCh)
 			crdSharedInformerFactory.WaitForCacheSync(context.StopCh)
 
-			clusterController.Start(2, context.StopCh)
-			apiresourceController.Start(2, context.StopCh)
+			clusterController.Start(ctx, 2)
+			apiresourceController.Start(ctx, 2)
 
 			return nil
 		}); err != nil {


### PR DESCRIPTION
Simplify etcd Server Run() so it returns the client info instead of taking in a run func.

Replace the runFunc with inline code.

Create clients and shared informer factories higher in the stack so they can be shared by multiple controllers.

Plumb the context's Done channel to as many places as possible.