### PR TITLE
Make OpenAPIV3Schema atomic

### DIFF
--- a/config/apiresource.kcp.dev_apiresourceimports.yaml
+++ b/config/apiresource.kcp.dev_apiresourceimports.yaml
@@ -139,6 +139,7 @@ spec:
                 type: string
               openAPIV3Schema:
                 type: object
+                x-kubernetes-map-type: atomic
                 x-kubernetes-preserve-unknown-fields: true
               plural:
                 description: plural is the plural name of the resource to serve. The

--- a/config/apiresource.kcp.dev_negotiatedapiresources.yaml
+++ b/config/apiresource.kcp.dev_negotiatedapiresources.yaml
@@ -133,6 +133,7 @@ spec:
                 type: string
               openAPIV3Schema:
                 type: object
+                x-kubernetes-map-type: atomic
                 x-kubernetes-preserve-unknown-fields: true
               plural:
                 description: plural is the plural name of the resource to serve. The

--- a/pkg/apis/apiresource/v1alpha1/common_types.go
+++ b/pkg/apis/apiresource/v1alpha1/common_types.go
@@ -132,6 +132,7 @@ type CommonAPIResourceSpec struct {
 
 	// +required
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// +structType=atomic
 	OpenAPIV3Schema runtime.RawExtension `json:"openAPIV3Schema"`
 
 	// +patchMergeKey=name


### PR DESCRIPTION
Set the x-kubernetes-map-type to atomic for the OpenAPIV3Schema field in
apiresourceimports and negotiatedapiresources. This causes server-side
apply to treat the schema as an atomic unit, instead of trying to track
each individual field/element of the schema (which causes 34-second
timeouts in the apiserver trying to process the data).

Signed-off-by: Andy Goldstein <andy.goldstein@redhat.com>