### PR TITLE
e2e: framework: expose artifact and data dirs to tests

### DIFF
--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -39,7 +39,7 @@ import (
 func TestAPIInheritance(t *testing.T) {
 	const serverName = "main"
 
-	framework.Run(t, "Basic workspace API inheritance", func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+	framework.Run(t, "Basic workspace API inheritance", func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 		ctx := context.Background()
 		if deadline, ok := t.Deadline(); ok {
 			withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -41,7 +41,7 @@ type RunningServer interface {
 	Artifact(t TestingTInterface, producer func() (runtime.Object, error))
 }
 
-type TestFunc func(t TestingTInterface, servers map[string]RunningServer)
+type TestFunc func(t TestingTInterface, servers map[string]RunningServer, artifactDir, dataDir string)
 
 // KcpConfig qualify a kcp server to start
 type KcpConfig struct {
@@ -129,7 +129,7 @@ func Run(top *testing.T, name string, f TestFunc, cfgs ...KcpConfig) {
 			t.Logf("Started kcp servers after %s", time.Since(start))
 
 			// run the test
-			f(t, runningServers)
+			f(t, runningServers, artifactDir, dataDir)
 		}(bottom)
 
 		bottom.Wait()

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -148,7 +148,7 @@ func TestClusterController(t *testing.T) {
 	}
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			start := time.Now()
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -167,7 +167,7 @@ func TestIngressController(t *testing.T) {
 	}
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			start := time.Now()
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
@@ -267,7 +267,7 @@ func TestIngressController(t *testing.T) {
 			ingressController := ingressControllerConfig{
 				t:               t,
 				kubeconfigPath:  cfg.Clusters[cfg.CurrentContext].LocationOfOrigin,
-				artifactDir:     t.TempDir(),
+				artifactDir:     artifactDir,
 				xdsListenPort:   xdsListenerPort,
 				envoyListenPort: envoyListenerPort,
 			}

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -193,7 +193,7 @@ func TestNamespaceScheduler(t *testing.T) {
 	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -280,7 +280,7 @@ func TestWorkspaceController(t *testing.T) {
 	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -355,7 +355,7 @@ func TestWorkspaceShardController(t *testing.T) {
 	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer) {
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)


### PR DESCRIPTION
When we're running many tests in parallel, random directories are chosen
for every invocation. In order to ensure that test processes are placing
artifacts and data in the correct place, we need to pass that
information down.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>