### PR TITLE
Add workspace invariant of valid baseURL

### DIFF
--- a/pkg/admission/clusterworkspace/admission.go
+++ b/pkg/admission/clusterworkspace/admission.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	kcpadmissionhelpers "github.com/kcp-dev/kcp/pkg/admission/helpers"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+// Validate ClusterWorkspace creation and updates for
+// - immutability of fields like type
+// - valid phase transitions fulfilling pre-conditions
+// - status.location.current and status.baseURL cannot be unset.
+
+const (
+	PluginName = "tenancy.kcp.dev/ClusterWorkspace"
+)
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return &clusterWorkspace{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+			}, nil
+		})
+}
+
+type clusterWorkspace struct {
+	*admission.Handler
+}
+
+// Ensure that the required admission interfaces are implemented.
+var _ = admission.ValidationInterface(&clusterWorkspace{})
+
+var phaseOrdinal = map[tenancyv1alpha1.ClusterWorkspacePhaseType]int{
+	tenancyv1alpha1.ClusterWorkspacePhaseType(""):     1,
+	tenancyv1alpha1.ClusterWorkspacePhaseScheduling:   2,
+	tenancyv1alpha1.ClusterWorkspacePhaseInitializing: 3,
+	tenancyv1alpha1.ClusterWorkspacePhaseReady:        4,
+}
+
+// Validate ensures that
+// - the workspace only does a valid phase transition
+// - has a valid type
+// - has valid initializers when transitioning to initializing
+func (o *clusterWorkspace) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	if a.GetResource().GroupResource() != tenancyv1alpha1.Resource("clusterworkspaces") {
+		return nil
+	}
+
+	obj, err := kcpadmissionhelpers.NativeObject(a.GetObject())
+	if err != nil {
+		// nolint: nilerr
+		return nil // only work on unstructured ClusterWorkspaces
+	}
+	cw, ok := obj.(*tenancyv1alpha1.ClusterWorkspace)
+	if !ok {
+		// nolint: nilerr
+		return nil // only work on unstructured ClusterWorkspaces
+	}
+
+	if a.GetOperation() == admission.Update {
+		obj, err = kcpadmissionhelpers.NativeObject(a.GetOldObject())
+		if err != nil {
+			return fmt.Errorf("unexpected unknown old object, got %v, expected ClusterWorkspace", a.GetOldObject().GetObjectKind().GroupVersionKind().Kind)
+		}
+		old, ok := obj.(*tenancyv1alpha1.ClusterWorkspace)
+		if !ok {
+			return fmt.Errorf("unexpected unknown old object, got %v, expected ClusterWorkspace", obj.GetObjectKind().GroupVersionKind().Kind)
+		}
+
+		if errs := validation.ValidateImmutableField(cw.Spec.Type, old.Spec.Type, field.NewPath("spec", "type")); len(errs) > 0 {
+			return admission.NewForbidden(a, errs.ToAggregate())
+		}
+		if old.Spec.Type != cw.Spec.Type {
+			return admission.NewForbidden(a, errors.New("spec.type is immutable"))
+		}
+
+		if old.Status.Location.Current != "" && cw.Status.Location.Current == "" {
+			return admission.NewForbidden(a, errors.New("status.location.current cannot be unset"))
+		}
+
+		if old.Status.BaseURL != "" && cw.Status.BaseURL == "" {
+			return admission.NewForbidden(a, errors.New("status.baseURL cannot be unset"))
+		}
+
+		if phaseOrdinal[old.Status.Phase] > phaseOrdinal[cw.Status.Phase] {
+			return admission.NewForbidden(a, fmt.Errorf("cannot transition from %q to %q", old.Status.Phase, cw.Status.Phase))
+		}
+	}
+
+	if phaseOrdinal[cw.Status.Phase] > phaseOrdinal[tenancyv1alpha1.ClusterWorkspacePhaseReady] && len(cw.Status.Initializers) > 0 {
+		return admission.NewForbidden(a, fmt.Errorf("spec.initializers must be empty for phase %s", cw.Status.Phase))
+	}
+
+	if phaseOrdinal[cw.Status.Phase] > phaseOrdinal[tenancyv1alpha1.ClusterWorkspacePhaseScheduling] {
+		if cw.Status.Location.Current == "" {
+			return admission.NewForbidden(a, fmt.Errorf("status.location.current must be set for phase %s", cw.Status.Phase))
+		}
+		if cw.Status.BaseURL == "" {
+			return admission.NewForbidden(a, fmt.Errorf("status.baseURL must be set for phase %s", cw.Status.Phase))
+		}
+	}
+
+	return nil
+}

--- a/pkg/admission/clusterworkspace/admission_test.go
+++ b/pkg/admission/clusterworkspace/admission_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+func createAttr(ws *tenancyv1alpha1.ClusterWorkspace) admission.Attributes {
+	return admission.NewAttributesRecord(
+		ws,
+		nil,
+		tenancyv1alpha1.Kind("ClusterWorkspace").WithVersion("v1alpha1"),
+		"",
+		"test",
+		tenancyv1alpha1.Resource("clusterworkspaces").WithVersion("v1alpha1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func updateAttr(ws, old *tenancyv1alpha1.ClusterWorkspace) admission.Attributes {
+	return admission.NewAttributesRecord(
+		ws,
+		old,
+		tenancyv1alpha1.Kind("ClusterWorkspace").WithVersion("v1alpha1"),
+		"",
+		"test",
+		tenancyv1alpha1.Resource("clusterworkspaces").WithVersion("v1alpha1"),
+		"",
+		admission.Update,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       admission.Attributes
+		wantErr bool
+	}{
+		{
+			name: "rejects type mutations",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Universal",
+					},
+				}),
+			wantErr: true,
+		},
+		{
+			name: "rejects unsetting location",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Location: tenancyv1alpha1.ClusterWorkspaceLocation{
+						Current: "",
+					},
+				}},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						Location: tenancyv1alpha1.ClusterWorkspaceLocation{
+							Current: "cluster",
+						},
+					},
+				}),
+			wantErr: true,
+		},
+		{
+			name: "rejects unsetting baseURL",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						BaseURL: "https://cluster/clsuters/test",
+					},
+				}),
+			wantErr: true,
+		},
+		{
+			name: "rejects transition from Initializing with non-empty initializers",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
+				},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
+						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
+					},
+				}),
+			wantErr: true,
+		},
+		{
+			name: "allows transition from Initializing with empty initializers",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
+					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
+				},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
+						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
+						Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+						BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
+					},
+				}),
+		},
+		{
+			name: "allows transition to ready directly when valid",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
+					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
+				},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
+						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
+					},
+				}),
+		},
+		{
+			name: "allows creation to ready directly when valid",
+			a: createAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
+					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
+				},
+			}),
+		},
+		{
+			name: "rejects transition to ready directly when invalid",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
+					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+				},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
+						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
+					},
+				}),
+			wantErr: true,
+		},
+		{
+			name: "rejects transition to previous phase",
+			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: "Foo",
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
+					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
+				},
+			},
+				&tenancyv1alpha1.ClusterWorkspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+						Type: "Foo",
+					},
+					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
+						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
+						Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+						BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
+					},
+				}),
+			wantErr: true,
+		},
+		{
+			name: "ignores different resources",
+			a: admission.NewAttributesRecord(
+				&tenancyv1alpha1.WorkspaceShard{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+				},
+				nil,
+				tenancyv1alpha1.Kind("WorkspaceShard").WithVersion("v1alpha1"),
+				"",
+				"test",
+				tenancyv1alpha1.Resource("workspaceshards").WithVersion("v1alpha1"),
+				"",
+				admission.Create,
+				&metav1.CreateOptions{},
+				false,
+				&user.DefaultInfo{},
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &clusterWorkspace{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+			}
+			ctx := request.WithCluster(context.Background(), request.Cluster{Name: "root:org"})
+			if err := o.Validate(ctx, tt.a, nil); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -223,7 +223,7 @@ func TestAdmit(t *testing.T) {
 			},
 		},
 		{
-			name: "ignors different resources",
+			name: "ignores different resources",
 			a: admission.NewAttributesRecord(
 				&tenancyv1alpha1.WorkspaceShard{
 					ObjectMeta: metav1.ObjectMeta{
@@ -427,7 +427,7 @@ func TestValidate(t *testing.T) {
 				}),
 		},
 		{
-			name:  "ignors different resources",
+			name:  "ignores different resources",
 			types: nil,
 			attr: admission.NewAttributesRecord(
 				&tenancyv1alpha1.WorkspaceShard{

--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -351,33 +351,6 @@ func TestValidate(t *testing.T) {
 			}),
 		},
 		{
-			name: "rejects type mutations",
-			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "root:org#$#foo",
-					},
-				},
-			},
-			attr: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-					Type: "Foo",
-				},
-			},
-				&tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-						Type: "Universal",
-					},
-				}),
-			wantErr: true,
-		},
-		{
 			name: "validates initializers on phase transition",
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				{
@@ -454,86 +427,8 @@ func TestValidate(t *testing.T) {
 				}),
 		},
 		{
-			name: "rejects transition from Initializing with non-empty initializers",
-			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "root:org#$#foo",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceTypeSpec{
-						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a", "b"},
-					},
-				},
-			},
-			attr: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-					Type: "Foo",
-				},
-				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
-					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
-				},
-			},
-				&tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-						Type: "Foo",
-					},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
-						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
-					},
-				}),
-			wantErr: true,
-		},
-		{
-			name: "allows transition from Initializing with empty initializers",
-			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "root:org#$#foo",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceTypeSpec{
-						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a", "b"},
-					},
-				},
-			},
-			attr: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-				},
-				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-					Type: "Foo",
-				},
-				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
-					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
-					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
-					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
-				},
-			},
-				&tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-						Type: "Foo",
-					},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
-						Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
-						Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
-						BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
-					},
-				}),
-		},
-		{
-			name: "ignors different resources",
+			name:  "ignors different resources",
+			types: nil,
 			attr: admission.NewAttributesRecord(
 				&tenancyv1alpha1.WorkspaceShard{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -39,11 +39,13 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/storage/storageclass/setdefault"
 	"k8s.io/kubernetes/plugin/pkg/admission/storage/storageobjectinuseprotection"
 
+	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspace"
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspacetypeexists"
 )
 
 // AllOrderedPlugins is the list of all the plugins in order.
 var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
+	clusterworkspace.PluginName,
 	clusterworkspacetypeexists.PluginName,
 )
 
@@ -62,6 +64,7 @@ func beforeWebhooks(recommended []string, plugins ...string) []string {
 // The order of registration is irrelevant, see AllOrderedPlugins for execution order.
 func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	kubeapiserveroptions.RegisterAllAdmissionPlugins(plugins)
+	clusterworkspace.Register(plugins)
 	clusterworkspacetypeexists.Register(plugins)
 }
 
@@ -75,6 +78,7 @@ var defaultOnPluginsInKcp = sets.NewString(
 	certsubjectrestriction.PluginName, // CertificateSubjectRestriction
 
 	// KCP
+	clusterworkspace.PluginName,
 	clusterworkspacetypeexists.PluginName,
 )
 

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -172,6 +172,9 @@ const (
 	// WorkspaceReasonUnschedulable reason in WorkspaceScheduled WorkspaceCondition means that the scheduler
 	// can't schedule the workspace right now, for example due to insufficient resources in the cluster.
 	WorkspaceReasonUnschedulable = "Unschedulable"
+	// WorkspaceReasonReasonUnknown reason in WorkspaceScheduled means that scheduler has failed for
+	// some unexpected reason.
+	WorkspaceReasonReasonUnknown = "Unknown"
 
 	// WorkspaceShardValid represents status of the connection process for this workspace.
 	WorkspaceShardValid conditionsv1alpha1.ConditionType = "WorkspaceShardValid"
@@ -184,6 +187,9 @@ const (
 	// WorkspaceShardValidReasonShardNotFound reason in WorkspaceShardValid condition means that the
 	// referenced WorkspaceShard object got deleted.
 	WorkspaceShardValidReasonShardNotFound = "ShardNotFound"
+	// WorkspaceShardValidReasonMissingConnectionInfo reason in WorkspaceShardValid condition means that the
+	// referenced WorkspaceShard object lacks connection info.
+	WorkspaceShardValidReasonMissingConnectionInfo = "MissingConnectionInfo"
 )
 
 // ClusterWorkspaceLocation specifies workspace placement information, including current, desired (target), and

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -173,14 +173,17 @@ const (
 	// can't schedule the workspace right now, for example due to insufficient resources in the cluster.
 	WorkspaceReasonUnschedulable = "Unschedulable"
 
-	// WorkspaceURLValid represents status of the connection process for this workspace.
-	WorkspaceURLValid conditionsv1alpha1.ConditionType = "WorkspaceURLValid"
-	// WorkspaceURLReasonMissing reason in WorkspaceURLValid condition means that the
+	// WorkspaceShardValid represents status of the connection process for this workspace.
+	WorkspaceShardValid conditionsv1alpha1.ConditionType = "WorkspaceShardValid"
+	// WorkspaceShardValidReasonMissingCredentials reason in WorkspaceShardValid condition means that the
 	// connection information in the referenced WorkspaceShard could not be found.
-	WorkspaceURLReasonMissing = "Missing"
-	// WorkspaceURLReasonInvalid reason in WorkspaceURLValid condition means that the
+	WorkspaceShardValidReasonMissingCredentials = "MissingShardCredentials"
+	// WorkspaceShardValidReasonURLInvalid reason in WorkspaceShardValid condition means that the
 	// connection information in the referenced WorkspaceShard were invalid.
-	WorkspaceURLReasonInvalid = "Invalid"
+	WorkspaceShardValidReasonURLInvalid = "InvalidShardURL"
+	// WorkspaceShardValidReasonShardNotFound reason in WorkspaceShardValid condition means that the
+	// referenced WorkspaceShard object got deleted.
+	WorkspaceShardValidReasonShardNotFound = "ShardNotFound"
 )
 
 // ClusterWorkspaceLocation specifies workspace placement information, including current, desired (target), and

--- a/pkg/reconciler/workspaceindex/controller.go
+++ b/pkg/reconciler/workspaceindex/controller.go
@@ -260,7 +260,7 @@ func (c *Controller) processOrg(ctx context.Context, key string) error {
 // latest credentials available for the Shard on which the Organization is held
 func (c *Controller) handleOrg(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) error {
 	if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceScheduled) ||
-		!conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceURLValid) {
+		!conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceShardValid) {
 		klog.Infof("org workspace %s/%s not ready, skipping...", workspace.ClusterName, workspace.Name)
 		return nil // not ready yet
 	}

--- a/pkg/virtual/workspaces/registry/kubeconfig_rest.go
+++ b/pkg/virtual/workspaces/registry/kubeconfig_rest.go
@@ -69,7 +69,7 @@ func (s *KubeconfigSubresourceREST) Get(ctx context.Context, name string, option
 		return nil, err
 	}
 	scope := ctx.Value(WorkspacesScopeKey).(string)
-	if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceURLValid) {
+	if !conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceShardValid) {
 		return nil, wrapError(errors.New("ClusterWorkspace URL is not valid"))
 	}
 	shard, err := s.workspaceShardClient.Get(ctx, workspace.Status.Location.Current, metav1.GetOptions{})

--- a/pkg/virtual/workspaces/registry/kubeconfig_rest_test.go
+++ b/pkg/virtual/workspaces/registry/kubeconfig_rest_test.go
@@ -153,7 +153,7 @@ func TestKubeconfigPersonalWorkspaceWithPrettyName(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -237,7 +237,7 @@ func TestKubeconfigPersonalWorkspace(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -321,7 +321,7 @@ func TestKubeconfigOrganizationWorkspace(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -405,7 +405,7 @@ func TestKubeconfigFailBecauseInvalidCADataBase64(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -492,7 +492,7 @@ func TestKubeconfigFailBecauseWithoutContext(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -578,7 +578,7 @@ func TestKubeconfigFailBecauseInvalid(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -664,7 +664,7 @@ func TestKubeconfigFailSecretDataNotFound(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -747,7 +747,7 @@ func TestKubeconfigFailBecauseSecretNotFound(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},
@@ -822,7 +822,7 @@ func TestKubeconfigFailBecauseShardNotFound(t *testing.T) {
 						},
 						Conditions: conditionsv1alpha1.Conditions{
 							{
-								Type:   tenancyv1alpha1.WorkspaceURLValid,
+								Type:   tenancyv1alpha1.WorkspaceShardValid,
 								Status: corev1.ConditionTrue,
 							},
 						},

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -251,8 +251,8 @@ func TestWorkspaceController(t *testing.T) {
 					if err := scheduled(workspaceShard.Name)(workspace); err != nil {
 						return err
 					}
-					if !utilconditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceURLValid) {
-						return fmt.Errorf("expected valid URL on workspace, got: %v", utilconditions.Get(workspace, tenancyv1alpha1.WorkspaceURLValid))
+					if !utilconditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceShardValid) {
+						return fmt.Errorf("expected valid URL on workspace, got: %v", utilconditions.Get(workspace, tenancyv1alpha1.WorkspaceShardValid))
 					}
 					if diff := cmp.Diff(workspace.Status.BaseURL, "https://kcp.dev/apiprefix/clusters/"+workspaceClusterName); diff != "" {
 						return fmt.Errorf("got incorrect base URL on workspace: %v", diff)

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -30,6 +30,7 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
@@ -54,22 +55,19 @@ func TestWorkspaceController(t *testing.T) {
 		work func(ctx context.Context, t *testing.T, server runningServer)
 	}{
 		{
-			name: "create a workspace without shards, expect it to be unschedulable",
+			name: "create a workspace with a shard, expect it to be scheduled",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				t.Logf("Delete all pre-configured shards, we have to control the creation of the workspace shards in this test")
-				err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
-				require.NoError(t, err)
+				// note that the root shard always exists if not deleted
 
-				t.Logf("Create a workspace without shards")
-				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}, Status: tenancyv1alpha1.ClusterWorkspaceStatus{}}, metav1.CreateOptions{})
+				t.Logf("Create a workspace with a shard")
+				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create workspace")
 				server.Artifact(t, func() (runtime.Object, error) {
 					return server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				})
 
-				t.Logf("Expect workspace to be unschedulable")
-				err = server.orgExpect(workspace, unschedulable)
-				require.NoError(t, err, "did not see workspace marked unschedulable")
+				err = server.orgExpect(workspace, scheduled("root"))
+				require.NoError(t, err, "did not see workspace scheduled")
 			},
 		},
 		{
@@ -90,113 +88,6 @@ func TestWorkspaceController(t *testing.T) {
 				err = server.orgExpect(workspace, unschedulable)
 				require.NoError(t, err, "did not see workspace marked unschedulable")
 
-				t.Logf("Add a shard")
-				bostonShard, err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create workspace shard")
-				server.Artifact(t, func() (runtime.Object, error) {
-					return server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
-				})
-
-				t.Logf("Expect workspace to be scheduled")
-				err = server.orgExpect(workspace, scheduled(bostonShard.Name))
-				require.NoError(t, err, "did not see workspace scheduled")
-			},
-		},
-		{
-			name: "create a workspace with a shard, expect it to be scheduled",
-			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				t.Logf("Create a workspace with a shard")
-				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create workspace")
-				server.Artifact(t, func() (runtime.Object, error) {
-					return server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
-				})
-
-				err = server.orgExpect(workspace, scheduled("root"))
-				require.NoError(t, err, "did not see workspace scheduled")
-			},
-		},
-		{
-			name: "delete a shard that a workspace is scheduled to, expect it to move to another shard",
-			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				t.Logf("Delete all pre-configured shards, we have to control the creation of the workspace shards in this test")
-				err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
-				require.NoError(t, err)
-
-				t.Logf("Create two shards: boston and atlanta")
-				bostonShard, err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "boston"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create first workspace shard")
-				atlantaShard, err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{ObjectMeta: metav1.ObjectMeta{Name: "atlanta"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create second workspace shard")
-
-				t.Logf("Create a workspace")
-				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create workspace")
-				server.Artifact(t, func() (runtime.Object, error) {
-					return server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
-				})
-
-				t.Logf("Expect workspace to be scheduled to some shard")
-				var currentShard, otherShard string
-				err = server.orgExpect(workspace, func(current *tenancyv1alpha1.ClusterWorkspace) error {
-					expectationErr := scheduledAnywhere(current)
-					if expectationErr == nil {
-						currentShard = current.Status.Location.Current
-						for _, name := range []string{bostonShard.Name, atlantaShard.Name} {
-							if name != currentShard {
-								otherShard = name
-								break
-							}
-						}
-					}
-					return expectationErr
-				})
-				require.NoError(t, err, "did not see workspace scheduled")
-
-				// Only collect the other shard - the current shard won't be available after deletion.
-				server.Artifact(t, func() (runtime.Object, error) {
-					return server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Get(ctx, otherShard, metav1.GetOptions{})
-				})
-
-				t.Logf("Delete the current shard")
-				err = server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Delete(ctx, currentShard, metav1.DeleteOptions{})
-				require.NoError(t, err, "failed to delete workspace shard")
-
-				t.Logf("Expect workspace to be scheduled to the other shard")
-				err = server.orgExpect(workspace, scheduled(otherShard))
-				require.NoError(t, err, "did not see workspace rescheduled")
-			},
-		},
-		{
-			name: "delete all shards, expect workspace to be unschedulable",
-			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				t.Logf("Create workspace with a shard")
-				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create workspace")
-				server.Artifact(t, func() (runtime.Object, error) {
-					return server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
-				})
-
-				t.Logf("Expect workspace to be scheduled to some shard")
-				err = server.orgExpect(workspace, scheduled("root"))
-				require.NoError(t, err, "did not see workspace scheduled")
-
-				t.Logf("Delete all shards")
-				err = server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
-				require.NoError(t, err, "failed to delete workspace shard")
-
-				t.Logf("Expect workspace to be unschedulable")
-				err = server.orgExpect(workspace, unschedulable)
-				require.NoError(t, err, "did not see workspace marked unschedulable")
-			},
-		},
-		{
-			name: "create a workspace with a shard that has credentials, expect workspace to have base URL",
-			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				t.Logf("Delete all pre-configured shards, we have to control the creation of the workspace shards in this test")
-				err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
-				require.NoError(t, err)
-
 				t.Logf("Create a kubeconfig secret for a workspace shard in the root workspace")
 				_, err = server.rootKubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "credentials"}}, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create credentials namespace")
@@ -216,31 +107,17 @@ func TestWorkspaceController(t *testing.T) {
 				}, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create credentials secret")
 
-				t.Logf("Create a workspace with a shard that references those credentials")
-				workspaceShard, err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{
-					ObjectMeta: metav1.ObjectMeta{Name: "of-glass"},
+				t.Logf("Add a shard, pointing to the credentials/credentials kubeconfig secret")
+				bostonShard, err := server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Create(ctx, &tenancyv1alpha1.WorkspaceShard{
+					ObjectMeta: metav1.ObjectMeta{Name: "boston"},
 					Spec: tenancyv1alpha1.WorkspaceShardSpec{Credentials: corev1.SecretReference{
 						Name:      "kubeconfig",
 						Namespace: "credentials",
 					}},
 				}, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create workspace shard")
-
-				t.Logf("Expect the shard to show valid credentials")
-				err = server.rootExpectShard(workspaceShard, func(shard *tenancyv1alpha1.WorkspaceShard) error {
-					if !utilconditions.IsTrue(shard, tenancyv1alpha1.WorkspaceShardCredentialsValid) {
-						return fmt.Errorf("workspace shard %s does not have valid credentials, conditions: %#v", shard.Name, shard.GetConditions())
-					}
-					return nil
-				})
-				require.NoError(t, err, "did not see workspace shard get valid credentials")
-
-				t.Logf("Create a workspace")
-				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create workspace")
-
 				server.Artifact(t, func() (runtime.Object, error) {
-					return server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+					return server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Get(ctx, bostonShard.Name, metav1.GetOptions{})
 				})
 
 				t.Logf("Expect workspace to be scheduled to the shard with the base URL stored in the credentials")
@@ -248,7 +125,7 @@ func TestWorkspaceController(t *testing.T) {
 				require.NoError(t, err, "failed to parse logical cluster name of workspace")
 				workspaceClusterName := helper.EncodeOrganizationAndWorkspace(orgName, workspace.Name)
 				err = server.orgExpect(workspace, func(workspace *tenancyv1alpha1.ClusterWorkspace) error {
-					if err := scheduled(workspaceShard.Name)(workspace); err != nil {
+					if err := scheduled(bostonShard.Name)(workspace); err != nil {
 						return err
 					}
 					if !utilconditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceShardValid) {
@@ -260,6 +137,36 @@ func TestWorkspaceController(t *testing.T) {
 					return nil
 				})
 				require.NoError(t, err, "did not see workspace updated")
+			},
+		},
+		{
+			name: "delete a shard that a workspace is scheduled to, expect WorkspaceShardValid condition to turn false",
+			work: func(ctx context.Context, t *testing.T, server runningServer) {
+				t.Logf("Create a workspace")
+				workspace, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{ObjectMeta: metav1.ObjectMeta{Name: "steve"}}, metav1.CreateOptions{})
+				require.NoError(t, err, "failed to create workspace")
+				server.Artifact(t, func() (runtime.Object, error) {
+					return server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+				})
+
+				t.Logf("Expect workspace to be scheduled to some shard")
+				var currentShard string
+				err = server.orgExpect(workspace, func(current *tenancyv1alpha1.ClusterWorkspace) error {
+					expectationErr := scheduledAnywhere(current)
+					if expectationErr == nil {
+						currentShard = current.Status.Location.Current
+					}
+					return expectationErr
+				})
+				require.NoError(t, err, "did not see workspace scheduled")
+
+				t.Logf("Delete the current shard")
+				err = server.rootKcpClient.TenancyV1alpha1().WorkspaceShards().Delete(ctx, currentShard, metav1.DeleteOptions{})
+				require.NoError(t, err, "failed to delete workspace shard")
+
+				t.Logf("Expect WorkspaceShardValid condition to turn false")
+				err = server.orgExpect(workspace, invalidShard)
+				require.NoError(t, err, "did not see WorkspaceShardValid condition to turn false")
 			},
 		},
 	}
@@ -323,6 +230,7 @@ func isUnschedulable(workspace *tenancyv1alpha1.ClusterWorkspace) bool {
 
 func unschedulable(object *tenancyv1alpha1.ClusterWorkspace) error {
 	if !isUnschedulable(object) {
+		klog.Infof("Workspace is not unscheduled: %v", utilconditions.Get(object, tenancyv1alpha1.WorkspaceScheduled))
 		return fmt.Errorf("expected an unschedulable workspace, got status.conditions: %#v", object.Status.Conditions)
 	}
 	return nil
@@ -331,13 +239,22 @@ func unschedulable(object *tenancyv1alpha1.ClusterWorkspace) error {
 func scheduled(target string) func(workspace *tenancyv1alpha1.ClusterWorkspace) error {
 	return func(object *tenancyv1alpha1.ClusterWorkspace) error {
 		if isUnschedulable(object) {
+			klog.Infof("Workspace %s is unschedulable", object.Name)
 			return fmt.Errorf("expected a scheduled workspace, got status.conditions: %#v", object.Status.Conditions)
 		}
 		if object.Status.Location.Current != target {
+			klog.Infof("Workspace %s is scheduled to %s, expected %s", object.Name, object.Status.Location.Current, target)
 			return fmt.Errorf("expected workspace.status.location.current to be %q, got %q", target, object.Status.Location.Current)
 		}
 		return nil
 	}
+}
+
+func invalidShard(workspace *tenancyv1alpha1.ClusterWorkspace) error {
+	if !utilconditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceShardValid) {
+		return fmt.Errorf("expected invalid shard, got status.conditions: %#v", workspace.Status.Conditions)
+	}
+	return nil
 }
 
 func scheduledAnywhere(object *tenancyv1alpha1.ClusterWorkspace) error {

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -182,8 +182,8 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 							return false, nil
 						}
 						return false, err
-					} else if !conditions.IsTrue(cw, tenancyv1alpha1.WorkspaceURLValid) {
-						return false, fmt.Errorf("ClusterWorkspace %s is not valid: %s", cw.Name, conditions.GetMessage(cw, tenancyv1alpha1.WorkspaceURLValid))
+					} else if !conditions.IsTrue(cw, tenancyv1alpha1.WorkspaceShardValid) {
+						return false, fmt.Errorf("ClusterWorkspace %s is not valid: %s", cw.Name, conditions.GetMessage(cw, tenancyv1alpha1.WorkspaceShardValid))
 					}
 					workspaceURL = cw.Status.BaseURL
 					return true, nil


### PR DESCRIPTION
This PR does the following:
1. To simplify the state machine as seen by users and controllers, this PR adds the invariant that

   - After scheduling `status.baseURL` of a ClusterWorkspace stays valid.

   In other words: there is no unscheduling. A workspace has state (obviously) and a workspace without a shard does not make sense.

   Corrolary: We have to make sure (through movement and high availability measures) that a workspace is available. Clients should not be expected to hande the case that a workspace is not accessible. Reason:
   - client-go clients don't watch the workspace object.
   - processes talk to some URL via clients, and clients cannot update the URL they talk to (that's not part of the Kubernetes client contract).

   tl/dr: we have to make sure the workspace baseURL keeps working at all time.
2. A `ClusterWorkspace` admission plugin is added verifying the state transitions of cluster workspace objects.