### PR TITLE
Improvements to E2E framework, artifact capture

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
     - name: Check codegen
       run: make verify-codegen
     - run: make build
-    - run: PATH="${PATH}:$(pwd)/bin/" go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+    - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" go test -race -coverprofile=coverage.txt -covermode=atomic ./...
     # Because verify-codegen updates imports under the covers, and it affects
     # everything in the working directory, we have to check out kubernetes
     # after verifying codegen; otherwise, kubernetes code will get modified,
@@ -93,3 +93,8 @@ jobs:
       working-directory: ./kubernetes
     - run: WORKDIR=/tmp/e2e hack/run-sharded-kcp.sh
     - run: WORKDIR=/tmp/cluster hack/run-cluster-kcp.sh
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: e2e-artifacts
+        path: /tmp/e2e/**/artifacts/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
     - name: Check codegen
       run: make verify-codegen
     - run: make build
-    - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" go test -race -coverprofile=coverage.txt -covermode=atomic ./...
+    - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" go test -race -coverprofile=coverage.txt -covermode=atomic -count 5 ./...
     # Because verify-codegen updates imports under the covers, and it affects
     # everything in the working directory, we have to check out kubernetes
     # after verifying codegen; otherwise, kubernetes code will get modified,

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ build:
 	go build -o bin ./cmd/...
 .PHONY: build
 
+install:
+	go install ./cmd/...
+.PHONY: install
+
 vendor:
 	go mod tidy
 	go mod vendor
@@ -64,3 +68,7 @@ $(OPENSHIFT_GOIMPORTS):
 .PHONY: imports
 imports: $(OPENSHIFT_GOIMPORTS)
 	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev/kcp
+
+.PHONY: test-e2e
+test-e2e: install
+	go test -race ./test/e2e... $(WHAT)

--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ imports: $(OPENSHIFT_GOIMPORTS)
 
 .PHONY: test-e2e
 test-e2e: install
-	go test -race ./test/e2e... $(WHAT)
+	go test -race -count 5 ./test/e2e... $(WHAT)

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -55,7 +55,7 @@ func (c *kcpServer) ArtifactDir() string {
 	return c.artifactDir
 }
 
-func newKcpServer(t *T, args ...string) (*kcpServer, error) {
+func newKcpServer(t *T, cfg KcpConfig) (*kcpServer, error) {
 	t.Helper()
 	ctx := context.Background()
 	if deadline, ok := t.Deadline(); ok {
@@ -78,7 +78,7 @@ func newKcpServer(t *T, args ...string) (*kcpServer, error) {
 	if err != nil {
 		return nil, err
 	}
-	artifactDir, err := ArtifactDir(t, kcpListenPort)
+	artifactDir, err := ArtifactDir(t, "kcp", cfg.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func newKcpServer(t *T, args ...string) (*kcpServer, error) {
 			"--etcd_client_port=" + etcdClientPort,
 			"--etcd_peer_port=" + etcdPeerPort,
 			"--kubeconfig_path=admin.kubeconfig"},
-			args...),
+			cfg.Args...),
 		artifactDir: artifactDir,
 		ctx:         ctx,
 		t:           t,

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -73,10 +73,16 @@ func Run(top *testing.T, name string, f TestFunc, cfgs ...KcpConfig) {
 		mid.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
 		bottom := NewT(ctx, mid)
+		artifactDir, dataDir, err := ScratchDirs(bottom)
+		if err != nil {
+			bottom.Errorf("failed to create scratch dirs: %v", err)
+			cancel()
+			return
+		}
 		var servers []*kcpServer
 		var runningServers []RunningServer
 		for _, cfg := range cfgs {
-			server, err := newKcpServer(bottom, cfg)
+			server, err := newKcpServer(bottom, cfg, artifactDir, dataDir)
 			if err != nil {
 				mid.Fatal(err)
 			}

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"k8s.io/client-go/rest"
 )
@@ -36,6 +37,12 @@ type RunningServer interface {
 }
 
 type TestFunc func(t TestingTInterface, servers ...RunningServer)
+
+// KcpConfig qualify a kcp server to start
+type KcpConfig struct {
+	Name string
+	Args []string
+}
 
 // Run mimics the testing.T.Run function while providing a nice set of concurrency
 // guarantees for the processes that we create and manage for test cases. We ensure:
@@ -58,7 +65,7 @@ type TestFunc func(t TestingTInterface, servers ...RunningServer)
 // other than the main testing goroutine. Therefore, when more than one routine needs
 // to be able to influence the execution flow (e.g. preempt other routines) we must
 // have the central routine watch for incoming errors from delegate routines.
-func Run(top *testing.T, name string, f TestFunc, args ...[]string) {
+func Run(top *testing.T, name string, f TestFunc, cfgs ...KcpConfig) {
 	if _, previouslyCalled := seen.LoadOrStore(fmt.Sprintf("%p", top), nil); !previouslyCalled {
 		top.Parallel()
 	}
@@ -68,8 +75,8 @@ func Run(top *testing.T, name string, f TestFunc, args ...[]string) {
 		bottom := NewT(ctx, mid)
 		var servers []*kcpServer
 		var runningServers []RunningServer
-		for _, arg := range args {
-			server, err := newKcpServer(bottom, arg...)
+		for _, cfg := range cfgs {
+			server, err := newKcpServer(bottom, cfg)
 			if err != nil {
 				mid.Fatal(err)
 			}
@@ -82,6 +89,8 @@ func Run(top *testing.T, name string, f TestFunc, args ...[]string) {
 		go func(t TestingTInterface) {
 			defer func() { cancel() }() // stop waiting for errors
 
+			start := time.Now()
+			t.Log("Starting kcp servers...")
 			// launch kcp servers and ensure they are ready before starting the test
 			wg := sync.WaitGroup{}
 			wg.Add(len(servers))
@@ -101,6 +110,7 @@ func Run(top *testing.T, name string, f TestFunc, args ...[]string) {
 				}
 			}
 			wg.Wait()
+			t.Logf("Started kcp servers after %s", time.Since(start))
 
 			// if we've failed during startup, don't bother running the test
 			if t.Failed() {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -38,6 +38,11 @@ func ArtifactDir(t TestingTInterface, segments ...string) (string, error) {
 		baseDir, strings.NewReplacer("/", "_", "\\", "_", ":", "_").Replace(t.Name()),
 	}, segments...)
 	artifactDir := filepath.Join(segments...)
+	if info, err := os.Stat(artifactDir); err == nil {
+		if info.IsDir() {
+			return "", fmt.Errorf("artifact dir %s already exists, ensure clean output directory", artifactDir)
+		}
+	}
 	if err := os.MkdirAll(artifactDir, 0755); err != nil {
 		return "", fmt.Errorf("could not create artifact dir: %w", err)
 	}

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -188,7 +188,8 @@ func TestWorkspaceController(t *testing.T) {
 			},
 		},
 	}
-	for _, testCase := range testCases {
+	for i := range testCases {
+		testCase := testCases[i]
 		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers ...framework.RunningServer) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -223,7 +223,10 @@ func TestWorkspaceController(t *testing.T) {
 				return
 			}
 			testCase.work(ctx, t, client, watcher)
-		}, []string{"--install_workspace_controller"})
+		}, framework.KcpConfig{
+			Name: "main",
+			Args: []string{"--install_workspace_controller"},
+		})
 	}
 }
 


### PR DESCRIPTION
e2e: framework: allow naming kcp servers

For better UX when poking around inside of the artifact directory for
tests with more than one kcp server, we allow naming them.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

makefile: add a helper for running e2e tests

Since the e2e runs kcp servers via the binary, we need to make sure that
a) the built binaries are in $PATH and b) we re-build when running.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

e2e: workspace: scope testCase variable

Without this scoping step, the reference leaks out to each test
goroutine.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test: e2e: improve artifact capture, run more tests

We now distinguish between the data directories for kcp servers we start
and the artifacts that a test produces, as we only want to capture the
latter in CI for review when a test fails. This commit also adds the
artifact publishing to CI.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Supersedes https://github.com/kcp-dev/kcp/pull/287
/assign @sttts 