### PR TITLE
reconciler: workspace: deflake movement

### DIFF
--- a/pkg/reconciler/workspace/controller.go
+++ b/pkg/reconciler/workspace/controller.go
@@ -312,7 +312,7 @@ func (c *Controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.W
 			klog.Infof("scheduling workspace %q to %q", workspace.Name, target)
 		}
 	}
-	if workspace.Status.Location.Current != workspace.Status.Location.Target {
+	if workspace.Status.Location.Target != "" && workspace.Status.Location.Current != workspace.Status.Location.Target {
 		klog.Infof("moving workspace %q from %q to %q", workspace.Name, workspace.Status.Location.Current, workspace.Status.Location.Target)
 		workspace.Status.Location.Current = workspace.Status.Location.Target
 		workspace.Status.Location.Target = ""

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -139,7 +139,7 @@ func TestWorkspaceController(t *testing.T) {
 				}
 				var otherShard string
 				for _, name := range []string{bostonShard.Name, atlantaShard.Name} {
-					if name != otherShard {
+					if name != workspace.Status.Location.Current {
 						otherShard = name
 						break
 					}


### PR DESCRIPTION
We never set target to be an empty string, so this logic was bugged and
coudl race.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/kcp-dev/kcp/issues/268