### PR TITLE
workspaceshard: record the version of loaded credentials

### DIFF
--- a/config/tenancy.kcp.dev_workspaceshards.yaml
+++ b/config/tenancy.kcp.dev_workspaceshards.yaml
@@ -133,6 +133,9 @@ spec:
                 - api_path
                 - host
                 type: object
+              credentialsHash:
+                description: Version of credentials last successfully loaded.
+                type: string
             type: object
         type: object
     served: true

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -210,6 +210,10 @@ type WorkspaceShardStatus struct {
 	// Connection information for the WorkspaceShard.
 	// +optional
 	ConnectionInfo *ConnectionInfo `json:"connectionInfo,omitempty"`
+
+	// Version of credentials last successfully loaded.
+	// +optional
+	CredentialsHash string `json:"credentialsHash,omitempty"`
 }
 
 // ConnectionInfo holds the information necessary to connect to a shard.


### PR DESCRIPTION
Downstream consumers of shard credentials need to know when the
credentials are rotated. For instance, any client that first determines
that data they care about is on a shard, then begins some process to
monitor that data, must know when the credentials used to access that
shard change. In order to not require that all of these clients watch
Secrets, record the version of the credentials that are loaded.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>