### PR TITLE
test/e2e: use a build tag for e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           only-new-issues: true
-          args: --timeout=5m
+          args: --build-tags e2e --timeout=5m
 
   codegen:
     name: codegen

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ install: install-ingress-controller
 	go install ./cmd/...
 .PHONY: install
 
+lint:
+	golangci-lint run --build-tags e2e ./...
+.PHONY: lint
 
 INGRESS_CONTROLLER_DIR = ./build/kcp-ingress
 
@@ -98,10 +101,10 @@ COUNT ?= 5
 
 .PHONY: test-e2e
 test-e2e: install
-	go test -race -count $(COUNT) ./test/e2e... $(WHAT)
+	go test -tags e2e -race -count $(COUNT) ./test/e2e... $(WHAT)
 
 .PHONY: test
-test: install
+test:
 	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic ./... $(WHAT)
 
 .PHONY: demos

--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/accessory.go
+++ b/test/e2e/framework/accessory.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/t.go
+++ b/test/e2e/framework/t.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/testhelper.go
+++ b/test/e2e/framework/testhelper.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/testhelper_test.go
+++ b/test/e2e/framework/testhelper_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/users.go
+++ b/test/e2e/framework/users.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/workspaceindex/controller_test.go
+++ b/test/e2e/reconciler/workspaceindex/controller_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/framework/composite_test.go
+++ b/test/e2e/virtual/framework/composite_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/framework/compositecmd/cmd.go
+++ b/test/e2e/virtual/framework/compositecmd/cmd.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/framework/compositecmd/rest.go
+++ b/test/e2e/virtual/framework/compositecmd/rest.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/helpers/helpers.go
+++ b/test/e2e/virtual/helpers/helpers.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 The KCP Authors.
 


### PR DESCRIPTION
With the new 'e2e' build tag, end-to-end tests do not compile by
default. This means that tools like `go test` and `golangci-lint` won't
run anything from those files by default, you need to ask for it. The
`make test-e2e` target does that for tests, and the `make lint` target
makes sure you do it for static analysis as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @ncdc 