### PR TITLE
prototype2-script: the Ingress demo can run on MacOS

### DIFF
--- a/contrib/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demo/clusters/kind/createKindClusters.sh
@@ -56,13 +56,20 @@ detect_podman() {
         return
     fi
 
+    if [[ "$OSTYPE" == "darwin"* && -z "$(podman ps)" ]]; then
+        # Podman machine is not started
+        return
+    fi
+
     if [[ -z "$(podman system connection ls --format=json)" ]]; then
         return
     fi
 
+    KIND_EXPERIMENTAL_PROVIDER=podman
+
     PODMAN_VERSION=$(podman version -f '{{.Server.Version}}')
     PODMAN_MAJOR=$(echo "${PODMAN_VERSION}" | cut -d. -f1)
-    if [[ "${PODMAN_MAJOR}" == "3" ]]; then
+    if [[ "${PODMAN_MAJOR}" == "3" && "$OSTYPE" == "darwin"* ]]; then
         PODMAN_MAC_SSH_WORKAROUND=1
 
         # Setup the control socket if it's not already running
@@ -94,14 +101,14 @@ for cluster in "${CLUSTERS[@]}"; do
 
     # Only create if we're not reusing existing clusters, or the cluster doesn't exist
     if [[ -z "${REUSE_KIND_CLUSTERS:-}" || -z "${clusterExists}" ]]; then
-        kind create cluster \
+        KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER:-} kind create cluster \
             --config "${CLUSTERS_DIR}/${cluster}.config" \
             --kubeconfig "${CLUSTERS_DIR}/${cluster}.kubeconfig" \
             "${IMAGE_FLAG[@]}"
     fi
 
     if [[ ! -f "${CLUSTERS_DIR}/${cluster}.yaml" ]]; then
-        clusterKubeconfig=$(kind get kubeconfig --name "${cluster}")
+        clusterKubeconfig=$(KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER:-} kind get kubeconfig --name "${cluster}")
 
         echo "${clusterKubeconfig}" | sed -e 's/^/    /' | cat "${DEMO_ROOT}/clusters/${cluster}.yaml" - > "${CLUSTERS_DIR}/${cluster}.yaml"
     fi

--- a/contrib/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demo/clusters/kind/createKindClusters.sh
@@ -109,7 +109,7 @@ for cluster in "${CLUSTERS[@]}"; do
         KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER:-} kind create cluster \
             --config "${CLUSTERS_DIR}/${cluster}.config" \
             --kubeconfig "${CLUSTERS_DIR}/${cluster}.kubeconfig" \
-            "${IMAGE_FLAG[@]}"
+            "${IMAGE_FLAG[@]:[]}"
     fi
 
     if [[ ! -f "${CLUSTERS_DIR}/${cluster}.yaml" ]]; then

--- a/contrib/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demo/clusters/kind/createKindClusters.sh
@@ -53,17 +53,22 @@ podman_ssh() {
 
 detect_podman() {
     if ! command -v podman; then
+        echo "The podman binary could not be found, falling back to Docker."
         return
     fi
 
     if [[ "$OSTYPE" == "darwin"* && -z "$(podman ps)" ]]; then
         # Podman machine is not started
+        echo "The Podman machine does not seem to be started, falling back to Docker."
         return
     fi
 
     if [[ -z "$(podman system connection ls --format=json)" ]]; then
+        echo "The Podman SSH destinations could not be listed, falling back to Docker."
         return
     fi
+
+    echo "Using Podman as container engine."
 
     KIND_EXPERIMENTAL_PROVIDER=podman
 

--- a/contrib/demo/prototype2-script/script
+++ b/contrib/demo/prototype2-script/script
@@ -171,17 +171,11 @@ c "And create an ingress"
 pe "cat ${DEMO_DIR}/ingress-kuard.yaml"
 pe "kubectl apply -f ${DEMO_DIR}/ingress-kuard.yaml"
 
-if [ "$(uname)" = "Darwin" ]; then
-  c "On Linux, we would now see how to access our application with curl through local envoy - we would get a 200 status code"
-  c "curl -s -o /dev/null --write-out '%{http_code}' -H 'Host: kuard.kcp-apps.127.0.0.1.nip.io' localhost:8181"
-  c "On Mac, unfortunately accessing the ingress inside of kind is little tricky and still WIP 🤷‍"
-else
-  c "Wait for the ingress to be accepted by the ingress controller in the us-east1 cluster"
-  pe "while ! kubectl get ingress -l ingress.kcp.dev/envoy=true -o=jsonpath='{.items[*].status.loadBalancer.ingress[*].ip}' | grep -qoE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b'; do sleep 1; done"
+c "Wait for the ingress to be accepted by the ingress controller in the us-east1 cluster"
+pe "while ! kubectl get ingress -l ingress.kcp.dev/envoy=true -o=jsonpath='{.items[*].status.loadBalancer.ingress[*].ip}' | grep -qoE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b'; do sleep 1; done"
 
-  c "Now let's access our application with curl - we should get a 200 status code"
-  pe "curl -s -o /dev/null --write-out '%{http_code}' -H 'Host: kuard.kcp-apps.127.0.0.1.nip.io' localhost:8181"
-fi
+c "Now let's access our application with curl - we should get a 200 status code"
+pe "curl -s -o /dev/null --write-out '%{http_code}' -H 'Host: kuard.kcp-apps.127.0.0.1.nip.io' localhost:8181"
 
 wait;clear
 
@@ -215,15 +209,10 @@ clear
 c "Let's see if the deployment got rescheduled"
 pe "kubectl describe deployment/kuard"
 
-if [ "$(uname)" = "Darwin" ]; then
-  c "On Linux, we would now see how to access our application with curl through local envoy - we would get a 200 status code from us-west1 cluster."
-  c "curl -s -o /dev/null --write-out '%{http_code}' -H 'Host: kuard.kcp-apps.127.0.0.1.nip.io' localhost:8181"
-else
-  c "Let's wait for the ingress to be accepted by the ingress controller in the us-west1 cluster"
-  pe "while ! kubectl get ingress -l ingress.kcp.dev/envoy=true -o=jsonpath='{.items[*].status.loadBalancer.ingress[*].ip}' | grep -qoE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b'; do sleep 1; done"
-  c "And now, lets make an http request to our application again"
-  pe "curl -s -o /dev/null --write-out '%{http_code}' -H 'Host: kuard.kcp-apps.127.0.0.1.nip.io' localhost:8181"
-fi
+c "Let's wait for the ingress to be accepted by the ingress controller in the us-west1 cluster"
+pe "while ! kubectl get ingress -l ingress.kcp.dev/envoy=true -o=jsonpath='{.items[*].status.loadBalancer.ingress[*].ip}' | grep -qoE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b'; do sleep 1; done"
+c "And now, lets make an http request to our application again"
+pe "curl -s -o /dev/null --write-out '%{http_code}' -H 'Host: kuard.kcp-apps.127.0.0.1.nip.io' localhost:8181"
 
 #### Section 3 Policy/Orgs
 wait

--- a/contrib/demo/prototype2-script/script
+++ b/contrib/demo/prototype2-script/script
@@ -56,9 +56,6 @@ clear
 
 c "Install nginx-based ingress into both kind clusters"
 
-# TODO(ncdc): trying to get ingress working on mac+podman+kind
-#pe "sed -e 's,hostPort: 80,hostPort: 8080,' -e 's,hostPort: 443,hostPort: 8443,' ${DEMOS_DIR}/ingress-script/nginx-ingress.yaml | kubectl --kubeconfig ${CLUSTERS_DIR}/us-east1.kubeconfig apply -f -"
-#pe "sed -e 's,hostPort: 80,hostPort: 9080,' -e 's,hostPort: 443,hostPort: 9443,' ${DEMOS_DIR}/ingress-script/nginx-ingress.yaml | kubectl --kubeconfig ${CLUSTERS_DIR}/us-west1.kubeconfig apply -f -"
 pe "kubectl --kubeconfig ${CLUSTERS_DIR}/us-east1.kubeconfig apply -f ${DEMOS_DIR}/ingress-script/nginx-ingress.yaml"
 pe "kubectl --kubeconfig ${CLUSTERS_DIR}/us-west1.kubeconfig apply -f ${DEMOS_DIR}/ingress-script/nginx-ingress.yaml"
 
@@ -100,7 +97,7 @@ pe "kubectl apply --context root -f ${DEMO_DIR}/user-rbac.yaml"
 c "Let's start by creating a \"real\" workspace and using it. That's what organization workspace are for, to hold the actual application workspaces."
 pe "kubectl kcp workspace --token user-1-token create workspace1 --use"
 
-c "Because KCP doesn’t include Deployments by default, and we haven’t registered any Clusters yet, we need to teach KCP about Deployments"
+c "Because KCP doesn't include Deployments by default, and we haven't registered any Clusters yet, we need to teach KCP about Deployments"
 
 c "First grab the schema for deployments from one of our kind clusters"
 pe "(cd ${KCP_DATA_DIR} && go run ${KCP_DIR}/cmd/crd-puller/pull-crds.go --kubeconfig ${CLUSTERS_DIR}/us-east1.kubeconfig deployments.apps)"

--- a/contrib/demo/prototype2-script/startKcp.sh
+++ b/contrib/demo/prototype2-script/startKcp.sh
@@ -95,7 +95,7 @@ bootstrapAddress="host.docker.internal"
 if [[ "${CONTAINER_ENGINE}" == "podman" ]]; then
   bootstrapAddress="host.containers.internal"
 fi
-sed "s/BOOTSTRAP_ADDRESS/$bootstrapAddress/" "${KCP_DIR}"/contrib/envoy/bootstrap.yaml > "${KCP_DATA_DIR}"/envoy-bootstrap.yaml
+sed "s/BOOTSTRAP_ADDRESS/$bootstrapAddress/" "${KCP_DIR}"/contrib/envoy/bootstrap.template.yaml > "${KCP_DATA_DIR}"/envoy-bootstrap.yaml
 "${CONTAINER_ENGINE}" create --rm -t --net=kind -p 8181:8181 envoyproxy/envoy-dev:d803505d919aff1c4207b353c3b430edfa047010
 ENVOY_CID=$("${CONTAINER_ENGINE}" ps -q -n1)
 "${CONTAINER_ENGINE}" cp "${KCP_DATA_DIR}"/envoy-bootstrap.yaml "${ENVOY_CID}":/etc/envoy/envoy.yaml

--- a/contrib/demo/prototype2-script/startKcp.sh
+++ b/contrib/demo/prototype2-script/startKcp.sh
@@ -23,7 +23,13 @@ source "${DEMO_DIR}"/../.setupEnv
 source "${DEMOS_DIR}"/.startUtils
 setupTraps "$0"
 
-trap cleanup EXIT 1 2 3 6 15
+for sig in INT QUIT HUP TERM; do
+  trap "
+    cleanup
+    trap - $sig EXIT
+    kill -s $sig "'"$$"' "$sig"
+done
+trap "cleanup" EXIT
 
 cleanup() {
   echo "Killing Envoy container"

--- a/contrib/demo/runDemoScripts.sh
+++ b/contrib/demo/runDemoScripts.sh
@@ -93,7 +93,7 @@ for demo in ${DEMOS} ; do
   if $DEMO_AS_TESTS ; then
     (export NO_COLORS="true" ; ${DEMO_DIR}/script -n &> demo.log)
   else
-    (${DEMO_DIR}/script |& tee demo.log)
+    (${DEMO_DIR}/script 2>&1 tee demo.log)
   fi
 
   echo "Dumping the admin logical cluster APIs for demo ${demo} to ${TEST_DIR}/apis.log..."

--- a/contrib/envoy/bootstrap.template.yaml
+++ b/contrib/envoy/bootstrap.template.yaml
@@ -27,7 +27,7 @@ static_resources:
             endpoint:
               address:
                 socket_address:
-                  address: "localhost"
+                  address: BOOTSTRAP_ADDRESS
                   port_value: 18000
       http2_protocol_options: {}
 admin:

--- a/contrib/envoy/bootstrap.yaml
+++ b/contrib/envoy/bootstrap.yaml
@@ -27,7 +27,7 @@ static_resources:
             endpoint:
               address:
                 socket_address:
-                  address: "localhost"
+                  address: BOOTSTRAP_ADDRESS
                   port_value: 18000
       http2_protocol_options: {}
 admin:


### PR DESCRIPTION
This PR moves the Envoy proxy, used in the Ingress part of the P2 demo, to be running in container, so that it can connect to the network created by KinD, to be able to proxy downstream clusters, even while it runs in the extra virtualisation layer introduced by Docker or Podman on MacOS.

Fixes #550.