### PR TITLE
Build and publish kcp image

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -22,13 +22,17 @@ jobs:
       with:
         go-version: v1.17
 
+    - name: Get the short sha
+      id: vars
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
     # Build and push a KCP image, tagged with latest and the commit SHA.
     - name: Build KCP Image
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
         image: kcp
-        tags: latest ${{ github.sha }}
+        tags: latest ${{ steps.vars.outputs.sha_short }}
         containerfiles: |
           ./Dockerfile
 

--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -1,0 +1,44 @@
+name: Build and Publish KCP Image
+
+permissions:
+  packages: write
+
+on:
+  workflow_run:
+    workflows: [ "CI" ]
+    branches: [ "main" ]
+    types:
+      - completed
+
+jobs:
+  kcp-image:
+    if: ${{ github.event.workflow_run.conclusion == "success" && github.event_name == "push" }}
+    name: Build and Publish KCP Image
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: v1.17
+
+    # Build and push a KCP image, tagged with latest and the commit SHA.
+    - name: Build KCP Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: kcp
+        tags: latest ${{ github.sha }}
+        containerfiles: |
+          ./Dockerfile
+
+    - name: Push to ghcr.io
+      id: push-to-ghcr
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: ghcr.io/${{ github.repository_owner }}
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-4 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+USER 0
+RUN go mod download
+
+COPY Makefile Makefile
+
+# Copy the go source
+COPY config/ config/
+COPY pkg/ pkg/
+COPY cmd/ cmd/
+COPY third_party/ third_party/
+
+RUN mkdir bin; CGO_ENABLED=0 go build -o bin ./cmd/...
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+# FROM gcr.io/distroless/static:nonroot
+FROM alpine:3.15
+WORKDIR /
+COPY --from=builder workspace/bin/* /
+USER 65532:65532

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
-# Build the manager binary
+# Copyright 2022 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the binary
 FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12-4 as builder
 
 WORKDIR /workspace


### PR DESCRIPTION
Build a kcp image from main and publish it to ghcr if the CI workflow succeeds.