### PR TITLE
Correct syncer in pull mode, missing parameter: from_cluster

### DIFF
--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -145,6 +145,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 	args := []string{
 		"-cluster", clusterID,
 		"-from_kubeconfig", "/kcp/kubeconfig",
+		"-from_cluster", logicalCluster,
 	}
 	args = append(args, groupResourcesToSync...)
 


### PR DESCRIPTION
Missing parameter: `from_cluster`