### PR TITLE
Adds missing flag to demo files

### DIFF
--- a/contrib/demo/apiNegotiation-startKcp.sh
+++ b/contrib/demo/apiNegotiation-startKcp.sh
@@ -25,7 +25,7 @@ setupTraps $0
 KUBECONFIG=${KCP_DATA_ROOT}/.kcp/admin.kubeconfig
 export KCP_LISTEN_ADDR="127.0.0.1:6443"
 
-${DEMO_ROOT}/startKcpAndClusterController.sh --auto_publish_apis=false deployments.apps &
+${DEMO_ROOT}/startKcpAndClusterController.sh --auto_publish_apis=false --resources_to_sync deployments.apps &
 
 wait_command "grep 'Serving securely' ${CURRENT_DIR}/kcp.log"
 

--- a/contrib/demo/kubecon-startKcp.sh
+++ b/contrib/demo/kubecon-startKcp.sh
@@ -25,7 +25,7 @@ setupTraps $0
 KUBECONFIG=${KCP_DATA_ROOT}/.kcp/admin.kubeconfig
 export KCP_LISTEN_ADDR="127.0.0.1:6443"
 
-${DEMO_ROOT}/startKcpAndClusterController.sh --auto_publish_apis=true deployments.apps &
+${DEMO_ROOT}/startKcpAndClusterController.sh --auto_publish_apis=true --resources_to_sync deployments.apps &
 KCP_PID=$!
 
 wait_command "grep 'Serving securely' ${CURRENT_DIR}/kcp.log"


### PR DESCRIPTION
Due to the latest changes on how flags are parsed, demos were broken.

Demos just requiring only "deployments.app" to be synced, were working out of pure luck as it matched the set defaults for the unset flag.

Signed-off-by: Joaquim Moreno <joaquim@redhat.com>