### PR TITLE
Add a label to deactivate automatic namespace scheduling

### DIFF
--- a/pkg/reconciler/namespace/conditions.go
+++ b/pkg/reconciler/namespace/conditions.go
@@ -36,6 +36,10 @@ const (
 	// means that the scheduler can't schedule the namespace right now, e.g. due to a
 	// lack of ready clusters being available.
 	NamespaceReasonUnschedulable = "Unschedulable"
+	// NamespaceReasonSchedulingDisabled reason in NamespaceScheduled Namespace Condition
+	// means that the automated scheduling for this namespace is disabled, e.g., when it's
+	// labelled with ScheduleDisabledLabel.
+	NamespaceReasonSchedulingDisabled = "SchedulingDisabled"
 )
 
 // NamespaceConditionsAdapter enables the use of the conditions helper
@@ -113,10 +117,8 @@ func statusPatchBytes(ns *corev1.Namespace, updateConditions updateConditionsFun
 // IsScheduled returns whether the given namespace's status indicates
 // it is scheduled.
 func IsScheduled(ns *corev1.Namespace) bool {
-	for _, condition := range ns.Status.Conditions {
-		if condition.Type == corev1.NamespaceConditionType(NamespaceScheduled) {
-			return condition.Status == corev1.ConditionTrue
-		}
+	if condition := conditions.Get(&NamespaceConditionsAdapter{ns}, NamespaceScheduled); condition != nil {
+		return condition.Status == corev1.ConditionTrue
 	}
 	return false
 }

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/apis/cluster"
 	clusterv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
 	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/cluster/v1alpha1"
 	clusterclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/cluster/v1alpha1"
 	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/namespace"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
@@ -59,43 +60,215 @@ func TestNamespaceScheduler(t *testing.T) {
 		physicalCluster2Name = "pcluster2"
 	)
 
-	f := framework.NewKcpFixture(t,
-		framework.KcpConfig{
-			Name: serverName,
-			Args: []string{
-				"--discovery-poll-interval=2s",
-				"--push-mode=true", // Required to ensure clusters are ready for scheduling
-			},
-		},
-		// this is a kcp acting as a physical cluster
-		framework.KcpConfig{
-			Name: physicalCluster1Name,
-			Args: []string{
-				"--run-controllers=false",
-			},
-		},
-		// this is a kcp acting as a physical cluster
-		framework.KcpConfig{
-			Name: physicalCluster2Name,
-			Args: []string{
-				"--run-controllers=false",
-			},
-		},
-	)
+	type runningServer struct {
+		framework.RunningServer
+		client        kubernetes.Interface
+		clusterClient v1alpha1.ClusterInterface
+		expect        registerNamespaceExpectation
+	}
 
-	// TODO(marun) Collapse this sub test into its parent. It's only
-	// left in this form to simplify review of the transition to the
-	// new fixture.
-	t.Run("validate namespace scheduling",
-		func(t *testing.T) {
+	var testCases = []struct {
+		name string
+		work func(ctx context.Context, t *testing.T, f *framework.KcpFixture, server runningServer)
+	}{
+		{
+			name: "validate namespace scheduling",
+			work: func(ctx context.Context, t *testing.T, f *framework.KcpFixture, server runningServer) {
+				t.Log("Create a namespace without a cluster available and expect it to be marked unschedulable")
+
+				namespace, err := server.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "e2e-nss-",
+					},
+				}, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create namespace1")
+
+				server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+				})
+
+				err = server.expect(namespace, unscheduledMatcher(nscontroller.NamespaceReasonUnschedulable))
+				require.NoError(t, err, "did not see namespace marked unschedulable")
+
+				t.Log("Create a cluster and expect the namespace to be scheduled to it")
+
+				server1RawConfig, err := f.Servers[physicalCluster1Name].RawConfig()
+				require.NoError(t, err, "failed to get server 1 raw config")
+
+				server1Kubeconfig, err := clientcmd.Write(server1RawConfig)
+				require.NoError(t, err, "failed to marshal server 1 kubeconfig")
+
+				cluster1, err := server.clusterClient.Create(ctx, &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "e2e-nss-1-",
+					},
+					Spec: clusterv1alpha1.ClusterSpec{
+						KubeConfig: string(server1Kubeconfig),
+					},
+				}, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create cluster1")
+
+				// Wait for the cluster to become ready. A namespace can only be assigned to a ready cluster.
+				waitForClusterReadiness(t, ctx, server.clusterClient, cluster1.Name)
+
+				err = server.expect(namespace, scheduledMatcher(cluster1.Name))
+				require.NoError(t, err, "did not see namespace marked scheduled for cluster1 %q", cluster1.Name)
+
+				t.Log("Create a new cordoned cluster")
+
+				server2RawConfig, err := f.Servers[physicalCluster2Name].RawConfig()
+				require.NoError(t, err, "failed to get server 2 raw config")
+
+				server2Kubeconfig, err := clientcmd.Write(server2RawConfig)
+				require.NoError(t, err, "failed to get server 2 kubeconfig")
+
+				cluster2, err := server.clusterClient.Create(ctx, &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "e2e-nss-2-",
+					},
+					Spec: clusterv1alpha1.ClusterSpec{
+						KubeConfig:    string(server2Kubeconfig),
+						Unschedulable: true, // cordoned.
+					},
+				}, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create cluster2")
+
+				t.Log("Delete the old cluster and expect the namespace to end up unschedulable (since the new cluster is cordoned).")
+
+				err = server.clusterClient.Delete(ctx, cluster1.Name, metav1.DeleteOptions{})
+				require.NoError(t, err, "failed to delete cluster1 %q", cluster1.Name)
+
+				err = server.expect(namespace, unscheduledMatcher(nscontroller.NamespaceReasonUnschedulable))
+				require.NoError(t, err, "did not see namespace marked unschedulable")
+
+				t.Log("Uncordon the new cluster and expect the namespace to end up scheduled to it.")
+
+				schedulablePatchBytes := []byte(`[{"op":"replace","path":"/spec/unschedulable","value":false}]`) // uncordoned.
+				cluster2, err = server.clusterClient.Patch(ctx, cluster2.Name, types.JSONPatchType, schedulablePatchBytes, metav1.PatchOptions{})
+				require.NoError(t, err, "failed to uncordon cluster2")
+
+				err = server.expect(namespace, scheduledMatcher(cluster2.Name))
+				require.NoError(t, err, "did not see namespace marked scheduled for cluster2 %q", cluster2.Name)
+
+				t.Log("Mark the new cluster for immediate eviction, and see the namespace get unschedulable.")
+
+				anHourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
+				evictPatchBytes := []byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/evictAfter","value":%q}]`, anHourAgo.Format(time.RFC3339)))
+				cluster2, err = server.clusterClient.Patch(ctx, cluster2.Name, types.JSONPatchType, evictPatchBytes, metav1.PatchOptions{})
+				require.NoError(t, err, "failed to evict cluster2")
+
+				err = server.expect(namespace, unscheduledMatcher(nscontroller.NamespaceReasonUnschedulable))
+				require.NoError(t, err, "did not see namespace marked unschedulable")
+
+				t.Log("Unevict the new cluster and see the namespace scheduled to it.")
+
+				unevictPatchBytes := []byte(`[{"op":"replace","path":"/spec/evictAfter","value":null}]`)
+				cluster2, err = server.clusterClient.Patch(ctx, cluster2.Name, types.JSONPatchType, unevictPatchBytes, metav1.PatchOptions{})
+				require.NoError(t, err, "failed to unevict cluster2")
+
+				waitForClusterReadiness(t, ctx, server.clusterClient, cluster2.Name)
+
+				err = server.expect(namespace, scheduledMatcher(cluster2.Name))
+				require.NoError(t, err, "did not see namespace marked scheduled for cluster2 %q", cluster2.Name)
+
+				t.Log("Delete the remaining cluster and expect the namespace to be marked unschedulable.")
+
+				err = server.clusterClient.Delete(ctx, cluster2.Name, metav1.DeleteOptions{})
+				require.NoError(t, err, "failed to delete cluster2 %q", cluster2.Name)
+
+				err = server.expect(namespace, unscheduledMatcher(nscontroller.NamespaceReasonUnschedulable))
+				require.NoError(t, err, "did not see namespace marked unschedulable")
+			},
+		},
+		{
+			name: "validate namespace with manual scheduling",
+			work: func(ctx context.Context, t *testing.T, f *framework.KcpFixture, server runningServer) {
+				t.Log("Create a cluster and expect the namespace not to be scheduled to it")
+
+				server1RawConfig, err := f.Servers[physicalCluster1Name].RawConfig()
+				require.NoError(t, err, "failed to get server 1 raw config")
+
+				server1Kubeconfig, err := clientcmd.Write(server1RawConfig)
+				require.NoError(t, err, "failed to marshal server 1 kubeconfig")
+
+				cluster, err := server.clusterClient.Create(ctx, &clusterv1alpha1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "e2e-nss-",
+					},
+					Spec: clusterv1alpha1.ClusterSpec{
+						KubeConfig: string(server1Kubeconfig),
+					},
+				}, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create cluster1")
+
+				t.Log("Create a namespace with manual scheduling and expect it to be marked unscheduled")
+
+				namespace, err := server.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "e2e-nss-",
+						Labels: map[string]string{
+							nscontroller.ScheduleDisabledLabel: "",
+						},
+					},
+				}, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create namespace")
+
+				server.Artifact(t, func() (runtime.Object, error) {
+					return server.client.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+				})
+
+				err = server.expect(namespace, unscheduledMatcher(nscontroller.NamespaceReasonSchedulingDisabled))
+				require.NoError(t, err, "did not see namespace marked with scheduling disabled")
+
+				t.Log("Assign a cluster to the namespace manually")
+				patchType, patchBytes := nscontroller.ClusterLabelPatchBytes(cluster.Name)
+				namespace, err = server.client.CoreV1().Namespaces().
+					Patch(ctx, namespace.Name, patchType, patchBytes, metav1.PatchOptions{})
+				require.NoError(t, err, "failed to update namespace")
+
+				err = server.expect(namespace, scheduledMatcher(cluster.Name))
+				require.NoError(t, err, "did not see namespace marked scheduled for cluster %q", cluster.Name)
+			},
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
+			start := time.Now()
 			ctx := context.Background()
 			if deadline, ok := t.Deadline(); ok {
 				withDeadline, cancel := context.WithDeadline(ctx, deadline)
 				t.Cleanup(cancel)
 				ctx = withDeadline
 			}
+
+			f := framework.NewKcpFixture(t,
+				framework.KcpConfig{
+					Name: serverName,
+					Args: []string{
+						"--discovery-poll-interval=2s",
+						"--push-mode=true", // Required to ensure clusters are ready for scheduling
+					},
+				},
+				// this is a kcp acting as a physical cluster
+				framework.KcpConfig{
+					Name: physicalCluster1Name,
+					Args: []string{
+						"--run-controllers=false",
+					},
+				},
+				// this is a kcp acting as a physical cluster
+				framework.KcpConfig{
+					Name: physicalCluster2Name,
+					Args: []string{
+						"--run-controllers=false",
+					},
+				},
+			)
 
 			require.Equal(t, 3, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
@@ -126,122 +299,37 @@ func TestNamespaceScheduler(t *testing.T) {
 			expect, err := expectNamespaces(ctx, t, client)
 			require.NoError(t, err, "failed to start expecter")
 
-			t.Log("Create a namespace without a cluster available and expect it to be marked unschedulable")
+			s := runningServer{
+				RunningServer: server,
+				clusterClient: clusterClient,
+				client:        client,
+				expect:        expect,
+			}
 
-			namespace, err := client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "e2e-nss-",
-				},
-			}, metav1.CreateOptions{})
-			require.NoError(t, err, "failed to create namespace1")
+			t.Logf("Set up clients for test after %s", time.Since(start))
+			t.Log("Starting test...")
 
-			server.Artifact(t, func() (runtime.Object, error) {
-				return client.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
-			})
-
-			err = expect(namespace, unschedulableMatcher())
-			require.NoError(t, err, "did not see namespace marked unschedulable")
-
-			t.Log("Create a cluster and expect the namespace to be scheduled to it")
-
-			server1RawConfig, err := f.Servers[physicalCluster1Name].RawConfig()
-			require.NoError(t, err, "failed to get server 1 raw config")
-
-			server1Kubeconfig, err := clientcmd.Write(server1RawConfig)
-			require.NoError(t, err, "failed to marshal server 1 kubeconfig")
-
-			cluster1, err := clusterClient.Create(ctx, &clusterv1alpha1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "e2e-nss-1-",
-				},
-				Spec: clusterv1alpha1.ClusterSpec{
-					KubeConfig: string(server1Kubeconfig),
-				},
-			}, metav1.CreateOptions{})
-			require.NoError(t, err, "failed to create cluster1")
-
-			// Wait for the cluster to become ready. A namespace can only be assigned to a ready cluster.
-			waitForClusterReadiness(t, ctx, clusterClient, cluster1.Name)
-
-			err = expect(namespace, scheduledMatcher(cluster1.Name))
-			require.NoError(t, err, "did not see namespace marked scheduled for cluster1 %q", cluster1.Name)
-
-			t.Log("Create a new cordoned cluster")
-
-			server2RawConfig, err := f.Servers[physicalCluster2Name].RawConfig()
-			require.NoError(t, err, "failed to get server 2 raw config")
-
-			server2Kubeconfig, err := clientcmd.Write(server2RawConfig)
-			require.NoError(t, err, "failed to get server 2 kubeconfig")
-
-			cluster2, err := clusterClient.Create(ctx, &clusterv1alpha1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "e2e-nss-2-",
-				},
-				Spec: clusterv1alpha1.ClusterSpec{
-					KubeConfig:    string(server2Kubeconfig),
-					Unschedulable: true, // cordoned.
-				},
-			}, metav1.CreateOptions{})
-			require.NoError(t, err, "failed to create cluster2")
-
-			t.Log("Delete the old cluster and expect the namespace to end up unschedulable (since the new cluster is cordoned).")
-
-			err = clusterClient.Delete(ctx, cluster1.Name, metav1.DeleteOptions{})
-			require.NoError(t, err, "failed to delete cluster1 %q", cluster1.Name)
-
-			err = expect(namespace, unschedulableMatcher())
-			require.NoError(t, err, "did not see namespace marked unschedulable")
-
-			t.Log("Uncordon the new cluster and expect the namespace to end up scheduled to it.")
-
-			schedulablePatchBytes := []byte(`[{"op":"replace","path":"/spec/unschedulable","value":false}]`) // uncordoned.
-			cluster2, err = clusterClient.Patch(ctx, cluster2.Name, types.JSONPatchType, schedulablePatchBytes, metav1.PatchOptions{})
-			require.NoError(t, err, "failed to uncordon cluster2")
-
-			err = expect(namespace, scheduledMatcher(cluster2.Name))
-			require.NoError(t, err, "did not see namespace marked scheduled for cluster2 %q", cluster2.Name)
-
-			t.Log("Mark the new cluster for immediate eviction, and see the namespace get unschedulable.")
-
-			anHourAgo := metav1.NewTime(time.Now().Add(-time.Hour))
-			evictPatchBytes := []byte(fmt.Sprintf(`[{"op":"replace","path":"/spec/evictAfter","value":%q}]`, anHourAgo.Format(time.RFC3339)))
-			cluster2, err = clusterClient.Patch(ctx, cluster2.Name, types.JSONPatchType, evictPatchBytes, metav1.PatchOptions{})
-			require.NoError(t, err, "failed to evict cluster2")
-
-			err = expect(namespace, unschedulableMatcher())
-			require.NoError(t, err, "did not see namespace marked unscheablable")
-
-			t.Log("Unevict the new cluster and see the namespace scheduled to it.")
-
-			unevictPatchBytes := []byte(`[{"op":"replace","path":"/spec/evictAfter","value":null}]`)
-			cluster2, err = clusterClient.Patch(ctx, cluster2.Name, types.JSONPatchType, unevictPatchBytes, metav1.PatchOptions{})
-			require.NoError(t, err, "failed to unevict cluster2")
-
-			waitForClusterReadiness(t, ctx, clusterClient, cluster2.Name)
-
-			err = expect(namespace, scheduledMatcher(cluster2.Name))
-			require.NoError(t, err, "did not see namespace marked scheduled for cluster2 %q", cluster2.Name)
-
-			t.Log("Delete the remaining cluster and expect the namespace to be marked unschedulable.")
-
-			err = clusterClient.Delete(ctx, cluster2.Name, metav1.DeleteOptions{})
-			require.NoError(t, err, "failed to delete cluster2 %q", cluster2.Name)
-
-			err = expect(namespace, unschedulableMatcher())
-			require.NoError(t, err, "did not see namespace marked unschedulable")
+			testCase.work(ctx, t, f, s)
 		},
-	)
+		)
+	}
 }
 
 type namespaceExpectation func(*corev1.Namespace) error
 
-func unschedulableMatcher() namespaceExpectation {
+func unscheduledMatcher(reason string) namespaceExpectation {
 	return func(object *corev1.Namespace) error {
-		if nscontroller.IsScheduled(object) {
-			return fmt.Errorf("expected an unschedulable namespace, got cluster=%q; status.conditions: %#v", object.Labels["kcp.dev/cluster"], object.Status.Conditions)
+		if condition := conditions.Get(&nscontroller.NamespaceConditionsAdapter{Namespace: object}, nscontroller.NamespaceScheduled); condition != nil {
+			if condition.Status == corev1.ConditionTrue {
+				return fmt.Errorf("expected an unscheduled namespace, got cluster=%q; status.conditions: %#v", object.Labels["kcp.dev/cluster"], object.Status.Conditions)
+			}
+			if condition.Reason != reason {
+				return fmt.Errorf("expected an unscheduled namespace with reason %s, got status.conditions: %#v", reason, object.Status.Conditions)
+			}
+			return nil
+		} else {
+			return fmt.Errorf("expected an unscheduled namespace, missing scheduled condition: %#v", object.Status.Conditions)
 		}
-		return nil
 	}
 }
 


### PR DESCRIPTION
Currently the namespace controller owns the responsibility of assigning namespaces to physical clusters. The only option for other controllers, like the `deployment-splitter` one, or users manually, to distribute resources across physical clusters is to deactivate the namespace controller by starting KCP with `--run-controllers=false --unsupported-run-individual-controllers="workspace-scheduler,cluster"`.

Meanwhile more advanced scheduling / placement scenarios are supported, this PR proposes to introduce the `experimental.scheduling.kcp.dev/disabled` label, that can be added to namespaces, in order to deactivate the automatic placement to physical clusters, performed by the namespace controller.

Setting this label to `false` prevents the namespace controller from overriding the scheduling logic performed by the `deployment-splitter` controller, but also manual scheduling, when working on global load-balancing use cases for example.

Fixes #494