### PR TITLE
Add code-generator to tools.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
+	k8s.io/code-generator v0.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	k8s.io/kubernetes v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,7 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-202111181
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cloud-provider v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:S4VzMEga23uK7wdtJ7kpdYChDEwtcWiJF90jKDJ4IU0=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20211118181850-ab2ca04a5894 h1:xVqW3aFvSlaouRolUCxdT4+oY4dYdTmwbbTbSBS6a/0=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cluster-bootstrap v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:ppZJmhTukDTa5g/F0ksVMLM0Owbi9GeKhzuTXAVVJig=
+github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20211118181850-ab2ca04a5894 h1:yeSbsh+jkdUrJvmoIsogK+4AVh7eDwi27Kn+wJm/e9c=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/code-generator v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:sUUmwtmwhRVMXuCc1xDCW0VAqgY6LwabgtXcWxMBL8Y=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20211118181850-ab2ca04a5894 h1:F/rRn/NR5jBJStieXBfmTuzu9Uxdl65D7ERDwhvnYZY=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20211118181850-ab2ca04a5894/go.mod h1:o9dIqwQ1nmWNusj8M3G0ftwE9y/7wLG1UuOB+6oIZLQ=
@@ -1069,6 +1070,7 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027 h1:Uusb3oh8XcdzDF/ndlI4ToKTYVlkCSJP39SRY2mfRAw=
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -22,4 +22,9 @@ package tools
 // This package imports things required by this repository, to force `go mod` to see them as dependencies
 import (
 	_ "github.com/coreydaley/openshift-goimports"
+
+	_ "k8s.io/code-generator/cmd/client-gen"
+	_ "k8s.io/code-generator/cmd/deepcopy-gen"
+	_ "k8s.io/code-generator/cmd/informer-gen"
+	_ "k8s.io/code-generator/cmd/lister-gen"
 )


### PR DESCRIPTION
Add the generators from code-generator to tools.go so the 'go list'
command in hack/update-codegent-client.sh can find k8s.io/code-generator
correctly.

(The additional gengo line in go.sum comes from running `go mod tidy` 🤷)