### PR TITLE
Remove e2e build tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           only-new-issues: true
-          args: --build-tags e2e --timeout=5m
+          args: --timeout=5m
 
   codegen:
     name: codegen

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test-e2e: install
 .PHONY: test
 test: WHAT ?= ./...
 test:
-	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic
+	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic $$(go list "$(WHAT)" | grep -v ./test/e2e/)
 
 .PHONY: demos
 demos: build ## Runs all the default demos (kubecon and apiNegotiation).

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install: install-ingress-controller
 .PHONY: install
 
 lint:
-	golangci-lint run --build-tags e2e ./...
+	golangci-lint run ./...
 .PHONY: lint
 
 INGRESS_CONTROLLER_DIR = ./build/kcp-ingress
@@ -103,12 +103,12 @@ E2E_PARALLELISM ?= 1
 .PHONY: test-e2e
 test-e2e: WHAT ?= ./test/e2e...
 test-e2e: install
-	go test -tags e2e -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT)
+	go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT)
 
 .PHONY: test
 test: WHAT ?= ./...
 test:
-	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic $(WHAT)
+	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic
 
 .PHONY: demos
 demos: build ## Runs all the default demos (kubecon and apiNegotiation).

--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/accessory.go
+++ b/test/e2e/framework/accessory.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/t.go
+++ b/test/e2e/framework/t.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/testhelper.go
+++ b/test/e2e/framework/testhelper.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/testhelper_test.go
+++ b/test/e2e/framework/testhelper_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/users.go
+++ b/test/e2e/framework/users.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/workspaceindex/controller_test.go
+++ b/test/e2e/reconciler/workspaceindex/controller_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/framework/composite_test.go
+++ b/test/e2e/virtual/framework/composite_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/framework/compositecmd/cmd.go
+++ b/test/e2e/virtual/framework/compositecmd/cmd.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/framework/compositecmd/rest.go
+++ b/test/e2e/virtual/framework/compositecmd/rest.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/helpers/helpers.go
+++ b/test/e2e/virtual/helpers/helpers.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2021 The KCP Authors.
 


### PR DESCRIPTION
Requiring build tags for e2e tests complicates invoking tests via editor shortcuts. The same result of limiting the `make test` target to non-e2e files can be accomplished by path exclusion.