### PR TITLE
e2e: framework: fix segfault in race condition

### DIFF
--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -145,7 +145,12 @@ func (c *expectationController) ExpectBefore(ctx context.Context, expectation Ex
 	// evaluate once to get the current state once we're registered to see future events
 	go func() {
 		c.lock.RLock()
-		c.expectations[id]()
+		// It's possible that this first evaluation races with us getting called from the
+		// controller, so we need to make sure that there's still an expectation registered
+		// here before running it!
+		if f, ok := c.expectations[id]; ok {
+			f()
+		}
 		c.lock.RUnlock()
 	}()
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1d58a91]

goroutine 2539 [running]:
github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore.func3()
	/home/runner/work/kcp/kcp/test/e2e/framework/expect.go:148 +0x91
created by github.com/kcp-dev/kcp/test/e2e/framework.(*expectationController).ExpectBefore
	/home/runner/work/kcp/kcp/test/e2e/framework/expect.go:146 +0x40a
```