### PR TITLE
e2e: use honest func name framework.RunParallel

### DIFF
--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -61,7 +61,7 @@ func TestAPIInheritance(t *testing.T) {
 	}
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -40,7 +40,7 @@ import (
 func TestCrossLogicalClusterList(t *testing.T) {
 	const serverName = "main"
 
-	framework.Run(t, "Ensure cross logical cluster list works", func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+	framework.RunParallel(t, "Ensure cross logical cluster list works", func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 		ctx := context.Background()
 		if deadline, ok := t.Deadline(); ok {
 			withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -53,7 +53,7 @@ type KcpConfig struct {
 	Args []string
 }
 
-// Run mimics the testing.T.Run function while providing a nice set of concurrency
+// RunParallel mimics the testing.T.Run function while providing a nice set of concurrency
 // guarantees for the processes that we create and manage for test cases. We ensure:
 // - any kcp processes that are started will only be exposed to the test
 //   code once they have signalled that they are healthy, ready, and live
@@ -74,7 +74,7 @@ type KcpConfig struct {
 // other than the main testing goroutine. Therefore, when more than one routine needs
 // to be able to influence the execution flow (e.g. preempt other routines) we must
 // have the central routine watch for incoming errors from delegate routines.
-func Run(top *testing.T, name string, f TestFunc, cfgs ...KcpConfig) {
+func RunParallel(top *testing.T, name string, f TestFunc, cfgs ...KcpConfig) {
 	if _, previouslyCalled := seen.LoadOrStore(fmt.Sprintf("%p", top), nil); !previouslyCalled {
 		top.Parallel()
 	}

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -163,7 +163,7 @@ func TestClusterController(t *testing.T) {
 	}
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			start := time.Now()
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -171,7 +171,7 @@ func TestIngressController(t *testing.T) {
 	}
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			start := time.Now()
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -196,7 +196,7 @@ func TestNamespaceScheduler(t *testing.T) {
 	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -286,7 +286,7 @@ func TestWorkspaceController(t *testing.T) {
 	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/reconciler/workspaceindex/controller_test.go
+++ b/test/e2e/reconciler/workspaceindex/controller_test.go
@@ -196,7 +196,7 @@ func TestWorkspaceIndex(t *testing.T) {
 	)
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -358,7 +358,7 @@ func TestWorkspaceShardController(t *testing.T) {
 	const serverName = "main"
 	for i := range testCases {
 		testCase := testCases[i]
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)

--- a/test/e2e/virtual/framework/composite_test.go
+++ b/test/e2e/virtual/framework/composite_test.go
@@ -464,7 +464,7 @@ func TestCompositeVirtualWorkspace(t *testing.T) {
 	for i := range testCases {
 		testCase := testCases[i]
 
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			if len(servers) != 1 {
 				t.Errorf("incorrect number of servers: %d", len(servers))
 				return

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -302,7 +302,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 			continue
 		}
 
-		framework.Run(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
+		framework.RunParallel(t, testCase.name, func(t framework.TestingTInterface, servers map[string]framework.RunningServer, artifactDir, dataDir string) {
 			if len(servers) != 1 {
 				t.Errorf("incorrect number of servers: %d", len(servers))
 				return


### PR DESCRIPTION
Having a function mimicing `testing.Run`, but adding parallisim has smell. At least, use a honest name and call it `RunParallel`.