### PR TITLE
workflows/gh-issues-issue-opened: no projects env and use kcp-dev org

### DIFF
--- a/.github/workflows/gh-issues-issue-opened.yml
+++ b/.github/workflows/gh-issues-issue-opened.yml
@@ -7,13 +7,12 @@ jobs:
     permissions:
       issues: write
       repository-projects: write
-    environment: projects
     runs-on: ubuntu-latest
     steps:
       - name: Get project data
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACCOUNT: sttts
+          ACCOUNT: kcp-dev
           PROJECT_NUMBER: 1
         run: |
           gh api graphql --header 'GraphQL-Features: projects_next_graphql' -f query='


### PR DESCRIPTION
- do not use the projects environment, not needed anymore with GITHUB_TOKENS
- account = kcp-dev, the org