### PR TITLE
server: add kcp admission plumbing

### DIFF
--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializers
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+)
+
+// NewKcpInformersInitializer returns an admission plugin initializer that injects
+// kcp shared informer factories into admission plugins.
+func NewKcpInformersInitializer(
+	kcpInformers kcpinformers.SharedInformerFactory,
+) *kcpInformersInitializer {
+	return &kcpInformersInitializer{
+		kcpInformers: kcpInformers,
+	}
+}
+
+type kcpInformersInitializer struct {
+	kcpInformers kcpinformers.SharedInformerFactory
+}
+
+func (i *kcpInformersInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsKcpInformers); ok {
+		wants.SetKcpInformers(i.kcpInformers)
+	}
+}

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializers
+
+import (
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+)
+
+// WantsKcpInformers interface should be implemented by admission plugins
+// that want to have an kcp informer factory injected.
+type WantsKcpInformers interface {
+	SetKcpInformers(informers kcpinformers.SharedInformerFactory)
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
+	"k8s.io/apiserver/pkg/admission/plugin/resourcequota"
+	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
+	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
+	kubeapiserveroptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+	certapproval "k8s.io/kubernetes/plugin/pkg/admission/certificates/approval"
+	certsigning "k8s.io/kubernetes/plugin/pkg/admission/certificates/signing"
+	certsubjectrestriction "k8s.io/kubernetes/plugin/pkg/admission/certificates/subjectrestriction"
+	"k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
+	"k8s.io/kubernetes/plugin/pkg/admission/limitranger"
+	"k8s.io/kubernetes/plugin/pkg/admission/network/defaultingressclass"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
+	"k8s.io/kubernetes/plugin/pkg/admission/runtimeclass"
+	"k8s.io/kubernetes/plugin/pkg/admission/security/podsecurity"
+	"k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+	"k8s.io/kubernetes/plugin/pkg/admission/storage/persistentvolume/resize"
+	"k8s.io/kubernetes/plugin/pkg/admission/storage/storageclass/setdefault"
+	"k8s.io/kubernetes/plugin/pkg/admission/storage/storageobjectinuseprotection"
+)
+
+// AllOrderedPlugins is the list of all the plugins in order.
+var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins)
+
+func beforeWebhooks(recommended []string, plugins ...string) []string {
+	ret := make([]string, 0, len(recommended)+len(plugins))
+	for _, plugin := range recommended {
+		if plugin == mutatingwebhook.PluginName {
+			ret = append(ret, plugins...)
+		}
+		ret = append(ret, plugin)
+	}
+	return ret
+}
+
+// RegisterAllKcpAdmissionPlugins registers all admission plugins.
+// The order of registration is irrelevant, see AllOrderedPlugins for execution order.
+func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
+	kubeapiserveroptions.RegisterAllAdmissionPlugins(plugins)
+}
+
+var defaultOnPluginsInKcp = sets.NewString(
+	lifecycle.PluginName,              // NamespaceLifecycle
+	limitranger.PluginName,            // LimitRanger
+	mutatingwebhook.PluginName,        // MutatingAdmissionWebhook
+	validatingwebhook.PluginName,      // ValidatingAdmissionWebhook
+	certapproval.PluginName,           // CertificateApproval
+	certsigning.PluginName,            // CertificateSigning
+	certsubjectrestriction.PluginName, // CertificateSubjectRestriction
+)
+
+// defaultOnKubePluginsInKube is a copy of kubeapiserveroptions.defaultOnKubePlugins.
+// Always keep this in sync with upstream. It is meant to detect during rebase which
+// new plugins got added upstream and to react (enable or disable by default). We
+// have a unit test in place to avoid drift.
+var defaultOnKubePluginsInKube = sets.NewString(
+	lifecycle.PluginName,                    // NamespaceLifecycle
+	limitranger.PluginName,                  // LimitRanger
+	serviceaccount.PluginName,               // ServiceAccount
+	setdefault.PluginName,                   // DefaultStorageClass
+	resize.PluginName,                       // PersistentVolumeClaimResize
+	defaulttolerationseconds.PluginName,     // DefaultTolerationSeconds
+	mutatingwebhook.PluginName,              // MutatingAdmissionWebhook
+	validatingwebhook.PluginName,            // ValidatingAdmissionWebhook
+	resourcequota.PluginName,                // ResourceQuota
+	storageobjectinuseprotection.PluginName, // StorageObjectInUseProtection
+	podpriority.PluginName,                  // PodPriority
+	nodetaint.PluginName,                    // TaintNodesByCondition
+	runtimeclass.PluginName,                 // RuntimeClass
+	certapproval.PluginName,                 // CertificateApproval
+	certsigning.PluginName,                  // CertificateSigning
+	certsubjectrestriction.PluginName,       // CertificateSubjectRestriction
+	defaultingressclass.PluginName,          // DefaultIngressClass
+	podsecurity.PluginName,                  // PodSecurity)
+)
+
+// DefaultOffAdmissionPlugins get admission plugins off by default for kcp.
+func DefaultOffAdmissionPlugins() sets.String {
+	return sets.NewString(AllOrderedPlugins...).Difference(defaultOnPluginsInKcp)
+}

--- a/pkg/admission/plugins_test.go
+++ b/pkg/admission/plugins_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	kubeapiserveroptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+)
+
+func TestPluginDrift(t *testing.T) {
+	kubeOffPlugins := kubeapiserveroptions.DefaultOffAdmissionPlugins()
+	kubeOnPlugins := sets.NewString(kubeapiserveroptions.AllOrderedPlugins...).Difference(kubeOffPlugins)
+
+	if newInKube := kubeOnPlugins.Difference(defaultOnKubePluginsInKube); newInKube.Len() > 0 {
+		t.Errorf("Default-on plugins got added in kube. Add to defaultOnKubePluginsInKube, and decide whether to add to defaultOnPluginsInKcp: %v", newInKube.List())
+	}
+	if goneInKube := defaultOnKubePluginsInKube.Difference(kubeOnPlugins); goneInKube.Len() > 0 {
+		t.Errorf("Default-on plugins got removed in kube. Remove in defaultOnKubePluginsInKube, and decide whether to remove from defaultOnPluginsInKcp: %v", goneInKube.List())
+	}
+}

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -29,6 +29,8 @@ import (
 	_ "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+
+	kcpadmission "github.com/kcp-dev/kcp/pkg/admission"
 )
 
 type Options struct {
@@ -95,6 +97,11 @@ func NewOptions() *Options {
 		WithTokenFile()
 	//WithWebHook()
 	o.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = []string{"embedded"}
+
+	// override set of admission plugins
+	kcpadmission.RegisterAllKcpAdmissionPlugins(o.GenericControlPlane.Admission.Plugins)
+	o.GenericControlPlane.Admission.DisablePlugins = kcpadmission.DefaultOffAdmissionPlugins().List()
+	o.GenericControlPlane.Admission.RecommendedPluginOrder = kcpadmission.AllOrderedPlugins
 
 	return o
 }


### PR DESCRIPTION
- wire a sensible subset of kube-apiserver's admission
- add kcp informer admission initializer
- add drift unit test to notice when upstream adds or removes admission plugins