### PR TITLE
e2e: framework: fix double-nested artifacts

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -99,7 +99,7 @@ func (c *kcpServer) Artifact(tinterface TestingTInterface, producer func() (runt
 		t.Logf("artifact has no object meta: %#v", data)
 		return
 	}
-	dir := path.Join(c.artifactDir, "kcp", c.Name(), accessor.GetClusterName())
+	dir := path.Join(c.artifactDir, accessor.GetClusterName())
 	if accessor.GetNamespace() != "" {
 		dir = path.Join(dir, accessor.GetNamespace())
 	}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Before:

```
$ tree /tmp/e2e/TestClusterController/create_an_object,_expect_spec_to_sync_to_sink/3102095384/artifacts/
/tmp/e2e/TestClusterController/create_an_object,_expect_spec_to_sync_to_sink/3102095384/artifacts/
└── kcp
    ├── sink
    │   ├── kcp
    │   │   └── sink
    │   │       └── 192-168-0-243-41769---admin
    │   │           └── cluster-controller-test
    │   │               └── cowboys.wildwest.dev_timothy.yaml
    │   └── kcp.log
    └── source
        ├── kcp
        │   └── source
        │       ├── 192-168-0-243-41333---admin
        │       │   └── clusters.cluster.example.dev_us-east1.yaml
        │       └── 192-168-0-243-41769---admin
        │           └── cluster-controller-test
        │               └── cowboys.wildwest.dev_timothy.yaml
        └── kcp.log

12 directories, 5 files
```

After:
```
$ tree /tmp/e2e/TestClusterController/create_an_object,_expect_spec_to_sync_to_sink/2874492820/artifacts/
/tmp/e2e/TestClusterController/create_an_object,_expect_spec_to_sync_to_sink/2874492820/artifacts/
└── kcp
    ├── sink
    │   ├── 192-168-0-243-38903---admin
    │   │   └── cluster-controller-test
    │   │       └── cowboys.wildwest.dev_timothy.yaml
    │   └── kcp.log
    └── source
        ├── 192-168-0-243-38903---admin
        │   └── cluster-controller-test
        │       └── cowboys.wildwest.dev_timothy.yaml
        ├── 192-168-0-243-42693---admin
        │   └── clusters.cluster.example.dev_us-east1.yaml
        └── kcp.log

8 directories, 5 files
```