### PR TITLE
ci: don't run e2e & other tests for documentation-only PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 
 jobs:
   boilerplate:

--- a/.github/workflows/demos.yaml
+++ b/.github/workflows/demos.yaml
@@ -2,35 +2,35 @@ name: Demos
 on:
   workflow_dispatch:
   pull_request:
-    types: [ labeled ]
+    types: [labeled]
 jobs:
   build-and-run-demos:
     if: ${{ github.event.label.name == 'check-demos' }}
     name: Build and Run Demos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: v1.17
-    - run: make build
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - run: make build
 
-    - name: Install latest version of Kind
-      run: |
-        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
-        chmod +x ./kind
-        sudo cp kind /usr/local/bin
-    - name: Install dependencies before running demos
-      run: |
-        sudo apt-get install pv
-    - name: Test Demos
-      run: |
-        mkdir tests
-        cd tests
-        ../contrib/demo/runDemos.sh -t
-    - name: Archive Demo test results
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: demo-tests
-        path: tests/**/*.log
+      - name: Install latest version of Kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+          chmod +x ./kind
+          sudo cp kind /usr/local/bin
+      - name: Install dependencies before running demos
+        run: |
+          sudo apt-get install pv
+      - name: Test Demos
+        run: |
+          mkdir tests
+          cd tests
+          ../contrib/demo/runDemos.sh -t
+      - name: Archive Demo test results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: demo-tests
+          path: tests/**/*.log

--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-    - main
+      - main
 
 jobs:
   kcp-image:
@@ -14,31 +14,31 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: v1.17
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
 
-    - name: Get the short sha
-      id: vars
-      run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
+      - name: Get the short sha
+        id: vars
+        run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
 
-    # Build and push a KCP image, tagged with latest and the commit SHA.
-    - name: Build KCP Image
-      id: build-image
-      uses: redhat-actions/buildah-build@v2
-      with:
-        image: kcp
-        tags: latest ${{ steps.vars.outputs.sha_short }}
-        containerfiles: |
-          ./Dockerfile
+      # Build and push a KCP image, tagged with latest and the commit SHA.
+      - name: Build KCP Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: kcp
+          tags: latest ${{ steps.vars.outputs.sha_short }}
+          containerfiles: |
+            ./Dockerfile
 
-    - name: Push to ghcr.io
-      id: push-to-ghcr
-      uses: redhat-actions/push-to-registry@v2
-      with:
-        image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ steps.build-image.outputs.tags }}
-        registry: ghcr.io/${{ github.repository_owner }}
-        username: ${{ github.actor }}
-        password: ${{ github.token }}
+      - name: Push to ghcr.io
+        id: push-to-ghcr
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ghcr.io/${{ github.repository_owner }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}

--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -5,18 +5,18 @@ permissions:
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
 
 jobs:
   syncer-image:
     name: Build Syncer Image
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: v1.17
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
 
-    # Build and push a syncer image, tagged with the commit SHA.
-    - uses: imjasonh/setup-ko@v0.4
-    - run: ko publish ./cmd/syncer -t $(git rev-parse --short "$GITHUB_SHA")
+      # Build and push a syncer image, tagged with the commit SHA.
+      - uses: imjasonh/setup-ko@v0.4
+      - run: ko publish ./cmd/syncer -t $(git rev-parse --short "$GITHUB_SHA")


### PR DESCRIPTION
# What is changed?
    
 - Exclude docs and markdowns
 - Reformat workflow files
 - Fixes #573