### PR TITLE
Fix the label used to select Ingresses for Envoy

### DIFF
--- a/pkg/localenvoy/controllers/ingress/envoyingress.go
+++ b/pkg/localenvoy/controllers/ingress/envoyingress.go
@@ -25,11 +25,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/klog/v2"
+
+	envoycontrolplane "github.com/kcp-dev/kcp/pkg/localenvoy/controlplane"
 )
 
 const (
 	clusterLabel     = "kcp.dev/cluster"
-	toEnvoyLabel     = "ingress.kcp.dev/envoy"
 	ownedByCluster   = "ingress.kcp.dev/owned-by-cluster"
 	ownedByIngress   = "ingress.kcp.dev/owned-by-ingress"
 	ownedByNamespace = "ingress.kcp.dev/owned-by-namespace"
@@ -64,7 +65,7 @@ func (c *Controller) reconcile(ctx context.Context, ingress *networkingv1.Ingres
 
 	// Label the received ingress for envoy, as we want the controlplane to use this leaf
 	// for updating the envoy config.
-	ingress.Labels[toEnvoyLabel] = "true"
+	ingress.Labels[envoycontrolplane.ToEnvoyLabel] = "true"
 
 	return nil
 }
@@ -90,7 +91,7 @@ func generateStatusHost(domain string, ingress *networkingv1.Ingress) string {
 		}
 	}
 
-	//TODO(jmprusi): Hardcoded to the first one...
+	// TODO(jmprusi): Hardcoded to the first one...
 	if allRulesAreDomain {
 		return ingress.Spec.Rules[0].Host
 	}

--- a/pkg/localenvoy/controllers/ingress/envoyingresscontroller.go
+++ b/pkg/localenvoy/controllers/ingress/envoyingresscontroller.go
@@ -184,16 +184,16 @@ func (c *Controller) process(ctx context.Context, key string) (requeue bool, err
 		return false, err
 	}
 	if !equality.Semantic.DeepEqual(previous, current) {
-		if current.Labels[toEnvoyLabel] == "" {
+		if current.Labels[envoycontrolplane.ToEnvoyLabel] == "" {
 			// If it's a root, we need to patch only status
-			//TODO(jmprusi): Move to patch instead of Update.
+			// TODO(jmprusi): Move to patch instead of Update.
 			_, err := c.client.Cluster(current.ClusterName).NetworkingV1().Ingresses(current.Namespace).UpdateStatus(ctx, current, metav1.UpdateOptions{})
 			if err != nil {
 				return false, err
 			}
 		} else {
 			// If it's a leaf, we need to patch only non-status (to set labels)
-			//TODO(jmprusi): Move to patch instead of Update.
+			// TODO(jmprusi): Move to patch instead of Update.
 			_, err := c.client.Cluster(current.ClusterName).NetworkingV1().Ingresses(current.Namespace).Update(ctx, current, metav1.UpdateOptions{})
 			if err != nil {
 				return false, err

--- a/pkg/localenvoy/controlplane/controlplane.go
+++ b/pkg/localenvoy/controlplane/controlplane.go
@@ -45,15 +45,16 @@ import (
 const (
 	grpcMaxConcurrentStreams = 1000000
 
-	NodeID       = "kcp-ingress"
-	toEnvoyLabel = "ingress-controller/envoy"
+	NodeID = "kcp-ingress"
+
+	ToEnvoyLabel = "ingress.kcp.dev/envoy"
 )
 
 func init() {
 	var err error
 
 	// Create the selector
-	envoyReadySelector, err = labels.Parse(toEnvoyLabel + "=" + "true")
+	envoyReadySelector, err = labels.Parse(ToEnvoyLabel + "=" + "true")
 	if err != nil {
 		klog.Fatalf("failed to parse selector: %v", err)
 	}
@@ -127,7 +128,7 @@ func (ecp *EnvoyControlPlane) Start(ctx context.Context) error {
 }
 
 // UpdateEnvoyConfig creates a new envoy config snapshot and updates the xDS server
-// using the information from the ingresses that are labeled with the toEnvoyLabel.
+// using the information from the ingresses that are labeled with the ToEnvoyLabel.
 func (ecp *EnvoyControlPlane) UpdateEnvoyConfig(ctx context.Context) error {
 	clustersResources := make([]cachetypes.Resource, 0)
 	virtualhosts := make([]*envoyroutev3.VirtualHost, 0)


### PR DESCRIPTION
That PR fixes the label used to select Ingresses ready to be exposed via Envoy, from `ingress-controller/envoy` to `ingress.kcp.dev/envoy`.

I faced this issue while working on #550, after a rebase on #478.

/cc @jmprusi 