### PR TITLE
Pin controller-gen to v0.7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,8 +68,8 @@ jobs:
         go-version: v1.16
     - name: Download modules
       run: go mod download
-    - name: Check generated clients
-      run: hack/verify-codegen-clients.sh
+    - name: Check codegen
+      run: make verify-codegen
     - run: make build
     - run: make WHAT=test/e2e/e2e.test
       working-directory: ./kubernetes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,12 +57,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
-      with:
-        repository: kcp-dev/kubernetes
-        ref: feature-logical-clusters-1.22
-        path: kubernetes
-        fetch-depth: 1
     - uses: actions/setup-go@v2
       with:
         go-version: v1.16
@@ -71,6 +65,16 @@ jobs:
     - name: Check codegen
       run: make verify-codegen
     - run: make build
+    # Because verify-codegen updates imports under the covers, and it affects
+    # everything in the working directory, we have to check out kubernetes
+    # after verifying codegen; otherwise, kubernetes code will get modified,
+    # and we'll get compiler errors trying to compile e2e.test.
+    - uses: actions/checkout@v2
+      with:
+        repository: kcp-dev/kubernetes
+        ref: feature-logical-clusters-1.22
+        path: kubernetes
+        fetch-depth: 1
     - run: make WHAT=test/e2e/e2e.test
       working-directory: ./kubernetes
     - run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ contrib/demo/clusters/kind/*.yaml
 contrib/demo/clusters/kind/*.kubeconfig
 *.log
 coverage.*
+tools

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,13 @@
+GO_INSTALL = ./hack/go-install.sh
+
+TOOLS_DIR=hack/tools
+GOBIN_DIR := $(abspath $(TOOLS_DIR))
+
+CONTROLLER_GEN_VER := v0.7.0
+CONTROLLER_GEN_BIN := controller-gen
+CONTROLLER_GEN := $(TOOLS_DIR)/$(CONTROLLER_GEN_BIN)-$(CONTROLLER_GEN_VER)
+export CONTROLLER_GEN # so hack scripts can use it
+
 all: build
 .PHONY: all
 
@@ -10,9 +20,22 @@ vendor:
 	go mod vendor
 .PHONY: vendor
 
-codegen:
+$(CONTROLLER_GEN):
+	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-tools/cmd/controller-gen $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)
+
+codegen: $(CONTROLLER_GEN)
 	./hack/update-codegen.sh
+	$(MAKE) imports
 .PHONY: codegen
+
+# Note, running this locally if you have any modified files, even those that are not generated,
+# will result in an error. This target is mostly for CI jobs.
+.PHONY: verify-codegen
+verify-codegen: codegen
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "You need to run 'make codegen' to update generated files and commit them"; exit 1; \
+	fi
 
 .PHONY: imports
 imports:

--- a/config/apiresource.kcp.dev_apiresourceimports.yaml
+++ b/config/apiresource.kcp.dev_apiresourceimports.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: apiresourceimports.apiresource.kcp.dev
 spec:
@@ -46,21 +46,30 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: APIResourceImport describes an API resource imported from external clusters (either physical or logical) for a given GVR.
+        description: APIResourceImport describes an API resource imported from external
+          clusters (either physical or logical) for a given GVR.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: APIResourceImportSpec holds the desired state of the APIResourceImport (from the client).
+            description: APIResourceImportSpec holds the desired state of the APIResourceImport
+              (from the client).
             properties:
               categories:
-                description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                description: categories is a list of grouped resources this custom
+                  resource belongs to (e.g. 'all'). This is published in API discovery
+                  documents, and used by clients to support invocations like `kubectl
+                  get all`.
                 items:
                   type: string
                 type: array
@@ -68,10 +77,17 @@ spec:
                 items:
                   properties:
                     description:
-                      description: description is a human readable description of this column.
+                      description: description is a human readable description of
+                        this column.
                       type: string
                     format:
-                      description: format is an optional OpenAPI type modifier for this column. A format modifies the type and imposes additional rules, like date or time formatting for a string. The 'name' format is applied to the primary identifier column which has type 'string' to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                      description: format is an optional OpenAPI type modifier for
+                        this column. A format modifies the type and imposes additional
+                        rules, like date or time formatting for a string. The 'name'
+                        format is applied to the primary identifier column which has
+                        type 'string' to assist in clients identifying column is the
+                        resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                        for more.
                       type: string
                     jsonPath:
                       type: string
@@ -79,11 +95,16 @@ spec:
                       description: name is a human readable name for the column.
                       type: string
                     priority:
-                      description: priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a higher priority.
+                      description: priority is an integer defining the relative importance
+                        of this column compared to others. Lower numbers are considered
+                        higher priority. Columns that may be omitted in limited space
+                        scenarios should be given a higher priority.
                       format: int32
                       type: integer
                     type:
-                      description: type is an OpenAPI type definition for this column, such as number, integer, string, or array. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                      description: type is an OpenAPI type definition for this column,
+                        such as number, integer, string, or array. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                        for more.
                       type: string
                   required:
                   - description
@@ -104,33 +125,45 @@ spec:
                 - version
                 type: object
               kind:
-                description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                description: kind is the serialized kind of the resource. It is normally
+                  CamelCase and singular. Custom resource instances will use this
+                  value as the `kind` attribute in API calls.
                 type: string
               listKind:
-                description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                description: listKind is the serialized kind of the list for this
+                  resource. Defaults to "`kind`List".
                 type: string
               location:
-                description: Locaton the API resource is imported from This field is required
+                description: Locaton the API resource is imported from This field
+                  is required
                 type: string
               openAPIV3Schema:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               plural:
-                description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                description: plural is the plural name of the resource to serve. The
+                  custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                  Must match the name of the CustomResourceDefinition (in the form
+                  `<names.plural>.<group>`). Must be all lowercase.
                 type: string
               schemaUpdateStrategy:
-                description: SchemaUpdateStrategy defines the schema update strategy for this API Resource import. Default value is UpdateUnpublished
+                description: SchemaUpdateStrategy defines the schema update strategy
+                  for this API Resource import. Default value is UpdateUnpublished
                 type: string
               scope:
-                description: ResourceScope is an enum defining the different scopes available to a custom resource
+                description: ResourceScope is an enum defining the different scopes
+                  available to a custom resource
                 type: string
               shortNames:
-                description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                description: shortNames are short names for the resource, exposed
+                  in API discovery documents, and used by clients to support invocations
+                  like `kubectl get <shortname>`. It must be all lowercase.
                 items:
                   type: string
                 type: array
               singular:
-                description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                description: singular is the singular name of the resource. It must
+                  be all lowercase. Defaults to lowercased `kind`.
                 type: string
               subResources:
                 items:
@@ -150,27 +183,34 @@ spec:
             - scope
             type: object
           status:
-            description: APIResourceImportStatus communicates the observed state of the APIResourceImport (from the controller).
+            description: APIResourceImportStatus communicates the observed state of
+              the APIResourceImport (from the controller).
             properties:
               conditions:
                 items:
-                  description: APIResourceImportCondition contains details for the current condition of this negotiated api resource.
+                  description: APIResourceImportCondition contains details for the
+                    current condition of this negotiated api resource.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
+                      description: Status is the status of the condition. Can be True,
+                        False, Unknown.
                       type: string
                     type:
-                      description: Type is the type of the condition. Types include Compatible.
+                      description: Type is the type of the condition. Types include
+                        Compatible.
                       type: string
                   required:
                   - status

--- a/config/apiresource.kcp.dev_negotiatedapiresources.yaml
+++ b/config/apiresource.kcp.dev_negotiatedapiresources.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: negotiatedapiresources.apiresource.kcp.dev
 spec:
@@ -42,21 +42,32 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: NegotiatedAPIResource describes the result of either the normalization of any number of imports of an API resource from external clusters (either physical or logical), or the the manual application of a CRD version for the corresponding GVR.
+        description: NegotiatedAPIResource describes the result of either the normalization
+          of any number of imports of an API resource from external clusters (either
+          physical or logical), or the the manual application of a CRD version for
+          the corresponding GVR.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: NegotiatedAPIResourceSpec holds the desired state of the NegotiatedAPIResource (from the client).
+            description: NegotiatedAPIResourceSpec holds the desired state of the
+              NegotiatedAPIResource (from the client).
             properties:
               categories:
-                description: categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+                description: categories is a list of grouped resources this custom
+                  resource belongs to (e.g. 'all'). This is published in API discovery
+                  documents, and used by clients to support invocations like `kubectl
+                  get all`.
                 items:
                   type: string
                 type: array
@@ -64,10 +75,17 @@ spec:
                 items:
                   properties:
                     description:
-                      description: description is a human readable description of this column.
+                      description: description is a human readable description of
+                        this column.
                       type: string
                     format:
-                      description: format is an optional OpenAPI type modifier for this column. A format modifies the type and imposes additional rules, like date or time formatting for a string. The 'name' format is applied to the primary identifier column which has type 'string' to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                      description: format is an optional OpenAPI type modifier for
+                        this column. A format modifies the type and imposes additional
+                        rules, like date or time formatting for a string. The 'name'
+                        format is applied to the primary identifier column which has
+                        type 'string' to assist in clients identifying column is the
+                        resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                        for more.
                       type: string
                     jsonPath:
                       type: string
@@ -75,11 +93,16 @@ spec:
                       description: name is a human readable name for the column.
                       type: string
                     priority:
-                      description: priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a higher priority.
+                      description: priority is an integer defining the relative importance
+                        of this column compared to others. Lower numbers are considered
+                        higher priority. Columns that may be omitted in limited space
+                        scenarios should be given a higher priority.
                       format: int32
                       type: integer
                     type:
-                      description: type is an OpenAPI type definition for this column, such as number, integer, string, or array. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.
+                      description: type is an OpenAPI type definition for this column,
+                        such as number, integer, string, or array. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+                        for more.
                       type: string
                   required:
                   - description
@@ -100,29 +123,39 @@ spec:
                 - version
                 type: object
               kind:
-                description: kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+                description: kind is the serialized kind of the resource. It is normally
+                  CamelCase and singular. Custom resource instances will use this
+                  value as the `kind` attribute in API calls.
                 type: string
               listKind:
-                description: listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+                description: listKind is the serialized kind of the list for this
+                  resource. Defaults to "`kind`List".
                 type: string
               openAPIV3Schema:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               plural:
-                description: plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+                description: plural is the plural name of the resource to serve. The
+                  custom resources are served under `/apis/<group>/<version>/.../<plural>`.
+                  Must match the name of the CustomResourceDefinition (in the form
+                  `<names.plural>.<group>`). Must be all lowercase.
                 type: string
               publish:
                 type: boolean
               scope:
-                description: ResourceScope is an enum defining the different scopes available to a custom resource
+                description: ResourceScope is an enum defining the different scopes
+                  available to a custom resource
                 type: string
               shortNames:
-                description: shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+                description: shortNames are short names for the resource, exposed
+                  in API discovery documents, and used by clients to support invocations
+                  like `kubectl get <shortname>`. It must be all lowercase.
                 items:
                   type: string
                 type: array
               singular:
-                description: singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+                description: singular is the singular name of the resource. It must
+                  be all lowercase. Defaults to lowercased `kind`.
                 type: string
               subResources:
                 items:
@@ -141,27 +174,34 @@ spec:
             - scope
             type: object
           status:
-            description: NegotiatedAPIResourceStatus communicates the observed state of the NegotiatedAPIResource (from the controller).
+            description: NegotiatedAPIResourceStatus communicates the observed state
+              of the NegotiatedAPIResource (from the controller).
             properties:
               conditions:
                 items:
-                  description: NegotiatedAPIResourceCondition contains details for the current condition of this negotiated api resource.
+                  description: NegotiatedAPIResourceCondition contains details for
+                    the current condition of this negotiated api resource.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
+                      description: Last time the condition transitioned from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: Human-readable message indicating details about last transition.
+                      description: Human-readable message indicating details about
+                        last transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
-                      description: Status is the status of the condition. Can be True, False, Unknown.
+                      description: Status is the status of the condition. Can be True,
+                        False, Unknown.
                       type: string
                     type:
-                      description: Type is the type of the condition. Types include Submitted, Published, Refused and Enforced.
+                      description: Type is the type of the condition. Types include
+                        Submitted, Published, Refused and Enforced.
                       type: string
                   required:
                   - status

--- a/config/cluster.example.dev_clusters.yaml
+++ b/config/cluster.example.dev_clusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: clusters.cluster.example.dev
 spec:
@@ -36,10 +36,14 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -59,11 +63,15 @@ spec:
                   description: 'TODO: Use metav1.Condition (available in v1.19+)'
                   properties:
                     lastTransitionTime:
-                      description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
                       description: The reason for the condition's last transition.

--- a/config/tenancy.kcp.dev_workspaces.yaml
+++ b/config/tenancy.kcp.dev_workspaces.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: workspaces.tenancy.kcp.dev
 spec:
@@ -24,10 +24,14 @@ spec:
         description: Workspace describes how clients access (kubelike) APIs
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -41,7 +45,8 @@ spec:
                 minLength: 1
                 type: string
               targetShard:
-                description: Name of the WorkspaceShard this Workspace should move to.
+                description: Name of the WorkspaceShard this Workspace should move
+                  to.
                 type: string
             required:
             - shard
@@ -50,21 +55,29 @@ spec:
             description: WorkspaceStatus communicates the observed state of the Workspace.
             properties:
               baseURL:
-                description: 'Base URL where this Workspace can be targeted. This will generally be of the form: https://<workspace shard server>/cluster/<workspace name>. But a workspace could also be targetable by a unique hostname in the future.'
+                description: 'Base URL where this Workspace can be targeted. This
+                  will generally be of the form: https://<workspace shard server>/cluster/<workspace
+                  name>. But a workspace could also be targetable by a unique hostname
+                  in the future.'
                 type: string
               phase:
                 description: Phase of the workspace  (Initializing / Active / Terminating)
                 type: string
               shards:
-                description: List of shards related to this workspace. The first shard in this list with LiveAfterResourceVersion is set is the active shard
+                description: List of shards related to this workspace. The first shard
+                  in this list with LiveAfterResourceVersion is set is the active
+                  shard
                 items:
-                  description: ShardStatus contains details for the current status of a workspace shard.
+                  description: ShardStatus contains details for the current status
+                    of a workspace shard.
                   properties:
                     liveAfterResourceVersion:
-                      description: Resource version after which writes can be accepted on this shard.
+                      description: Resource version after which writes can be accepted
+                        on this shard.
                       type: string
                     liveBeforeResourceVersion:
-                      description: Resource version at which writes to this shard should not be accepted.
+                      description: Resource version at which writes to this shard
+                        should not be accepted.
                       type: string
                     name:
                       description: Name of an active WorkspaceShard.

--- a/config/tenancy.kcp.dev_workspaceshards.yaml
+++ b/config/tenancy.kcp.dev_workspaceshards.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: workspaceshards.tenancy.kcp.dev
 spec:
@@ -21,13 +21,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WorkspaceShard describes a Shard (== KCP instance) on which a number of workspaces will live
+        description: WorkspaceShard describes a Shard (== KCP instance) on which a
+          number of workspaces will live
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -35,7 +40,8 @@ spec:
             description: WorkspaceShardSpec holds the desired state of the WorkspaceShard.
             type: object
           status:
-            description: WorkspaceShardStatus communicates the observed state of the WorkspaceShard.
+            description: WorkspaceShardStatus communicates the observed state of the
+              WorkspaceShard.
             properties:
               capacity:
                 additionalProperties:
@@ -44,7 +50,8 @@ spec:
                   - type: string
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
-                description: Set of integer resources that workspaces can be scheduled into
+                description: Set of integer resources that workspaces can be scheduled
+                  into
                 type: object
             type: object
         type: object

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
-	k8s.io/code-generator v0.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	k8s.io/kubernetes v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -392,7 +392,6 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-202111181
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:S4VzMEga23uK7wdtJ7kpdYChDEwtcWiJF90jKDJ4IU0=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20211118181850-ab2ca04a5894 h1:xVqW3aFvSlaouRolUCxdT4+oY4dYdTmwbbTbSBS6a/0=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:ppZJmhTukDTa5g/F0ksVMLM0Owbi9GeKhzuTXAVVJig=
-github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20211118181850-ab2ca04a5894 h1:yeSbsh+jkdUrJvmoIsogK+4AVh7eDwi27Kn+wJm/e9c=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:sUUmwtmwhRVMXuCc1xDCW0VAqgY6LwabgtXcWxMBL8Y=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20211118181850-ab2ca04a5894 h1:F/rRn/NR5jBJStieXBfmTuzu9Uxdl65D7ERDwhvnYZY=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:o9dIqwQ1nmWNusj8M3G0ftwE9y/7wLG1UuOB+6oIZLQ=
@@ -1070,7 +1069,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Originally copied from
+# https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/c26a68b23e9317323d5d37660fe9d29b3d2ff40c/scripts/go_install.sh
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${1}" ]; then
+  echo "must provide module as first parameter"
+  exit 1
+fi
+
+if [ -z "${2}" ]; then
+  echo "must provide binary name as second parameter"
+  exit 1
+fi
+
+if [ -z "${3}" ]; then
+  echo "must provide version as third parameter"
+  exit 1
+fi
+
+if [ -z "${GOBIN}" ]; then
+  echo "GOBIN is not set. Must set GOBIN to install the bin in a specified directory."
+  exit 1
+fi
+
+mkdir -p "${GOBIN}"
+
+tmp_dir=$(mktemp -d -t goinstall_XXXXXXXXXX)
+function clean {
+  rm -rf "${tmp_dir}"
+}
+trap clean EXIT
+
+rm "${GOBIN}/${2}"* > /dev/null 2>&1 || true
+
+cd "${tmp_dir}"
+
+# create a new module in the tmp directory
+go mod init fake/mod
+
+# install the golang module specified as the first argument
+go get -tags tools "${1}@${3}"
+mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
+ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -22,6 +22,4 @@ package tools
 // This package imports things required by this repository, to force `go mod` to see them as dependencies
 import (
 	_ "github.com/coreydaley/openshift-goimports"
-
-	_ "k8s.io/code-generator"
 )

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -4,22 +4,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GOPATH=$(go env GOPATH)
-if [[ -x "${GOPATH}/bin/controller-gen" ]]
-then
-    version=$(${GOPATH}/bin/controller-gen --version | sed -e 's/Version: v0\.\(5\)\../\1/')
-    if [[ $version -lt 5 ]]
-    then
-        echo "You should use at least version 0.5.0 of controller-gen"
-        exit 1
-    fi
-else
-    echo "Installing 'controller-gen'"
-    go get sigs.k8s.io/controller-tools/cmd/controller-gen
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen
+if [[ -z "${MAKELEVEL:-}" ]]; then
+    echo 'You must invoke this script via make'
+    exit 1
 fi
 
-"$( dirname "${BASH_SOURCE[0]}")/update-codegen-clients.sh"
+"$(dirname "${BASH_SOURCE[0]}")/update-codegen-clients.sh"
 
 # Update generated CRD YAML
-${GOPATH}/bin/controller-gen crd:preserveUnknownFields=false rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/
+${CONTROLLER_GEN} \
+    crd \
+    rbac:roleName=manager-role \
+    webhook \
+    paths="./..." \
+    output:crd:artifacts:config=config/


### PR DESCRIPTION
- Now installing controller-gen in a consistent location for everyone hacking on this project - thanks to the Cluster API folks for the install script!
- Pinned controller-gen to v0.7.0
- Remove code-generator from hack/tools.go so it's not listed in our project's go.mod any more
- hack/update-codegen.sh now must be invoked via `make` (it errors if not)
- Fixed codegen script to work with controller-gen v0.7.0
- Regenerated CRDs using updated controller-gen version