### PR TITLE
Cluster conditions

### DIFF
--- a/third_party/conditions/apis/conditions/v1alpha1/constants.go
+++ b/third_party/conditions/apis/conditions/v1alpha1/constants.go
@@ -251,3 +251,21 @@ const (
 	// ScalingDownReason (Severity=Info) documents a MachineSet is decreasing the number of replicas.
 	ScalingDownReason = "ScalingDown"
 )
+
+// Conditions and ConditionReasons for the kcp Cluster object.
+const (
+	// ClusterReadyCondition means the Cluster is available.
+	ClusterReadyCondition ConditionType = "Ready"
+
+	// ClusterUnknownReason documents a Cluster which readyness is unknown.
+	ClusterUnknownReason = "ClusterStatusUnknown"
+
+	// ClusterReadyReason documents a Cluster that is ready.
+	ClusterReadyReason = "ClusterReady"
+
+	// ClusterNotReadyReason documents a Cluster is not ready, when the "readyz" check returns false.
+	ClusterNotReadyReason = "ClusterNotReady"
+
+	// ClusterUnreachableReason documents the Cluster state when the Syncer is unable to reach the Cluster "readyz" API endpoint
+	ClusterUnreachableReason = "ClusterUnreachable"
+)

--- a/third_party/conditions/apis/conditions/v1alpha1/types.go
+++ b/third_party/conditions/apis/conditions/v1alpha1/types.go
@@ -67,6 +67,11 @@ type Condition struct {
 	// +optional
 	Severity ConditionSeverity `json:"severity,omitempty"`
 
+	// Last time the condition got an update.
+	// Can be used by the system to determine if the ConditionStatus is Unknown in certain cases.
+	// +optional
+	LastHeartbeatTime metav1.Time `json:"lastHeartbeatTime,omitempty"`
+
 	// Last time the condition transitioned from one status to another.
 	// This should be when the underlying condition changed. If that is not known, then using the time when
 	// the API field changed is acceptable.


### PR DESCRIPTION
- Adds new cluster conditions, as discussed in: [[PUBLIC] Exploration of a kcp API model: ThingClusterCapacityForWorkloads, Location APIs](https://docs.google.com/document/d/1pDv2OVXpT5TUgO0rKNFwsht1EFasUE_15mvvBY_R-LA/edit#)
- Adds an optional LastHeartbeatTime field to the Conditions struct 