### PR TITLE
Avoid syncer crash by checking if deleteFn is defined

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -330,7 +330,7 @@ func (c *Controller) process(gvr schema.GroupVersionResource, obj interface{}) e
 		return err
 	}
 
-	if !exists {
+	if !exists && c.deleteFn != nil {
 		klog.Infof("Object with gvr=%q was deleted : %s/%s", gvr, namespace, name)
 		return c.deleteFn(c, ctx, gvr, namespace, name)
 	}


### PR DESCRIPTION
(note: I am not sure it is the correct fix, feel free to close it)

I1215 15:41:45.629884   56741 syncer.go:334] Object with gvr="/v1, Resource=pods" was deleted : default/el-github-listener-797f77d845-4xhqx
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2b99731]

goroutine 14320 [running]:
github.com/kcp-dev/kcp/pkg/syncer.(*Controller).process(0xc007776a80, {{0xc007df2655, 0x0}, {0xc007df2655, 0x2}, {0xc007df2650, 0x4}}, {0x34b3e60, 0xc0047748d0})
	work/kcp/pkg/syncer/syncer.go:335 +0x8b1
github.com/kcp-dev/kcp/pkg/syncer.(*Controller).processNextWorkItem(0xc007776a80)
	work/kcp/pkg/syncer/syncer.go:276 +0x1d0
github.com/kcp-dev/kcp/pkg/syncer.(*Controller).startWorker(0xc007776a80)
	work/kcp/pkg/syncer/syncer.go:250 +0x29
created by github.com/kcp-dev/kcp/pkg/syncer.(*Controller).Start
	work/kcp/pkg/syncer/syncer.go:238 +0x30