### PR TITLE
Fix verify-codegen

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,12 +2,11 @@ name: CI
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['main']
+    branches: ["main"]
 
 jobs:
-
   boilerplate:
     name: boilerplate
     runs-on: ubuntu-latest
@@ -34,7 +33,7 @@ jobs:
           path: kcp
       - uses: actions/setup-go@v2
         with:
-          go-version: v1.16
+          go-version: v1.17
       - name: Check imports
         run: |
           cd kcp
@@ -51,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: v1.16
+          go-version: v1.17
       - uses: golangci/golangci-lint-action@v2
         with:
           only-new-issues: true
@@ -64,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: v1.16
+          go-version: v1.17
       - name: Download modules
         run: go mod download
       - name: Check codegen
@@ -77,7 +76,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: v1.16
+          go-version: v1.17
       - run: make build
       - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" make test
       - uses: actions/upload-artifact@v2
@@ -93,7 +92,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: v1.16
+          go-version: v1.17
       - run: make build
       - uses: actions/checkout@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# We need bash for some conditional logic below.
+SHELL := /usr/bin/env bash
+
 GO_INSTALL = ./hack/go-install.sh
 
 TOOLS_DIR=hack/tools
@@ -55,10 +58,18 @@ codegen: $(CONTROLLER_GEN)
 # Note, running this locally if you have any modified files, even those that are not generated,
 # will result in an error. This target is mostly for CI jobs.
 .PHONY: verify-codegen
-verify-codegen: codegen
-	@if !(git diff --quiet HEAD); then \
+verify-codegen:
+	if [[ -n "${GITHUB_WORKSPACE}" ]]; then \
+		mkdir -p $$(go env GOPATH)/src/github.com/kcp-dev; \
+		ln -s ${GITHUB_WORKSPACE} $$(go env GOPATH)/src/github.com/kcp-dev/kcp; \
+	fi
+
+	$(MAKE) codegen
+
+	if ! git diff --quiet HEAD; then \
 		git diff; \
-		echo "You need to run 'make codegen' to update generated files and commit them"; exit 1; \
+		echo "You need to run 'make codegen' to update generated files and commit them"; \
+		exit 1; \
 	fi
 
 

--- a/pkg/client/clientset/versioned/typed/apiresource/v1alpha1/apiresourceimport.go
+++ b/pkg/client/clientset/versioned/typed/apiresource/v1alpha1/apiresourceimport.go
@@ -103,6 +103,7 @@ func (c *aPIResourceImports) Watch(ctx context.Context, opts v1.ListOptions) (wa
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Cluster(c.cluster).
 		Resource("apiresourceimports").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/pkg/client/clientset/versioned/typed/apiresource/v1alpha1/negotiatedapiresource.go
+++ b/pkg/client/clientset/versioned/typed/apiresource/v1alpha1/negotiatedapiresource.go
@@ -103,6 +103,7 @@ func (c *negotiatedAPIResources) Watch(ctx context.Context, opts v1.ListOptions)
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Cluster(c.cluster).
 		Resource("negotiatedapiresources").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/pkg/client/clientset/versioned/typed/cluster/v1alpha1/cluster.go
+++ b/pkg/client/clientset/versioned/typed/cluster/v1alpha1/cluster.go
@@ -103,6 +103,7 @@ func (c *clusters) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interf
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Cluster(c.cluster).
 		Resource("clusters").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/pkg/client/clientset/versioned/typed/tenancy/v1alpha1/workspace.go
+++ b/pkg/client/clientset/versioned/typed/tenancy/v1alpha1/workspace.go
@@ -103,6 +103,7 @@ func (c *workspaces) Watch(ctx context.Context, opts v1.ListOptions) (watch.Inte
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Cluster(c.cluster).
 		Resource("workspaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/pkg/client/clientset/versioned/typed/tenancy/v1alpha1/workspaceshard.go
+++ b/pkg/client/clientset/versioned/typed/tenancy/v1alpha1/workspaceshard.go
@@ -103,6 +103,7 @@ func (c *workspaceShards) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Cluster(c.cluster).
 		Resource("workspaceshards").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).

--- a/test/e2e/reconciler/cluster/client/clientset/versioned/typed/wildwest/v1alpha1/cowboy.go
+++ b/test/e2e/reconciler/cluster/client/clientset/versioned/typed/wildwest/v1alpha1/cowboy.go
@@ -107,6 +107,7 @@ func (c *cowboys) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interfa
 	}
 	opts.Watch = true
 	return c.client.Get().
+		Cluster(c.cluster).
 		Namespace(c.ns).
 		Resource("cowboys").
 		VersionedParams(&opts, scheme.ParameterCodec).


### PR DESCRIPTION
Bump go CI version to 1.17.

Fix verify-codegen when running in CI. Because this repo is not cloned into GOPATH, we have to set up a symlink so the code generators that currently only support outputting in GOPATH will work correctly. Otherwise, it will look like code generation always passes verification because it's not checking the right files.

Regenerate clients to match generators in current Kubernetes version.