### PR TITLE
Better support for running the demos on Mac and with podman 3.x

### DIFF
--- a/contrib/demo/.setupEnv
+++ b/contrib/demo/.setupEnv
@@ -1,5 +1,8 @@
-export DEMOS_DIR="$(cd "${DEMO_DIR}/.."; pwd)"
-export CLUSTERS_DIR=${CLUSTERS_DIR:-${DEMOS_DIR}/clusters/kind}
-export KCP_DIR="$( cd ${DEMOS_DIR}/../.. && pwd)"
-export KCP_DATA_DIR=${KCP_DATA_DIR:-$KCP_DIR}
+# shellcheck shell=bash
 
+DEMOS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTERS_DIR=${CLUSTERS_DIR:-${DEMOS_DIR}/clusters/kind}
+KCP_DIR="$(cd "${DEMOS_DIR}/../.." && pwd)"
+KCP_DATA_DIR=${KCP_DATA_DIR:-$KCP_DIR}
+
+export DEMOS_DIR CLUSTERS_DIR KCP_DIR KCP_DATA_DIR

--- a/contrib/demo/.startUtils
+++ b/contrib/demo/.startUtils
@@ -8,9 +8,17 @@ wait_command() {
 }
 
 cleanup() {
-    echo "Cleaning processes started by $1" 
+    echo "Cleaning processes started by $1"
+
     # kill all processes whose parent is this process
     pkill -P $$
+
+    # Podman 3.x Mac/kind workaround - clean up ssh control socket
+    if test -e "${DEMOS_DIR}/${PODMAN_SSH_CONTROL_SOCKET}"; then
+      pkill -f "${PODMAN_SSH_CONTROL_SOCKET}"
+    fi
+
+    # Is this used?
     eval "$2"
 }
 

--- a/contrib/demo/apiNegotiation-script/prepareClusters.sh
+++ b/contrib/demo/apiNegotiation-script/prepareClusters.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+
 export DEMO_DIR="$( dirname "${BASH_SOURCE[0]}" )"
 source "${DEMO_DIR}"/../.setupEnv
 

--- a/contrib/demo/runDemoScripts.sh
+++ b/contrib/demo/runDemoScripts.sh
@@ -58,8 +58,11 @@ for demo in ${DEMOS} ; do
   DEMO_DIR=${DEMOS_DIR}/${demo}-script
 
   if test -f "${DEMO_DIR}/prepareClusters.sh" ; then
-    echo "Preparing Kind physical clusters for demo ${demo} ..."  
-    ${DEMO_DIR}/prepareClusters.sh &> ${TEST_DIR}/clusters.log
+    echo "Preparing Kind physical clusters for demo ${demo} ..."
+    if ! ${DEMO_DIR}/prepareClusters.sh &> ${TEST_DIR}/clusters.log; then
+      echo "Error starting Kind clusters - check ${TEST_DIR}/clusters.log for details"
+      exit 1
+    fi
   fi
 
   echo "Starting demo ${demo} in directory ${TEST_DIR}"

--- a/contrib/demo/startKcpAndClusterController.sh
+++ b/contrib/demo/startKcpAndClusterController.sh
@@ -34,9 +34,9 @@ fi
 echo "Starting KCP server ..."
 (cd ${KCP_DATA_DIR} && exec ${KCP_DIR}/bin/kcp start ${KCP_FLAGS}) &> kcp.log &
 KCP_PID=$!
-echo "KCP server started: $KCP_PID" 
+echo "KCP server started: $KCP_PID"
 
-echo "Waiting for KCP server to be up and running..." 
+echo "Waiting for KCP server to be up and running..."
 wait_command "grep 'Serving securely' ${CURRENT_DIR}/kcp.log"
 
 echo "Applying CRDs..."
@@ -46,7 +46,7 @@ echo ""
 echo "Starting Cluster Controller..."
 ${KCP_DIR}/bin/cluster-controller --push-mode=true --pull-mode=false --kubeconfig=${KUBECONFIG} "$@" &> cluster-controller.log &
 CC_PID=$!
-echo "Cluster Controller started: $CC_PID" 
+echo "Cluster Controller started: $CC_PID"
 
 echo ""
 echo "Use ctrl-C to stop all components"


### PR DESCRIPTION
Don't pass --posix to sed (breaks on Mac's BSD-based sed).

For podman 3.x, work around an issue where podman isn't able to
correctly port forward to a service bound to localhost in the podman vm
(see podman issue 11528). The workaround is to manually set up SSH port
forwarding.