### PR TITLE
Fix CRD bootstrapping for already existing

### DIFF
--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -71,9 +72,10 @@ func BootstrapCustomResourceDefinition(ctx context.Context, client apiextensions
 	}
 
 	crd, err := client.Create(ctx, rawCrd, metav1.CreateOptions{})
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("could not create CRD %s: %w", gk.String(), err)
 	}
+
 	watcher, err := client.Watch(ctx, metav1.ListOptions{
 		FieldSelector:   fields.OneTermEqualSelector("metadata.name", crd.Name).String(),
 		ResourceVersion: crd.ResourceVersion,


### PR DESCRIPTION
When bootstrapping CRDs, if they already exist, don't consider it an
error.

Fixes #232