### PR TITLE
Disable codecov

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,9 +1,0 @@
-ignore:
-- "**/zz_*_generated.go" # Ignore generated files.
-- "hack"
-- "pkg/client" # Ignore generated files.
-
-coverage:
-  status:
-    patch:
-      informational: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,4 +62,3 @@ jobs:
 
     - run: make build
     - run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
-    - uses: codecov/codecov-action@v1


### PR DESCRIPTION
![sillyplace](https://user-images.githubusercontent.com/210737/140982654-72f63784-6fb5-4660-8fd6-d8a3827d87ab.gif)

We can reenable it later if we think being constantly reminded of coverage is a benefit.