### PR TITLE
Add lease controller to syncer

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -36,11 +36,12 @@ import (
 const numThreads = 2
 
 var (
-	fromKubeconfig = flag.String("from_kubeconfig", "", "Kubeconfig file for -from cluster.")
-	fromCluster    = flag.String("from_cluster", "", "Name of the -from logical cluster.")
-	toKubeconfig   = flag.String("to_kubeconfig", "", "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
-	toContext      = flag.String("to_context", "", "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
-	clusterID      = flag.String("cluster", "", "ID of the -to cluster. Resources with this ID set in the 'kcp.dev/cluster' label will be synced.")
+	fromKubeconfig       = flag.String("from_kubeconfig", "", "Kubeconfig file for -from cluster.")
+	fromCluster          = flag.String("from_cluster", "", "Name of the -from logical cluster.")
+	toKubeconfig         = flag.String("to_kubeconfig", "", "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
+	toContext            = flag.String("to_context", "", "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
+	clusterID            = flag.String("cluster", "", "ID of the -to cluster. Resources with this ID set in the 'kcp.dev/cluster' label will be synced.")
+	leaseDurationSeconds = flag.Int("lease-duration-seconds", 0, "Cluster lease duration seconds, set to 0 to disable lease controller (default).")
 )
 
 func main() {
@@ -91,7 +92,7 @@ func main() {
 	defer cancel()
 
 	klog.Infoln("Starting workers")
-	syncer, err := syncer.StartSyncer(fromConfig, toConfig, sets.NewString(syncedResourceTypes...), *clusterID, *fromCluster, numThreads)
+	syncer, err := syncer.StartSyncer(fromConfig, toConfig, sets.NewString(syncedResourceTypes...), *clusterID, *fromCluster, numThreads, int32(*leaseDurationSeconds))
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	k8s.io/apiserver v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/code-generator v0.0.0
+	k8s.io/component-helpers v0.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	k8s.io/kubectl v0.0.0

--- a/pkg/reconciler/cluster/cluster.go
+++ b/pkg/reconciler/cluster/cluster.go
@@ -139,7 +139,7 @@ func (c *Controller) reconcile(ctx context.Context, cluster *clusterv1alpha1.Clu
 				return nil // Don't retry.
 			}
 
-			newSyncer, err := syncer.StartSyncer(upstream, downstream, groupResources, cluster.Name, logicalCluster, numSyncerThreads)
+			newSyncer, err := syncer.StartSyncer(upstream, downstream, groupResources, cluster.Name, logicalCluster, numSyncerThreads, 0)
 			if err != nil {
 				klog.Errorf("error starting syncer in push mode: %v", err)
 				cluster.Status.SetConditionReady(corev1.ConditionFalse,

--- a/pkg/reconciler/cluster/syncer.go
+++ b/pkg/reconciler/cluster/syncer.go
@@ -161,6 +161,7 @@ func installSyncer(ctx context.Context, client kubernetes.Interface, syncerImage
 	}
 
 	args := []string{
+		"-lease-duration-seconds", "40",
 		"-cluster", clusterID,
 		"-from_kubeconfig", "/kcp/kubeconfig",
 		"-from_cluster", logicalCluster,


### PR DESCRIPTION
This PR adds one lease controller to syncer (part of #285).

Syncer (in pull mode) will renew the lease periodically and KCP should use the lease infos to health check physical clusters.

NOTE: ideally lease should be owned by cluster resource in KCP so that deleting a cluster also removes the lease.

---

```shell
$ k get cluster,lease -A -o wide
NAME                            LOCATION   READY   SYNCED API RESOURCES
cluster.cluster.example.dev/a   a          True    ["statefulsets.apps"]
cluster.cluster.example.dev/b   b          True    ["statefulsets.apps"]
cluster.cluster.example.dev/c   c          True    ["statefulsets.apps"]

NAMESPACE       NAME        HOLDER      AGE
syncer-system   cluster-a   cluster-a   9s
syncer-system   cluster-b   cluster-b   11s
syncer-system   cluster-c   cluster-c   11s
```