### PR TITLE
Fix flag error handling mode for cluster-controller and shard-proxy

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -69,7 +69,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
 	defer cancel()
 
-	fs := pflag.NewFlagSet("cluster-controller", pflag.ExitOnError)
+	fs := pflag.NewFlagSet("cluster-controller", pflag.ContinueOnError)
 	options := bindOptions(fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/shard-proxy/main.go
+++ b/cmd/shard-proxy/main.go
@@ -67,7 +67,7 @@ func (o *options) Validate() error {
 func main() {
 	ctx := genericapiserver.SetupSignalContext()
 
-	fs := pflag.NewFlagSet("shard-proxy", pflag.ExitOnError)
+	fs := pflag.NewFlagSet("shard-proxy", pflag.ContinueOnError)
 	o := bindOptions(defaultOptions(), fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		klog.Fatalf("failed to parse arguments: %v", err)


### PR DESCRIPTION
Both commands expect `Parse` to return an error, which is consistent with `ContinueOnError`. `ExitOnError` would result in `Parse` calling os.Exit(2) rather than returning an error.