### PR TITLE
Use the correct ctx for MemberList

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -150,7 +150,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 	defer c.Close()
-	r, err := c.Cluster.MemberList(context.Background())
+	r, err := c.Cluster.MemberList(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use the passed in ctx for MemberList instead of context.Background() so
the MemberList call respects when the ctx is done (e.g. via ctrl-c).

Signed-off-by: Andy Goldstein <andy.goldstein@redhat.com>