### PR TITLE
syncer: Fix Object to synchronize is expected to be Unstructured, but is <nil>

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -389,14 +389,17 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		return err
 	}
 
-	if !exists && c.deleteFn != nil {
+	if !exists {
 		klog.Infof("Object with gvr=%q was deleted : %s/%s", gvr, namespace, meta.GetName())
-		return c.deleteFn(ctx, gvr, targetNamespace, targetName)
+		if c.deleteFn != nil {
+			return c.deleteFn(ctx, gvr, targetNamespace, targetName)
+		}
+		return nil
 	}
 
 	unstrob, isUnstructured := obj.(*unstructured.Unstructured)
 	if !isUnstructured {
-		err := fmt.Errorf("Object to synchronize is expected to be Unstructured, but is %T", obj)
+		err := fmt.Errorf("object to synchronize is expected to be Unstructured, but is %T", obj)
 		klog.Error(err)
 		return err
 	}


### PR DESCRIPTION
When deleting a resource, the syncer errors with the following message, that's repeated multiple times as the item gets re-queued for retry:

```
E0204 18:30:52.939061   49166 syncer.go:401] Object to synchronize is expected to be Unstructured, but is <nil>
E0204 18:30:53.589096   49166 syncer.go:319] Error reconciling key {{"apps" "v1" "deployments"} %!q(*unstructured.Unstructured=&{map[apiVersion:apps/v1 kind:Deployment metadata:map[annotations:map[deployment.kubernetes.io/revision:1 kubectl.kubernetes.io/last-applied-configuration:{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"kcp.dev/cluster":"kcp-cluster-a"},"name":"echo-deployment","namespace":"myns"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"echo-server"}},"template":{"metadata":{"labels":{"app":"echo-server"}},"spec":{"containers":[{"image":"jmalloc/echo-server","name":"echo-server","ports":[{"containerPort":8080,"name":"http-port","protocol":"TCP"}]}]}}}}
```