### PR TITLE
Speed-up CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,22 @@ jobs:
       - run: make build
       - run: PATH="${PATH}:$(pwd)/bin/" make test
 
+  e2e-single-run:
+    name: e2e-single-run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - run: make build
+      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" COUNT=1 E2E_PARALLELISM=2 make test-e2e
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: e2e-artifacts
+          path: /tmp/e2e/**/artifacts/
+
   e2e:
     name: e2e
     runs-on: ubuntu-latest
@@ -89,7 +105,7 @@ jobs:
         with:
           go-version: v1.17
       - run: make build
-      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" make test-e2e
+      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" COUNT=5 E2E_PARALLELISM=2 make test-e2e
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,18 @@ jobs:
         with:
           go-version: v1.17
       - run: make build
-      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" make test test-e2e
+      - run: PATH="${PATH}:$(pwd)/bin/" make test
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - run: make build
+      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" make test-e2e
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:

--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,11 @@ imports: $(OPENSHIFT_GOIMPORTS)
 	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev/kcp
 
 COUNT ?= 5
+E2E_PARALLELISM ?= 1
 
 .PHONY: test-e2e
 test-e2e: install
-	go test -tags e2e -race -count $(COUNT) ./test/e2e... $(WHAT)
+	go test -tags e2e -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) ./test/e2e... $(WHAT)
 
 .PHONY: test
 test:


### PR DESCRIPTION
- split test workflow into test and test-e2e
- limit concurrency to 2 for e2e

e2e tests with this run in 5:30min, instead of 7:50min before.