### PR TITLE
DRY out server startup

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -2,112 +2,78 @@ package main
 
 import (
 	"context"
-	"flag"
+	"errors"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/spf13/pflag"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/genericcontrolplane/clientutils"
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
 )
 
-const numThreads = 2
 const resyncPeriod = 10 * time.Hour
 
-var (
-	kubeconfigPath  = flag.String("kubeconfig", "", "Path to kubeconfig")
-	syncerImage     = flag.String("syncer_image", "", "Syncer image to install on clusters")
-	pullMode        = flag.Bool("pull_mode", true, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
-	pushMode        = flag.Bool("push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
-	autoPublishAPIs = flag.Bool("auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
-)
+func bindOptions(fs *pflag.FlagSet) *options {
+	o := options{
+		Options: cluster.BindOptions(fs),
+	}
+	fs.StringVar(&o.kubeconfigPath, "kubeconfig", "", "Path to kubeconfig")
+	return &o
+}
+
+type options struct {
+	// in the all-in-one startup, client credentials already exist; in this
+	// standalone startup, we need to load credentials ourselves
+	kubeconfigPath string
+	*cluster.Options
+}
+
+func (o *options) Validate() error {
+	if o.kubeconfigPath == "" {
+		return errors.New("--kubeconfig is required")
+	}
+	return o.Options.Validate()
+}
 
 func main() {
 	// Setup signal handler for a cleaner shutdown
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
 	defer cancel()
 
-	flag.Parse()
+	fs := pflag.NewFlagSet("cluster-controller", pflag.ExitOnError)
+	options := bindOptions(fs)
+	if err := fs.Parse(fs.Args()[1:]); err != nil {
+		klog.Fatal(err)
+	}
+	if err := options.Validate(); err != nil {
+		klog.Fatal(err)
+	}
 
 	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: *kubeconfigPath},
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.kubeconfigPath},
 		&clientcmd.ConfigOverrides{})
 
 	r, err := configLoader.ClientConfig()
 	if err != nil {
 		klog.Fatal(err)
 	}
-	clientutils.EnableMultiCluster(r, nil, true, "clusters", "customresourcedefinitions", "apiresourceimports", "negotiatedapiresources")
 	kubeconfig, err := configLoader.RawConfig()
 	if err != nil {
 		klog.Fatal(err)
 	}
-
-	resourcesToSync := flag.Args()
-	if len(resourcesToSync) == 0 {
-		resourcesToSync = []string{"deployments.apps"}
-	}
-	klog.Infof("Syncing resources: %v", resourcesToSync)
-
-	if *pullMode && *pushMode {
-		klog.Fatal("can't set --push_mode and --pull_mode")
-	}
-	syncerMode := cluster.SyncerModeNone
-	if *pullMode {
-		syncerMode = cluster.SyncerModePull
-	}
-	if *pushMode {
-		syncerMode = cluster.SyncerModePush
-	}
-
 	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(kcpclient.NewForConfigOrDie(r), resyncPeriod)
 	crdSharedInformerFactory := crdexternalversions.NewSharedInformerFactoryWithOptions(apiextensionsclient.NewForConfigOrDie(r), resyncPeriod)
-
-	apiExtensionsClient := apiextensionsclient.NewForConfigOrDie(r)
-	kcpClient := kcpclient.NewForConfigOrDie(r)
-
-	clusterController, err := cluster.NewController(
-		apiExtensionsClient,
-		kcpClient,
-		kcpSharedInformerFactory.Cluster().V1alpha1().Clusters(),
-		kcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
-		*syncerImage,
-		kubeconfig,
-		resourcesToSync,
-		syncerMode,
-	)
-	if err != nil {
+	if err := options.Options.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory).Start(ctx); err != nil {
 		klog.Fatal(err)
 	}
-
-	apiresourceController, err := apiresource.NewController(
-		apiExtensionsClient,
-		kcpClient,
-		*autoPublishAPIs,
-		kcpSharedInformerFactory.Apiresource().V1alpha1().NegotiatedAPIResources(),
-		kcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
-		crdSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
-	)
-	if err != nil {
-		klog.Fatal(err)
-	}
-
-	kcpSharedInformerFactory.Start(ctx.Done())
-	kcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
-
-	crdSharedInformerFactory.Start(ctx.Done())
-	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
-
-	go clusterController.Start(ctx, numThreads)
-	go apiresourceController.Start(ctx, numThreads)
 
 	<-ctx.Done()
 }

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -53,7 +53,7 @@ func main() {
 			return srv.Run(ctx)
 		},
 	}
-	cfg = server.BindOptions(startCmd.Flags())
+	cfg = server.BindOptions(server.DefaultConfig(), startCmd.Flags())
 	cmd.AddCommand(startCmd)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -33,6 +33,7 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	var cfg *server.Config
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the control plane process",
@@ -46,16 +47,13 @@ func main() {
 			used to access the control plane.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			//flag.CommandLine.Lookup("v").Value.Set("9")
-
-			// Setup signal handler for a cleaner shutdown
 			ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
 			defer cancel()
-			srv := server.NewServer(server.ConfigFromFlags(cmd.Flags()))
+			srv := server.NewServer(cfg)
 			return srv.Run(ctx)
 		},
 	}
-	server.AddConfigFlags(startCmd.Flags())
+	cfg = server.BindOptions(startCmd.Flags())
 	cmd.AddCommand(startCmd)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/pkg/reconciler/cluster/startup.go
+++ b/pkg/reconciler/cluster/startup.go
@@ -23,16 +23,27 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
 )
 
+// DefaultOptions are the default options for the cluster controller.
+func DefaultOptions() *Options {
+	return &Options{
+		SyncerImage:     "",
+		PullMode:        false,
+		PushMode:        false,
+		AutoPublishAPIs: false,
+		NumThreads:      runtime.NumCPU(),
+		ResourcesToSync: []string{"deployments.apps"},
+	}
+}
+
 // BindOptions binds the cluster controller options to the flag set.
-func BindOptions(fs *pflag.FlagSet) *Options {
-	o := Options{}
-	fs.StringVar(&o.SyncerImage, "syncer_image", "", "Syncer image to install on clusters")
-	fs.BoolVar(&o.PullMode, "pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
-	fs.BoolVar(&o.PushMode, "push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
-	fs.BoolVar(&o.AutoPublishAPIs, "auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
-	fs.IntVar(&o.NumThreads, "cluster_controller_threads", runtime.NumCPU(), "Number of threads to use for the cluster controller.")
-	fs.StringSliceVar(&o.ResourcesToSync, "resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
-	return &o
+func BindOptions(o *Options, fs *pflag.FlagSet) *Options {
+	fs.StringVar(&o.SyncerImage, "syncer_image", o.SyncerImage, "Syncer image to install on clusters")
+	fs.BoolVar(&o.PullMode, "pull_mode", o.PullMode, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
+	fs.BoolVar(&o.PushMode, "push_mode", o.PushMode, "If true, run syncer for each cluster from inside cluster controller")
+	fs.BoolVar(&o.AutoPublishAPIs, "auto_publish_apis", o.AutoPublishAPIs, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
+	fs.IntVar(&o.NumThreads, "cluster_controller_threads", o.NumThreads, "Number of threads to use for the cluster controller.")
+	fs.StringSliceVar(&o.ResourcesToSync, "resources_to_sync", o.ResourcesToSync, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
+	return o
 }
 
 // Options are the options for the cluster controller

--- a/pkg/reconciler/cluster/startup.go
+++ b/pkg/reconciler/cluster/startup.go
@@ -1,0 +1,138 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"runtime"
+
+	"github.com/spf13/pflag"
+
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/kubernetes/pkg/genericcontrolplane/clientutils"
+
+	"github.com/kcp-dev/kcp/config"
+	apiresourceapi "github.com/kcp-dev/kcp/pkg/apis/apiresource"
+	clusterapi "github.com/kcp-dev/kcp/pkg/apis/cluster"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
+)
+
+// BindOptions binds the cluster controller options to the flag set.
+func BindOptions(fs *pflag.FlagSet) *Options {
+	o := Options{}
+	fs.StringVar(&o.SyncerImage, "syncer_image", "", "Syncer image to install on clusters")
+	fs.BoolVar(&o.PullMode, "pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
+	fs.BoolVar(&o.PushMode, "push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
+	fs.BoolVar(&o.AutoPublishAPIs, "auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
+	fs.IntVar(&o.NumThreads, "cluster_controller_threads", runtime.NumCPU(), "Number of threads to use for the cluster controller.")
+	fs.StringSliceVar(&o.ResourcesToSync, "resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
+	return &o
+}
+
+// Options are the options for the cluster controller
+type Options struct {
+	SyncerImage     string
+	PullMode        bool
+	PushMode        bool
+	AutoPublishAPIs bool
+	NumThreads      int
+	ResourcesToSync []string
+}
+
+func (o *Options) Validate() error {
+	if o.PullMode && o.PushMode {
+		return errors.New("can't set both --push_mode and --pull_mode")
+	}
+	return nil
+}
+
+func (o *Options) Complete(kubeconfig clientcmdapi.Config, kcpSharedInformerFactory kcpexternalversions.SharedInformerFactory, crdSharedInformerFactory crdexternalversions.SharedInformerFactory) *Config {
+	return &Config{
+		Options:                  o,
+		kubeconfig:               kubeconfig,
+		kcpSharedInformerFactory: kcpSharedInformerFactory,
+		crdSharedInformerFactory: crdSharedInformerFactory,
+	}
+}
+
+type Config struct {
+	*Options
+	kubeconfig               clientcmdapi.Config
+	kcpSharedInformerFactory kcpexternalversions.SharedInformerFactory
+	crdSharedInformerFactory crdexternalversions.SharedInformerFactory
+}
+
+func (c *Config) Start(ctx context.Context) error {
+	// Register CRDs in both the admin and user logical clusters
+	requiredCrds := []metav1.GroupKind{
+		{Group: apiresourceapi.GroupName, Kind: "apiresourceimports"},
+		{Group: apiresourceapi.GroupName, Kind: "negotiatedapiresources"},
+		{Group: clusterapi.GroupName, Kind: "clusters"},
+	}
+	for _, contextName := range []string{"admin", "user"} {
+		logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(c.kubeconfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+		if err != nil {
+			return err
+		}
+		crdClient := apiextensionsv1client.NewForConfigOrDie(logicalClusterConfig).CustomResourceDefinitions()
+		if err := config.BootstrapCustomResourceDefinitions(ctx, crdClient, requiredCrds); err != nil {
+			return err
+		}
+	}
+
+	syncerMode := SyncerModeNone
+	if c.PullMode {
+		syncerMode = SyncerModePull
+	}
+	if c.PushMode {
+		syncerMode = SyncerModePush
+	}
+
+	adminConfig, err := clientcmd.NewNonInteractiveClientConfig(c.kubeconfig, "admin", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+	if err != nil {
+		return err
+	}
+	clientutils.EnableMultiCluster(adminConfig, nil, true, "clusters", "customresourcedefinitions", "apiresourceimports", "negotiatedapiresources")
+
+	apiExtensionsClient := apiextensionsclient.NewForConfigOrDie(adminConfig)
+	kcpClient := kcpclient.NewForConfigOrDie(adminConfig)
+
+	clusterController, err := NewController(
+		apiExtensionsClient,
+		kcpClient,
+		c.kcpSharedInformerFactory.Cluster().V1alpha1().Clusters(),
+		c.kcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
+		c.SyncerImage,
+		c.kubeconfig,
+		c.ResourcesToSync,
+		syncerMode,
+	)
+	if err != nil {
+		return err
+	}
+
+	apiresourceController, err := apiresource.NewController(
+		apiExtensionsClient,
+		kcpClient,
+		c.AutoPublishAPIs,
+		c.kcpSharedInformerFactory.Apiresource().V1alpha1().NegotiatedAPIResources(),
+		c.kcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
+		c.crdSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+	)
+	if err != nil {
+		return err
+	}
+
+	c.kcpSharedInformerFactory.Start(ctx.Done())
+	c.crdSharedInformerFactory.Start(ctx.Done())
+	go clusterController.Start(ctx, c.NumThreads)
+	go apiresourceController.Start(ctx, c.NumThreads)
+
+	return nil
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -29,133 +29,29 @@ type Config struct {
 	EnableSharding             bool
 }
 
-// DefaultConfig returns a configuration with default values.
-func DefaultConfig() *Config {
-	return &Config{
-		AutoPublishAPIs:          false,
-		EtcdClientInfo:           etcd.ClientInfo{},
-		EtcdDirectory:            "data",
-		EtcdPeerPort:             "2380",
-		EtcdClientPort:           "2379",
-		InstallClusterController: false,
-		KubeConfigPath:           "admin.kubeconfig",
-		Listen:                   ":6443",
-		PullMode:                 false,
-		PushMode:                 false,
-		ResourcesToSync:          []string{"deployments.apps"},
-		RootDirectory:            ".kcp",
-		SyncerImage:              "quay.io/kcp-dev/kcp-syncer",
-	}
-}
+func BindOptions(fs *pflag.FlagSet) *Config {
+	c := Config{EtcdClientInfo: etcd.ClientInfo{}}
 
-// ConfigFromFlags returns a default configuration with config values set from the provided flag set
-func ConfigFromFlags(flags *pflag.FlagSet) *Config {
-	cfg := DefaultConfig()
-	listen, err := flags.GetString("listen")
-	if err == nil {
-		cfg.Listen = listen
-	}
-	syncerImage, err := flags.GetString("syncer_image")
-	if err == nil {
-		cfg.SyncerImage = syncerImage
-	}
-	resourcesToSync, err := flags.GetStringSlice("resources_to_sync")
-	if err == nil {
-		cfg.ResourcesToSync = resourcesToSync
-	}
-	installClusterController, err := flags.GetBool("install_cluster_controller")
-	if err == nil {
-		cfg.InstallClusterController = installClusterController
-	}
-	installWorkspaceController, err := flags.GetBool("install_workspace_controller")
-	if err == nil {
-		cfg.InstallWorkspaceController = installWorkspaceController
-	}
-	pullMode, err := flags.GetBool("pull_mode")
-	if err == nil {
-		cfg.PullMode = pullMode
-	}
-	pushMode, err := flags.GetBool("push_mode")
-	if err == nil {
-		cfg.PushMode = pushMode
-	}
-	autoPublishAPIs, err := flags.GetBool("auto_publish_apis")
-	if err == nil {
-		cfg.AutoPublishAPIs = autoPublishAPIs
-	}
-	etcdServers, err := flags.GetStringSlice("etcd-servers")
-	if err == nil {
-		cfg.EtcdClientInfo.Endpoints = etcdServers
-	}
-	etcdKeyFile, err := flags.GetString("etcd-keyfile")
-	if err == nil {
-		cfg.EtcdClientInfo.KeyFile = etcdKeyFile
-	}
-	etcdCertFile, err := flags.GetString("etcd-certfile")
-	if err == nil {
-		cfg.EtcdClientInfo.CertFile = etcdCertFile
-	}
-	etcdTrustedCAFile, err := flags.GetString("etcd-cafile")
-	if err == nil {
-		cfg.EtcdClientInfo.TrustedCAFile = etcdTrustedCAFile
-	}
-	if profilerAddress, err := flags.GetString("profiler-address"); err == nil {
-		cfg.ProfilerAddress = profilerAddress
-	}
-	shardKubeconfigFile, err := flags.GetString("shard-kubeconfig-file")
-	if err == nil {
-		cfg.ShardKubeconfigFile = shardKubeconfigFile
-	}
-	enableSharding, err := flags.GetBool("enable-sharding")
-	if err == nil {
-		cfg.EnableSharding = enableSharding
-	}
-	rootDirectory, err := flags.GetString("root_directory")
-	if err == nil {
-		cfg.RootDirectory = rootDirectory
-	}
-	etcdPeerPort, err := flags.GetString("etcd_peer_port")
-	if err == nil {
-		cfg.EtcdPeerPort = etcdPeerPort
-	}
-	etcdClientPort, err := flags.GetString("etcd_client_port")
-	if err == nil {
-		cfg.EtcdClientPort = etcdClientPort
-	}
-	kubeConfigPath, err := flags.GetString("kubeconfig_path")
-	if err == nil {
-		cfg.KubeConfigPath = kubeConfigPath
-	}
-	return cfg
-}
+	fs.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
+	fs.StringVar(&c.SyncerImage, "syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
+	fs.StringSliceVar(&c.ResourcesToSync, "resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
+	fs.BoolVar(&c.InstallClusterController, "install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
+	fs.BoolVar(&c.InstallWorkspaceController, "install_workspace_controller", false, "Registers the workspace custom resource, and the related controller to allow scheduling workspaces to shards")
+	fs.BoolVar(&c.PullMode, "pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
+	fs.BoolVar(&c.PushMode, "push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
+	fs.StringVar(&c.Listen, "listen", ":6443", "Address:port to bind to")
+	fs.BoolVar(&c.AutoPublishAPIs, "auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
+	fs.StringSliceVar(&c.EtcdClientInfo.Endpoints, "etcd-servers", []string{}, "List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
+	fs.StringVar(&c.EtcdClientInfo.KeyFile, "etcd-keyfile", "", "TLS key file used to secure etcd communication.")
+	fs.StringVar(&c.EtcdClientInfo.CertFile, "etcd-certfile", "", "TLS certification file used to secure etcd communication.")
+	fs.StringVar(&c.EtcdClientInfo.TrustedCAFile, "etcd-cafile", "", "TLS Certificate Authority file used to secure etcd communication.")
+	fs.StringVar(&c.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to.")
+	fs.StringVar(&c.ShardKubeconfigFile, "shard-kubeconfig-file", "", "Kubeconfig holding admin(!) credentials to peer kcp shards.")
+	fs.BoolVar(&c.EnableSharding, "enable-sharding", false, "Enable delegating to peer kcp shards.")
+	fs.StringVar(&c.RootDirectory, "root_directory", ".kcp", "Root directory.")
+	fs.StringVar(&c.EtcdPeerPort, "etcd_peer_port", "2380", "Port for etcd peer communication.")
+	fs.StringVar(&c.EtcdClientPort, "etcd_client_port", "2379", "Port for etcd client communication.")
+	fs.StringVar(&c.KubeConfigPath, "kubeconfig_path", "admin.kubeconfig", "Path to which the administrative kubeconfig should be written at startup.")
 
-// AddConfigFlags adds all the config flags to the provided flag set
-func AddConfigFlags(flags *pflag.FlagSet) {
-	flags.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
-	flags.String("syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
-	flags.StringSlice("resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
-	flags.Bool("install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
-	flags.Bool("install_workspace_controller", false, "Registers the workspace custom resource, and the related controller to allow scheduling workspaces to shards")
-	flags.Bool("pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
-	flags.Bool("push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
-	flags.String("listen", ":6443", "Address:port to bind to")
-	flags.Bool("auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
-	flags.StringSlice("etcd-servers", []string{},
-		"List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
-	flags.String("etcd-keyfile", "",
-		"TLS key file used to secure etcd communication.")
-	flags.String("etcd-certfile", "",
-		"TLS certification file used to secure etcd communication.")
-	flags.String("etcd-cafile", "",
-		"TLS Certificate Authority file used to secure etcd communication.")
-	flags.String("profiler-address", "", "[Address]:port to bind the profiler to.")
-	flags.String("shard-kubeconfig-file", "",
-		"Kubeconfig holding admin(!) credentials to peer kcp shards.")
-	flags.Bool("enable-sharding", false,
-		"Enable delegating to peer kcp shards.")
-	flags.String("root_directory", ".kcp",
-		"Root directory.")
-	flags.String("etcd_peer_port", "2380", "Port for etcd peer communication.")
-	flags.String("etcd_client_port", "2379", "Port for etcd client communication.")
-	flags.String("kubeconfig_path", "admin.kubeconfig", "Path to which the administrative kubeconfig should be written at startup.")
+	return &c
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -9,6 +9,25 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
 )
 
+// DefaultConfig is the default behavior of the KCP server.
+func DefaultConfig() *Config {
+	return &Config{
+		EtcdClientInfo:             etcd.ClientInfo{},
+		EtcdDirectory:              "",
+		EtcdPeerPort:               "2380",
+		EtcdClientPort:             "2379",
+		InstallClusterController:   false,
+		ClusterControllerOptions:   cluster.DefaultOptions(),
+		InstallWorkspaceController: false,
+		KubeConfigPath:             "admin.kubeconfig",
+		Listen:                     ":6443",
+		RootDirectory:              ".kcp",
+		ProfilerAddress:            "",
+		ShardKubeconfigFile:        "",
+		EnableSharding:             false,
+	}
+}
+
 // Config determines the behavior of the KCP server.
 type Config struct {
 	EtcdClientInfo             etcd.ClientInfo
@@ -26,26 +45,24 @@ type Config struct {
 	EnableSharding             bool
 }
 
-func BindOptions(fs *pflag.FlagSet) *Config {
-	c := Config{EtcdClientInfo: etcd.ClientInfo{}}
-
+func BindOptions(c *Config, fs *pflag.FlagSet) *Config {
 	fs.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
-	fs.BoolVar(&c.InstallClusterController, "install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
-	fs.BoolVar(&c.InstallWorkspaceController, "install_workspace_controller", false, "Registers the workspace custom resource, and the related controller to allow scheduling workspaces to shards")
-	fs.StringVar(&c.Listen, "listen", ":6443", "Address:port to bind to")
-	fs.StringSliceVar(&c.EtcdClientInfo.Endpoints, "etcd-servers", []string{}, "List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
-	fs.StringVar(&c.EtcdClientInfo.KeyFile, "etcd-keyfile", "", "TLS key file used to secure etcd communication.")
-	fs.StringVar(&c.EtcdClientInfo.CertFile, "etcd-certfile", "", "TLS certification file used to secure etcd communication.")
-	fs.StringVar(&c.EtcdClientInfo.TrustedCAFile, "etcd-cafile", "", "TLS Certificate Authority file used to secure etcd communication.")
-	fs.StringVar(&c.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to.")
-	fs.StringVar(&c.ShardKubeconfigFile, "shard-kubeconfig-file", "", "Kubeconfig holding admin(!) credentials to peer kcp shards.")
-	fs.BoolVar(&c.EnableSharding, "enable-sharding", false, "Enable delegating to peer kcp shards.")
-	fs.StringVar(&c.RootDirectory, "root_directory", ".kcp", "Root directory.")
-	fs.StringVar(&c.EtcdPeerPort, "etcd_peer_port", "2380", "Port for etcd peer communication.")
-	fs.StringVar(&c.EtcdClientPort, "etcd_client_port", "2379", "Port for etcd client communication.")
-	fs.StringVar(&c.KubeConfigPath, "kubeconfig_path", "admin.kubeconfig", "Path to which the administrative kubeconfig should be written at startup.")
+	fs.BoolVar(&c.InstallClusterController, "install_cluster_controller", c.InstallClusterController, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
+	fs.BoolVar(&c.InstallWorkspaceController, "install_workspace_controller", c.InstallWorkspaceController, "Registers the workspace custom resource, and the related controller to allow scheduling workspaces to shards")
+	fs.StringVar(&c.Listen, "listen", c.Listen, "Address:port to bind to")
+	fs.StringSliceVar(&c.EtcdClientInfo.Endpoints, "etcd-servers", c.EtcdClientInfo.Endpoints, "List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
+	fs.StringVar(&c.EtcdClientInfo.KeyFile, "etcd-keyfile", c.EtcdClientInfo.KeyFile, "TLS key file used to secure etcd communication.")
+	fs.StringVar(&c.EtcdClientInfo.CertFile, "etcd-certfile", c.EtcdClientInfo.CertFile, "TLS certification file used to secure etcd communication.")
+	fs.StringVar(&c.EtcdClientInfo.TrustedCAFile, "etcd-cafile", c.EtcdClientInfo.TrustedCAFile, "TLS Certificate Authority file used to secure etcd communication.")
+	fs.StringVar(&c.ProfilerAddress, "profiler-address", c.ProfilerAddress, "[Address]:port to bind the profiler to.")
+	fs.StringVar(&c.ShardKubeconfigFile, "shard-kubeconfig-file", c.ShardKubeconfigFile, "Kubeconfig holding admin(!) credentials to peer kcp shards.")
+	fs.BoolVar(&c.EnableSharding, "enable-sharding", c.EnableSharding, "Enable delegating to peer kcp shards.")
+	fs.StringVar(&c.RootDirectory, "root_directory", c.RootDirectory, "Root directory.")
+	fs.StringVar(&c.EtcdPeerPort, "etcd_peer_port", c.EtcdPeerPort, "Port for etcd peer communication.")
+	fs.StringVar(&c.EtcdClientPort, "etcd_client_port", c.EtcdClientPort, "Port for etcd client communication.")
+	fs.StringVar(&c.KubeConfigPath, "kubeconfig_path", c.KubeConfigPath, "Path to which the administrative kubeconfig should be written at startup.")
 
-	c.ClusterControllerOptions = cluster.BindOptions(fs)
+	c.ClusterControllerOptions = cluster.BindOptions(c.ClusterControllerOptions, fs)
 
-	return &c
+	return c
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -6,24 +6,21 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/kcp-dev/kcp/pkg/etcd"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
 )
 
 // Config determines the behavior of the KCP server.
 type Config struct {
-	AutoPublishAPIs            bool
 	EtcdClientInfo             etcd.ClientInfo
 	EtcdDirectory              string
 	EtcdPeerPort               string
 	EtcdClientPort             string
 	InstallClusterController   bool
+	ClusterControllerOptions   *cluster.Options
 	InstallWorkspaceController bool
 	KubeConfigPath             string
 	Listen                     string
-	PullMode                   bool
-	PushMode                   bool
-	ResourcesToSync            []string
 	RootDirectory              string
-	SyncerImage                string
 	ProfilerAddress            string
 	ShardKubeconfigFile        string
 	EnableSharding             bool
@@ -33,14 +30,9 @@ func BindOptions(fs *pflag.FlagSet) *Config {
 	c := Config{EtcdClientInfo: etcd.ClientInfo{}}
 
 	fs.AddFlag(pflag.PFlagFromGoFlag(flag.CommandLine.Lookup("v")))
-	fs.StringVar(&c.SyncerImage, "syncer_image", "quay.io/kcp-dev/kcp-syncer", "References a container image that contains syncer and will be used by the syncer POD in registered physical clusters.")
-	fs.StringSliceVar(&c.ResourcesToSync, "resources_to_sync", []string{"deployments.apps"}, "Provides the list of resources that should be synced from KCP logical cluster to underlying physical clusters")
 	fs.BoolVar(&c.InstallClusterController, "install_cluster_controller", false, "Registers the sample cluster custom resource, and the related controller to allow registering physical clusters")
 	fs.BoolVar(&c.InstallWorkspaceController, "install_workspace_controller", false, "Registers the workspace custom resource, and the related controller to allow scheduling workspaces to shards")
-	fs.BoolVar(&c.PullMode, "pull_mode", false, "Deploy the syncer in registered physical clusters in POD, and have it sync resources from KCP")
-	fs.BoolVar(&c.PushMode, "push_mode", false, "If true, run syncer for each cluster from inside cluster controller")
 	fs.StringVar(&c.Listen, "listen", ":6443", "Address:port to bind to")
-	fs.BoolVar(&c.AutoPublishAPIs, "auto_publish_apis", false, "If true, the APIs imported from physical clusters will be published automatically as CRDs")
 	fs.StringSliceVar(&c.EtcdClientInfo.Endpoints, "etcd-servers", []string{}, "List of external etcd servers to connect with (scheme://ip:port), comma separated. If absent an in-process etcd will be created.")
 	fs.StringVar(&c.EtcdClientInfo.KeyFile, "etcd-keyfile", "", "TLS key file used to secure etcd communication.")
 	fs.StringVar(&c.EtcdClientInfo.CertFile, "etcd-certfile", "", "TLS certification file used to secure etcd communication.")
@@ -52,6 +44,8 @@ func BindOptions(fs *pflag.FlagSet) *Config {
 	fs.StringVar(&c.EtcdPeerPort, "etcd_peer_port", "2380", "Port for etcd peer communication.")
 	fs.StringVar(&c.EtcdClientPort, "etcd_client_port", "2379", "Port for etcd client communication.")
 	fs.StringVar(&c.KubeConfigPath, "kubeconfig_path", "admin.kubeconfig", "Path to which the administrative kubeconfig should be written at startup.")
+
+	c.ClusterControllerOptions = cluster.BindOptions(fs)
 
 	return &c
 }


### PR DESCRIPTION
config: use a more common pattern for binding flags

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

server: refactor cluster controller to DRY it out

The server options loading and startup code is identical between the
standalone binary and the post-start-hook. This commit makes the code
actually shared.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

