### PR TITLE
Fix panic when calling help

### DIFF
--- a/cmd/kcp/help.go
+++ b/cmd/kcp/help.go
@@ -37,13 +37,13 @@ func setPartialUsageAndHelpFunc(cmd *cobra.Command, fss cliflag.NamedFlagSets, c
 	cmd.SetUsageFunc(func(cmd *cobra.Command) error {
 		fmt.Fprintf(cmd.OutOrStderr(), usageFmt, cmd.UseLine())
 		printMostImportantFlags(cmd.OutOrStderr(), fss, cols, flags)
-		fmt.Fprintf(cmd.OutOrStderr(), "\nUse \"%s %s\" for a list of all flags available.\n", cmd.Parent().CommandPath(), cmd.Use)
+		fmt.Fprintf(cmd.OutOrStderr(), "\nUse \"%s\" for a list of all flags available.\n", cmd.CommandPath())
 		return nil
 	})
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(cmd.OutOrStdout(), "%s\n\n"+usageFmt, cmd.Long, cmd.UseLine())
 		printMostImportantFlags(cmd.OutOrStdout(), fss, cols, flags)
-		fmt.Fprintf(cmd.OutOrStderr(), "\nUse \"%s %s options\" for a list of all flags available.\n", cmd.Parent().CommandPath(), cmd.Use)
+		fmt.Fprintf(cmd.OutOrStderr(), "\nUse \"%s options\" for a list of all flags available.\n", cmd.CommandPath())
 	})
 }
 

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -57,6 +57,8 @@ func main() {
 		SilenceErrors: true,
 	}
 
+	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
+
 	serverOptions := options.NewOptions()
 	startCmd := &cobra.Command{
 		Use:   "start",
@@ -108,13 +110,6 @@ func main() {
 		startFlags.AddFlagSet(f)
 	}
 
-	// wire start help to print the named sections
-	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
-	setPartialUsageAndHelpFunc(cmd, namedStartFlagSets, cols, []string{
-		"etcd-servers",
-		"run-controllers",
-	})
-
 	startOptionsCmd := &cobra.Command{
 		Use:   "options",
 		Short: "Show all start command options",
@@ -136,8 +131,12 @@ func main() {
 		},
 	}
 	startCmd.AddCommand(startOptionsCmd)
-
 	cmd.AddCommand(startCmd)
+
+	setPartialUsageAndHelpFunc(cmd, namedStartFlagSets, cols, []string{
+		"etcd-servers",
+		"run-controllers",
+	})
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)


### PR DESCRIPTION
Fixes #500

This Pull Request fixed panic when calling `/kcp -h` (in all variations).

Before the fix, the most problematic was the hierarchy of commands: `cmd -> startCmd -> startOptionsCmd`. The `setPartialUsageAndHelpFunc` function was trying to call `cmd.Parent()` on `cmd`, which was the root command. Therefore, it was crashing. It seems like this was some sort of leftover after refactoring.
