### PR TITLE
Only reconcile on root deployment and leaf deployment

### DIFF
--- a/pkg/reconciler/deployment/deployment.go
+++ b/pkg/reconciler/deployment/deployment.go
@@ -38,7 +38,7 @@ func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deploymen
 			}
 		}
 
-	} else {
+	} else if deployment.Labels[ownedByLabel] != "" {
 		rootDeploymentName := deployment.Labels[ownedByLabel]
 		// A leaf deployment was updated; get others and aggregate status.
 		sel, err := labels.Parse(fmt.Sprintf("%s=%s", ownedByLabel, rootDeploymentName))


### PR DESCRIPTION
The deployment `splitter` controller should only touch `root` deployment(no label `kcp.dev/cluster` exsited), or `leaf` deployment (with labels: `kcp.dev/cluster`, `kcp.dev/owned-by` both)

Current implement will keep raising `err: Root deployment not found`, when reconcile on a normal deployment(with label: `kcp.dev/cluster` but no `kcp.dev/owned-by`)