### PR TITLE
e2e/framework: don't monitor {ready,live}z when in-process

### DIFF
--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -69,11 +69,11 @@ func NewKcpFixture(t *testing.T, cfgs ...KcpConfig) *KcpFixture {
 		require.NoError(t, err)
 
 		// Wait for the server to become ready
-		go func(s *kcpServer) {
+		go func(s *kcpServer, i int) {
 			defer wg.Done()
-			err := s.Ready()
+			err := s.Ready(!cfgs[i].RunInProcess)
 			require.NoError(t, err, "kcp server %s never became ready: %v", s.name, err)
-		}(srv)
+		}(srv, i)
 	}
 	wg.Wait()
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -299,7 +299,7 @@ func (c *kcpServer) RawConfig() (clientcmdapi.Config, error) {
 // Ready blocks until the server is healthy and ready. Before returning,
 // goroutines are started to ensure that the test is failed if the server
 // does not remain so.
-func (c *kcpServer) Ready() error {
+func (c *kcpServer) Ready(keepMonitoring bool) error {
 	if err := c.loadCfg(); err != nil {
 		return err
 	}
@@ -330,10 +330,12 @@ func (c *kcpServer) Ready() error {
 	}
 	wg.Wait()
 
-	for _, endpoint := range []string{"/livez", "/readyz"} {
-		go func(endpoint string) {
-			c.monitorEndpoint(client, endpoint)
-		}(endpoint)
+	if keepMonitoring {
+		for _, endpoint := range []string{"/livez", "/readyz"} {
+			go func(endpoint string) {
+				c.monitorEndpoint(client, endpoint)
+			}(endpoint)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
These are far to noisy for debugging sessions.