### PR TITLE
Strip finalizers and owner references before syncing downstream

### DIFF
--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -155,6 +155,9 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	downstreamObj.SetNamespace(downstreamNamespace)
 	downstreamObj.SetManagedFields(nil)
 	downstreamObj.SetClusterName("")
+	// Deletion fields are immutable and set by the downstream API server
+	downstreamObj.SetDeletionTimestamp(nil)
+	downstreamObj.SetDeletionGracePeriodSeconds(nil)
 	// Strip owner references, to avoid orphaning by broken references,
 	// and make sure cascading deletion is only performed once upstream.
 	downstreamObj.SetOwnerReferences(nil)

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -155,23 +155,16 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	downstreamObj.SetNamespace(downstreamNamespace)
 	downstreamObj.SetManagedFields(nil)
 	downstreamObj.SetClusterName("")
-
-	ownedByLabel := downstreamObj.GetLabels()["kcp.dev/owned-by"]
-	var ownerReferences []metav1.OwnerReference
-	for _, reference := range downstreamObj.GetOwnerReferences() {
-		if reference.Name == ownedByLabel {
-			continue
-		}
-		ownerReferences = append(ownerReferences, reference)
-	}
-	downstreamObj.SetOwnerReferences(ownerReferences)
+	// Strip owner references, to avoid orphaning by broken references,
+	// and make sure cascading deletion is only performed once upstream.
+	downstreamObj.SetOwnerReferences(nil)
+	// Strip finalizers to avoid the deletion of the downstream resource from being blocked.
+	downstreamObj.SetFinalizers(nil)
 
 	// Run name transformations on the downstreamObj.
 	transformName(downstreamObj, KcpToPhysicalCluster)
 
-	// TODO: wipe things like finalizers, owner-refs and any other life-cycle fields. The life-cycle
-	//       should exclusively owned by the syncer. Let's not some Kubernetes magic interfere with it.
-
+	// Marshalling the unstructured object is good enough as SSA patch
 	data, err := json.Marshal(downstreamObj)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR strips finalizers before syncing downstream, to prevent deletion of downstream resources from being blocked. It also strips owner references, to avoid broken references and orphaning, and to make sure cascading deletion happens only once upstream.