### PR TITLE
Fix Group{Kind -> Resource} everywhere in CRD bootstrapping

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -110,10 +110,10 @@ func main() {
 	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
 
 	// TODO(sttts): remove CRD creation from controller startup
-	requiredCrds := []metav1.GroupKind{
-		{Group: apiresourceapi.GroupName, Kind: "apiresourceimports"},
-		{Group: apiresourceapi.GroupName, Kind: "negotiatedapiresources"},
-		{Group: clusterapi.GroupName, Kind: "clusters"},
+	requiredCrds := []metav1.GroupResource{
+		{Group: apiresourceapi.GroupName, Resource: "apiresourceimports"},
+		{Group: apiresourceapi.GroupName, Resource: "negotiatedapiresources"},
+		{Group: clusterapi.GroupName, Resource: "clusters"},
 	}
 	for _, contextName := range []string{"admin", "user"} {
 		logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(kubeconfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -179,9 +179,9 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, clientConfig cli
 		}
 
 		// Register CRDs in both the admin and user logical clusters
-		requiredCrds := []metav1.GroupKind{
-			{Group: tenancyapi.GroupName, Kind: "workspaces"},
-			{Group: tenancyapi.GroupName, Kind: "workspaceshards"},
+		requiredCrds := []metav1.GroupResource{
+			{Group: tenancyapi.GroupName, Resource: "workspaces"},
+			{Group: tenancyapi.GroupName, Resource: "workspaceshards"},
 		}
 		crdClient := apiextensionsv1client.NewForConfigOrDie(adminConfig).CustomResourceDefinitions()
 		if err := config.BootstrapCustomResourceDefinitions(ctx, crdClient, requiredCrds); err != nil {
@@ -226,10 +226,10 @@ func (s *Server) installClusterController(clientConfig clientcmdapi.Config, serv
 		}
 
 		// TODO(sttts): remove CRD creation from controller startup
-		requiredCrds := []metav1.GroupKind{
-			{Group: apiresourceapi.GroupName, Kind: "apiresourceimports"},
-			{Group: apiresourceapi.GroupName, Kind: "negotiatedapiresources"},
-			{Group: clusterapi.GroupName, Kind: "clusters"},
+		requiredCrds := []metav1.GroupResource{
+			{Group: apiresourceapi.GroupName, Resource: "apiresourceimports"},
+			{Group: apiresourceapi.GroupName, Resource: "negotiatedapiresources"},
+			{Group: clusterapi.GroupName, Resource: "clusters"},
 		}
 		for _, contextName := range []string{"admin", "user"} {
 			logicalClusterConfig, err := clientcmd.NewNonInteractiveClientConfig(*kubeconfig, contextName, &clientcmd.ConfigOverrides{}, nil).ClientConfig()

--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -83,8 +83,8 @@ func TestAPIInheritance(t *testing.T) {
 			}
 
 			rootCRDClient := apiExtensionsClients.Cluster(helper.OrganizationCluster).ApiextensionsV1().CustomResourceDefinitions()
-			rootCRDs := []metav1.GroupKind{
-				{Group: "apiresource.kcp.dev", Kind: "apiresourceimports"},
+			rootCRDs := []metav1.GroupResource{
+				{Group: "apiresource.kcp.dev", Resource: "apiresourceimports"},
 			}
 
 			if err := config.BootstrapCustomResourceDefinitions(ctx, rootCRDClient, rootCRDs); err != nil {
@@ -94,8 +94,8 @@ func TestAPIInheritance(t *testing.T) {
 
 			crdClient := apiExtensionsClients.Cluster(testCase.logicalClusterName).ApiextensionsV1().CustomResourceDefinitions()
 
-			workspaceCRDs := []metav1.GroupKind{
-				{Group: tenancy.GroupName, Kind: "workspaces"},
+			workspaceCRDs := []metav1.GroupResource{
+				{Group: tenancy.GroupName, Resource: "workspaces"},
 			}
 
 			t.Logf("Bootstrapping CRDs")
@@ -151,8 +151,8 @@ func TestAPIInheritance(t *testing.T) {
 			)
 
 			t.Logf("Install a clusters CRD into source workspace")
-			crdsForWorkspaces := []metav1.GroupKind{
-				{Group: cluster.GroupName, Kind: "clusters"},
+			crdsForWorkspaces := []metav1.GroupResource{
+				{Group: cluster.GroupName, Resource: "clusters"},
 			}
 			sourceCrdClient := apiExtensionsClients.Cluster(sourceWorkspaceClusterName).ApiextensionsV1().CustomResourceDefinitions()
 			if err := config.BootstrapCustomResourceDefinitions(ctx, sourceCrdClient, crdsForWorkspaces); err != nil {

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -69,8 +69,8 @@ func TestCrossLogicalClusterList(t *testing.T) {
 
 			crdClient := apiExtensionsClients.Cluster(logicalCluster).ApiextensionsV1().CustomResourceDefinitions()
 
-			workspaceCRDs := []metav1.GroupKind{
-				{Group: tenancy.GroupName, Kind: "workspaces"},
+			workspaceCRDs := []metav1.GroupResource{
+				{Group: tenancy.GroupName, Resource: "workspaces"},
 			}
 
 			if err := config.BootstrapCustomResourceDefinitions(ctx, crdClient, workspaceCRDs); err != nil {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -235,7 +235,7 @@ func GetFreePort(t TestingTInterface) (string, error) {
 }
 
 // InstallCrd installs a CRD on one or multiple servers.
-func InstallCrd(ctx context.Context, gvk metav1.GroupKind, servers map[string]RunningServer, embeddedResources embed.FS) error {
+func InstallCrd(ctx context.Context, gr metav1.GroupResource, servers map[string]RunningServer, embeddedResources embed.FS) error {
 	wg := sync.WaitGroup{}
 	bootstrapErrChan := make(chan error, len(servers))
 	for _, server := range servers {
@@ -252,7 +252,7 @@ func InstallCrd(ctx context.Context, gvk metav1.GroupKind, servers map[string]Ru
 				bootstrapErrChan <- fmt.Errorf("failed to construct client for server: %w", err)
 				return
 			}
-			bootstrapErrChan <- config.BootstrapCustomResourceDefinitionFromFS(ctx, crdClient.CustomResourceDefinitions(), gvk, embeddedResources)
+			bootstrapErrChan <- config.BootstrapCustomResourceDefinitionFromFS(ctx, crdClient.CustomResourceDefinitions(), gr, embeddedResources)
 		}(server)
 	}
 	wg.Wait()

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -170,7 +170,7 @@ func TestClusterController(t *testing.T) {
 			require.Equalf(t, len(f.Servers), 2, "incorrect number of servers")
 
 			t.Log("Installing test CRDs...")
-			err := framework.InstallCrd(ctx, metav1.GroupKind{Group: wildwest.GroupName, Kind: "cowboys"}, f.Servers, rawCustomResourceDefinitions)
+			err := framework.InstallCrd(ctx, metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"}, f.Servers, rawCustomResourceDefinitions)
 			require.NoError(t, err)
 
 			t.Logf("Installed test CRDs after %s", time.Since(start))

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -192,10 +192,10 @@ func TestIngressController(t *testing.T) {
 				return
 			}
 			t.Log("Installing test CRDs...")
-			requiredCrds := []metav1.GroupKind{
-				{Group: "core.k8s.io", Kind: "services"},
-				{Group: "apps.k8s.io", Kind: "deployments"},
-				{Group: "networking.k8s.io", Kind: "ingresses"},
+			requiredCrds := []metav1.GroupResource{
+				{Group: "core.k8s.io", Resource: "services"},
+				{Group: "apps.k8s.io", Resource: "deployments"},
+				{Group: "networking.k8s.io", Resource: "ingresses"},
 			}
 			for _, requiredCrd := range requiredCrds {
 				if err := framework.InstallCrd(ctx, requiredCrd, servers, embeddedResources); err != nil {

--- a/test/e2e/reconciler/workspaceindex/controller_test.go
+++ b/test/e2e/reconciler/workspaceindex/controller_test.go
@@ -71,9 +71,9 @@ func resolveRunningServer(ctx context.Context, t framework.TestingTInterface, se
 			return runningServer{}, fmt.Errorf("failed to construct extensions client for server: %w", err)
 		}
 		extensionsClient := extensionsClients.Cluster(clusterName)
-		requiredCrds := []metav1.GroupKind{
-			{Group: tenancyapi.GroupName, Kind: "workspaces"},
-			{Group: tenancyapi.GroupName, Kind: "workspaceshards"},
+		requiredCrds := []metav1.GroupResource{
+			{Group: tenancyapi.GroupName, Resource: "workspaces"},
+			{Group: tenancyapi.GroupName, Resource: "workspaceshards"},
 		}
 		crdClient := extensionsClient.ApiextensionsV1().CustomResourceDefinitions()
 		if err := config.BootstrapCustomResourceDefinitions(ctx, crdClient, requiredCrds); err != nil {


### PR DESCRIPTION
Lower-case plural type names are resources, not kinds.