### PR TITLE
cmd: add a shard proxy server

### DIFF
--- a/cmd/shard-proxy/main.go
+++ b/cmd/shard-proxy/main.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"runtime"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	kubernetesclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/reconciler/workspaceindex"
+)
+
+const resyncPeriod = 10 * time.Hour
+
+func defaultOptions() *options {
+	return &options{
+		numThreads: runtime.NumCPU(),
+	}
+}
+
+func bindOptions(defaultOptions *options, fs *pflag.FlagSet) *options {
+	fs.StringVar(&defaultOptions.rootKubeconfigPath, "root-kubeconfig", "", "Path to root kubeconfig.")
+	fs.IntVar(&defaultOptions.numThreads, "threads", defaultOptions.numThreads, "Number of threads to use.")
+	fs.IntVar(&defaultOptions.port, "port", defaultOptions.port, "Port to serve index on.")
+	return defaultOptions
+}
+
+type options struct {
+	// rootKubeconfigPath should hold a kubeconfig where the current context is
+	// scoped to the logical cluster that contains organization workspaces
+	rootKubeconfigPath string
+	numThreads         int
+	port               int
+}
+
+func (o *options) Validate() error {
+	if o.rootKubeconfigPath == "" {
+		return errors.New("--root-kubeconfig is required")
+	}
+	return nil
+}
+
+func main() {
+	// Setup signal handler for a cleaner shutdown
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
+	defer cancel()
+
+	fs := pflag.NewFlagSet("shard-proxy", pflag.ExitOnError)
+	o := bindOptions(defaultOptions(), fs)
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		klog.Fatalf("failed to parse arguments: %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		klog.Fatalf("invalid options: %v", err)
+	}
+
+	rootConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: o.rootKubeconfigPath}, nil).ClientConfig()
+	if err != nil {
+		klog.Fatalf("failed to load root credentials: %v", err)
+	}
+	rootClient, err := kcpclient.NewForConfig(rootConfig)
+	if err != nil {
+		klog.Fatalf("failed to create root client: %v", err)
+	}
+	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(rootClient, resyncPeriod)
+	rootKubeClient, err := kubernetesclientset.NewClusterForConfig(rootConfig)
+	if err != nil {
+		klog.Fatalf("failed to create root k8s client: %v", err)
+	}
+
+	index := workspaceindex.NewIndex()
+	controller, err := workspaceindex.NewController(
+		rootKubeClient,
+		kcpSharedInformerFactory.Tenancy().V1alpha1().Workspaces(),
+		kcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceShards(),
+		index,
+	)
+	if err != nil {
+		klog.Fatalf("failed to create workspace index controller: %v", err)
+	}
+	server := workspaceindex.NewServer(o.port, kcpSharedInformerFactory, index, controller.Stable)
+
+	kcpSharedInformerFactory.Start(ctx.Done())
+	go controller.Start(ctx, o.numThreads)
+	go server.ListenAndServe(ctx)
+
+	<-ctx.Done()
+}

--- a/pkg/apis/tenancy/v1alpha1/helper/helper.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+const (
+	separator = "_"
+
+	// OrganizationCluster is the name of the logical cluster we expect to find
+	// organization inside.
+	OrganizationCluster = "admin"
+)
+
+// EncodeLogicalClusterName determines the logical cluster name for a workspace.
+// We assume that the organization that this workspace resides in is the cluster
+// it lives in.
+func EncodeLogicalClusterName(workspace *tenancyapi.Workspace) (string, error) {
+	orgName := workspace.ClusterName
+	if workspace.ClusterName != OrganizationCluster {
+		_, name, err := ParseLogicalClusterName(workspace.ClusterName)
+		if err != nil {
+			return "", err
+		}
+		orgName = name
+	}
+	return orgName + separator + workspace.Name, nil
+}
+
+// ParseLogicalClusterName determines the organization and workspace name from a
+// logical cluster name.
+func ParseLogicalClusterName(name string) (string, string, error) {
+	parts := strings.Split(name, separator)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("expected logical cluster name to be in org_name format, got %s", name)
+	}
+	return parts[0], parts[1], nil
+}

--- a/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+func TestEncodeLogicalClusterName(t *testing.T) {
+	for _, testCase := range []struct {
+		name        string
+		input       *tenancyv1alpha1.Workspace
+		expected    string
+		expectedErr bool
+	}{
+		{
+			name: "organization workspace",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "admin",
+					Name:        "organization",
+				},
+			},
+			expected: "admin_organization",
+		},
+		{
+			name: "normal workspace",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "admin_organization",
+					Name:        "workspace",
+				},
+			},
+			expected: "organization_workspace",
+		},
+		{
+			name: "organization workspace in wrong root cluster",
+			input: &tenancyv1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: "somethingwrong",
+					Name:        "organization",
+				},
+			},
+			expectedErr: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, actualErr := EncodeLogicalClusterName(testCase.input)
+			if actualErr != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error, got %v", testCase.name, actualErr)
+			}
+			if actualErr == nil && testCase.expectedErr {
+				t.Errorf("%s: expected error, got none", testCase.name)
+			}
+			if actual != testCase.expected {
+				t.Errorf("%s: got incorrect logical cluster name, expected %s got %s", testCase.name, testCase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseLogicalClusterName(t *testing.T) {
+	for _, testCase := range []struct {
+		name         string
+		input        string
+		expectedOrg  string
+		expectedName string
+		expectedErr  bool
+	}{
+		{
+			name:         "valid name",
+			input:        "organization_workspace",
+			expectedOrg:  "organization",
+			expectedName: "workspace",
+		},
+		{
+			name:        "invalid name",
+			input:       "whoathere",
+			expectedErr: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualOrg, actualName, actualErr := ParseLogicalClusterName(testCase.input)
+			if actualErr != nil && !testCase.expectedErr {
+				t.Errorf("%s: expected no error, got %v", testCase.name, actualErr)
+			}
+			if actualErr == nil && testCase.expectedErr {
+				t.Errorf("%s: expected error, got none", testCase.name)
+			}
+			if actualOrg != testCase.expectedOrg {
+				t.Errorf("%s: got incorrect logical cluster name, expected %s got %s", testCase.name, testCase.expectedOrg, actualOrg)
+			}
+			if actualName != testCase.expectedName {
+				t.Errorf("%s: got incorrect logical cluster name, expected %s got %s", testCase.name, testCase.expectedName, actualName)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/workspaceindex/controller.go
+++ b/pkg/reconciler/workspaceindex/controller.go
@@ -1,0 +1,472 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaceindex
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	tenancyinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
+	tenancylister "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+const (
+	rootShard         = "root"
+	currentShardIndex = "shard"
+	controllerName    = "workspaceindex-controller"
+)
+
+const resyncPeriod = 10 * time.Hour
+
+func NewController(
+	kubeClient kubernetes.ClusterInterface,
+	workspaceInformer tenancyinformer.WorkspaceInformer,
+	workspaceShardInformer tenancyinformer.WorkspaceShardInformer,
+	index Index,
+) (*Controller, error) {
+	orgQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	workspaceQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	c := &Controller{
+		orgQueue:              orgQueue,
+		workspaceQueue:        workspaceQueue,
+		kubeClient:            kubeClient,
+		workspaceIndexer:      workspaceInformer.Informer().GetIndexer(),
+		workspaceLister:       workspaceInformer.Lister(),
+		workspaceShardIndexer: workspaceShardInformer.Informer().GetIndexer(),
+		workspaceShardLister:  workspaceShardInformer.Lister(),
+		syncChecks: []cache.InformerSynced{
+			workspaceInformer.Informer().HasSynced,
+			workspaceShardInformer.Informer().HasSynced,
+		},
+		shardInformers: map[string]map[string]organizationInformer{},
+		index:          index,
+	}
+
+	workspaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueOrg(obj)
+			c.enqueueWorkspace(rootShard, rootShard, obj)
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			c.enqueueOrg(obj)
+			c.enqueueWorkspace(rootShard, rootShard, obj)
+		},
+		// TODO: handle deletes
+	})
+	if err := c.workspaceIndexer.AddIndexers(map[string]cache.IndexFunc{
+		currentShardIndex: func(obj interface{}) ([]string, error) {
+			if workspace, ok := obj.(*tenancyv1alpha1.Workspace); ok {
+				return []string{workspace.Status.Location.Current}, nil
+			}
+			return []string{}, nil
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add indexer for Workspace: %w", err)
+	}
+
+	workspaceShardInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueOrgsForShard(obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueOrgsForShard(obj) },
+	})
+
+	return c, nil
+}
+
+// Controller is meant to watch Workspaces and WorkspaceShards in the root logical
+// cluster which correspond to the Organizations present in the kcp fleet. Events in
+// the root logical cluster are used to create an in-memory record of the set of
+// Organizations that need to be watched as well as the credentials with which that
+// should be done. For each Organization, Workspaces are watched in order to build a
+// mapping of logical cluster name and resource version to the kcp shard on which the
+// data will be found.
+type Controller struct {
+	orgQueue       workqueue.RateLimitingInterface
+	workspaceQueue workqueue.RateLimitingInterface
+
+	// activeWorkersLock guards the counts of workers above - we need one lock for both
+	// instead of using sync.atomic as we need to read both in one atomic transaction
+	activeWorkersLock           sync.RWMutex
+	orgQueueActiveWorkers       uint64
+	workspaceQueueActiveWorkers uint64
+
+	// kubeClient is used to fetch kubeconfig secrets for shards in the root Workspace
+	kubeClient kubernetes.ClusterInterface
+
+	workspaceIndexer cache.Indexer
+	workspaceLister  tenancylister.WorkspaceLister
+
+	workspaceShardIndexer cache.Indexer
+	workspaceShardLister  tenancylister.WorkspaceShardLister
+
+	syncChecks []cache.InformerSynced
+
+	shardInformersLock sync.RWMutex
+	// shardInformers are the set of informers we manage for each shard that orgs are on
+	// mapped from shard to logical cluster to informer
+	shardInformers map[string]map[string]organizationInformer
+
+	// index holds resourceVersion-bound locations for workspaces through history.
+	index Index
+}
+
+type organizationInformer struct {
+	ctx    context.Context
+	cancel func()
+
+	workspaceIndexer cache.Indexer
+	workspaceLister  tenancylister.WorkspaceLister
+
+	credentialsHash string
+}
+
+func (c *Controller) enqueueOrg(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	klog.Infof("queueing org workspace %q", key)
+	c.orgQueue.Add(key)
+}
+
+func (c *Controller) enqueueOrgsForShard(obj interface{}) {
+	shard, ok := obj.(*tenancyv1alpha1.WorkspaceShard)
+	if !ok {
+		klog.V(2).Infof("Enqueued object that is not a WorkspaceShard: %#v", obj)
+		return
+	}
+	klog.Infof("handling shard %q", shard.Name)
+	workspaces, err := c.workspaceIndexer.ByIndex(currentShardIndex, shard.Name)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	for _, workspace := range workspaces {
+		key, err := cache.MetaNamespaceKeyFunc(workspace)
+		if err != nil {
+			runtime.HandleError(err)
+			return
+		}
+		klog.Infof("queuing associated org workspace %q", key)
+		c.orgQueue.Add(key)
+	}
+}
+
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.orgQueue.ShutDown()
+
+	klog.Info("Starting WorkspaceIndex orchestrator")
+	defer klog.Info("Shutting down WorkspaceIndex orchestrator")
+
+	if !cache.WaitForNamedCacheSync(controllerName, ctx.Done(), c.syncChecks...) {
+		klog.Warning("Failed to wait for caches to sync")
+		return
+	}
+
+	for i := 0; i < numThreads; i++ {
+		go wait.Until(func() { c.startOrgWorker(ctx) }, time.Second, ctx.Done())
+		go wait.Until(func() { c.startWorkspaceWorker(ctx) }, time.Second, ctx.Done())
+	}
+
+	<-ctx.Done()
+}
+
+func (c *Controller) startOrgWorker(ctx context.Context) {
+	for c.processNextOrgWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextOrgWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.orgQueue.Get()
+	if quit {
+		return false
+	}
+	c.activeWorkersLock.Lock()
+	c.orgQueueActiveWorkers += 1
+	c.activeWorkersLock.Unlock()
+	defer func() {
+		c.activeWorkersLock.Lock()
+		c.orgQueueActiveWorkers -= 1
+		c.activeWorkersLock.Unlock()
+	}()
+	key := k.(string)
+
+	klog.Infof("processing org %q", key)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.orgQueue.Done(key)
+
+	if err := c.processOrg(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.orgQueue.AddRateLimited(key)
+		return true
+	}
+	c.orgQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processOrg(ctx context.Context, key string) error {
+	obj, err := c.workspaceLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil // object deleted before we handled it
+		}
+		return err
+	}
+	obj = obj.DeepCopy()
+
+	return c.handleOrg(ctx, obj)
+}
+
+// handleOrg ensures that an informer is running for Workspaces in every Organization, using the
+// latest credentials available for the Shard on which the Organization is held
+func (c *Controller) handleOrg(ctx context.Context, workspace *tenancyv1alpha1.Workspace) error {
+	if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceScheduled) ||
+		!conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceURLValid) {
+		klog.Infof("org workspace %s/%s not ready, skipping...", workspace.ClusterName, workspace.Name)
+		return nil // not ready yet
+	}
+	logicalCluster, err := helper.EncodeLogicalClusterName(workspace)
+	if err != nil {
+		klog.Errorf("error creating client with workspace shard credentials: %v", err)
+		return nil
+	}
+
+	shardKey, err := cache.MetaNamespaceKeyFunc(&metav1.ObjectMeta{
+		ClusterName: workspace.ObjectMeta.ClusterName,
+		Name:        workspace.Status.Location.Current,
+	})
+	if err != nil {
+		klog.Errorf("failed to get key for workspace shard: %v", err)
+		return nil
+	}
+	workspaceShard, err := c.workspaceShardLister.Get(shardKey)
+	if err != nil {
+		klog.Errorf("failed to get workspace shard %q: %v", shardKey, err)
+		return nil
+	}
+
+	var previousCredentialsHash, previousResourceVersion string
+	c.shardInformersLock.Lock()
+	defer c.shardInformersLock.Unlock()
+	if informersByLogicalCluster, ok := c.shardInformers[workspace.Status.Location.Current]; ok {
+		if informer, ok := informersByLogicalCluster[logicalCluster]; ok {
+			previousCredentialsHash = informer.credentialsHash
+			items, err := informer.workspaceLister.List(labels.Everything())
+			if err != nil {
+				klog.Errorf("failed to list workspaces from previous lister on %s/%s: %v", workspace.Status.Location.Current, logicalCluster, err)
+				return nil
+			}
+			var largestResourceVersion int64
+			for _, item := range items {
+				rv, err := strconv.ParseInt(item.ResourceVersion, 10, 64)
+				if err != nil {
+					klog.Errorf("failed to parse resourceVersion for workspace %s from %s/%s: %v", item.Name, workspace.Status.Location.Current, logicalCluster, err)
+				}
+				if rv > largestResourceVersion {
+					largestResourceVersion = rv
+				}
+			}
+			previousResourceVersion = strconv.FormatInt(largestResourceVersion, 10)
+		}
+	}
+
+	if previousCredentialsHash == workspaceShard.Status.CredentialsHash {
+		// nothing to be done
+		return nil
+	}
+
+	secret, err := c.kubeClient.Cluster(workspaceShard.ClusterName).CoreV1().Secrets(workspaceShard.Spec.Credentials.Namespace).Get(ctx, workspaceShard.Spec.Credentials.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get workspace shard credentials: %v", shardKey, err)
+		return err // retry since this could flake in an otherwise OK situation
+	}
+
+	data, ok := secret.Data[tenancyv1alpha1.WorkspaceShardCredentialsKey]
+	if !ok {
+		klog.Error("workspace shard credentials missing data")
+		return nil
+	}
+
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(data)
+	if err != nil {
+		klog.Errorf("workspace shard credentials invalid: %v", err)
+		return nil
+	}
+
+	var options []kcpexternalversions.SharedInformerOption
+	if previousResourceVersion != "" {
+		options = append(options, kcpexternalversions.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.ResourceVersion = previousResourceVersion
+		}))
+	}
+
+	kcpClient, err := kcpclient.NewClusterForConfig(cfg)
+	if err != nil {
+		klog.Errorf("error creating client with workspace shard credentials: %v", err)
+		return nil
+	}
+
+	octx, cancel := context.WithCancel(ctx)
+	crossClusterKcpClient := kcpClient.Cluster(logicalCluster)
+	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(crossClusterKcpClient, resyncPeriod, options...)
+	workspaceInformer := kcpSharedInformerFactory.Tenancy().V1alpha1().Workspaces()
+
+	workspaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueueWorkspace(workspaceShard.Name, logicalCluster, obj) },
+		UpdateFunc: func(_, obj interface{}) { c.enqueueWorkspace(workspaceShard.Name, logicalCluster, obj) },
+		// TODO: handle deletes
+	})
+
+	if previousCredentialsHash != "" {
+		c.shardInformers[workspace.Status.Location.Current][logicalCluster].cancel()
+		delete(c.shardInformers[workspace.Status.Location.Current], logicalCluster)
+	}
+	if _, recorded := c.shardInformers[workspace.Status.Location.Current]; !recorded {
+		c.shardInformers[workspace.Status.Location.Current] = map[string]organizationInformer{}
+	}
+	c.shardInformers[workspace.Status.Location.Current][logicalCluster] = organizationInformer{
+		ctx:              octx,
+		cancel:           cancel,
+		workspaceIndexer: workspaceInformer.Informer().GetIndexer(),
+		workspaceLister:  workspaceInformer.Lister(),
+		credentialsHash:  workspaceShard.Status.CredentialsHash,
+	}
+	klog.Infof("starting informer for shard %s", workspace.Status.Location.Current)
+	// TODO: think through the concurrency here to make sure we're never getting extra events on credential reload
+	kcpSharedInformerFactory.Start(octx.Done())
+	kcpSharedInformerFactory.WaitForCacheSync(octx.Done())
+	klog.Infof("started informer for shard %s", workspace.Status.Location.Current)
+	return nil
+}
+
+func (c *Controller) enqueueWorkspace(shard, logicalCluster string, obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	key = fmt.Sprintf("%s|%s|%s", shard, logicalCluster, key)
+	klog.Infof("queueing workspace %q", key)
+	c.workspaceQueue.Add(key)
+}
+
+func (c *Controller) startWorkspaceWorker(ctx context.Context) {
+	for c.processNextWorkspaceWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkspaceWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.workspaceQueue.Get()
+	if quit {
+		return false
+	}
+	c.activeWorkersLock.Lock()
+	c.workspaceQueueActiveWorkers += 1
+	c.activeWorkersLock.Unlock()
+	defer func() {
+		c.activeWorkersLock.Lock()
+		c.workspaceQueueActiveWorkers -= 1
+		c.activeWorkersLock.Unlock()
+	}()
+	key := k.(string)
+
+	klog.Infof("processing workspace %q", key)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.workspaceQueue.Done(key)
+
+	if err := c.processWorkspace(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.workspaceQueue.AddRateLimited(key)
+		return true
+	}
+	c.workspaceQueue.Forget(key)
+	return true
+}
+
+func (c *Controller) processWorkspace(ctx context.Context, key string) error {
+	parts := strings.SplitN(key, "|", 3)
+	if len(parts) != 3 {
+		// programmer error
+		klog.Errorf("invalid key in workspace queue: %s", key)
+		return nil
+	}
+	var shard, logicalCluster string
+	shard, logicalCluster, key = parts[0], parts[1], parts[2]
+	var lister tenancylister.WorkspaceLister
+	if shard == rootShard {
+		lister = c.workspaceLister
+	} else {
+		informersByLogicalCluster, ok := c.shardInformers[shard]
+		if !ok {
+			klog.Infof("shard %s in workspace queue has no associated listers", shard)
+			return nil
+		}
+		informer, ok := informersByLogicalCluster[logicalCluster]
+		if !ok {
+			klog.Infof("shard %s in workspace queue has no associated lister for logical cluster %s", shard, logicalCluster)
+			return nil
+		}
+		lister = informer.workspaceLister
+	}
+	obj, err := lister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil // object deleted before we handled it
+		}
+		return err
+	}
+	obj = obj.DeepCopy()
+
+	return c.index.Record(obj)
+}
+
+// Stable exposes whether - to the best of our knowledge - the controller has stabilized.
+func (c *Controller) Stable() bool {
+	c.activeWorkersLock.RLock()
+	defer c.activeWorkersLock.RUnlock()
+	orgLen, orgWorkers, workspaceLen, workspaceWorkers := c.orgQueue.Len(), c.orgQueueActiveWorkers, c.workspaceQueue.Len(), c.workspaceQueueActiveWorkers
+	klog.Infof("workspaceQueue.Len()=%d, workspaceQueueActiveWorkers=%d, orgQueue.Len()=%d, orgQueueActiveWorkers=%d", workspaceLen, workspaceWorkers, orgLen, orgWorkers)
+	return workspaceWorkers == 0 && orgWorkers == 0 && orgLen == 0 && workspaceLen == 0
+}

--- a/pkg/reconciler/workspaceindex/index.go
+++ b/pkg/reconciler/workspaceindex/index.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaceindex
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"sync"
+
+	"k8s.io/klog/v2"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+// NewIndex creates a new workspace to shard assignment index.
+func NewIndex() *index {
+	return &index{
+		workspaceMapping: map[string]map[string][]ShardAssignment{},
+	}
+}
+
+// ShardAssignment holds a range of resource versions for which a workspace
+// was scheduled to a particular shard. math.MaxInt64 is used to indicate an
+// open upper interval.
+// TODO: should we just store ints on the API object?
+type ShardAssignment struct {
+	Name                      string `json:"name"`
+	LiveBeforeResourceVersion int64  `json:"liveBeforeResourceVersion"`
+	LiveAfterResourceVersion  int64  `json:"liveAfterResourceVersion"`
+}
+
+type Index interface {
+	Record(workspace *tenancyv1alpha1.Workspace) error
+	Get(organization, workspace string) ([]ShardAssignment, error)
+	json.Marshaler
+}
+
+type index struct {
+	sync.RWMutex
+	// workspaceMapping holds resourceVersion-bound locations for workspaces
+	// through history. The list of locations is sorted. The mapping is from
+	// org to workspace to history.
+	workspaceMapping map[string]map[string][]ShardAssignment
+}
+
+func (i *index) Record(workspace *tenancyv1alpha1.Workspace) error {
+	if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceScheduled) {
+		klog.Infof("workspace %s/%s not scheduled, skipping...", workspace.ClusterName, workspace.Name)
+		return nil
+	}
+	history, err := convertHistory(workspace.Status.Location.History)
+	if err != nil {
+		return fmt.Errorf("invalid history for workspace %s/%s: %w", workspace.ClusterName, workspace.Name, err)
+	}
+	// TODO: how to handle the root itself?
+	org := workspace.ClusterName
+	if workspace.ClusterName != helper.OrganizationCluster {
+		orgName, workspaceName, err := helper.ParseLogicalClusterName(workspace.ClusterName)
+		if err != nil {
+			klog.Errorf("failed to determine org for cluster: %v", err)
+			return nil
+		}
+		if orgName != helper.OrganizationCluster {
+			klog.Errorf("invalid org %q, only one level of nesting allowed", orgName)
+			return nil
+		}
+		org = workspaceName
+	}
+
+	i.Lock()
+	if _, ok := i.workspaceMapping[org]; !ok {
+		i.workspaceMapping[org] = map[string][]ShardAssignment{}
+	}
+	i.workspaceMapping[org][workspace.Name] = history
+	klog.Infof("added history for %s->%s:%v", org, workspace.Name, history)
+	i.Unlock()
+	return nil
+}
+
+func convertHistory(original []tenancyv1alpha1.ShardStatus) ([]ShardAssignment, error) {
+	var history []ShardAssignment
+	for i := range original {
+		converted, err := convertShardStatus(fmt.Sprintf("history[%d]", i), original[i])
+		if err != nil {
+			return nil, err
+		}
+		history = append(history, converted)
+	}
+	return history, nil
+}
+
+func convertShardStatus(prefix string, original tenancyv1alpha1.ShardStatus) (ShardAssignment, error) {
+	var liveBeforeResourceVersion int64
+	if original.LiveBeforeResourceVersion == "" {
+		liveBeforeResourceVersion = math.MaxInt64
+	} else {
+		var err error
+		liveBeforeResourceVersion, err = strconv.ParseInt(original.LiveBeforeResourceVersion, 10, 64)
+		if err != nil {
+			return ShardAssignment{}, fmt.Errorf("%s.liveBeforeResourceVersion: invalid: %w", prefix, err)
+		}
+	}
+	liveAfterResourceVersion, err := strconv.ParseInt(original.LiveAfterResourceVersion, 10, 64)
+	if err != nil {
+		return ShardAssignment{}, fmt.Errorf("%s.liveAfterResourceVersion: invalid: %w", prefix, err)
+	}
+	return ShardAssignment{
+		Name:                      original.Name,
+		LiveBeforeResourceVersion: liveBeforeResourceVersion,
+		LiveAfterResourceVersion:  liveAfterResourceVersion,
+	}, nil
+}
+
+func (i *index) Get(organization, workspace string) ([]ShardAssignment, error) {
+	i.RLock()
+	defer i.RUnlock()
+	historyByWorkspace, organizationExists := i.workspaceMapping[organization]
+	if !organizationExists {
+		return nil, fmt.Errorf("organization %q not found", organization)
+	}
+	history, workspaceExists := historyByWorkspace[workspace]
+	if !workspaceExists {
+		return nil, fmt.Errorf("workspace %q not found", workspace)
+	}
+	return history, nil
+}
+
+func (i *index) MarshalJSON() ([]byte, error) {
+	i.RLock()
+	defer i.RUnlock()
+	return json.Marshal(i.workspaceMapping)
+}
+
+var _ json.Marshaler = &index{}

--- a/pkg/reconciler/workspaceindex/server.go
+++ b/pkg/reconciler/workspaceindex/server.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaceindex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"strconv"
+
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+)
+
+// NewServer creates a new server that can respond to requests for versioned data in workspaces.
+func NewServer(port int, waiter cacheSyncWaiter, index Index, stable func() bool) Server {
+	return &server{
+		port:   port,
+		waiter: waiter,
+		index:  index,
+		stable: stable,
+	}
+}
+
+type Server interface {
+	ListenAndServe(ctx context.Context)
+}
+
+type server struct {
+	port   int
+	waiter cacheSyncWaiter
+	index  Index
+	stable func() bool
+}
+
+type cacheSyncWaiter interface {
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+func (s *server) ListenAndServe(ctx context.Context) {
+	mux := http.NewServeMux()
+	mux.Handle("/shard", http.HandlerFunc(s.handleShard))
+	mux.Handle("/data", http.HandlerFunc(s.handleData))
+	healthz.InstallHandler(mux)
+	healthz.InstallReadyzHandler(mux, healthz.NamedCheck("workspaces-synced", func(r *http.Request) error {
+		if !s.stable() {
+			return errors.New("work queues have outstanding keys")
+		}
+		return nil
+	}), healthz.NewInformerSyncHealthz(s.waiter))
+	httpServer := http.Server{Addr: ":" + strconv.Itoa(s.port), Handler: mux}
+	go func() {
+		<-ctx.Done()
+		if err := httpServer.Shutdown(context.Background()); err != nil {
+			klog.Error(err)
+		}
+	}()
+	if err := httpServer.ListenAndServe(); err != nil {
+		klog.Error(err)
+	}
+}
+
+const (
+	clusterNameQuery     = "clusterName"
+	resourceVersionQuery = "resourceVersion"
+)
+
+func (s *server) handleShard(w http.ResponseWriter, r *http.Request) {
+	// ensure the cache is stable before serving
+	if !s.stable() {
+		w.Header().Set("Retry-After", "10")
+		http.Error(w, "workspace index cache is not stable", http.StatusServiceUnavailable)
+		return
+	}
+	// first, validate the input from the user
+	q := r.URL.Query()
+	clusterName := q.Get(clusterNameQuery)
+	if clusterName == "" {
+		http.Error(w, "clusterName query must not be empty", http.StatusBadRequest)
+		return
+	}
+	organization, workspace, err := helper.ParseLogicalClusterName(clusterName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("clusterName query invalid: %v", err), http.StatusBadRequest)
+		return
+	}
+	resourceVersionString := q.Get(resourceVersionQuery)
+	if resourceVersionString == "" {
+		resourceVersionString = "0"
+	}
+	resourceVersion, err := strconv.ParseInt(resourceVersionString, 10, 64)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("resourceVersion query must be an integer: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// then, find the shard history for the workspace in question
+	history, err := s.index.Get(organization, workspace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	if len(history) == 0 {
+		http.Error(w, fmt.Sprintf("cluster %q has no shard history", clusterName), http.StatusInternalServerError)
+		return
+	}
+
+	// finally, find the part of the history that the user asked for. We assume that the
+	// history is sorted in ascending order of resourceVersion and that no resourceVersion
+	// ranges overlap
+	var shardName string
+	if resourceVersion == 0 {
+		// if the user asked for no particular resource version or literally "0", we want
+		// up-to-date results, served from the current shard this workspace sits on
+		shardName = history[len(history)-1].Name
+	} else {
+		idx := sort.Search(len(history), func(i int) bool {
+			return history[i].LiveAfterResourceVersion < resourceVersion && history[i].LiveBeforeResourceVersion >= resourceVersion
+		})
+		if idx == len(history) {
+			// this should never happen, since the current shard should have no liveBefore set
+			http.Error(w, fmt.Sprintf("cluster %q has no shard history containing resourceVersion %d", clusterName, resourceVersion), http.StatusInternalServerError)
+			return
+		}
+		shardName = history[idx].Name
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	fmt.Fprint(w, shardName)
+}
+
+func (s *server) handleData(w http.ResponseWriter, r *http.Request) {
+	if !s.stable() {
+		w.Header().Set("Retry-After", "10")
+		http.Error(w, "workspace index cache is not stable", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	raw, err := s.index.MarshalJSON()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to marshal data: %v", err), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprint(w, string(raw))
+}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
 )
 
-var reClusterName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$`)
+var reClusterName = regexp.MustCompile(`^([a-z0-9][a-z0-9-]{0,78}[a-z0-9]_)?[a-z0-9][a-z0-9-]{0,78}[a-z0-9]$`)
 
 func ServeHTTP(apiHandler http.Handler) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {

--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -94,7 +94,7 @@ func TestAPIInheritance(t *testing.T) {
 			t.Errorf("error creating source workspace: %v", err)
 			return
 		}
-		defer server.Artifact(t, func() (runtime.Object, error) {
+		server.Artifact(t, func() (runtime.Object, error) {
 			return kcpAdminClient.TenancyV1alpha1().Workspaces().Get(ctx, "source", metav1.GetOptions{})
 		})
 
@@ -108,7 +108,7 @@ func TestAPIInheritance(t *testing.T) {
 			t.Errorf("error creating target workspace: %v", err)
 			return
 		}
-		defer server.Artifact(t, func() (runtime.Object, error) {
+		server.Artifact(t, func() (runtime.Object, error) {
 			return kcpAdminClient.TenancyV1alpha1().Workspaces().Get(ctx, "target", metav1.GetOptions{})
 		})
 
@@ -164,7 +164,7 @@ func TestAPIInheritance(t *testing.T) {
 			t.Errorf("Error creating sourceWorkspaceCluster inside source: %v", err)
 			return
 		}
-		defer server.Artifact(t, func() (runtime.Object, error) {
+		server.Artifact(t, func() (runtime.Object, error) {
 			return sourceClusterClient.Get(ctx, "source-cluster", metav1.GetOptions{})
 		})
 
@@ -243,7 +243,7 @@ func TestAPIInheritance(t *testing.T) {
 			t.Errorf("error creating targetWorkspaceCluster inside target: %v", err)
 			return
 		}
-		defer server.Artifact(t, func() (runtime.Object, error) {
+		server.Artifact(t, func() (runtime.Object, error) {
 			return targetClusterClient.Get(ctx, "target-cluster", metav1.GetOptions{})
 		})
 

--- a/test/e2e/framework/accessory.go
+++ b/test/e2e/framework/accessory.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package framework
 
 import (
@@ -5,11 +21,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // NewAccessory creates a new accessory process.
@@ -24,6 +45,7 @@ func NewAccessory(t TestingTInterface, artifactDir string, cmd string, args ...s
 
 // Accessory knows how to run an executable with arguments for the duration of the context.
 type Accessory struct {
+	ctx         context.Context
 	t           TestingTInterface
 	artifactDir string
 	cmd         string
@@ -45,6 +67,7 @@ func (a *Accessory) Run(parentCtx context.Context) error {
 		<-cleanupCtx.Done()
 	})
 
+	a.ctx = ctx
 	cmd := exec.CommandContext(ctx, a.cmd, a.args...)
 
 	a.t.Logf("running: %v", strings.Join(cmd.Args, " "))
@@ -70,4 +93,47 @@ func (a *Accessory) Run(parentCtx context.Context) error {
 		}
 	}()
 	return nil
+}
+
+// Ready blocks until the server is healthy and ready.
+func Ready(ctx context.Context, t TestingTInterface, port string) bool {
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	for _, endpoint := range []string{"/healthz", "/readyz"} {
+		go func(endpoint string) {
+			defer wg.Done()
+			waitForEndpoint(ctx, t, port, endpoint)
+		}(endpoint)
+	}
+	wg.Wait()
+	return !t.Failed()
+}
+
+func waitForEndpoint(ctx context.Context, t TestingTInterface, port, endpoint string) {
+	var lastMsg string
+	var succeeded bool
+	loadCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	wait.UntilWithContext(loadCtx, func(ctx context.Context) {
+		url := fmt.Sprintf("http://[::1]:%s%s", port, endpoint)
+		resp, err := http.Get(url)
+		if err == nil {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				lastMsg = fmt.Sprintf("error reading response from %s: %v", url, err)
+				return
+			}
+			if resp.StatusCode != 200 {
+				lastMsg = fmt.Sprintf("unready response from %s: %v", url, string(body))
+				return
+			}
+			t.Logf("success contacting %s", url)
+			cancel()
+			succeeded = true
+		} else {
+			lastMsg = fmt.Sprintf("error contacting %s: %v", url, err)
+		}
+	}, 100*time.Millisecond)
+	if !succeeded {
+		t.Errorf(lastMsg)
+	}
 }

--- a/test/e2e/framework/accessory.go
+++ b/test/e2e/framework/accessory.go
@@ -1,0 +1,73 @@
+package framework
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// NewAccessory creates a new accessory process.
+func NewAccessory(t TestingTInterface, artifactDir string, cmd string, args ...string) *Accessory {
+	return &Accessory{
+		t:           t,
+		artifactDir: artifactDir,
+		cmd:         cmd,
+		args:        args,
+	}
+}
+
+// Accessory knows how to run an executable with arguments for the duration of the context.
+type Accessory struct {
+	t           TestingTInterface
+	artifactDir string
+	cmd         string
+	args        []string
+}
+
+func (a *Accessory) Run(parentCtx context.Context) error {
+	ctx, cancel := context.WithCancel(parentCtx)
+
+	if deadline, ok := a.t.Deadline(); ok {
+		deadlinedCtx, deadlinedCancel := context.WithDeadline(ctx, deadline.Add(-10*time.Second))
+		ctx = deadlinedCtx
+		a.t.Cleanup(deadlinedCancel) // this does not really matter but govet is upset
+	}
+	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
+	a.t.Cleanup(func() {
+		a.t.Logf("cleanup: ending `%s`", a.cmd)
+		cancel()
+		<-cleanupCtx.Done()
+	})
+
+	cmd := exec.CommandContext(ctx, a.cmd, a.args...)
+
+	a.t.Logf("running: %v", strings.Join(cmd.Args, " "))
+	logFile, err := os.Create(filepath.Join(a.artifactDir, fmt.Sprintf("%s.log", a.cmd)))
+	if err != nil {
+		cleanupCancel()
+		return fmt.Errorf("could not create log file: %w", err)
+	}
+	log := bytes.Buffer{}
+	writers := []io.Writer{&log, logFile}
+	mw := io.MultiWriter(writers...)
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+	if err := cmd.Start(); err != nil {
+		cleanupCancel()
+		return err
+	}
+	go func() {
+		defer func() { cleanupCancel() }()
+		err := cmd.Wait()
+		if err != nil && ctx.Err() == nil {
+			a.t.Errorf("`%s` failed: %w output: %s", a.cmd, err, log)
+		}
+	}()
+	return nil
+}

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -50,8 +50,11 @@ type kcpServer struct {
 	dataDir     string
 	artifactDir string
 
-	lock           *sync.Mutex
-	cfg            clientcmd.ClientConfig
+	artifactsLock *sync.RWMutex
+	artifacts []func()
+
+	lock *sync.Mutex
+	cfg  clientcmd.ClientConfig
 	kubeconfigPath string
 	// TODO: remove once https://github.com/kcp-dev/kcp/issues/301 is fixed
 	rawCfg *clientcmdapi.Config
@@ -103,6 +106,7 @@ func newKcpServer(t *T, cfg KcpConfig, artifactDir, dataDir string) (*kcpServer,
 			cfg.Args...),
 		dataDir:     dataDir,
 		artifactDir: artifactDir,
+		artifactsLock: &sync.RWMutex{},
 		ctx:         ctx,
 		t:           t,
 		lock:        &sync.Mutex{},

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -51,10 +51,10 @@ type kcpServer struct {
 	artifactDir string
 
 	artifactsLock *sync.RWMutex
-	artifacts []func()
+	artifacts     []func()
 
-	lock *sync.Mutex
-	cfg  clientcmd.ClientConfig
+	lock           *sync.Mutex
+	cfg            clientcmd.ClientConfig
 	kubeconfigPath string
 	// TODO: remove once https://github.com/kcp-dev/kcp/issues/301 is fixed
 	rawCfg *clientcmdapi.Config
@@ -104,12 +104,12 @@ func newKcpServer(t *T, cfg KcpConfig, artifactDir, dataDir string) (*kcpServer,
 			"--etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
 			"--kubeconfig-path=admin.kubeconfig"},
 			cfg.Args...),
-		dataDir:     dataDir,
-		artifactDir: artifactDir,
+		dataDir:       dataDir,
+		artifactDir:   artifactDir,
 		artifactsLock: &sync.RWMutex{},
-		ctx:         ctx,
-		t:           t,
-		lock:        &sync.Mutex{},
+		ctx:           ctx,
+		t:             t,
+		lock:          &sync.Mutex{},
 	}, nil
 }
 

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -120,6 +120,7 @@ func Run(top *testing.T, name string, f TestFunc, cfgs ...KcpConfig) {
 						}
 					}(srv)
 				}
+				defer srv.GatherArtifacts()
 			}
 			wg.Wait()
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -96,7 +96,6 @@ func init() {
 	utilruntime.Must(localSchemeBuilder.AddToScheme(scheme.Scheme))
 }
 
-
 func (c *kcpServer) GatherArtifacts() {
 	c.artifactsLock.RLock()
 	defer c.artifactsLock.RUnlock()

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -96,75 +96,87 @@ func init() {
 	utilruntime.Must(localSchemeBuilder.AddToScheme(scheme.Scheme))
 }
 
-// Artifact runs the data-producing function and dumps the YAML-formatted output
-// to the artifact directory for the test. Normal usage looks like:
-// defer framework.Artifact(t, kcp, client.Get(ctx, name, metav1.GetOptions{}))
+
+func (c *kcpServer) GatherArtifacts() {
+	c.artifactsLock.RLock()
+	defer c.artifactsLock.RUnlock()
+	for _, artifact := range c.artifacts {
+		artifact()
+	}
+}
+
+// Artifact registers the data-producing function to run and dump the YAML-formatted output
+// to the artifact directory for the test before the kcp process is terminated.
 func (c *kcpServer) Artifact(tinterface TestingTInterface, producer func() (runtime.Object, error)) {
-	t, ok := tinterface.(*T)
-	if !ok {
-		tinterface.Logf("Artifact() called with %#v, not a framework.T", tinterface)
-		return
-	}
-	data, err := producer()
-	if err != nil {
-		t.Logf("error fetching artifact: %v", err)
-		return
-	}
-	accessor, ok := data.(metav1.Object)
-	if !ok {
-		t.Logf("artifact has no object meta: %#v", data)
-		return
-	}
-	dir := path.Join(c.artifactDir, accessor.GetClusterName())
-	if accessor.GetNamespace() != "" {
-		dir = path.Join(dir, accessor.GetNamespace())
-	}
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		t.Logf("could not create dir: %v", err)
-		return
-	}
-	gvks, _, err := scheme.Scheme.ObjectKinds(data)
-	if err != nil {
-		t.Logf("error finding gvk for artifact: %v", err)
-		return
-	}
-	if len(gvks) == 0 {
-		t.Logf("found no gvk for artifact: %T", data)
-		return
-	}
-	gvk := gvks[0]
-	data.GetObjectKind().SetGroupVersionKind(gvk)
+	c.artifactsLock.Lock()
+	defer c.artifactsLock.Unlock()
+	c.artifacts = append(c.artifacts, func() {
+		t, ok := tinterface.(*T)
+		if !ok {
+			tinterface.Logf("Artifact() called with %#v, not a framework.T", tinterface)
+			return
+		}
+		data, err := producer()
+		if err != nil {
+			t.Logf("error fetching artifact: %v", err)
+			return
+		}
+		accessor, ok := data.(metav1.Object)
+		if !ok {
+			t.Logf("artifact has no object meta: %#v", data)
+			return
+		}
+		dir := path.Join(c.artifactDir, accessor.GetClusterName())
+		if accessor.GetNamespace() != "" {
+			dir = path.Join(dir, accessor.GetNamespace())
+		}
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Logf("could not create dir: %v", err)
+			return
+		}
+		gvks, _, err := scheme.Scheme.ObjectKinds(data)
+		if err != nil {
+			t.Logf("error finding gvk for artifact: %v", err)
+			return
+		}
+		if len(gvks) == 0 {
+			t.Logf("found no gvk for artifact: %T", data)
+			return
+		}
+		gvk := gvks[0]
+		data.GetObjectKind().SetGroupVersionKind(gvk)
 
-	cfg, err := c.Config()
-	if err != nil {
-		t.Logf("could not get config for server: %v", err)
-		return
-	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		t.Logf("could not get discovery client for server: %v", err)
-		return
-	}
-	scopedDiscoveryClient := discoveryClient.WithCluster(accessor.GetClusterName())
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(scopedDiscoveryClient))
-	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		t.Logf("could not get REST mapping for artifact's GVK: %v", err)
-		return
-	}
-	file := path.Join(dir, fmt.Sprintf("%s_%s.yaml", mapping.Resource.GroupResource().String(), accessor.GetName()))
-	t.Logf("saving artifact to %s", file)
+		cfg, err := c.Config()
+		if err != nil {
+			t.Logf("could not get config for server: %v", err)
+			return
+		}
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+		if err != nil {
+			t.Logf("could not get discovery client for server: %v", err)
+			return
+		}
+		scopedDiscoveryClient := discoveryClient.WithCluster(accessor.GetClusterName())
+		mapper := restmapper.NewDeferredDiscoveryRESTMapper(cacheddiscovery.NewMemCacheClient(scopedDiscoveryClient))
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			t.Logf("could not get REST mapping for artifact's GVK: %v", err)
+			return
+		}
+		file := path.Join(dir, fmt.Sprintf("%s_%s.yaml", mapping.Resource.GroupResource().String(), accessor.GetName()))
+		t.Logf("saving artifact to %s", file)
 
-	serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, json.SerializerOptions{Yaml: true})
-	raw := bytes.Buffer{}
-	if err := serializer.Encode(data, &raw); err != nil {
-		t.Logf("error marshalling artifact: %v", err)
-		return
-	}
-	if err := ioutil.WriteFile(file, raw.Bytes(), 0644); err != nil {
-		t.Logf("error writing artifact: %v", err)
-		return
-	}
+		serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, json.SerializerOptions{Yaml: true})
+		raw := bytes.Buffer{}
+		if err := serializer.Encode(data, &raw); err != nil {
+			t.Logf("error marshalling artifact: %v", err)
+			return
+		}
+		if err := ioutil.WriteFile(file, raw.Bytes(), 0644); err != nil {
+			t.Logf("error writing artifact: %v", err)
+			return
+		}
+	})
 }
 
 // GetFreePort asks the kernel for a free open port that is ready to use.
@@ -285,7 +297,7 @@ func InstallCluster(t TestingTInterface, ctx context.Context, source, server Run
 	if err != nil {
 		return fmt.Errorf("failed to create cluster on source kcp: %w", err)
 	}
-	defer source.Artifact(t, func() (runtime.Object, error) {
+	source.Artifact(t, func() (runtime.Object, error) {
 		return sourceKcpClient.ClusterV1alpha1().Clusters().Get(ctx, cluster.Name, metav1.GetOptions{})
 	})
 	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -83,7 +83,7 @@ func TestClusterController(t *testing.T) {
 					return
 				}
 				for _, name := range []string{sourceClusterName, sinkClusterName} {
-					defer servers[name].Artifact(t, func() (runtime.Object, error) {
+					servers[name].Artifact(t, func() (runtime.Object, error) {
 						return servers[name].client.Get(ctx, cowboy.Name, metav1.GetOptions{})
 					})
 				}
@@ -115,7 +115,7 @@ func TestClusterController(t *testing.T) {
 					return
 				}
 				for _, name := range []string{sourceClusterName, sinkClusterName} {
-					defer servers[name].Artifact(t, func() (runtime.Object, error) {
+					servers[name].Artifact(t, func() (runtime.Object, error) {
 						return servers[name].client.Get(ctx, cowboy.Name, metav1.GetOptions{})
 					})
 				}

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -57,7 +57,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspace, unschedulable); err != nil {
@@ -74,7 +74,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspace, unschedulable); err != nil {
@@ -86,7 +86,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspace, scheduled(bostonShard.Name)); err != nil {
@@ -103,7 +103,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
 				})
 				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
@@ -111,7 +111,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspace, scheduled(bostonShard.Name)); err != nil {
@@ -128,7 +128,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create first workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
 				})
 				atlantaShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "atlanta"}}, metav1.CreateOptions{})
@@ -136,7 +136,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create second workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, atlantaShard.Name, metav1.GetOptions{})
 				})
 				workspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
@@ -144,7 +144,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				})
 				var currentShard, otherShard string
@@ -189,7 +189,7 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspace, scheduled(bostonShard.Name)); err != nil {
@@ -259,6 +259,9 @@ func TestWorkspaceController(t *testing.T) {
 					t.Errorf("failed to create workspace: %v", err)
 					return
 				}
+				server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
 				if err := server.expect(workspace, func(workspace *tenancyv1alpha1.Workspace) error {
 					if err := scheduled(workspaceShard.Name)(workspace); err != nil {
 						return err

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -269,7 +269,7 @@ func TestWorkspaceController(t *testing.T) {
 					if !utilconditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceURLValid) {
 						return fmt.Errorf("expected valid URL on workspace, got: %v", utilconditions.Get(workspace, tenancyv1alpha1.WorkspaceURLValid))
 					}
-					if diff := cmp.Diff(workspace.Status.BaseURL, "https://kcp.dev/apiprefix/clusters/steve"); diff != "" {
+					if diff := cmp.Diff(workspace.Status.BaseURL, "https://kcp.dev/apiprefix/clusters/admin_steve"); diff != "" {
 						return fmt.Errorf("got incorrect base URL on workspace: %v", diff)
 					}
 					return nil

--- a/test/e2e/reconciler/workspaceindex/controller_test.go
+++ b/test/e2e/reconciler/workspaceindex/controller_test.go
@@ -1,0 +1,452 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspaceindex
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	kubernetesclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kcp-dev/kcp/config"
+	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	utilconditions "github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+type runningServer struct {
+	framework.RunningServer
+	client          clientset.Interface
+	kubeClient      kubernetesclientset.Interface
+	expectWorkspace framework.RegisterWorkspaceExpectation
+	expectShard     framework.RegisterWorkspaceShardExpectation
+}
+
+func resolveRunningServer(ctx context.Context, t framework.TestingTInterface, server framework.RunningServer, clusterName string) (runningServer, error) {
+	cfg, err := server.Config()
+	if err != nil {
+		return runningServer{}, err
+	}
+	if clusterName == "" {
+		detectedName, err := framework.DetectClusterName(cfg, ctx, "workspaces.tenancy.kcp.dev")
+		if err != nil {
+			return runningServer{}, fmt.Errorf("failed to detect cluster name: %w", err)
+		}
+		clusterName = detectedName
+	} else {
+		extensionsClients, err := apiextensionsclient.NewClusterForConfig(cfg)
+		if err != nil {
+			return runningServer{}, fmt.Errorf("failed to construct extensions client for server: %w", err)
+		}
+		extensionsClient := extensionsClients.Cluster(clusterName)
+		requiredCrds := []metav1.GroupKind{
+			{Group: tenancyapi.GroupName, Kind: "workspaces"},
+			{Group: tenancyapi.GroupName, Kind: "workspaceshards"},
+		}
+		crdClient := extensionsClient.ApiextensionsV1().CustomResourceDefinitions()
+		if err := config.BootstrapCustomResourceDefinitions(ctx, crdClient, requiredCrds); err != nil {
+			return runningServer{}, err
+		}
+	}
+	clients, err := kcpclientset.NewClusterForConfig(cfg)
+	if err != nil {
+		return runningServer{}, fmt.Errorf("failed to construct client for server: %w", err)
+	}
+	client := clients.Cluster(clusterName)
+	expectWorkspace, err := framework.ExpectWorkspaces(ctx, t, client)
+	if err != nil {
+		return runningServer{}, fmt.Errorf("failed to start expecter: %w", err)
+	}
+	expectShard, err := framework.ExpectWorkspaceShards(ctx, t, client)
+	if err != nil {
+		return runningServer{}, fmt.Errorf("failed to start expecter: %w", err)
+	}
+	kubeClients, err := kubernetesclientset.NewClusterForConfig(cfg)
+	if err != nil {
+		return runningServer{}, fmt.Errorf("failed to construct kube client for server: %w", err)
+	}
+	kubeClient := kubeClients.Cluster(clusterName)
+	return runningServer{
+		RunningServer:   server,
+		client:          client,
+		kubeClient:      kubeClient,
+		expectWorkspace: expectWorkspace,
+		expectShard:     expectShard,
+	}, nil
+}
+
+func TestWorkspaceIndex(t *testing.T) {
+	var testCases = []struct {
+		name string
+		work func(ctx context.Context, t framework.TestingTInterface, port string, observed map[string]map[string]string)
+	}{
+		{
+			name: "test",
+			work: func(ctx context.Context, t framework.TestingTInterface, port string, observed map[string]map[string]string) {
+				resolve := func(logicalCluster, resourceVersion string) (string, error) {
+					u, err := url.Parse(fmt.Sprintf("http://[::1]:%s/shard", port))
+					if err != nil {
+						return "", err
+					}
+					q := u.Query()
+					q.Set("clusterName", logicalCluster)
+					q.Set("resourceVersion", resourceVersion)
+					u.RawQuery = q.Encode()
+					resp, err := http.Get(u.String())
+					if err != nil {
+						return "", err
+					}
+					if resp.StatusCode != http.StatusOK {
+						return "", fmt.Errorf("request did not get 200, but %d", resp.StatusCode)
+					}
+					body, err := ioutil.ReadAll(resp.Body)
+					if err != nil {
+						return "", err
+					}
+					if err := resp.Body.Close(); err != nil {
+						return "", err
+					}
+					t.Logf("resolved %s@%s to %s", logicalCluster, resourceVersion, string(body))
+					return string(body), nil
+				}
+
+				resp, err := http.Get(fmt.Sprintf("http://[::1]:%s/data", port))
+				if err != nil {
+					t.Errorf("failed to get data from proxy: %v", err)
+					return
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("request for data did not get 200, but %d", resp.StatusCode)
+					return
+				}
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("failed to read data from body: %v", err)
+					return
+				}
+				if err := resp.Body.Close(); err != nil {
+					t.Errorf("failed to close body: %v", err)
+					return
+				}
+				t.Log(string(body))
+
+				for orgName, workspaces := range observed {
+					for workspaceName, shardName := range workspaces {
+						logicalCluster := orgName + "_" + workspaceName
+						shard, err := resolve(logicalCluster, "")
+						if err != nil {
+							t.Errorf("%s/%s: expected no error but got one: %v", orgName, workspaceName, err)
+							return
+						}
+						if shard != shardName {
+							t.Errorf("%s/%s: expected %s on %s, got %s", orgName, workspaceName, logicalCluster, shardName, shard)
+							return
+						}
+					}
+				}
+			},
+		},
+	}
+	const (
+		// serverNameMain will hold the root workspace
+		serverNameMain = "main"
+		// serverName* will hold org workspaces
+		serverNameEast    = "east"
+		serverNameCentral = "central"
+		serverNameWest    = "west"
+		// orgName* are the organizations
+		orgNameAcme    = "acme"
+		orgNameInitech = "initech"
+		orgNameGlobex  = "globex"
+	)
+	for i := range testCases {
+		testCase := testCases[i]
+		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+			ctx := context.Background()
+			if deadline, ok := t.Deadline(); ok {
+				withDeadline, cancel := context.WithDeadline(ctx, deadline)
+				t.Cleanup(cancel)
+				ctx = withDeadline
+			}
+			if len(servers) != 4 {
+				t.Errorf("incorrect number of servers: %d", len(servers))
+				return
+			}
+			mainServer, err := resolveRunningServer(ctx, t, servers[serverNameMain], "")
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			// in the root workspace, set up:
+			// - WorkspaceShard objects with the credentials for our servers
+			// - Workspace objects for our organizations
+			// in the "admin" workspace on each shard, set up:
+			// - WorkspaceShard object for the scheduler (this will be removed when we have a cross-shard client)
+			// - Workspace objects (these are end-user-facing)
+			serverNames := []string{serverNameEast, serverNameCentral, serverNameWest}
+			orgs := []string{orgNameAcme, orgNameInitech, orgNameGlobex}
+			workspaces := []string{"accounting", "engineering", "executive"}
+			initErrorChan := make(chan error, len(serverNames)+len(orgs))
+			wg := sync.WaitGroup{}
+			wg.Add(len(serverNames))
+			initStart := time.Now()
+			t.Log("bootstrapping WorkspaceShards in root logical cluster")
+			for _, serverName := range serverNames {
+				go func(serverName string) {
+					defer wg.Done()
+
+					rawCfg, err := servers[serverName].RawConfig()
+					if err != nil {
+						initErrorChan <- fmt.Errorf("failed to resolve raw credentials: %w", err)
+						return
+					}
+					if err := initializeShard(ctx, t, mainServer, serverName, rawCfg); err != nil {
+						initErrorChan <- err
+						return
+					}
+				}(serverName)
+			}
+			wg.Wait()
+			close(initErrorChan)
+			t.Logf("finished bootstrapping WorkspaceShards in root logical cluster in %s", time.Since(initStart))
+			var initErrors []error
+			for err := range initErrorChan {
+				if err != nil {
+					initErrors = append(initErrors, err)
+				}
+			}
+			if len(initErrors) > 0 {
+				t.Errorf("failed to bootstrap shards: %v", kerrors.NewAggregate(initErrors))
+				return
+			}
+			mapping := map[string]map[string]string{} // org to workspace to shard
+			mappingLock := sync.Mutex{}
+			orgErrorChan := make(chan error, len(orgs))
+			wg.Add(len(orgs))
+			orgInitStart := time.Now()
+			t.Log("bootstrapping organizational Workspaces in root logical cluster and their data")
+			for _, orgName := range orgs {
+				go func(orgName string) {
+					defer wg.Done()
+					orgWorkspace, err := initializeWorkspace(ctx, t, mainServer, orgName)
+					if err != nil {
+						orgErrorChan <- err
+						return
+					}
+					mappingLock.Lock()
+					if _, recorded := mapping[helper.OrganizationCluster]; !recorded {
+						mapping[helper.OrganizationCluster] = map[string]string{}
+					}
+					mapping[helper.OrganizationCluster][orgName] = orgWorkspace.Status.Location.Current
+					mappingLock.Unlock()
+
+					clusterName, err := helper.EncodeLogicalClusterName(orgWorkspace)
+					if err != nil {
+						orgErrorChan <- err
+						return
+					}
+					shardServer, err := resolveRunningServer(ctx, t, servers[orgWorkspace.Status.Location.Current], clusterName)
+					if err != nil {
+						orgErrorChan <- err
+						return
+					}
+
+					// TODO: when we have a cross-shard workspace scheduler in the root shard, we don't need this shard object in the delegate kcp shard
+					if err := initializeShard(ctx, t, shardServer, orgName+"-delegate", clientcmdapi.Config{
+						Clusters:       map[string]*clientcmdapi.Cluster{"cluster": {Server: "https://kcp.dev/apiprefix"}},
+						Contexts:       map[string]*clientcmdapi.Context{"context": {Cluster: "cluster", AuthInfo: "user"}},
+						CurrentContext: "context",
+						AuthInfos:      map[string]*clientcmdapi.AuthInfo{"user": {Username: "user", Password: "password"}},
+					}); err != nil {
+						orgErrorChan <- err
+						return
+					}
+
+					for _, workspaceName := range workspaces {
+						workspace, err := initializeWorkspace(ctx, t, shardServer, workspaceName)
+						if err != nil {
+							orgErrorChan <- err
+							return
+						}
+						mappingLock.Lock()
+						if _, recorded := mapping[orgName]; !recorded {
+							mapping[orgName] = map[string]string{}
+						}
+						mapping[orgName][workspaceName] = workspace.Status.Location.Current
+						mappingLock.Unlock()
+					}
+				}(orgName)
+			}
+			wg.Wait()
+			t.Logf("finished bootstrapping organizational Workspaces in root logical cluster and their data in %s", time.Since(orgInitStart))
+			close(orgErrorChan)
+			var orgErrors []error
+			for err := range orgErrorChan {
+				if err != nil {
+					orgErrors = append(orgErrors, err)
+				}
+			}
+			if len(orgErrors) > 0 {
+				t.Errorf("failed to bootstrap org workspaces in root workspace: %v", kerrors.NewAggregate(orgErrors))
+				return
+			}
+			port, err := framework.GetFreePort(t)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			cfg, err := servers[serverNameMain].RawConfig()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			proxy := framework.NewAccessory(t, artifactDir,
+				"shard-proxy",
+				"--port="+port,
+				"--root-kubeconfig="+cfg.Clusters[cfg.CurrentContext].LocationOfOrigin,
+			)
+			go func() {
+				if err := proxy.Run(ctx); err != nil {
+					t.Error(err)
+				}
+			}()
+			if !framework.Ready(ctx, t, port) {
+				t.Log("failed to wait for accessory to be ready")
+				return
+			}
+			mappingLock.Lock()
+			defer mappingLock.Unlock()
+			t.Logf("expecting: %#v", mapping)
+			testCase.work(ctx, t, port, mapping)
+		}, framework.KcpConfig{
+			Name: serverNameMain,
+			Args: []string{"--install-workspace-controller"},
+		}, framework.KcpConfig{
+			Name: serverNameEast,
+			Args: []string{"--install-workspace-controller"}, // TODO: when we have the shard proxy working for API requests, we only need to run the workspace-related controllers in the main shard
+		}, framework.KcpConfig{
+			Name: serverNameCentral,
+			Args: []string{"--install-workspace-controller"},
+		}, framework.KcpConfig{
+			Name: serverNameWest,
+			Args: []string{"--install-workspace-controller"},
+		})
+	}
+}
+
+func isUnschedulable(workspace *tenancyv1alpha1.Workspace) bool {
+	return utilconditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceScheduled) && utilconditions.GetReason(workspace, tenancyv1alpha1.WorkspaceScheduled) == tenancyv1alpha1.WorkspaceReasonUnschedulable
+}
+
+func scheduledAnywhere(object *tenancyv1alpha1.Workspace) error {
+	if isUnschedulable(object) {
+		return fmt.Errorf("expected a scheduled workspace, got status.conditions: %#v", object.Status.Conditions)
+	}
+	if object.Status.Location.Current == "" {
+		return fmt.Errorf("expected workspace.status.location.current to be anything, got %q", object.Status.Location.Current)
+	}
+	return nil
+}
+
+func initializeShard(ctx context.Context, t framework.TestingTInterface, server runningServer, serverName string, rawCfg clientcmdapi.Config) error {
+	if _, err := server.kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "credentials"}}, metav1.CreateOptions{}); !errors.IsAlreadyExists(err) && err != nil {
+		return fmt.Errorf("failed to create credentials namespace: %w", err)
+	}
+	server.Artifact(t, func() (runtime.Object, error) {
+		return server.kubeClient.CoreV1().Namespaces().Get(ctx, "credentials", metav1.GetOptions{})
+	})
+
+	rawBytes, err := clientcmd.Write(rawCfg)
+	if err != nil {
+		return fmt.Errorf("could not serialize raw config: %w", err)
+	}
+	if _, err := server.kubeClient.CoreV1().Secrets("credentials").Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: serverName},
+		Data: map[string][]byte{
+			"kubeconfig": rawBytes,
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create credentials secret: %w", err)
+	}
+	server.Artifact(t, func() (runtime.Object, error) {
+		return server.kubeClient.CoreV1().Secrets("credentials").Get(ctx, serverName, metav1.GetOptions{})
+	})
+	workspaceShard, err := server.client.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{
+		ObjectMeta: metav1.ObjectMeta{Name: serverName},
+		Spec: tenancyv1alpha1.WorkspaceShardSpec{Credentials: corev1.SecretReference{
+			Name:      serverName,
+			Namespace: "credentials",
+		}},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create workspace shard: %w", err)
+	}
+	server.Artifact(t, func() (runtime.Object, error) {
+		return server.client.TenancyV1alpha1().WorkspaceShards().Get(ctx, serverName, metav1.GetOptions{})
+	})
+	if err := server.expectShard(workspaceShard, func(shard *tenancyv1alpha1.WorkspaceShard) error {
+		if !utilconditions.IsTrue(shard, tenancyv1alpha1.WorkspaceShardCredentialsValid) {
+			return fmt.Errorf("workspace shard %s does not have valid credentials, conditions: %#v", shard.Name, shard.GetConditions())
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("did not see workspace shard get valid credentials: %w", err)
+	}
+	return nil
+}
+
+func initializeWorkspace(ctx context.Context, t framework.TestingTInterface, server runningServer, name string) (*tenancyv1alpha1.Workspace, error) {
+	orgWorkspace, err := server.client.TenancyV1alpha1().Workspaces().Create(ctx, &tenancyv1alpha1.Workspace{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create workspace: %w", err)
+	}
+	server.Artifact(t, func() (runtime.Object, error) {
+		return server.client.TenancyV1alpha1().Workspaces().Get(ctx, name, metav1.GetOptions{})
+	})
+	var ws *tenancyv1alpha1.Workspace
+	if err := server.expectWorkspace(orgWorkspace, func(workspace *tenancyv1alpha1.Workspace) error {
+		if err := scheduledAnywhere(workspace); err != nil {
+			return err
+		}
+		if !utilconditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceURLValid) {
+			return fmt.Errorf("expected valid URL on workspace, got: %v", utilconditions.Get(workspace, tenancyv1alpha1.WorkspaceURLValid))
+		}
+		ws = workspace
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("did not see workspace updated: %w", err)
+	}
+	return ws, nil
+}

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -57,7 +57,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.Get(ctx, workspaceShard.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspaceShard, func(workspaceShard *tenancyv1alpha1.WorkspaceShard) error {
@@ -85,7 +85,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.Get(ctx, workspaceShard.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspaceShard, func(workspaceShard *tenancyv1alpha1.WorkspaceShard) error {
@@ -116,7 +116,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create credentials secret: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kubeClient.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
 				})
 				workspaceShard, err := server.client.Create(ctx, &tenancyv1alpha1.WorkspaceShard{
@@ -130,7 +130,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.Get(ctx, workspaceShard.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspaceShard, func(workspaceShard *tenancyv1alpha1.WorkspaceShard) error {
@@ -161,7 +161,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create credentials secret: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kubeClient.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
 				})
 				workspaceShard, err := server.client.Create(ctx, &tenancyv1alpha1.WorkspaceShard{
@@ -175,7 +175,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.Get(ctx, workspaceShard.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspaceShard, func(workspaceShard *tenancyv1alpha1.WorkspaceShard) error {
@@ -222,7 +222,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create credentials secret: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kubeClient.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
 				})
 				workspaceShard, err := server.client.Create(ctx, &tenancyv1alpha1.WorkspaceShard{
@@ -236,7 +236,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.Get(ctx, workspaceShard.Name, metav1.GetOptions{})
 				})
 				if err := server.expect(workspaceShard, func(workspaceShard *tenancyv1alpha1.WorkspaceShard) error {
@@ -289,7 +289,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create credentials secret: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kubeClient.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
 				})
 				workspaceShard, err := server.client.Create(ctx, &tenancyv1alpha1.WorkspaceShard{
@@ -303,7 +303,7 @@ func TestWorkspaceShardController(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.client.Get(ctx, workspaceShard.Name, metav1.GetOptions{})
 				})
 				var version string


### PR DESCRIPTION
e2e: framework: expose artifact and data dirs to tests

When we're running many tests in parallel, random directories are chosen
for every invocation. In order to ensure that test processes are placing
artifacts and data in the correct place, we need to pass that
information down.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

e2e: framework: isolate the accessory process code

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

e2e: rework how artifacts are deferred

Now, you can call server.Artifact() from anywhere and it should
correctly be run before the test is finished and kcp has been
terminated.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

cmd: add a shard proxy server

Today, this server knows how to find all of the organizational
workspaces, the per-organization workspaces, and map them to the shards
they are placed on through history.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

