### PR TITLE
test: e2e: framework: add a simple artifact saver

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -43,6 +43,7 @@ import (
 //  - all ports and data directories are unique to support
 //    concurrent execution within a test case and across tests
 type kcpServer struct {
+	name        string
 	args        []string
 	ctx         context.Context
 	dataDir     string
@@ -86,6 +87,7 @@ func newKcpServer(t *T, cfg KcpConfig, artifactDir, dataDir string) (*kcpServer,
 		return nil, fmt.Errorf("could not create data dir: %w", err)
 	}
 	return &kcpServer{
+		name: cfg.Name,
 		args: append([]string{
 			"--root_directory=" + dataDir,
 			"--listen=:" + kcpListenPort,
@@ -180,6 +182,11 @@ func (c *kcpServer) filterKcpLogs(logs *bytes.Buffer) string {
 		}
 	}
 	return output.String()
+}
+
+// Name exposes the name of this kcp server
+func (c *kcpServer) Name() string {
+	return c.name
 }
 
 // Config exposes a copy of the client config for this server.

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -37,6 +38,7 @@ type RunningServer interface {
 	Name() string
 	RawConfig() (clientcmdapi.Config, error)
 	Config() (*rest.Config, error)
+	Artifact(t TestingTInterface, producer func() (runtime.Object, error))
 }
 
 type TestFunc func(t TestingTInterface, servers map[string]RunningServer)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -55,16 +55,22 @@ var rawCustomResourceDefinitions embed.FS
 
 const testNamespace = "cluster-controller-test"
 const clusterName = "us-east1"
+const sourceClusterName, sinkClusterName = "source", "sink"
 
 func TestClusterController(t *testing.T) {
+	type runningServer struct {
+		framework.RunningServer
+		client wildwestclient.CowboyInterface
+		watcher watch.Interface
+	}
 	var testCases = []struct {
 		name string
-		work func(ctx context.Context, t framework.TestingTInterface, sourceClient, sinkClient wildwestclient.CowboyInterface, sourceWatcher, sinkWatcher watch.Interface)
+		work func(ctx context.Context, t framework.TestingTInterface, servers map[string]runningServer)
 	}{
 		{
 			name: "create an object, expect spec to sync to sink",
-			work: func(ctx context.Context, t framework.TestingTInterface, sourceClient, sinkClient wildwestclient.CowboyInterface, sourceWatcher, sinkWatcher watch.Interface) {
-				cowboy, err := sourceClient.Create(ctx, &wildwestv1alpha1.Cowboy{
+			work: func(ctx context.Context, t framework.TestingTInterface, servers map[string]runningServer) {
+				cowboy, err := servers[sourceClusterName].client.Create(ctx, &wildwestv1alpha1.Cowboy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "timothy",
 						Labels: map[string]string{
@@ -77,11 +83,11 @@ func TestClusterController(t *testing.T) {
 					t.Errorf("failed to create cowboy: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(sourceWatcher, watch.Added, exactMatcher(cowboy), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(servers[sourceClusterName].watcher, watch.Added, exactMatcher(cowboy), 30*time.Second); err != nil {
 					t.Errorf("did not see cowboy created: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(sinkWatcher, watch.Added, func(object *wildwestv1alpha1.Cowboy) error {
+				if _, err := expectNextEvent(servers[sinkClusterName].watcher, watch.Added, func(object *wildwestv1alpha1.Cowboy) error {
 					if expected, actual := cowboy.ObjectMeta.Namespace, object.ObjectMeta.Namespace; expected != actual {
 						return fmt.Errorf("saw incorrect namespace, expected %s, saw %s", expected, actual)
 					}
@@ -94,17 +100,14 @@ func TestClusterController(t *testing.T) {
 					return nil
 				}, 30*time.Second); err != nil {
 					t.Errorf("did not see cowboy spec updated on sink cluster: %v", err)
-					data, err := sinkClient.List(ctx, metav1.ListOptions{})
-					t.Errorf("%#v", data)
-					t.Errorf("%#v", err)
 					return
 				}
 			},
 		},
 		{
 			name: "update a synced object, expect status to sync to source",
-			work: func(ctx context.Context, t framework.TestingTInterface, sourceClient, sinkClient wildwestclient.CowboyInterface, sourceWatcher, sinkWatcher watch.Interface) {
-				cowboy, err := sourceClient.Create(ctx, &wildwestv1alpha1.Cowboy{
+			work: func(ctx context.Context, t framework.TestingTInterface, servers map[string]runningServer) {
+				cowboy, err := servers[sourceClusterName].client.Create(ctx, &wildwestv1alpha1.Cowboy{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "timothy",
 						Labels: map[string]string{
@@ -118,24 +121,24 @@ func TestClusterController(t *testing.T) {
 					return
 				}
 				// the sync happens and we don't care to validate it in this test case
-				if err := ignoreNextEvent(sourceWatcher, 30*time.Second); err != nil {
+				if err := ignoreNextEvent(servers[sourceClusterName].watcher, 30*time.Second); err != nil {
 					t.Errorf("error ignoring source event when watching cowboys: %v", err)
 					return
 				}
-				if err := ignoreNextEvent(sinkWatcher, 30*time.Second); err != nil {
+				if err := ignoreNextEvent(servers[sinkClusterName].watcher, 30*time.Second); err != nil {
 					t.Errorf("error ignoring sink event when watching cowboys: %v", err)
 					return
 				}
-				updated, err := sinkClient.Patch(ctx, cowboy.Name, types.MergePatchType, []byte(`{"status":{"result":"giddyup"}}`), metav1.PatchOptions{}, "status")
+				updated, err := servers[sinkClusterName].client.Patch(ctx, cowboy.Name, types.MergePatchType, []byte(`{"status":{"result":"giddyup"}}`), metav1.PatchOptions{}, "status")
 				if err != nil {
 					t.Errorf("failed to patch cowboy: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(sinkWatcher, watch.Modified, exactMatcher(updated), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(servers[sinkClusterName].watcher, watch.Modified, exactMatcher(updated), 30*time.Second); err != nil {
 					t.Errorf("did not see cowboy patched: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(sourceWatcher, watch.Modified, func(object *wildwestv1alpha1.Cowboy) error {
+				if _, err := expectNextEvent(servers[sourceClusterName].watcher, watch.Modified, func(object *wildwestv1alpha1.Cowboy) error {
 					if expected, actual := cowboy.ObjectMeta.Namespace, object.ObjectMeta.Namespace; expected != actual {
 						return fmt.Errorf("saw incorrect namespace, expected %s, saw %s", expected, actual)
 					}
@@ -155,7 +158,7 @@ func TestClusterController(t *testing.T) {
 	}
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers ...framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
 			start := time.Now()
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
@@ -168,13 +171,13 @@ func TestClusterController(t *testing.T) {
 				return
 			}
 			t.Log("Installing test CRDs...")
-			if err := installCrd(ctx, servers...); err != nil {
+			if err := installCrd(ctx, servers); err != nil {
 				t.Error(err)
 				return
 			}
 			t.Logf("Installed test CRDs after %s", time.Since(start))
 			start = time.Now()
-			source, sink := servers[0], servers[1]
+			source, sink := servers[sourceClusterName], servers[sinkClusterName]
 			t.Log("Installing sink cluster...")
 			if err := installCluster(ctx, source, sink); err != nil {
 				t.Error(err)
@@ -187,10 +190,9 @@ func TestClusterController(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			var clients []wildwestclient.CowboyInterface
-			var watchers []watch.Interface
-			for _, server := range servers {
-				cfg, err := server.Config()
+			runningServers := map[string]runningServer{}
+			for _, name := range []string{sourceClusterName, sinkClusterName} {
+				cfg, err := servers[name].Config()
 				if err != nil {
 					t.Error(err)
 					return
@@ -211,16 +213,19 @@ func TestClusterController(t *testing.T) {
 					t.Errorf("failed to start watching cowboys: %v", err)
 					return
 				}
-				clients = append(clients, wildwestClient.WildwestV1alpha1().Cowboys(testNamespace))
-				watchers = append(watchers, watcher)
+				runningServers[name] = runningServer{
+					RunningServer: servers[name],
+					client:        wildwestClient.WildwestV1alpha1().Cowboys(testNamespace),
+					watcher:       watcher,
+				}
 			}
 			t.Logf("Set up clients for test after %s", time.Since(start))
 			t.Log("Starting test...")
-			testCase.work(ctx, t, clients[0], clients[1], watchers[0], watchers[1])
+			testCase.work(ctx, t, runningServers)
 		},
 			// this is the host kcp cluster from which we sync spec
 			framework.KcpConfig{
-				Name: "source",
+				Name: sourceClusterName,
 				Args: []string{
 					"--push_mode",
 					"--install_cluster_controller",
@@ -230,7 +235,7 @@ func TestClusterController(t *testing.T) {
 			},
 			// this is a kcp acting as a target cluster to sync status from
 			framework.KcpConfig{
-				Name: "sink",
+				Name: sinkClusterName,
 				Args: []string{},
 			},
 		)
@@ -257,7 +262,7 @@ func installNamespace(ctx context.Context, server framework.RunningServer) error
 	return err
 }
 
-func installCrd(ctx context.Context, servers ...framework.RunningServer) error {
+func installCrd(ctx context.Context, servers map[string]framework.RunningServer) error {
 	wg := sync.WaitGroup{}
 	bootstrapErrChan := make(chan error, len(servers))
 	for _, server := range servers {

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -28,6 +28,7 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 
@@ -55,6 +56,9 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
 				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
@@ -73,6 +77,9 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
 				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
@@ -86,6 +93,9 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
+				})
 				if _, err := expectNextEvent(server.watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
@@ -100,11 +110,17 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
+				})
 				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
 				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
@@ -123,16 +139,25 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
+				})
 				atlantaShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "atlanta"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create second workspace shard: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, atlantaShard.Name, metav1.GetOptions{})
+				})
 				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
 				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
@@ -173,6 +198,9 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
+				defer server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
 				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -38,23 +38,28 @@ import (
 )
 
 func TestWorkspaceController(t *testing.T) {
+	type runningServer struct {
+		framework.RunningServer
+		client  clientset.Interface
+		watcher watch.Interface
+	}
 	var testCases = []struct {
 		name string
-		work func(ctx context.Context, t framework.TestingTInterface, client clientset.Interface, watcher watch.Interface)
+		work func(ctx context.Context, t framework.TestingTInterface, server runningServer)
 	}{
 		{
 			name: "create a workspace without shards, expect it to be unschedulable",
-			work: func(ctx context.Context, t framework.TestingTInterface, client clientset.Interface, watcher watch.Interface) {
-				workspace, err := client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}, Status: tenancyv1alpha1.WorkspaceStatus{}}, metav1.CreateOptions{})
+			work: func(ctx context.Context, t framework.TestingTInterface, server runningServer) {
+				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}, Status: tenancyv1alpha1.WorkspaceStatus{}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, unschedulableMatcher(), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, unschedulableMatcher(), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
@@ -62,26 +67,26 @@ func TestWorkspaceController(t *testing.T) {
 		},
 		{
 			name: "add a shard after a workspace is unschedulable, expect it to be scheduled",
-			work: func(ctx context.Context, t framework.TestingTInterface, client clientset.Interface, watcher watch.Interface) {
-				workspace, err := client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+			work: func(ctx context.Context, t framework.TestingTInterface, server runningServer) {
+				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, unschedulableMatcher(), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, unschedulableMatcher(), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
-				bostonShard, err := client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+				bostonShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
@@ -89,22 +94,22 @@ func TestWorkspaceController(t *testing.T) {
 		},
 		{
 			name: "create a workspace with a shard, expect it to be scheduled",
-			work: func(ctx context.Context, t framework.TestingTInterface, client clientset.Interface, watcher watch.Interface) {
-				bostonShard, err := client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+			work: func(ctx context.Context, t framework.TestingTInterface, server runningServer) {
+				bostonShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
-				workspace, err := client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
@@ -112,27 +117,27 @@ func TestWorkspaceController(t *testing.T) {
 		},
 		{
 			name: "delete a shard that a workspace is scheduled to, expect it to move to another shard",
-			work: func(ctx context.Context, t framework.TestingTInterface, client clientset.Interface, watcher watch.Interface) {
-				bostonShard, err := client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+			work: func(ctx context.Context, t framework.TestingTInterface, server runningServer) {
+				bostonShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
-				atlantaShard, err := client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "atlanta"}}, metav1.CreateOptions{})
+				atlantaShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "atlanta"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create second workspace shard: %v", err)
 					return
 				}
-				workspace, err := client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
 				}
-				workspace, err = expectNextEvent(watcher, watch.Modified, scheduledAnywhereMatcher(), 30*time.Second)
+				workspace, err = expectNextEvent(server.watcher, watch.Modified, scheduledAnywhereMatcher(), 30*time.Second)
 				if err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
@@ -144,12 +149,12 @@ func TestWorkspaceController(t *testing.T) {
 						break
 					}
 				}
-				err = client.TenancyV1alpha1().WorkspaceShards().Delete(ctx, workspace.Status.Location.Current, metav1.DeleteOptions{})
+				err = server.client.TenancyV1alpha1().WorkspaceShards().Delete(ctx, workspace.Status.Location.Current, metav1.DeleteOptions{})
 				if err != nil {
 					t.Errorf("failed to delete workspace shard: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(otherShard), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, scheduledMatcher(otherShard), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
@@ -157,40 +162,41 @@ func TestWorkspaceController(t *testing.T) {
 		},
 		{
 			name: "delete all shards, expect workspace to be unschedulable",
-			work: func(ctx context.Context, t framework.TestingTInterface, client clientset.Interface, watcher watch.Interface) {
-				bostonShard, err := client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
+			work: func(ctx context.Context, t framework.TestingTInterface, server runningServer) {
+				bostonShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
-				workspace, err := client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Added, exactMatcher(workspace), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace created: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, scheduledMatcher(bostonShard.Name), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
-				err = client.TenancyV1alpha1().WorkspaceShards().Delete(ctx, bostonShard.Name, metav1.DeleteOptions{})
+				err = server.client.TenancyV1alpha1().WorkspaceShards().Delete(ctx, bostonShard.Name, metav1.DeleteOptions{})
 				if err != nil {
 					t.Errorf("failed to delete workspace shard: %v", err)
 					return
 				}
-				if _, err := expectNextEvent(watcher, watch.Modified, unschedulableMatcher(), 30*time.Second); err != nil {
+				if _, err := expectNextEvent(server.watcher, watch.Modified, unschedulableMatcher(), 30*time.Second); err != nil {
 					t.Errorf("did not see workspace updated: %v", err)
 					return
 				}
 			},
 		},
 	}
+	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers ...framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)
@@ -201,7 +207,7 @@ func TestWorkspaceController(t *testing.T) {
 				t.Errorf("incorrect number of servers: %d", len(servers))
 				return
 			}
-			server := servers[0]
+			server := servers[serverName]
 			cfg, err := server.Config()
 			if err != nil {
 				t.Error(err)
@@ -223,9 +229,13 @@ func TestWorkspaceController(t *testing.T) {
 				t.Errorf("failed to watch workspaces: %v", err)
 				return
 			}
-			testCase.work(ctx, t, client, watcher)
+			testCase.work(ctx, t, runningServer{
+				RunningServer: server,
+				client:        client,
+				watcher:       watcher,
+			})
 		}, framework.KcpConfig{
-			Name: "main",
+			Name: serverName,
 			Args: []string{"--install_workspace_controller"},
 		})
 	}


### PR DESCRIPTION
Deferring the new framework.Artifact() will write a YAML file with the
object that you're asking to be saved. The file will be placed under
directories as necessary for the logical cluster and namespace it's in,
and named by kind.group_name.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/kcp-dev/kcp/issues/271