### PR TITLE
config: fix timing log

### DIFF
--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -69,7 +69,9 @@ func BootstrapCustomResourceDefinitions(ctx context.Context, client apiextension
 func BootstrapCustomResourceDefinition(ctx context.Context, client apiextensionsv1client.CustomResourceDefinitionInterface, gk metav1.GroupKind) error {
 	start := time.Now()
 	klog.Infof("bootstrapping %v", gk.String())
-	defer klog.Infof("bootstrapped %v after %s", gk.String(), time.Since(start).String())
+	defer func() {
+		klog.Infof("bootstrapped %v after %s", gk.String(), time.Since(start).String())
+	}()
 	raw, err := rawCustomResourceDefinitions.ReadFile(fmt.Sprintf("%s_%s.yaml", gk.Group, gk.Kind))
 	if err != nil {
 		return fmt.Errorf("could not read CRD %s: %w", gk.String(), err)


### PR DESCRIPTION
We need to defer the call to `time.Since()` or we don't get a meaningful
result.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>