### PR TITLE
server: allow configuring etcd WAL size

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"go.etcd.io/etcd/server/v3/embed"
+	"go.etcd.io/etcd/server/v3/wal"
 
 	"k8s.io/klog/v2"
 )
@@ -52,8 +53,11 @@ type ClientInfo struct {
 	TrustedCAFile string
 }
 
-func (s *Server) Run(ctx context.Context, peerPort, clientPort string) (ClientInfo, error) {
+func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBytes int64) (ClientInfo, error) {
 	klog.Info("Creating embedded etcd server")
+	if walSizeBytes != 0 {
+		wal.SegmentSizeBytes = walSizeBytes
+	}
 	cfg := embed.NewConfig()
 
 	cfg.Logger = "zap"

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	EtcdDirectory              string
 	EtcdPeerPort               string
 	EtcdClientPort             string
+	EtcdWalSizeBytes           int64
 	InstallClusterController   bool
 	ClusterControllerOptions   *cluster.Options
 	InstallWorkspaceController bool
@@ -80,6 +81,7 @@ func BindOptions(c *Config, fs *pflag.FlagSet) *Config {
 	fs.StringVar(&c.RootDirectory, "root_directory", c.RootDirectory, "Root directory.")
 	fs.StringVar(&c.EtcdPeerPort, "etcd_peer_port", c.EtcdPeerPort, "Port for etcd peer communication.")
 	fs.StringVar(&c.EtcdClientPort, "etcd_client_port", c.EtcdClientPort, "Port for etcd client communication.")
+	fs.Int64Var(&c.EtcdWalSizeBytes, "etcd_wal_size_bytes", c.EtcdWalSizeBytes, "Size in bytes for the etcd WAL. Leave unset to use the default.")
 	fs.StringVar(&c.KubeConfigPath, "kubeconfig_path", c.KubeConfigPath, "Path to which the administrative kubeconfig should be written at startup.")
 
 	c.ClusterControllerOptions = cluster.BindOptions(c.ClusterControllerOptions, fs)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -132,7 +132,7 @@ func (s *Server) Run(ctx context.Context) error {
 		es := &etcd.Server{
 			Dir: etcdDir,
 		}
-		embeddedClientInfo, err := es.Run(ctx, s.cfg.EtcdPeerPort, s.cfg.EtcdClientPort)
+		embeddedClientInfo, err := es.Run(ctx, s.cfg.EtcdPeerPort, s.cfg.EtcdClientPort, s.cfg.EtcdWalSizeBytes)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -95,6 +96,7 @@ func newKcpServer(t *T, cfg KcpConfig, artifactDir, dataDir string) (*kcpServer,
 			"--listen=:" + kcpListenPort,
 			"--etcd_client_port=" + etcdClientPort,
 			"--etcd_peer_port=" + etcdPeerPort,
+			"--etcd_wal_size_bytes=" + strconv.Itoa(5*1000), // 5KB
 			"--kubeconfig_path=admin.kubeconfig"},
 			cfg.Args...),
 		dataDir:     dataDir,


### PR DESCRIPTION
Running tests does not require hundreds of MB of WAL, so allow
configuring it to be smaller.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>