### PR TITLE
Start controllers in its goroutines

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -106,8 +106,8 @@ func main() {
 	crdSharedInformerFactory.Start(ctx.Done())
 	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
 
-	clusterController.Start(ctx, numThreads)
-	apiresourceController.Start(ctx, 2)
+	go clusterController.Start(ctx, numThreads)
+	go apiresourceController.Start(ctx, numThreads)
 
 	<-ctx.Done()
 }


### PR DESCRIPTION
When try to start `cluster-controller` by calling
```
go run ./cmd/cluster-controller \
    --syncer_image=$(ko publish ./cmd/syncer) \
    --kubeconfig=.kcp/admin.kubeconfig
```

It's not work, since the `apiresourceController` is not started...