### PR TITLE
syncer: Use Server-Side Apply to sync resources into downstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	k8s.io/kubectl v0.0.0
+	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704
 	k8s.io/kubernetes v0.0.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1219,6 +1219,8 @@ k8s.io/system-validators v1.5.0/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6g
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9 h1:imL9YgXQ9p7xmPzHFm/vVd/cF78jad+n4wK1ABwYtMM=
 k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 h1:ZKMMxTvduyf5WUtREOqg5LiXaN1KO/+0oOQPRFrClpo=
+k8s.io/utils v0.0.0-20211208161948-7d6a63dca704/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -40,6 +40,7 @@ import (
 
 const resyncPeriod = 10 * time.Hour
 const SyncerNamespaceKey = "SYNCER_NAMESPACE"
+const syncerApplyManager = "syncer"
 
 // Direction indicates which direction data is flowing for this particular syncer
 type Direction string
@@ -119,7 +120,7 @@ func New(fromDiscovery discovery.DiscoveryInterface, fromClient, toClient dynami
 	}
 
 	if direction == KcpToPhysicalCluster {
-		c.upsertFn = c.upsertIntoDownstream
+		c.upsertFn = c.applyToDownstream
 		c.deleteFn = c.deleteFromDownstream
 	} else {
 		c.upsertFn = c.updateStatusInUpstream


### PR DESCRIPTION
The syncer currently fails to update resources into downstream, when some fields are initialised by downstream controllers or admission webhooks, because it currently PUTs the whole upstream resources spec.  

One example is Service resources, for which unsetting `clusterIP` or `ipFamilies` is not allowed, and that cannot be synced downstream, once created:

```
E0204 16:41:06.117204   47047 specsyncer.go:155] Updating resource kcp--admin--myns/httpecho:
Service "httpecho" is invalid: [spec.clusterIPs[0]: Invalid value: []string(nil):
primary clusterIP can not be unset, spec.ipFamilies[0]:
Invalid value: []core.IPFamily(nil): primary ipFamily can not be unset]
E0204 16:41:06.907285   47047 syncer.go:318] Error reconciling key {{"" "v1" "services"}
%!q(*unstructured.Unstructured=&{map[apiVersion:v1 kind:Service
spec:map[ports:[map[name:http-port port:80 protocol:TCP targetPort:http-port]]
selector:map[app:echo-server]] status:map[loadBalancer:map[]]]})},
retrying... (#1): Service "httpecho" is invalid: [spec.clusterIPs[0]:
Invalid value: []string(nil):
primary clusterIP can not be unset,
spec.ipFamilies[0]: Invalid value: []core.IPFamily(nil): primary ipFamily can not be unset]
```

This PR changes the syncer to using SSA to apply upstream spec, without conflicting with downstream admission / validation.