### PR TITLE
Refactor namespace scheduler cluster assignment for testability

### DIFF
--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -19,12 +19,10 @@ package namespace
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -187,111 +185,32 @@ func (c *Controller) updateScheduledCondition(ctx context.Context, ns *corev1.Na
 	})
 }
 
-// assignCluster attempts to schedule a namespace to a random cluster. If no cluster is
-// available, any existing cluster assignment will be cleared.
-func (c *Controller) assignCluster(ctx context.Context, ns *corev1.Namespace) error {
-	allClusters, err := c.clusterLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-
-	var clusters []*clusterv1alpha1.Cluster
-	for i := range allClusters {
-		// Only include Clusters that are in the same logical cluster as ns
-		if allClusters[i].ClusterName != ns.ClusterName {
-			klog.V(6).InfoS("assignCluster: excluding cluster with different metadata.clusterName", "ns.clusterName", ns.ClusterName, "check", allClusters[i].ClusterName)
-			continue
-		}
-		if allClusters[i].Spec.Unschedulable {
-			klog.V(2).InfoS("assignCluster: excluding unschedulable cluster", "metadata.name", allClusters[i].Name)
-			continue
-		}
-		if evictAfter := allClusters[i].Spec.EvictAfter; evictAfter != nil && evictAfter.Time.Before(time.Now()) {
-			klog.V(2).InfoS("assignCluster: excluding cluster with evictAfter value that has passed", "metadata.name", allClusters[i].Name)
-			continue
-		}
-		if !conditions.IsTrue(allClusters[i], clusterv1alpha1.ClusterReadyCondition) {
-			klog.V(2).InfoS("assignCluster: excluding not-ready cluster", "metadata.name", allClusters[i].Name)
-			continue
-		}
-
-		klog.V(2).InfoS("assignCluster: found a ready candidate", "metadata.name", allClusters[i].Name)
-		clusters = append(clusters, allClusters[i])
-	}
-
-	newClusterName := ""
-	if len(clusters) > 0 {
-		// Select a cluster at random.
-		cluster := clusters[rand.Intn(len(clusters))]
-		newClusterName = cluster.Name
-	}
-
-	oldClusterName := ns.Labels[ClusterLabel]
-	if oldClusterName != newClusterName {
-		patchType, patchBytes := assignedClusterPatchBytes(newClusterName)
-		if _, err = c.kubeClient.Cluster(ns.ClusterName).CoreV1().Namespaces().
-			Patch(ctx, ns.Name, patchType, patchBytes, metav1.PatchOptions{}); err != nil {
-			return err
-		}
-		klog.Infof("Patched cluster assignment for namespace %q|%q: %q -> %q", ns.ClusterName, ns.Name, oldClusterName, newClusterName)
-	}
-
-	return nil
-}
-
-// isValidCluster checks whether the given cluster name exists and is valid for
-// the purposes of any namespace already scheduled to it (i.e., if it reports
-// as Ready, and any evictAfter value, if specified, has not yet passed).
-//
-// It doesn't take into account Unschedulable, and should only be used when
-// determining if a cluster that a namespace has already been assigned to
-// should keep having that namespace.
-func (c *Controller) isValidCluster(ctx context.Context, lclusterName, clusterName string) (bool, error) {
-	cluster, err := c.clusterLister.Get(clusters.ToClusterAwareKey(lclusterName, clusterName))
-	if apierrors.IsNotFound(err) {
-		klog.Infof("Cluster %q|%q does not exist", lclusterName, clusterName)
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	if ready := conditions.IsTrue(cluster, clusterv1alpha1.ClusterReadyCondition); !ready {
-		klog.Infof("Cluster %q|%q is not reporting ready", lclusterName, clusterName)
-		return false, nil
-	}
-	if evictAfter := cluster.Spec.EvictAfter; evictAfter != nil && evictAfter.Time.Before(time.Now()) {
-		klog.Infof("Cluster %q|%q is evicted", lclusterName, clusterName)
-		return false, nil
-	}
-	return true, nil
-}
-
 // ensureScheduled attempts to ensure the namespace is assigned to a viable cluster. This
 // will succeed without error if a cluster is assigned or if there are no viable clusters
 // to assign to. The condition of not being scheduled to a cluster will be reflected in
 // the namespace's status rather than by returning an error.
-func (c *Controller) ensureScheduled(ctx context.Context, lclusterName string, ns *corev1.Namespace) error {
-	clusterName := ns.Labels[ClusterLabel]
+func (c *Controller) ensureScheduled(ctx context.Context, ns *corev1.Namespace) error {
+	oldPClusterName := ns.Labels[ClusterLabel]
 
-	noClusterScheduled := clusterName == ""
-	if noClusterScheduled {
-		if err := c.assignCluster(ctx, ns); err != nil {
-			return err
-		}
-	} else {
-		isValidCluster, err := c.isValidCluster(ctx, lclusterName, clusterName)
-		if err != nil {
-			return err
-		}
-		if !isValidCluster {
-			// The currently assigned cluster no longer exists or is not ready.
-			if err := c.assignCluster(ctx, ns); err != nil {
-				return err
-			}
-		}
+	scheduler := namespaceScheduler{
+		getCluster:   c.clusterLister.Get,
+		listClusters: c.clusterLister.List,
+	}
+	newPClusterName, err := scheduler.AssignCluster(ns)
+	if err != nil {
+		return err
 	}
 
-	return nil
+	if oldPClusterName == newPClusterName {
+		return nil
+	}
+
+	klog.Infof("Patching to update cluster assignment for namespace %q|%q: %q -> %q",
+		ns.ClusterName, ns.Name, oldPClusterName, newPClusterName)
+	patchType, patchBytes := clusterLabelPatchBytes(newPClusterName)
+	_, err = c.kubeClient.Cluster(ns.ClusterName).CoreV1().Namespaces().
+		Patch(ctx, ns.Name, patchType, patchBytes, metav1.PatchOptions{})
+	return err
 }
 
 // ensureScheduledStatus ensures the status of the given namespace reflects whether the
@@ -326,13 +245,7 @@ func (c *Controller) reconcileNamespace(ctx context.Context, lclusterName string
 		ns.Labels = map[string]string{}
 	}
 
-	schedulingDisabled := !scheduleRequirement.Matches(labels.Set(ns.Labels))
-	if schedulingDisabled {
-		klog.Infof("Skipping placement for namespace %q|%q", lclusterName, ns.Name)
-		return c.ensureScheduledStatus(ctx, ns)
-	}
-
-	if err := c.ensureScheduled(ctx, lclusterName, ns); err != nil {
+	if err := c.ensureScheduled(ctx, ns); err != nil {
 		return err
 	}
 

--- a/pkg/reconciler/namespace/namespace.go
+++ b/pkg/reconciler/namespace/namespace.go
@@ -114,7 +114,7 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName string,
 	}
 
 	// Update the resource's assignment.
-	patchType, patchBytes := assignedClusterPatchBytes(new)
+	patchType, patchBytes := clusterLabelPatchBytes(new)
 	if _, err = c.dynClient.Cluster(lclusterName).Resource(*gvr).Namespace(ns.Name).
 		Patch(ctx, unstr.GetName(), patchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		return err
@@ -283,9 +283,9 @@ func (c *Controller) reconcileNamespace(ctx context.Context, lclusterName string
 	return nil
 }
 
-// assignedClusterPatchBytes returns JSON patch bytes expressing an operation
+// clusterLabelPatchBytes returns JSON patch bytes expressing an operation
 // to add, replace to the given value, or delete the cluster assignment label.
-func assignedClusterPatchBytes(val string) (types.PatchType, []byte) {
+func clusterLabelPatchBytes(val string) (types.PatchType, []byte) {
 	if val == "" {
 		return types.JSONPatchType,
 			[]byte(fmt.Sprintf(`[{"op": "remove", "path": "/metadata/labels/%s"}]`, strings.ReplaceAll(ClusterLabel, "/", "~1")))

--- a/pkg/reconciler/namespace/scheduler.go
+++ b/pkg/reconciler/namespace/scheduler.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"math/rand"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/klog/v2"
+
+	clusterv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+type getClusterFunc func(name string) (*clusterv1alpha1.Cluster, error)
+type listClustersFunc func(selector labels.Selector) ([]*clusterv1alpha1.Cluster, error)
+
+type namespaceScheduler struct {
+	getCluster   getClusterFunc
+	listClusters listClustersFunc
+}
+
+// AssignCluster returns the name of the cluster to assign to the provided
+// namespace. The current cluster assignment will be returned if it is valid or if
+// the automatic scheduling is disabled for the namespace. An new assignment will
+// be attempted if the current assignment is empty or invalid.
+func (s *namespaceScheduler) AssignCluster(ns *corev1.Namespace) (string, error) {
+	assignedCluster := ns.Labels[ClusterLabel]
+
+	schedulingDisabled := !scheduleRequirement.Matches(labels.Set(ns.Labels))
+	if schedulingDisabled {
+		klog.Infof("Automatic scheduling is disabled for namespace %s|%s", ns.ClusterName, ns.Name)
+		return assignedCluster, nil
+	}
+
+	if assignedCluster != "" {
+		isValid, invalidMsg, err := s.isValidCluster(ns.ClusterName, assignedCluster)
+		if err != nil {
+			return "", err
+		}
+		if isValid {
+			return assignedCluster, nil
+		}
+		// A new cluster needs to be assigned
+		klog.V(5).Infof("Cluster %q|%q %s", ns.ClusterName, assignedCluster, invalidMsg)
+	}
+
+	allClusters, err := s.listClusters(labels.Everything())
+	if err != nil {
+		return "", err
+	}
+	return pickCluster(allClusters, ns.ClusterName), nil
+}
+
+// isValidCluster checks whether the given cluster name exists and is valid for
+// the purposes of any namespace already scheduled to it (i.e., if it reports
+// as Ready, and any evictAfter value, if specified, has not yet passed).
+//
+// It doesn't take into account Unschedulable, and should only be used when
+// determining if a cluster that a namespace has already been assigned to
+// should keep having that namespace.
+func (s *namespaceScheduler) isValidCluster(lclusterName, clusterName string) (
+	isValid bool, invalidMsg string, err error) {
+
+	cluster, err := s.getCluster(clusters.ToClusterAwareKey(lclusterName, clusterName))
+	if apierrors.IsNotFound(err) {
+		return false, "does not exist", nil
+	}
+	if err != nil {
+		return false, "", err
+	}
+	// TODO(marun) Stop duplicating these checks here and in pickCluster
+	if ready := conditions.IsTrue(cluster, clusterv1alpha1.ClusterReadyCondition); !ready {
+		return false, "is not reporting ready", nil
+	}
+	if evictAfter := cluster.Spec.EvictAfter; evictAfter != nil && evictAfter.Time.Before(time.Now()) {
+		return false, "is cordoned", nil
+	}
+	return true, "", nil
+}
+
+// pickCluster attempts to choose a cluster in the given logical
+// cluster to assign to a namespace. If a suitable cluster is
+// identified, its name will be returned. Otherwise, an empty string
+// will be returned.
+func pickCluster(allClusters []*clusterv1alpha1.Cluster, lclusterName string) string {
+	var clusters []*clusterv1alpha1.Cluster
+	for i := range allClusters {
+		// Only include Clusters that are in the logical cluster
+		if allClusters[i].ClusterName != lclusterName {
+			klog.V(2).InfoS("pickCluster: excluding cluster with different metadata.clusterName",
+				"ns.clusterName", lclusterName, "check", allClusters[i].ClusterName)
+			continue
+		}
+		if allClusters[i].Spec.Unschedulable {
+			klog.V(2).InfoS("pickCluster: excluding unschedulable cluster", "metadata.name", allClusters[i].Name)
+			continue
+		}
+		if evictAfter := allClusters[i].Spec.EvictAfter; evictAfter != nil && evictAfter.Time.Before(time.Now()) {
+			klog.V(2).InfoS("pickCluster: excluding cluster with evictAfter value that has passed",
+				"metadata.name", allClusters[i].Name)
+			continue
+		}
+		if !conditions.IsTrue(allClusters[i], clusterv1alpha1.ClusterReadyCondition) {
+			klog.V(2).InfoS("pickCluster: excluding not-ready cluster", "metadata.name", allClusters[i].Name)
+			continue
+		}
+
+		klog.V(2).InfoS("pickCluster: found a ready candidate", "metadata.name", allClusters[i].Name)
+		clusters = append(clusters, allClusters[i])
+	}
+
+	newClusterName := ""
+	if len(clusters) > 0 {
+		// Select a cluster at random.
+		cluster := clusters[rand.Intn(len(clusters))]
+		newClusterName = cluster.Name
+	}
+
+	return newClusterName
+}

--- a/pkg/reconciler/namespace/scheduler_test.go
+++ b/pkg/reconciler/namespace/scheduler_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	clustertools "k8s.io/client-go/tools/clusters"
+
+	clusterv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/cluster/v1alpha1"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+const (
+	testClusterName      = "test-cluster"
+	otherTestClusterName = "other-test-cluster"
+
+	testLclusterName      = "test:lcluster"
+	otherTestLclusterName = "test:other-lcluster"
+)
+
+type clusterFixture struct {
+	cluster *clusterv1alpha1.Cluster
+}
+
+func newClusterFixture(lclusterName, clusterName string) *clusterFixture {
+	f := &clusterFixture{
+		cluster: &clusterv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        clusterName,
+				ClusterName: lclusterName,
+			},
+		},
+	}
+	return f
+}
+
+func defaultClusterFixture() *clusterFixture {
+	return newClusterFixture(testLclusterName, testClusterName)
+}
+
+func otherClusterFixture() *clusterFixture {
+	return newClusterFixture(testLclusterName, otherTestClusterName)
+}
+
+func (f *clusterFixture) withReady() *clusterFixture {
+	conditions.MarkTrue(f.cluster, clusterv1alpha1.ClusterReadyCondition)
+	return f
+}
+
+func (f *clusterFixture) withUnscheduable() *clusterFixture {
+	f.cluster.Spec.Unschedulable = true
+	return f
+}
+
+func (f *clusterFixture) withFutureEvictionTime() *clusterFixture {
+	futureTime := metav1.NewTime(time.Now().Add(1 * time.Hour))
+	f.cluster.Spec.EvictAfter = &futureTime
+	return f
+}
+
+func (f *clusterFixture) withPassedEvictionTime() *clusterFixture {
+	pastTime := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	f.cluster.Spec.EvictAfter = &pastTime
+	return f
+}
+
+func newTestScheduler(clusters []*clusterv1alpha1.Cluster) namespaceScheduler {
+	return namespaceScheduler{
+		getCluster: func(name string) (*clusterv1alpha1.Cluster, error) {
+			for _, cluster := range clusters {
+				if clustertools.ToClusterAwareKey(cluster.ClusterName, cluster.Name) == name {
+					return cluster, nil
+				}
+			}
+			return nil, apierrors.NewNotFound(clusterv1alpha1.Resource("cluster"), name)
+		},
+		listClusters: func(selector labels.Selector) ([]*clusterv1alpha1.Cluster, error) {
+			return clusters, nil
+		},
+	}
+}
+
+func TestAssignCluster(t *testing.T) {
+	unknownClusterName := "unknown-cluster"
+
+	testCases := map[string]struct {
+		labels          map[string]string
+		expectedCluster string
+	}{
+		"scheduling disabled set to empty -> no change even for unknown cluster name": {
+			labels: map[string]string{
+				ClusterLabel:            unknownClusterName,
+				SchedulingDisabledLabel: "",
+			},
+			expectedCluster: unknownClusterName,
+		},
+		"scheduling disabled set to any value -> no change even for unknown cluster name": {
+			labels: map[string]string{
+				ClusterLabel:            unknownClusterName,
+				SchedulingDisabledLabel: "foo",
+			},
+			expectedCluster: unknownClusterName,
+		},
+		"valid assignment -> no change": {
+			labels: map[string]string{
+				ClusterLabel: testClusterName,
+			},
+			expectedCluster: testClusterName,
+		},
+		"invalid assignment -> new assignment": {
+			labels: map[string]string{
+				ClusterLabel: unknownClusterName,
+			},
+			expectedCluster: testClusterName,
+		},
+		"no assignment -> new assignment": {
+			expectedCluster: testClusterName,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			clusters := []*clusterv1alpha1.Cluster{
+				defaultClusterFixture().withReady().cluster,
+			}
+			scheduler := newTestScheduler(clusters)
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					ClusterName: testLclusterName,
+					Labels:      testCase.labels,
+				},
+			}
+			clusterName, err := scheduler.AssignCluster(ns)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedCluster, clusterName)
+		})
+	}
+}
+
+func TestIsValidCluster(t *testing.T) {
+	testCases := map[string]struct {
+		cluster *clusterFixture
+		isValid bool
+	}{
+		"missing -> false": {},
+		"unready -> false": {
+			cluster: defaultClusterFixture(),
+		},
+		"ready -> true": {
+			cluster: defaultClusterFixture().withReady(),
+			isValid: true,
+		},
+		"ready and passed eviction time -> false": {
+			cluster: defaultClusterFixture().withReady().withPassedEvictionTime(),
+		},
+		"ready and future eviction time -> true": {
+			cluster: defaultClusterFixture().withReady().withFutureEvictionTime(),
+			isValid: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			clusters := []*clusterv1alpha1.Cluster{}
+			if testCase.cluster != nil {
+				clusters = append(clusters, testCase.cluster.cluster)
+			}
+			scheduler := newTestScheduler(clusters)
+			isValid, _, err := scheduler.isValidCluster(testLclusterName, testClusterName)
+			require.NoError(t, err)
+			require.Equal(t, testCase.isValid, isValid)
+		})
+	}
+}
+
+func TestPickCluster(t *testing.T) {
+	testCases := map[string]struct {
+		clusters        []*clusterFixture
+		anyAssignment   bool
+		expectedCluster string
+	}{
+		"ignore cluster in different logical cluster": {
+			clusters: []*clusterFixture{
+				newClusterFixture(otherTestLclusterName, testClusterName),
+			},
+		},
+		"ignore unschedulable cluster": {
+			clusters: []*clusterFixture{
+				defaultClusterFixture().withUnscheduable(),
+			},
+		},
+		"ignore cluster with eviction time in the past": {
+			clusters: []*clusterFixture{
+				defaultClusterFixture().withPassedEvictionTime(),
+			},
+		},
+		"return a cluster with eviction time in the future": {
+			clusters: []*clusterFixture{
+				defaultClusterFixture().withReady().withFutureEvictionTime(),
+			},
+			expectedCluster: testClusterName,
+		},
+		"ignore a cluster that is not ready": {
+			clusters: []*clusterFixture{
+				defaultClusterFixture(),
+			},
+		},
+		"1 ready cluster -> cluster name": {
+			clusters: []*clusterFixture{
+				defaultClusterFixture().withReady(),
+			},
+			expectedCluster: testClusterName,
+		},
+		"2 clusters -> any cluster name": {
+			clusters: []*clusterFixture{
+				defaultClusterFixture().withReady(),
+				otherClusterFixture().withReady(),
+			},
+			anyAssignment: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			clusters := []*clusterv1alpha1.Cluster{}
+			for _, fixture := range testCase.clusters {
+				clusters = append(clusters, fixture.cluster)
+			}
+			clusterName := pickCluster(clusters, testLclusterName)
+			if testCase.anyAssignment {
+				found := false
+				for _, cluster := range clusters {
+					if clusterName == cluster.Name {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "unknown cluster name %s", clusterName)
+			} else {
+				require.Equal(t, testCase.expectedCluster, clusterName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR extracts cluster selection from the namespace scheduling  controller and adds preliminary unit test coverage of the result.

API interaction is limited to functions that can be replaced in tests. Care was taken to ensure functional behavior which is easier to reason about and validate. Testing of API mutation is out-of-scope since the fixture cost would likely exceed the benefit.

This strategy of factoring out logic that can be unit tested enables trivial validation of corner-cases and is intended to reduce the cost of ongoing maintenance.