### PR TITLE
Complete bootstrap for CRDs that already exist

### DIFF
--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -102,7 +102,7 @@ func BootstrapCustomResourceDefinitionFromFS(ctx context.Context, client apiexte
 				return fmt.Errorf("Error creating CRD %s: %w", gk.String(), err)
 			}
 		} else {
-			return fmt.Errorf("Error fetching CRD 1 %s: %w", gk.String(), err)
+			return fmt.Errorf("Error fetching CRD %s: %w", gk.String(), err)
 		}
 	} else {
 		rawCrd.ResourceVersion = crdResource.ResourceVersion
@@ -118,7 +118,7 @@ func BootstrapCustomResourceDefinitionFromFS(ctx context.Context, client apiexte
 			if apierrors.IsNotFound(err) {
 				return false, fmt.Errorf("CRD %s was deleted before being established", gk.String())
 			}
-			return false, fmt.Errorf("Error fetching CRD 2 %s: %w", gk.String(), err)
+			return false, fmt.Errorf("Error fetching CRD %s: %w", gk.String(), err)
 		}
 
 		return crdhelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established), nil


### PR DESCRIPTION
When a KCP is restarted without wiping out the storage beforehand, bootstrapping CRDs will hang because the watch never gets any events since the CRDs already exist.

This will get the CRDs if they already exist and complete bootstrapping if they are already established.

Signed-off-by: Kyle Lape <klape@redhat.com>