### PR TITLE
Makefile: fix WHAT not overriding the default package path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,14 @@ COUNT ?= 5
 E2E_PARALLELISM ?= 1
 
 .PHONY: test-e2e
+test-e2e: WHAT ?= ./test/e2e...
 test-e2e: install
-	go test -tags e2e -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) ./test/e2e... $(WHAT)
+	go test -tags e2e -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT)
 
 .PHONY: test
+test: WHAT ?= ./...
 test:
-	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic ./... $(WHAT)
+	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic $(WHAT)
 
 .PHONY: demos
 demos: build ## Runs all the default demos (kubecon and apiNegotiation).


### PR DESCRIPTION
`WHAT=./foo... make ...` should replace the default path