### PR TITLE
e2e: Ensure cfg is written to temp dir for virtual workspace test

### DIFF
--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -285,7 +285,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 					cfg.Clusters[clusterName].Server = url.String()
 
 					// write kubeconfig to disk, next to kcp kubeconfig
-					cfgPath := filepath.Join(filepath.Base(kcpServer.KubeconfigPath()), "virtualworkspace.kubeconfig")
+					cfgPath := filepath.Join(filepath.Dir(kcpServer.KubeconfigPath()), "virtualworkspace.kubeconfig")
 					err = clientcmd.WriteToFile(*cfg, cfgPath)
 					require.NoError(t, err)
 


### PR DESCRIPTION
Use of `filepath.Base` instead of `filepath.Dir` meant the config was being written to the e2e path instead of a temp dir.