### PR TITLE
e2e/artifacts: use a scoped discovery client

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -129,7 +129,8 @@ func (c *kcpServer) Artifact(tinterface TestingTInterface, producer func() (runt
 		t.Logf("could not get discovery client for server: %v", err)
 		return
 	}
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(discoveryClient))
+	scopedDiscoveryClient := discoveryClient.WithCluster(accessor.GetClusterName())
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(scopedDiscoveryClient))
 	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		t.Logf("could not get REST mapping for artifact's GVK: %v", err)


### PR DESCRIPTION
Scope the discovery client to match the produced object's logical
cluster, so discovery is going against the same/correct logical cluster
when trying to use the RESTMapper. Otherwise, we may get "no matches for
GVK" errors.