### PR TITLE
reconciler/cluster: fix startup races

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -27,7 +27,9 @@ import (
 	"github.com/spf13/pflag"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kcp-dev/kcp/config"
@@ -36,8 +38,6 @@ import (
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cluster"
-	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const resyncPeriod = 10 * time.Hour
@@ -128,7 +128,12 @@ func main() {
 		}
 	}
 
-	go cluster.Start(ctx, c.NumThreads)
+	prepared, err := cluster.Prepare()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	go prepared.Start(ctx)
 	go apiresource.Start(ctx, c.NumThreads)
 
 	<-ctx.Done()

--- a/pkg/reconciler/apiresource/controller.go
+++ b/pkg/reconciler/apiresource/controller.go
@@ -301,11 +301,6 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	klog.Info("Starting APIResource controller")
 	defer klog.Info("Shutting down APIResource controller")
 
-	if !cache.WaitForNamedCacheSync("apiresource", ctx.Done(), c.syncChecks...) {
-		klog.Warning("Failed to wait for caches to sync")
-		return
-	}
-
 	for i := 0; i < numThreads; i++ {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}

--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -82,37 +82,6 @@ func NewController(
 ) (*Controller, error) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
-	var genericControlPlaneResources []schema.GroupVersionResource
-
-	//TODO(ncdc): does this need a per-cluster client?
-	discoveryClient := apiExtensionsClient.Discovery()
-	serverGroups, err := discoveryClient.ServerGroups()
-	if err != nil {
-		return nil, err
-	}
-	for _, apiGroup := range serverGroups.Groups {
-		if genericcontrolplanescheme.Scheme.IsGroupRegistered(apiGroup.Name) {
-			for _, version := range apiGroup.Versions {
-				gv := schema.GroupVersion{
-					Group:   apiGroup.Name,
-					Version: version.Version,
-				}
-				if genericcontrolplanescheme.Scheme.IsVersionRegistered(gv) {
-					apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(gv.String())
-					if err != nil {
-						return nil, err
-					}
-					for _, apiResource := range apiResourceList.APIResources {
-						gvk := gv.WithKind(apiResource.Kind)
-						if !strings.Contains(apiResource.Name, "/") && genericcontrolplanescheme.Scheme.Recognizes(gvk) {
-							genericControlPlaneResources = append(genericControlPlaneResources, gv.WithResource(apiResource.Name))
-						}
-					}
-				}
-			}
-		}
-	}
-
 	c := &Controller{
 		queue:                    queue,
 		apiExtensionsClient:      apiExtensionsClient,
@@ -123,13 +92,12 @@ func NewController(
 			clusterInformer.Informer().HasSynced,
 			apiResourceImportInformer.Informer().HasSynced,
 		},
-		syncerImage:                  syncerImage,
-		kubeconfig:                   kubeconfig,
-		resourcesToSync:              resourcesToSync,
-		syncerMode:                   syncerMode,
-		syncers:                      map[string]*syncer.Syncer{},
-		apiImporters:                 map[string]*APIImporter{},
-		genericControlPlaneResources: genericControlPlaneResources,
+		syncerImage:     syncerImage,
+		kubeconfig:      kubeconfig,
+		resourcesToSync: resourcesToSync,
+		syncerMode:      syncerMode,
+		syncers:         map[string]*syncer.Syncer{},
+		apiImporters:    map[string]*APIImporter{},
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -212,18 +180,59 @@ func (c *Controller) enqueueAPIResourceImportRelatedCluster(obj interface{}) {
 	}
 }
 
-func (c *Controller) Start(ctx context.Context, numThreads int) {
+type preparedController struct {
+	Controller
+}
+
+type PreparedController struct {
+	*preparedController
+}
+
+func (c *Controller) Prepare() (PreparedController, error) {
+	// TODO(ncdc): does this need a per-cluster client?
+	// TODO(sttts): make resilient to errors
+	discoveryClient := c.apiExtensionsClient.Discovery()
+	serverGroups, err := discoveryClient.ServerGroups()
+	if err != nil {
+		return PreparedController{}, err
+	}
+	for _, apiGroup := range serverGroups.Groups {
+		if genericcontrolplanescheme.Scheme.IsGroupRegistered(apiGroup.Name) {
+			for _, version := range apiGroup.Versions {
+				gv := schema.GroupVersion{
+					Group:   apiGroup.Name,
+					Version: version.Version,
+				}
+				if genericcontrolplanescheme.Scheme.IsVersionRegistered(gv) {
+					apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(gv.String())
+					if err != nil {
+						return PreparedController{}, err
+					}
+					for _, apiResource := range apiResourceList.APIResources {
+						gvk := gv.WithKind(apiResource.Kind)
+						if !strings.Contains(apiResource.Name, "/") && genericcontrolplanescheme.Scheme.Recognizes(gvk) {
+							c.genericControlPlaneResources = append(c.genericControlPlaneResources, gv.WithResource(apiResource.Name))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return PreparedController{&preparedController{
+		Controller: *c,
+	}}, nil
+}
+
+// TODO(sttts): fix the many races due to unprotected field access and then increase worker count
+func (c *PreparedController) Start(ctx context.Context) {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 
 	klog.Info("Starting Cluster controller")
 	defer klog.Info("Shutting down Cluster controller")
 
-	for i := 0; i < numThreads; i++ {
-		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
-	}
-
-	<-ctx.Done()
+	wait.Until(func() { c.startWorker(ctx) }, time.Millisecond*10, ctx.Done())
 }
 
 func (c *Controller) startWorker(ctx context.Context) {

--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -219,11 +219,6 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	klog.Info("Starting Cluster controller")
 	defer klog.Info("Shutting down Cluster controller")
 
-	if !cache.WaitForNamedCacheSync("cluster", ctx.Done(), c.syncChecks...) {
-		klog.Warning("Failed to wait for caches to sync")
-		return
-	}
-
 	for i := 0; i < numThreads; i++ {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
 	}

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -242,7 +242,11 @@ func (s *Server) installClusterController(clientConfig clientcmdapi.Config, serv
 		s.kcpSharedInformerFactory.WaitForCacheSync(context.StopCh)
 		s.kubeSharedInformerFactory.WaitForCacheSync(context.StopCh)
 
-		go cluster.Start(goContext(context), c.NumThreads)
+		cluster, err := cluster.Prepare()
+		if err != nil {
+			return err
+		}
+		go cluster.Start(goContext(context))
 		go apiresource.Start(goContext(context), c.NumThreads)
 
 		return nil

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/kubernetes/pkg/controller/namespace"
 
 	"github.com/kcp-dev/kcp/config"
+	apiresourceapi "github.com/kcp-dev/kcp/pkg/apis/apiresource"
+	clusterapi "github.com/kcp-dev/kcp/pkg/apis/cluster"
 	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	"github.com/kcp-dev/kcp/pkg/gvk"
@@ -209,13 +211,41 @@ func (s *Server) installClusterController(clientConfig clientcmdapi.Config, serv
 		cluster.Server = hostURL.String()
 	}
 
+	c := s.cfg.ClusterControllerOptions.Complete(*kubeconfig, s.kcpSharedInformerFactory, s.apiextensionsSharedInformerFactory)
+	cluster, apiresource, err := c.New()
+	if err != nil {
+		return err
+	}
+
 	if err := server.AddPostStartHook("install-cluster-controller", func(context genericapiserver.PostStartHookContext) error {
 		if err := s.waitForCRDServer(context.StopCh); err != nil {
 			return err
 		}
 
-		ctx := goContext(context)
-		return s.cfg.ClusterControllerOptions.Complete(*kubeconfig, s.kcpSharedInformerFactory, s.apiextensionsSharedInformerFactory).Start(ctx)
+		// TODO(sttts): remove CRD creation from controller startup
+		requiredCrds := []metav1.GroupKind{
+			{Group: apiresourceapi.GroupName, Kind: "apiresourceimports"},
+			{Group: apiresourceapi.GroupName, Kind: "negotiatedapiresources"},
+			{Group: clusterapi.GroupName, Kind: "clusters"},
+		}
+		for _, contextName := range []string{"admin", "user"} {
+			logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(*kubeconfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()
+			if err != nil {
+				return err
+			}
+			crdClient := apiextensionsv1client.NewForConfigOrDie(logicalClusterConfig).CustomResourceDefinitions()
+			if err := config.BootstrapCustomResourceDefinitions(goContext(context), crdClient, requiredCrds); err != nil {
+				return err
+			}
+		}
+
+		s.kcpSharedInformerFactory.WaitForCacheSync(context.StopCh)
+		s.kubeSharedInformerFactory.WaitForCacheSync(context.StopCh)
+
+		go cluster.Start(goContext(context), c.NumThreads)
+		go apiresource.Start(goContext(context), c.NumThreads)
+
+		return nil
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Informers and lister have to be created before shared informer factory start. This PR splits New() from Start().