### PR TITLE
Default `make test-e2e` to a single run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,8 +80,8 @@ jobs:
       - run: make build
       - run: PATH="${PATH}:$(pwd)/bin/" make test
 
-  e2e-single-run:
-    name: e2e-single-run
+  e2e:
+    name: e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -89,15 +89,15 @@ jobs:
         with:
           go-version: v1.17
       - run: make build
-      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" COUNT=1 E2E_PARALLELISM=2 make test-e2e
+      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" E2E_PARALLELISM=2 make test-e2e
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
           name: e2e-artifacts
           path: /tmp/e2e/**/artifacts/
 
-  e2e:
-    name: e2e
+  e2e-multiple-runs:
+    name: e2e-multiple-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ $(OPENSHIFT_GOIMPORTS):
 imports: $(OPENSHIFT_GOIMPORTS)
 	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev/kcp
 
-COUNT ?= 5
+COUNT ?= 1
 E2E_PARALLELISM ?= 1
 
 .PHONY: test-e2e


### PR DESCRIPTION
Previously, `make test-e2e` would execute each test 5 times which could be a surprising result for some. Developers would commonly have to set `COUNT=1` if they wanted quick feedback on changes they were making locally. This commit defaults `make test-e2e` to executing a single run, with multiple runs configurable by setting `COUNT=`.

In keeping with this change, the `e2e-single-run` ci job is renamed to `e2e` and no longer sets an explicit `COUNT=` to ensure it uses the default behavior of `make test-e2e`. The previous `e2e` suite - executing 5 runs - is accordingly renamed `e2e-multiple-runs`.