### PR TITLE
e2e: Ensure artifacts are saved at test completion for shared fixture

### DIFF
--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -113,6 +113,8 @@ func newUserClient(t *testing.T, username, orgWorkspace, workspace string, cfg *
 }
 
 func TestAuthorizer(t *testing.T) {
+	t.Parallel()
+
 	usersKCPArgs, err := framework.Users([]framework.User{
 		{
 			Name:   "user-1",

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -139,8 +139,7 @@ func TestAuthorizer(t *testing.T) {
 		Name: "main",
 		Args: usersKCPArgs,
 	})
-	teardown := f.SetUp(t)
-	defer teardown()
+	f.SetUp(t)
 
 	ctx := context.Background()
 	if deadline, ok := t.Deadline(); ok {

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -57,9 +57,6 @@ type kcpServer struct {
 	dataDir     string
 	artifactDir string
 
-	artifactsLock *sync.RWMutex
-	artifacts     []func()
-
 	lock           *sync.Mutex
 	cfg            clientcmd.ClientConfig
 	kubeconfigPath string
@@ -112,12 +109,11 @@ func newKcpServer(t *T, cfg KcpConfig, artifactDir, dataDir string) (*kcpServer,
 			"--kubeconfig-path=admin.kubeconfig",
 		},
 			cfg.Args...),
-		dataDir:       dataDir,
-		artifactDir:   artifactDir,
-		artifactsLock: &sync.RWMutex{},
-		ctx:           ctx,
-		t:             t,
-		lock:          &sync.Mutex{},
+		dataDir:     dataDir,
+		artifactDir: artifactDir,
+		ctx:         ctx,
+		t:           t,
+		lock:        &sync.Mutex{},
 	}, nil
 }
 

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -30,7 +30,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -101,13 +100,6 @@ func TestClusterController(t *testing.T) {
 					}
 					return true
 				}, wait.ForeverTestTimeout, time.Millisecond*100)
-
-				servers[sourceClusterName].Artifact(t, func() (runtime.Object, error) {
-					return servers[sourceClusterName].client.Cowboys(testNamespace).Get(ctx, cowboy.Name, metav1.GetOptions{})
-				})
-				servers[sinkClusterName].Artifact(t, func() (runtime.Object, error) {
-					return servers[sinkClusterName].client.Cowboys(targetNamespace).Get(ctx, cowboy.Name, metav1.GetOptions{})
-				})
 
 				t.Logf("Expecting same spec to show up in sink")
 				cowboy.SetNamespace(targetNamespace)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -102,10 +102,10 @@ func TestClusterController(t *testing.T) {
 					return true
 				}, wait.ForeverTestTimeout, time.Millisecond*100)
 
-				defer servers[sourceClusterName].Artifact(t, func() (runtime.Object, error) {
+				servers[sourceClusterName].Artifact(t, func() (runtime.Object, error) {
 					return servers[sourceClusterName].client.Cowboys(testNamespace).Get(ctx, cowboy.Name, metav1.GetOptions{})
 				})
-				defer servers[sinkClusterName].Artifact(t, func() (runtime.Object, error) {
+				servers[sinkClusterName].Artifact(t, func() (runtime.Object, error) {
 					return servers[sinkClusterName].client.Cowboys(targetNamespace).Get(ctx, cowboy.Name, metav1.GetOptions{})
 				})
 

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -165,7 +165,7 @@ func TestClusterController(t *testing.T) {
 			},
 		},
 	)
-	defer f.SetUp(t)()
+	f.SetUp(t)
 
 	for i := range testCases {
 		testCase := testCases[i]

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -61,6 +61,8 @@ const clusterName = "us-east1"
 const sourceClusterName, sinkClusterName = "source", "sink"
 
 func TestClusterController(t *testing.T) {
+	t.Parallel()
+
 	type runningServer struct {
 		framework.RunningServer
 		client     wildwestclient.WildwestV1alpha1Interface

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -108,7 +108,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 					return
 				}
 				assert.Equal(t, testData.workspace1.Name, workspace1.Name)
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kcpClient.TenancyV1alpha1().Workspaces().Get(ctx, testData.workspace1.Name, metav1.GetOptions{})
 				})
 				workspace2, err := vwUser2Client.TenancyV1alpha1().Workspaces().Create(ctx, testData.workspace2.DeepCopy(), metav1.CreateOptions{})
@@ -117,7 +117,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 					return
 				}
 				assert.Equal(t, testData.workspace2.Name, workspace2.Name)
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kcpClient.TenancyV1alpha1().Workspaces().Get(ctx, testData.workspace2.Name, metav1.GetOptions{})
 				})
 				if err := server.kcpExpect(workspace1, func(w *tenancyv1alpha1.Workspace) error {
@@ -205,7 +205,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 					t.Errorf("failed to create workspace shard: %v", err)
 					return
 				}
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kcpClient.TenancyV1alpha1().WorkspaceShards().Get(ctx, "boston", metav1.GetOptions{})
 				})
 				workspace1, err := vwUser1Client.TenancyV1alpha1().Workspaces().Create(ctx, testData.workspace1.DeepCopy(), metav1.CreateOptions{})
@@ -214,7 +214,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 					return
 				}
 				assert.Equal(t, testData.workspace1.Name, workspace1.Name)
-				defer server.Artifact(t, func() (runtime.Object, error) {
+				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kcpClient.TenancyV1alpha1().Workspaces().Get(ctx, testData.workspace1.Name, metav1.GetOptions{})
 				})
 				workspaceURL := ""


### PR DESCRIPTION
Previously, the new sharable fixture was running artifact-collecting functions registered at setup but not those registered during test execution. When executed in parallel, a sub-test's modification of a shared fixture's set of artifact functions wasn't propagating to the parent test.

This change switches to registering artifact functions with t.Cleanup() to ensure that artifact collection is tied to the scope of
the registering test rather than the scope of the fixture lifetime. It also ensures that artifacts for subtests using shared fixture are saved in a path specific to the subtest.