### PR TITLE
Improve syncer stopping

### DIFF
--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -91,14 +91,11 @@ func main() {
 	defer cancel()
 
 	klog.Infoln("Starting workers")
-	syncer, err := syncer.StartSyncer(ctx, fromConfig, toConfig, sets.NewString(syncedResourceTypes...), *clusterID, *fromCluster, numThreads)
-	if err != nil {
+	if err := syncer.StartSyncer(ctx, fromConfig, toConfig, sets.NewString(syncedResourceTypes...), *clusterID, *fromCluster, numThreads); err != nil {
 		klog.Fatal(err)
 	}
 
 	<-ctx.Done()
 
 	klog.Infoln("Stopping workers")
-	syncer.Stop()
-	syncer.WaitUntilDone()
 }

--- a/pkg/reconciler/apiresource/controller.go
+++ b/pkg/reconciler/apiresource/controller.go
@@ -54,7 +54,7 @@ func NewController(
 	apiResourceImportInformer apiresourceinformer.APIResourceImportInformer,
 	crdInformer crdinfomer.CustomResourceDefinitionInformer,
 ) (*Controller, error) {
-	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-apiresource")
 
 	c := &Controller{
 		queue:                            queue,

--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -41,7 +41,6 @@ import (
 	apiresourceinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apiresource/v1alpha1"
 	clusterinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/cluster/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
-	"github.com/kcp-dev/kcp/pkg/syncer"
 )
 
 type SyncerMode int
@@ -92,12 +91,12 @@ func NewController(
 			clusterInformer.Informer().HasSynced,
 			apiResourceImportInformer.Informer().HasSynced,
 		},
-		syncerImage:     syncerImage,
-		kubeconfig:      kubeconfig,
-		resourcesToSync: resourcesToSync,
-		syncerMode:      syncerMode,
-		syncers:         map[string]*syncer.Syncer{},
-		apiImporters:    map[string]*APIImporter{},
+		syncerImage:       syncerImage,
+		kubeconfig:        kubeconfig,
+		resourcesToSync:   resourcesToSync,
+		syncerMode:        syncerMode,
+		syncerCancelFuncs: map[string]func(){},
+		apiImporters:      map[string]*APIImporter{},
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -145,7 +144,7 @@ type Controller struct {
 	kubeconfig                   clientcmdapi.Config
 	resourcesToSync              []string
 	syncerMode                   SyncerMode
-	syncers                      map[string]*syncer.Syncer
+	syncerCancelFuncs            map[string]func()
 	apiImporters                 map[string]*APIImporter
 	genericControlPlaneResources []schema.GroupVersionResource
 }

--- a/pkg/reconciler/cluster/controller.go
+++ b/pkg/reconciler/cluster/controller.go
@@ -79,7 +79,7 @@ func NewController(
 	resourcesToSync []string,
 	syncerMode SyncerMode,
 ) (*Controller, error) {
-	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-cluster")
 
 	c := &Controller{
 		queue:                    queue,

--- a/pkg/reconciler/deployment/controller.go
+++ b/pkg/reconciler/deployment/controller.go
@@ -49,7 +49,7 @@ const controllerName = "deployment"
 func NewController(cfg *rest.Config) *Controller {
 	client := appsv1client.NewForConfigOrDie(cfg)
 	kubeClient := kubernetes.NewForConfigOrDie(cfg)
-	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-deployment")
 	stopCh := make(chan struct{}) // TODO: hook this up to SIGTERM/SIGINT
 
 	csif := externalversions.NewSharedInformerFactoryWithOptions(clusterclient.NewForConfigOrDie(cfg), resyncPeriod)

--- a/pkg/reconciler/namespace/controller.go
+++ b/pkg/reconciler/namespace/controller.go
@@ -65,10 +65,10 @@ func NewController(
 	pollInterval time.Duration,
 ) *Controller {
 
-	resourceQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	gvrQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	namespaceQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	clusterQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	resourceQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-namespace-resource")
+	gvrQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-namespace-gvr")
+	namespaceQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-namespace-namespace")
+	clusterQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-namespace-cluster")
 
 	c := &Controller{
 		resourceQueue:  resourceQueue,

--- a/pkg/reconciler/workspace/controller.go
+++ b/pkg/reconciler/workspace/controller.go
@@ -60,7 +60,7 @@ func NewController(
 	workspaceInformer tenancyinformer.WorkspaceInformer,
 	workspaceShardInformer tenancyinformer.WorkspaceShardInformer,
 ) (*Controller, error) {
-	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-workspace")
 
 	c := &Controller{
 		queue:                 queue,

--- a/pkg/reconciler/workspaceindex/controller.go
+++ b/pkg/reconciler/workspaceindex/controller.go
@@ -58,8 +58,8 @@ func NewController(
 	workspaceShardInformer tenancyinformer.WorkspaceShardInformer,
 	index Index,
 ) (*Controller, error) {
-	orgQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	workspaceQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	orgQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-workspaceindex-org")
+	workspaceQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-workspaceindex-workspace")
 
 	c := &Controller{
 		orgQueue:              orgQueue,

--- a/pkg/reconciler/workspaceshard/controller.go
+++ b/pkg/reconciler/workspaceshard/controller.go
@@ -58,7 +58,7 @@ func NewController(
 	secretInformer coreinformer.SecretInformer,
 	workspaceShardInformer tenancyinformer.WorkspaceShardInformer,
 ) (*Controller, error) {
-	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-workspaceshard")
 
 	c := &Controller{
 		queue:                 queue,

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -79,7 +79,7 @@ func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, clusterI
 	}
 	fromClient := fromClients.Cluster(logicalClusterID)
 	toClient := dynamic.NewForConfigOrDie(to)
-	return New(fromDiscovery, fromClient, toClient, KcpToPhysicalCluster, syncedResourceTypes, clusterID)
+	return New(clusterID, logicalClusterID, fromDiscovery, fromClient, toClient, KcpToPhysicalCluster, syncedResourceTypes, clusterID)
 }
 
 func (c *Controller) deleteFromDownstream(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) error {

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -60,7 +60,7 @@ func NewStatusSyncer(from, to *rest.Config, syncedResourceTypes []string, cluste
 		return nil, err
 	}
 	toClient := toClients.Cluster(logicalClusterID)
-	return New(discoveryClient, fromClient, toClient, PhysicalClusterToKcp, syncedResourceTypes, clusterID)
+	return New(clusterID, logicalClusterID, discoveryClient, fromClient, toClient, PhysicalClusterToKcp, syncedResourceTypes, clusterID)
 }
 
 func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.GroupVersionResource, namespace string, obj *unstructured.Unstructured) error {

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -334,7 +335,7 @@ func (c *kcpServer) monitorEndpoint(client *rest.RESTClient, endpoint string) {
 	}
 	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		_, err := rest.NewRequest(client).RequestURI(endpoint).Do(ctx).Raw()
-		if c.ctx.Err() != nil {
+		if errors.Is(err, context.Canceled) || c.ctx.Err() != nil {
 			return
 		}
 		if err != nil {

--- a/test/e2e/framework/t.go
+++ b/test/e2e/framework/t.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -102,7 +103,9 @@ func (t *T) flush() {
 	for {
 		select {
 		case err := <-t.errors:
-			t.T.Error(err)
+			if !errors.Is(err, context.Canceled) {
+				t.T.Error(err)
+			}
 		default:
 			return
 		}


### PR DESCRIPTION
Switch to creating a cancelable context from the outside (i.e. not in
the Syncer) and letting the caller manage the cancel functions.

Make the controller code more idiomatic.

Fixes #455 
