### PR TITLE
syncer: Fix informers and workers leak

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -258,11 +258,11 @@ func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}
 func (c *Controller) Start(ctx context.Context, numThreads int) {
 	c.ctx, c.cancelFn = context.WithCancel(ctx)
 
-	c.fromInformers.Start(ctx.Done())
-	c.fromInformers.WaitForCacheSync(ctx.Done())
+	c.fromInformers.Start(c.ctx.Done())
+	c.fromInformers.WaitForCacheSync(c.ctx.Done())
 
 	for i := 0; i < numThreads; i++ {
-		go c.startWorker(ctx)
+		go c.startWorker(c.ctx)
 	}
 }
 


### PR DESCRIPTION
Syncers currently leak informers and workers after being stopped, so that events from informers are still processed by the workers, while the underlying workqueue is shut down, which leads to infinite loops that starve CPU. 

The Done channel from the cancellable context is passed to the syncer informers and workers, instead of the parent context one, so that the syncer stop is properly propagated.

Fixes #409.