### PR TITLE
Remove e2e build tag from conformance test

### DIFF
--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 /*
 Copyright 2022 The KCP Authors.
 


### PR DESCRIPTION
This test was missed in the previous PR that removed the build tags.