### PR TITLE
Use environment secret gh token for gh-issues-issue-opened.yml

### DIFF
--- a/.github/workflows/gh-issues-issue-opened.yml
+++ b/.github/workflows/gh-issues-issue-opened.yml
@@ -3,11 +3,12 @@ on:
   issues:
     types: [opened]
 jobs:
-  automate-project-columns:
+  move-new-issues-to-new:
+    environment: projects
     runs-on: ubuntu-latest
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
           project: kcp
           column: New
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GHPROJECT_TOKEN }}


### PR DESCRIPTION
The normal token is read-only and cannot touch projects.