### PR TITLE
e2e: framework: squash one last concurrency bug

### DIFF
--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -143,7 +143,11 @@ func (c *expectationController) ExpectBefore(ctx context.Context, expectation Ex
 	}()
 
 	// evaluate once to get the current state once we're registered to see future events
-	go producer()
+	go func() {
+		c.lock.RLock()
+		c.expectations[id]()
+		c.lock.RUnlock()
+	}()
 
 	var expectationErrors []error
 	var processed int


### PR DESCRIPTION
It is required that the reader lock be held when writing to the results
channel. That was true in all cases but one.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Without this, you may see:

```
==================
WARNING: DATA RACE
Write at 0x00c000537b70 by goroutine 66:
  runtime.closechan()
      /usr/local/go/src/runtime/chan.go:355 +0x0
  github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore.func2()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:139 +0xdd
  github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:161 +0x56c
  github.com/kcp-dev/kcp/test/e2e/framework.ExpectWorkspaces.func1()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:191 +0x1db
  github.com/kcp-dev/kcp/test/e2e/reconciler/workspace.TestWorkspaceController.func5()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/reconciler/workspace/controller_test.go:189 +0x7d9
  github.com/kcp-dev/kcp/test/e2e/reconciler/workspace.TestWorkspaceController.func6()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/reconciler/workspace/controller_test.go:241 +0x92e
  github.com/kcp-dev/kcp/test/e2e/framework.Run.func1.1()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/test.go:132 +0x4ca

Previous read at 0x00c000537b70 by goroutine 83:
  runtime.chansend()
      /usr/local/go/src/runtime/chan.go:158 +0x0
  github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore.func1()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:105 +0xf0

Goroutine 66 (running) created at:
  github.com/kcp-dev/kcp/test/e2e/framework.Run.func1()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/test.go:100 +0x5d6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202

Goroutine 83 (running) created at:
  github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:146 +0x3a5
  github.com/kcp-dev/kcp/test/e2e/framework.ExpectWorkspaces.func1()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:191 +0x1db
  github.com/kcp-dev/kcp/test/e2e/reconciler/workspace.TestWorkspaceController.func5()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/reconciler/workspace/controller_test.go:189 +0x7d9
  github.com/kcp-dev/kcp/test/e2e/reconciler/workspace.TestWorkspaceController.func6()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/reconciler/workspace/controller_test.go:241 +0x92e
  github.com/kcp-dev/kcp/test/e2e/framework.Run.func1.1()
      /home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/test.go:132 +0x4ca
==================
panic: send on closed channel

goroutine 3248 [running]:
github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore.func1()
	/home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:105 +0xf1
created by github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore
	/home/stevekuznetsov/code/kcp-dev/kcp/src/github.com/kcp-dev/kcp/test/e2e/framework/expect.go:146 +0x3a6
```