### PR TITLE
Move misspell and gofmt into golangci-lint config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,23 +7,6 @@ on:
     branches: ['main']
 
 jobs:
-  gofmt:
-    name: gofmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: kcp
-      - uses: actions/setup-go@v2
-        with:
-          go-version: v1.16
-      - name: Check gofmt
-        run: |
-          cd kcp
-          gofmt -s -d \
-            $(find . \
-              -path './vendor' -prune \
-              -o -type f -name '*.go' -print)
 
   boilerplate:
     name: boilerplate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,16 +74,6 @@ jobs:
           only-new-issues: true
           args: --timeout=5m
 
-  misspell:
-    name: misspell
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: reviewdog/action-misspell@v1
-        with:
-          exclude: ./.github/workflows/*
-          ignore: creater,importas
-
   codegen:
     name: codegen
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,9 +3,15 @@ linters-settings:
     errorf: true
     asserts: true
     comparison: true
+  misspell:
+    ignore-words:
+    - creater
+
 linters:
   enable:
   - errorlint
   - exportloopref
+  - gofmt
   - importas
+  - misspell
   - nilerr


### PR DESCRIPTION
Import checking is already covered by `make verify-codegen`