### PR TITLE
fix issue: syncer cannot work when original resource was delete in logic cluster

### DIFF
--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -77,7 +77,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 				Resources: []string{"namespaces"},
 			},
 			{
-				Verbs:     []string{"list", "watch", "create", "update", "get"},
+				Verbs:     []string{"list", "watch", "create", "update", "get", "delete"},
 				Resources: resourcesWithStatus.List(),
 				APIGroups: apiGroups.List(),
 			},


### PR DESCRIPTION
Since in `pull mode`, when create `clusterrole` we do not grant `delete` permission to the `sa`.