### PR TITLE
authorization: rename org to bootstrap authorizer

### DIFF
--- a/pkg/authorization/bootstrap_policy_authorizer.go
+++ b/pkg/authorization/bootstrap_policy_authorizer.go
@@ -19,13 +19,14 @@ package authorization
 import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	clientgoinformers "k8s.io/client-go/informers"
+	"k8s.io/kubernetes/pkg/genericcontrolplane"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	frameworkrbac "github.com/kcp-dev/kcp/pkg/virtual/framework/rbac"
 )
 
-func NewOrgWorkspaceAuthorizer(informers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver) {
-	filteredInformer := frameworkrbac.FilterPerCluster("admin", informers.Rbac().V1())
+func NewBootstrapPolicyAuthorizer(informers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver) {
+	filteredInformer := frameworkrbac.FilterPerCluster(genericcontrolplane.RootClusterName, informers.Rbac().V1())
 
 	a := rbac.New(
 		&rbac.RoleGetter{Lister: filteredInformer.Roles().Lister()},

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -98,15 +98,15 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, informer coreex
 	}
 
 	// kcp authorizers
-	orgAuth, orgResolver := authorization.NewOrgWorkspaceAuthorizer(informer)
+	bootstrapAuth, bootstrapRules := authorization.NewBootstrapPolicyAuthorizer(informer)
 	localAuth, localResolver := authorization.NewLocalAuthorizer(informer)
 	authorizers = append(authorizers, authorization.NewWorkspaceContentAuthorizer(
 		informer,
 		workspaceLister,
-		union.New(orgAuth, localAuth),
+		union.New(bootstrapAuth, localAuth),
 	))
 
-	config.RuleResolver = union.NewRuleResolvers(orgResolver, localResolver)
+	config.RuleResolver = union.NewRuleResolvers(bootstrapRules, localResolver)
 	config.Authorization.Authorizer = union.New(authorizers...)
 	return nil
 }


### PR DESCRIPTION
The org workspace won't be the one providing a kube bootstrap policy.