### PR TITLE
cmd: wire genericapiserver.SetupSignalContext() into servers for proper shutdown behaviour

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -17,13 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
 
 	"github.com/spf13/cobra"
 
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
 
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
@@ -71,10 +70,7 @@ func main() {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
-			defer cancel()
-			srv := server.NewServer(cfg)
-			return srv.Run(ctx)
+			return server.NewServer(cfg).Run(genericapiserver.SetupSignalContext())
 		},
 	}
 	cfg = server.BindOptions(server.DefaultConfig(), startCmd.Flags())

--- a/cmd/shard-proxy/main.go
+++ b/cmd/shard-proxy/main.go
@@ -17,15 +17,14 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"errors"
 	"os"
-	"os/signal"
 	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
 
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
@@ -66,9 +65,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	// Setup signal handler for a cleaner shutdown
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
-	defer cancel()
+	ctx := genericapiserver.SetupSignalContext()
 
 	fs := pflag.NewFlagSet("shard-proxy", pflag.ExitOnError)
 	o := bindOptions(defaultOptions(), fs)


### PR DESCRIPTION
First ctrl-c closed context. Second ctrl-c exits.

Also post-start-hook should not return errors, but either return nil or keep going (otherwise you can a pretty `klog.Fatalf` stacktrace). `WaitForSync` only returns when the context is closed. So no need to put a loop around.