### PR TITLE
Kubeconfig for the virtual workspace APIserver

### DIFF
--- a/contrib/kcp.code-workspace
+++ b/contrib/kcp.code-workspace
@@ -207,8 +207,6 @@
 					"--secure-port",
 					"6444",
 					"--authentication-skip-lookup",
-					"--cert-dir",
-					"${workspaceFolder:kcp}/.kcp/data"
 				],
 			},
 			{

--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kcp-dev/kcp/pkg/cliplugins/workspace/plugin"
 )
@@ -52,10 +53,8 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 	}
 
 	opts.BindFlags(cmd)
-	kubeconfig, err := plugin.NewKubeConfig(opts)
-	if err != nil {
-		return nil, err
-	}
+	configAccess := clientcmd.NewDefaultClientConfigLoadingRules()
+	cmd.PersistentFlags().StringVar(&configAccess.ExplicitPath, "kubeconfig", "", "Path to the kubeconfig file to use for KCP plugin requests.")
 
 	useCmd := &cobra.Command{
 		Use:          "use < workspace name | - >",
@@ -67,6 +66,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 				return fmt.Errorf("The workspace name (or -) should be given")
 			}
 
+			kubeconfig, err := plugin.NewKubeConfig(configAccess, opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.UseWorkspace(c.Context(), opts, args[0]); err != nil {
 				return err
 			}
@@ -80,6 +83,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		Example:      "kcp workspace current",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(configAccess, opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.CurrentWorkspace(c.Context(), opts); err != nil {
 				return err
 			}
@@ -93,6 +100,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		Example:      "kcp workspace list",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(configAccess, opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.ListWorkspaces(c.Context(), opts); err != nil {
 				return err
 			}
@@ -117,6 +128,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 			if err != nil {
 				return err
 			}
+			kubeconfig, err := plugin.NewKubeConfig(configAccess, opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.CreateWorkspace(c.Context(), opts, args[0], useAfterCreation, inheritFrom); err != nil {
 				return err
 			}
@@ -133,6 +148,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(configAccess, opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.DeleteWorkspace(c.Context(), opts, args[0]); err != nil {
 				return err
 			}

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -222,7 +222,7 @@ func (kc *KubeConfig) getCurrentWorkspace(opts *Options) (scope string, name str
 	}
 
 	if !strings.HasPrefix(currentContextName, kcpWorkspaceContextNamePrefix) {
-		return "", "", errors.New("The current context is not a KCP workspace !")
+		return "", "", fmt.Errorf("The current context (%s) is not a KCP workspace !", currentContextName)
 	}
 
 	scope, workspaceName := extractScopeAndName(strings.TrimPrefix(currentContextName, kcpWorkspaceContextNamePrefix))

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -49,9 +49,7 @@ type KubeConfig struct {
 }
 
 // NewKubeConfig load a kubeconfig with default config access
-func NewKubeConfig(overridingOptions *Options) (*KubeConfig, error) {
-	configAccess := clientcmd.NewDefaultClientConfigLoadingRules()
-
+func NewKubeConfig(configAccess *clientcmd.ClientConfigLoadingRules, overridingOptions *Options) (*KubeConfig, error) {
 	var err error
 	startingConfig, err := configAccess.GetStartingConfig()
 	if err != nil {

--- a/pkg/cliplugins/workspace/plugin/options.go
+++ b/pkg/cliplugins/workspace/plugin/options.go
@@ -79,13 +79,12 @@ func (o *Options) BindFlags(cmd *cobra.Command) {
 
 	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.APIVersion.LongName = ""
 	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.APIServer.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.APIServer.Default = "https://127.0.0.1:6444/services/applications/personal"
 	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.CertificateAuthority.Description += descriptionSuffix
 	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.InsecureSkipTLSVerify.Description += descriptionSuffix
 	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.TLSServerName.Description += descriptionSuffix
 
 	workspaceDirectoryConfigOverrideFlags.CurrentContext.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.CurrentContext.Default = "workspace-directory"
+	workspaceDirectoryConfigOverrideFlags.CurrentContext.Default = "virtual.kcp.dev/workspaces/personal"
 	workspaceDirectoryConfigOverrideFlags.Timeout.LongName = ""
 
 	clientcmd.BindOverrideFlags(o.WorkspaceDirectoryOverrides, cmd.PersistentFlags(), workspaceDirectoryConfigOverrideFlags)

--- a/pkg/virtual/framework/cmd/kubeconfig.go
+++ b/pkg/virtual/framework/cmd/kubeconfig.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+)
+
+func (o *APIServerOptions) writeKubeConfig(server *genericapiserver.GenericAPIServer, virtualWorkspaces []framework.VirtualWorkspace) error {
+	var clientConfig clientcmdapi.Config
+
+	contextNames := sets.NewString()
+	clientConfig.Clusters = map[string]*clientcmdapi.Cluster{}
+	clientConfig.Contexts = map[string]*clientcmdapi.Context{}
+
+	for _, vw := range virtualWorkspaces {
+		for contextName, path := range vw.GetKubeContextPaths() {
+			if contextNames.Has(contextName) {
+				return fmt.Errorf("Duplicate Kubeconfig context names: %s", contextName)
+			}
+			clientConfig.Clusters[contextName] = &clientcmdapi.Cluster{
+				Server:                   server.LoopbackClientConfig.Host + path,
+				CertificateAuthorityData: server.LoopbackClientConfig.CAData,
+				TLSServerName:            server.LoopbackClientConfig.TLSClientConfig.ServerName,
+			}
+			clientConfig.Contexts[contextName] = &clientcmdapi.Context{Cluster: contextName}
+			contextNames.Insert(contextName)
+		}
+	}
+	clientConfig.CurrentContext = o.SubCommandOptions.GetCurrentKubeContext()
+
+	if err := clientcmd.WriteToFile(clientConfig, filepath.Join(o.RootDirectory, o.KubeConfigPath)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/virtual/framework/fixedgvs/types.go
+++ b/pkg/virtual/framework/fixedgvs/types.go
@@ -51,12 +51,15 @@ type GroupVersionAPISet struct {
 	BootstrapRestResources func(rootAPIServerConfig genericapiserver.CompletedConfig) (map[string]RestStorageBuilder, error)
 }
 
+var _ framework.VirtualWorkspace = (*FixedGroupVersionsVirtualWorkspace)(nil)
+
 // FixedGroupVersionsVirtualWorkspace is an implementation of
 // the VirtualWorkspace interface, which allows adding well-defined APIs
 // in a limited number of group/versions, implemented as Rest storages.
 type FixedGroupVersionsVirtualWorkspace struct {
 	Name                string
 	RootPathResolver    framework.RootPathResolverFunc
+	KubeContextPaths    map[string]string
 	Ready               framework.ReadyFunc
 	GroupVersionAPISets []GroupVersionAPISet
 }
@@ -71,4 +74,8 @@ func (vw *FixedGroupVersionsVirtualWorkspace) IsReady() error {
 
 func (vw *FixedGroupVersionsVirtualWorkspace) ResolveRootPath(urlPath string, context context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 	return vw.RootPathResolver(urlPath, context)
+}
+
+func (vw *FixedGroupVersionsVirtualWorkspace) GetKubeContextPaths() map[string]string {
+	return vw.KubeContextPaths
 }

--- a/pkg/virtual/framework/fixedgvs/types.go
+++ b/pkg/virtual/framework/fixedgvs/types.go
@@ -59,7 +59,7 @@ var _ framework.VirtualWorkspace = (*FixedGroupVersionsVirtualWorkspace)(nil)
 type FixedGroupVersionsVirtualWorkspace struct {
 	Name                string
 	RootPathResolver    framework.RootPathResolverFunc
-	KubeContextPaths    map[string]string
+	PublishedRootPaths  map[string]string
 	Ready               framework.ReadyFunc
 	GroupVersionAPISets []GroupVersionAPISet
 }
@@ -76,6 +76,6 @@ func (vw *FixedGroupVersionsVirtualWorkspace) ResolveRootPath(urlPath string, co
 	return vw.RootPathResolver(urlPath, context)
 }
 
-func (vw *FixedGroupVersionsVirtualWorkspace) GetKubeContextPaths() map[string]string {
-	return vw.KubeContextPaths
+func (vw *FixedGroupVersionsVirtualWorkspace) GetPublishedRootPaths() map[string]string {
+	return vw.PublishedRootPaths
 }

--- a/pkg/virtual/framework/types.go
+++ b/pkg/virtual/framework/types.go
@@ -49,9 +49,9 @@ type ReadyFunc func() error
 type VirtualWorkspace interface {
 	GetName() string
 	ResolveRootPath(urlPath string, context context.Context) (accepted bool, prefixToStrip string, completedContext context.Context)
-	// GetKubeContextPaths returns a map in which keys are the kubeconfig context names of published endpoints
-	// provided by this virtual workspace, and values are associated endpoint path prefix.
-	GetKubeContextPaths() map[string]string
+	// GetPublishedRootPaths returns the root paths of published endpoints, indexed by keys
+	// that allow identifying them.
+	GetPublishedRootPaths() map[string]string
 	IsReady() error
 	Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error)
 }

--- a/pkg/virtual/framework/types.go
+++ b/pkg/virtual/framework/types.go
@@ -22,6 +22,10 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
+// KcpVirtualWorkspaceContextNamePrefix defines the prefix for the names of all the contexts
+// that will be added in the generated kubeconfig
+const KcpVirtualWorkspaceContextNamePrefix string = "virtual.kcp.dev/"
+
 // RootPathResolverFunc is the type of a function that, based on the URL path of a request,
 // returns whether the request should be accepted and served by a given VirtuaWorkspace.
 // When it returns `true`, it will also set the VirtualWorkspace name in the request context,
@@ -45,6 +49,9 @@ type ReadyFunc func() error
 type VirtualWorkspace interface {
 	GetName() string
 	ResolveRootPath(urlPath string, context context.Context) (accepted bool, prefixToStrip string, completedContext context.Context)
+	// GetKubeContextPaths returns a map in which keys are the kubeconfig context names of published endpoints
+	// provided by this virtual workspace, and values are associated endpoint path prefix.
+	GetKubeContextPaths() map[string]string
 	IsReady() error
 	Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error)
 }

--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -42,6 +42,7 @@ import (
 
 const WorkspacesVirtualWorkspaceName string = "workspaces"
 const DefaultRootPathPrefix string = "/services/applications"
+const KubeContextNamePrefix string = framework.KcpVirtualWorkspaceContextNamePrefix + "workspaces/"
 
 func BuildVirtualWorkspace(rootPathPrefix string, workspaces workspaceinformer.WorkspaceInformer, kcpClient kcpclient.Interface, kubeClient kubernetes.Interface, rbacInformers rbacinformers.Interface, subjectLocator rbacauthorizer.SubjectLocator, ruleResolver rbacregistryvalidation.AuthorizationRuleResolver) framework.VirtualWorkspace {
 	crbInformer := rbacInformers.ClusterRoleBindings()
@@ -75,6 +76,10 @@ func BuildVirtualWorkspace(rootPathPrefix string, workspaces workspaceinformer.W
 				return true, rootPathPrefix + workspacesScope, context.WithValue(requestContext, virtualworkspacesregistry.WorkspacesScopeKey, workspacesScope)
 			}
 			return
+		},
+		KubeContextPaths: map[string]string{
+			KubeContextNamePrefix + virtualworkspacesregistry.PersonalScope:     rootPathPrefix + virtualworkspacesregistry.PersonalScope,
+			KubeContextNamePrefix + virtualworkspacesregistry.OrganizationScope: rootPathPrefix + virtualworkspacesregistry.OrganizationScope,
 		},
 		GroupVersionAPISets: []fixedgvs.GroupVersionAPISet{
 			{

--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -77,7 +77,7 @@ func BuildVirtualWorkspace(rootPathPrefix string, workspaces workspaceinformer.W
 			}
 			return
 		},
-		KubeContextPaths: map[string]string{
+		PublishedRootPaths: map[string]string{
 			KubeContextNamePrefix + virtualworkspacesregistry.PersonalScope:     rootPathPrefix + virtualworkspacesregistry.PersonalScope,
 			KubeContextNamePrefix + virtualworkspacesregistry.OrganizationScope: rootPathPrefix + virtualworkspacesregistry.OrganizationScope,
 		},

--- a/pkg/virtual/workspaces/cmd/cmd.go
+++ b/pkg/virtual/workspaces/cmd/cmd.go
@@ -40,6 +40,7 @@ import (
 	frameworkrbac "github.com/kcp-dev/kcp/pkg/virtual/framework/rbac"
 	rootapiserver "github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/builder"
+	virtualworkspacesregistry "github.com/kcp-dev/kcp/pkg/virtual/workspaces/registry"
 )
 
 var _ virtualframeworkcmd.SubCommandOptions = (*WorkspacesSubCommandOptions)(nil)
@@ -147,4 +148,8 @@ func (o *WorkspacesSubCommandOptions) PrepareVirtualWorkspaces() ([]rootapiserve
 		kcpInformer.Start,
 	}
 	return informerStarts, virtualWorkspaces, nil
+}
+
+func (o *WorkspacesSubCommandOptions) GetCurrentKubeContext() string {
+	return builder.KubeContextNamePrefix + virtualworkspacesregistry.PersonalScope
 }


### PR DESCRIPTION
We now generate a `virtual.kubeconfig` file at start of the virtual workspaces APIServer, exactly the same
way as it is done for the KCP APIServer.

This allows easily connecting to the virtual workspace from `kubectl| without having certificate problems, or complex commands, but simply with:
```
kubectl --kubeconfig .kcp/virtual.kubeconfig get workpaces
```

This will greatly simplify/shorten a number of workspace-related commands in the prototype 2 demo.

Signed-off-by: David Festal <dfestal@redhat.com>