### PR TITLE
KCP build and publish image workflow fixes

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -4,15 +4,12 @@ permissions:
   packages: write
 
 on:
-  workflow_run:
-    workflows: [ "CI" ]
-    branches: [ "main" ]
-    types:
-      - completed
+  push:
+    branches:
+    - main
 
 jobs:
   kcp-image:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event_name == 'push' }}
     name: Build and Publish KCP Image
     runs-on: ubuntu-latest
 
@@ -24,7 +21,7 @@ jobs:
 
     - name: Get the short sha
       id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
 
     # Build and push a KCP image, tagged with latest and the commit SHA.
     - name: Build KCP Image
@@ -45,4 +42,3 @@ jobs:
         registry: ghcr.io/${{ github.repository_owner }}
         username: ${{ github.actor }}
         password: ${{ github.token }}
-


### PR DESCRIPTION
The workflow_run trigger doesn't populate context objects with expected
info about the commit. Since the CI workflow runs on PRs as well as
pushes to main, I'm removing the build/publish dependency on it and
packaging on all pushes to main.

Signed-off-by: Christopher Sams <csams@redhat.com>