### PR TITLE
server: align with upstream logic to derive external address

### DIFF
--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -107,16 +107,9 @@ func (s *AdminAuthentication) ApplyTo(config *genericapiserver.Config) (newToken
 	return newTokenOrEmpty, tokenHash, nil
 }
 
-func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte) error {
+func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte, externalAddress string, servingPort int) error {
 	externalCACert, _ := config.SecureServing.Cert.CurrentCertKeyContent()
-	servingHostName, servingPort, err := config.SecureServing.HostPort()
-	if err != nil {
-		return err
-	}
-	if servingHostName == "0.0.0.0" || servingHostName == "::" {
-		servingHostName = "localhost"
-	}
-	externalKubeConfigHost := fmt.Sprintf("https://%s:%d", servingHostName, servingPort)
+	externalKubeConfigHost := fmt.Sprintf("https://%s:%d", externalAddress, servingPort)
 
 	externalAdminUserName := "admin"
 	if newToken == "" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -179,7 +179,12 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, newTokenOrEmpty, tokenHash); err != nil {
+	servingOpts := s.options.GenericControlPlane.SecureServing
+	externalAddress, err := servingOpts.DefaultExternalAddress()
+	if err != nil {
+		return err
+	}
+	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, newTokenOrEmpty, tokenHash, externalAddress.String(), servingOpts.BindPort); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We had our own logic to derive an external name from binding host+port somehow. As the cert is created with the external address data, diverging asks for trouble. This PR uses the same `DefaultExternalAdddress()" us in upstream for the cert.