### PR TITLE
ingresssplitter: fix panic

### DIFF
--- a/pkg/reconciler/ingresssplitter/controller.go
+++ b/pkg/reconciler/ingresssplitter/controller.go
@@ -229,7 +229,7 @@ func (c *Controller) ingressesFromService(obj interface{}) {
 	ingresses := c.tracker.getIngressesForService(serviceKey)
 
 	// One Service can be referenced by 0..n Ingresses, so we need to enqueue all the related ingreses.
-	for _, ingress := range ingresses {
+	for _, ingress := range ingresses.List() {
 		klog.Infof("tracked service %q triggered Ingress %q reconciliation", service.Name, ingress)
 		c.queue.Add(ingress)
 	}


### PR DESCRIPTION
```
E0224 21:43:58.528568   24959 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x1b6c820), concrete:(*runtime._type)(0x1bca300), asserted:(*runtime._type)(0x1ad9ee0), missingMethod:""} (interface conversion: interface {} is sets.Empty, not string)
```