### PR TITLE
WIP e2e: Optionally run the cluster controller in-process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,22 @@ jobs:
           name: e2e-artifacts
           path: /tmp/e2e/**/artifacts/
 
+  e2e-in-process:
+    name: e2e-in-process
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - run: make build
+      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" TEST_ARGS="-in-process-controllers" INPROCESS=true E2E_PARALLELISM=2 make test-e2e
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: e2e-artifacts
+          path: /tmp/e2e/**/artifacts/
+
   e2e-multiple-runs:
     name: e2e-multiple-runs
     runs-on: ubuntu-latest

--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -18,60 +18,14 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/spf13/pflag"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	"k8s.io/client-go/tools/clientcmd"
-
-	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
-	"github.com/kcp-dev/kcp/pkg/reconciler/cluster/apiimporter"
-	"github.com/kcp-dev/kcp/pkg/reconciler/cluster/syncer"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cluster/cmd"
 )
-
-const resyncPeriod = 10 * time.Hour
-
-func bindOptions(fs *pflag.FlagSet) *options {
-	o := options{
-		ApiImporterOptions: apiimporter.BindOptions(apiimporter.DefaultOptions(), fs),
-		ApiResourceOptions: apiresource.BindOptions(apiresource.DefaultOptions(), fs),
-		SyncerOptions:      syncer.BindOptions(syncer.DefaultOptions(), fs),
-	}
-	fs.StringVar(&o.kubeconfigPath, "kubeconfig", "", "Path to kubeconfig")
-	return &o
-}
-
-type options struct {
-	// in the all-in-one startup, client credentials already exist; in this
-	// standalone startup, we need to load credentials ourselves
-	kubeconfigPath string
-
-	ApiImporterOptions *apiimporter.Options
-	ApiResourceOptions *apiresource.Options
-	SyncerOptions      *syncer.Options
-}
-
-func (o *options) Validate() error {
-	if o.kubeconfigPath == "" {
-		return errors.New("--kubeconfig is required")
-	}
-	if err := o.ApiImporterOptions.Validate(); err != nil {
-		return err
-	}
-	if err := o.ApiResourceOptions.Validate(); err != nil {
-		return err
-	}
-
-	return o.SyncerOptions.Validate()
-}
 
 func main() {
 	// Setup signal handler for a cleaner shutdown
@@ -79,7 +33,7 @@ func main() {
 	defer cancel()
 
 	fs := pflag.NewFlagSet("cluster-controller", pflag.ContinueOnError)
-	options := bindOptions(fs)
+	options := cmd.BindCmdOptions(fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -89,60 +43,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.kubeconfigPath},
-		&clientcmd.ConfigOverrides{})
-
-	r, err := configLoader.ClientConfig()
-	if err != nil {
+	if err := cmd.StartController(ctx, options); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
-	}
-	kubeconfig, err := configLoader.RawConfig()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(kcpclient.NewForConfigOrDie(r), resyncPeriod)
-	crdSharedInformerFactory := crdexternalversions.NewSharedInformerFactoryWithOptions(apiextensionsclient.NewForConfigOrDie(r), resyncPeriod)
-
-	apiImporterOptions := options.ApiImporterOptions.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory)
-	apiImporter, err := apiImporterOptions.New()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	apiResourceOptions := options.ApiResourceOptions.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory)
-	apiresource, err := apiResourceOptions.New()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	syncerOptions := options.SyncerOptions.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory, apiImporterOptions.ResourcesToSync)
-	syncer, err := syncerOptions.New()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	kcpSharedInformerFactory.Start(ctx.Done())
-	crdSharedInformerFactory.Start(ctx.Done())
-
-	kcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
-	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
-
-	go apiImporter.Start(ctx)
-	go apiresource.Start(ctx, apiResourceOptions.NumThreads)
-
-	if syncer != nil {
-		prepared, err := syncer.Prepare()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		go prepared.Start(ctx)
 	}
 
 	<-ctx.Done()

--- a/pkg/reconciler/cluster/cmd/cluster_cmd.go
+++ b/pkg/reconciler/cluster/cmd/cluster_cmd.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/client-go/tools/clientcmd"
+
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apiresource"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cluster/apiimporter"
+	"github.com/kcp-dev/kcp/pkg/reconciler/cluster/syncer"
+)
+
+const resyncPeriod = 10 * time.Hour
+
+type CmdOptions struct {
+	// in the all-in-one startup, client credentials already exist; in this
+	// standalone startup, we need to load credentials ourselves
+	KubeConfigPath     string
+	APIImporterOptions *apiimporter.Options
+	APIResourceOptions *apiresource.Options
+	SyncerOptions      *syncer.Options
+}
+
+func BindCmdOptions(fs *pflag.FlagSet) *CmdOptions {
+	o := CmdOptions{
+		APIImporterOptions: apiimporter.BindOptions(apiimporter.DefaultOptions(), fs),
+		APIResourceOptions: apiresource.BindOptions(apiresource.DefaultOptions(), fs),
+		SyncerOptions:      syncer.BindOptions(syncer.DefaultOptions(), fs),
+	}
+	fs.StringVar(&o.KubeConfigPath, "kubeconfig", "", "Path to kubeconfig")
+	return &o
+}
+
+func (o *CmdOptions) Validate() error {
+	if o.KubeConfigPath == "" {
+		return errors.New("--kubeconfig is required")
+	}
+	if err := o.APIImporterOptions.Validate(); err != nil {
+		return err
+	}
+	if err := o.APIResourceOptions.Validate(); err != nil {
+		return err
+	}
+
+	return o.SyncerOptions.Validate()
+}
+
+func StartController(ctx context.Context, options *CmdOptions) error {
+	configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.KubeConfigPath},
+		&clientcmd.ConfigOverrides{})
+
+	r, err := configLoader.ClientConfig()
+	if err != nil {
+		return err
+	}
+	kubeconfig, err := configLoader.RawConfig()
+	if err != nil {
+		return err
+	}
+
+	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(kcpclient.NewForConfigOrDie(r), resyncPeriod)
+	crdSharedInformerFactory := crdexternalversions.NewSharedInformerFactoryWithOptions(apiextensionsclient.NewForConfigOrDie(r), resyncPeriod)
+
+	apiImporterOptions := options.APIImporterOptions.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory)
+	apiImporter, err := apiImporterOptions.New()
+	if err != nil {
+		return err
+	}
+
+	apiResourceOptions := options.APIResourceOptions.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory)
+	apiresource, err := apiResourceOptions.New()
+	if err != nil {
+		return err
+	}
+
+	syncerOptions := options.SyncerOptions.Complete(kubeconfig, kcpSharedInformerFactory, crdSharedInformerFactory, apiImporterOptions.ResourcesToSync)
+	syncer, err := syncerOptions.New()
+	if err != nil {
+		return err
+	}
+
+	kcpSharedInformerFactory.Start(ctx.Done())
+	crdSharedInformerFactory.Start(ctx.Done())
+
+	kcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
+	crdSharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+	go apiImporter.Start(ctx)
+	go apiresource.Start(ctx, apiResourceOptions.NumThreads)
+
+	if syncer != nil {
+		prepared, err := syncer.Prepare()
+		if err != nil {
+			return err
+		}
+		go prepared.Start(ctx)
+	}
+
+	return nil
+}

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KCP Authors.
+Copyright 2022 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,28 +17,22 @@ limitations under the License.
 package framework
 
 import (
-	"testing"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"flag"
 )
 
-type RunningServer interface {
-	Name() string
-	KubeconfigPath() string
-	RawConfig() (clientcmdapi.Config, error)
-	Config(context string) (*rest.Config, error)
-	Artifact(t *testing.T, producer func() (runtime.Object, error))
+type testConfig struct {
+	InProcessControllers bool
 }
 
-// KcpConfig qualify a kcp server to start
-type KcpConfig struct {
-	Name string
-	Args []string
+var TestConfig *testConfig
 
-	LogToConsole bool
-	RunInProcess bool
+func init() {
+	TestConfig = &testConfig{}
+	registerFlags(TestConfig)
+	// The testing package will call flags.Parse()
+}
 
-	Controllers []ControllerFixture
+func registerFlags(c *testConfig) {
+	flag.BoolVar(&c.InProcessControllers, "in-process-controllers", false,
+		"Whether controllers should be instantiated in the same process as the tests that require them.")
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -290,7 +290,7 @@ func CreateClusterAndWait(t *testing.T, ctx context.Context, artifacts ArtifactF
 		}
 		return false, nil
 	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cluster %s|%s failed to become ready: %w", cluster.ClusterName, cluster.Name, err)
 	}
 
 	return cluster, nil

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -152,10 +152,20 @@ func TestClusterController(t *testing.T) {
 		framework.KcpConfig{
 			Name: sourceClusterName,
 			Args: []string{
-				"--push-mode",
-				"--resources-to-sync=cowboys.wildwest.dev",
-				"--auto-publish-apis",
 				"--discovery-poll-interval=5s",
+			},
+			Controllers: []framework.ControllerFixture{
+				&framework.ClusterControllerFixture{
+					Args: []string{
+						"--push-mode",
+						"--resources-to-sync=cowboys.wildwest.dev",
+						"--auto-publish-apis",
+					},
+					InProcessServerArgs: []string{
+						"--run-controllers=false",
+						"--unsupported-run-individual-controllers=workspace-scheduler,namespace-scheduler",
+					},
+				},
 			},
 		},
 		// this is a kcp acting as a target cluster to sync status from


### PR DESCRIPTION
Passing `-in-process-controllers=true` as a test argument will enable running the cluster controller in the same process as the test to simplify development (change/build/test becomes change/test) and debugging ('start controller under debug and run test' becomes 'run test under debugger').