### PR TITLE
Convert cmd/syncer/main.go to be a cobra.Command

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -18,27 +18,22 @@ package cmd
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
-	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/namespace"
+	synceroptions "github.com/kcp-dev/kcp/cmd/syncer/options"
 	"github.com/kcp-dev/kcp/pkg/syncer"
 )
 
 const numThreads = 2
 
 func NewSyncerCommand() *cobra.Command {
-	options := NewDefaultOptions()
-
+	options := synceroptions.NewOptions()
 	syncerCommand := &cobra.Command{
 		Use:   "syncer",
 		Short: "Synchronizes resources in `kcp` assigned to the clusters",
@@ -52,7 +47,7 @@ func NewSyncerCommand() *cobra.Command {
 			}
 
 			ctx := genericapiserver.SetupSignalContext()
-			if err := options.Run(ctx); err != nil {
+			if err := Run(options, ctx); err != nil {
 				return err
 			}
 
@@ -62,89 +57,32 @@ func NewSyncerCommand() *cobra.Command {
 		},
 	}
 
-	options.BindFlags(syncerCommand.Flags())
+	options.AddFlags(syncerCommand.Flags())
 
 	return syncerCommand
 }
 
-func (options *Options) Validate() error {
-	if options.FromClusterName == "" {
-		return errors.New("--from-cluster is required")
-	}
-
-	return nil
-}
-
-func (options *Options) Complete() error {
+func Run(options *synceroptions.Options, ctx context.Context) error {
 	klog.Infof("Syncing the following resource types: %s", options.SyncedResourceTypes)
 
-	// Create a client to dynamically watch "from".
-	if cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.FromKubeconfig}, nil).ClientConfig(); err != nil {
+	kcpConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.FromKubeconfig}, nil).ClientConfig()
+	if err != nil {
 		return err
-	} else {
-		options.fromConfig = cfg
 	}
 
-	if options.ToKubeconfig != "" {
-		toOverrides := clientcmd.ConfigOverrides{
+	toConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
+		&clientcmd.ConfigOverrides{
 			CurrentContext: options.ToContext,
-		}
-
-		if cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
-			&toOverrides).ClientConfig(); err != nil {
-			return err
-		} else {
-			options.toConfig = cfg
-		}
+		}).ClientConfig()
+	if err != nil {
+		return err
 	}
 
-	return nil
-}
-
-func (options *Options) Run(ctx context.Context) error {
-	if err := syncer.StartSyncer(ctx, options.fromConfig, options.toConfig, sets.NewString(options.SyncedResourceTypes...), options.FromClusterName, options.PclusterID, numThreads); err != nil {
+	if err := syncer.StartSyncer(ctx, kcpConfig, toConfig, sets.NewString(options.SyncedResourceTypes...), options.FromClusterName, options.PclusterID, numThreads); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-type Options struct {
-	FromKubeconfig      string
-	FromClusterName     string
-	ToKubeconfig        string
-	ToContext           string
-	PclusterID          string
-	Logs                *logs.Options
-	SyncedResourceTypes []string
-
-	//non-exported members
-	toConfig   *rest.Config
-	fromConfig *rest.Config
-}
-
-func NewDefaultOptions() *Options {
-	return &Options{
-		FromKubeconfig:      "",
-		FromClusterName:     "",
-		ToKubeconfig:        "",
-		ToContext:           "",
-		PclusterID:          "",
-		SyncedResourceTypes: []string{"deployments.apps"},
-		Logs:                logs.NewOptions(),
-	}
-}
-
-func (options *Options) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&options.FromKubeconfig, "from-kubeconfig", options.FromKubeconfig, "Kubeconfig file for -from cluster.")
-	fs.StringVar(&options.FromClusterName, "from-cluster", options.FromClusterName, "Name of the -from logical cluster.")
-	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
-	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
-	fs.StringVar(&options.PclusterID, "cluster", options.PclusterID,
-		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", nscontroller.ClusterLabel))
-	fs.StringArrayVarP(&options.SyncedResourceTypes, "sync-resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
-
-	options.Logs.AddFlags(fs)
 }

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+
+	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/namespace"
+	"github.com/kcp-dev/kcp/pkg/syncer"
+)
+
+const numThreads = 2
+
+func NewSyncerCommand() *cobra.Command {
+	options := NewDefaultOptions()
+
+	syncerCommand := &cobra.Command{
+		Use:   "syncer",
+		Short: "Synchronizes resources in `kcp` assigned to the clusters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Complete(); err != nil {
+				return err
+			}
+
+			if err := options.Validate(); err != nil {
+				return err
+			}
+
+			ctx := genericapiserver.SetupSignalContext()
+			if err := options.Run(ctx); err != nil {
+				return err
+			}
+
+			<-ctx.Done()
+
+			return nil
+		},
+	}
+
+	options.BindFlags(syncerCommand.Flags())
+
+	return syncerCommand
+}
+
+func (options *Options) Validate() error {
+	if options.FromClusterName == "" {
+		return errors.New("--from-cluster is required")
+	}
+
+	return nil
+}
+
+func (options *Options) Complete() error {
+	klog.Infof("Syncing the following resource types: %s", options.SyncedResourceTypes)
+
+	// Create a client to dynamically watch "from".
+	if cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.FromKubeconfig}, nil).ClientConfig(); err != nil {
+		return err
+	} else {
+		options.fromConfig = cfg
+	}
+
+	if options.ToKubeconfig != "" {
+		toOverrides := clientcmd.ConfigOverrides{
+			CurrentContext: options.ToContext,
+		}
+
+		if cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
+			&toOverrides).ClientConfig(); err != nil {
+			return err
+		} else {
+			options.toConfig = cfg
+		}
+	}
+
+	return nil
+}
+
+func (options *Options) Run(ctx context.Context) error {
+	if err := syncer.StartSyncer(ctx, options.fromConfig, options.toConfig, sets.NewString(options.SyncedResourceTypes...), options.FromClusterName, options.PclusterID, numThreads); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type Options struct {
+	FromKubeconfig      string
+	FromClusterName     string
+	ToKubeconfig        string
+	ToContext           string
+	PclusterID          string
+	Logs                *logs.Options
+	SyncedResourceTypes []string
+
+	//non-exported members
+	toConfig   *rest.Config
+	fromConfig *rest.Config
+}
+
+func NewDefaultOptions() *Options {
+	return &Options{
+		FromKubeconfig:      "",
+		FromClusterName:     "",
+		ToKubeconfig:        "",
+		ToContext:           "",
+		PclusterID:          "",
+		SyncedResourceTypes: []string{"deployments.apps"},
+		Logs:                logs.NewOptions(),
+	}
+}
+
+func (options *Options) BindFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&options.FromKubeconfig, "from-kubeconfig", options.FromKubeconfig, "Kubeconfig file for -from cluster.")
+	fs.StringVar(&options.FromClusterName, "from-cluster", options.FromClusterName, "Name of the -from logical cluster.")
+	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
+	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
+	fs.StringVar(&options.PclusterID, "cluster", options.PclusterID,
+		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", nscontroller.ClusterLabel))
+	fs.StringArrayVarP(&options.SyncedResourceTypes, "sync-resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
+
+	options.Logs.AddFlags(fs)
+}

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -17,87 +17,15 @@ limitations under the License.
 package main
 
 import (
-	"context"
-	"flag"
-	"fmt"
 	"os"
-	"os/signal"
-	"path"
-	"syscall"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
+	"k8s.io/component-base/cli"
 
-	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/namespace"
-	"github.com/kcp-dev/kcp/pkg/syncer"
-)
-
-const numThreads = 2
-
-var (
-	fromKubeconfig  = flag.String("from_kubeconfig", "", "Kubeconfig file for -from cluster.")
-	fromClusterName = flag.String("from_cluster", "", "Name of the -from logical cluster.")
-	toKubeconfig    = flag.String("to_kubeconfig", "", "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
-	toContext       = flag.String("to_context", "", "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
-	pclusterID      = flag.String("cluster", "",
-		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", nscontroller.ClusterLabel))
+	"github.com/kcp-dev/kcp/cmd/syncer/cmd"
 )
 
 func main() {
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage of %s [resourceTypes...]:\n", path.Base(os.Args[0]))
-		flag.PrintDefaults()
-	}
-	flag.Parse()
-	syncedResourceTypes := flag.Args()
-	if len(syncedResourceTypes) == 0 {
-		syncedResourceTypes = []string{"deployments.apps"}
-		klog.Infoln("No resource types provided; using defaults.")
-	}
-	klog.Infof("Syncing the following resource types: %s", syncedResourceTypes)
-
-	// Create a client to dynamically watch "from".
-	if *fromClusterName == "" {
-		klog.Fatal("--from_cluster is required")
-	}
-
-	fromConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: *fromKubeconfig}, nil).ClientConfig()
-	if err != nil {
-		klog.Fatal(err)
-	}
-
-	var toConfig *rest.Config
-	if *toKubeconfig != "" {
-		var toOverrides clientcmd.ConfigOverrides
-		if *toContext != "" {
-			toOverrides.CurrentContext = *toContext
-		}
-
-		toConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			&clientcmd.ClientConfigLoadingRules{ExplicitPath: *toKubeconfig},
-			&toOverrides).ClientConfig()
-		if err != nil {
-			klog.Fatal(err)
-		}
-	} else {
-		toConfig, err = rest.InClusterConfig()
-	}
-	if err != nil {
-		klog.Fatal(err)
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGILL, syscall.SIGINT)
-	defer cancel()
-
-	klog.Infoln("Starting workers")
-	if err := syncer.StartSyncer(ctx, fromConfig, toConfig, sets.NewString(syncedResourceTypes...), *fromClusterName, *pclusterID, numThreads); err != nil {
-		klog.Fatal(err)
-	}
-
-	<-ctx.Done()
-
-	klog.Infoln("Stopping workers")
+	syncerCommand := cmd.NewSyncerCommand()
+	code := cli.Run(syncerCommand)
+	os.Exit(code)
 }

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/component-base/logs"
+
+	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/namespace"
+)
+
+type Options struct {
+	FromKubeconfig      string
+	FromClusterName     string
+	ToKubeconfig        string
+	ToContext           string
+	PclusterID          string
+	Logs                *logs.Options
+	SyncedResourceTypes []string
+}
+
+func NewOptions() *Options {
+	return &Options{
+		SyncedResourceTypes: []string{"deployments.apps"},
+		Logs:                logs.NewOptions(),
+	}
+}
+
+func (options *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&options.FromKubeconfig, "from-kubeconfig", options.FromKubeconfig, "Kubeconfig file for -from cluster.")
+	fs.StringVar(&options.FromClusterName, "from-cluster", options.FromClusterName, "Name of the -from logical cluster.")
+	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
+	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
+	fs.StringVar(&options.PclusterID, "workload-cluster-name", options.PclusterID,
+		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", nscontroller.ClusterLabel))
+	fs.StringArrayVarP(&options.SyncedResourceTypes, "sync-resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
+
+	options.Logs.AddFlags(fs)
+}
+
+func (options *Options) Complete() error {
+	return nil
+}
+
+func (options *Options) Validate() error {
+	if options.FromClusterName == "" {
+		return errors.New("--from-cluster is required")
+	}
+	if options.FromKubeconfig == "" {
+		return errors.New("--from-kubeconfig is required")
+	}
+	if options.ToKubeconfig == "" {
+		return errors.New("--to-kubeconfig is required")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## The Updates 
### Migrating to cobra.Command
* added cobra command equivalent of existing go flags.
* moved the main logic from ./cmd/syncer/main.go to ./cmd/syncer/cmd/syncer.go
* created a new exported ```Options struct``` for flags binding.
* syncedResourceTypes is a flag now
![image](https://user-images.githubusercontent.com/54385449/157079822-fe4e0d0c-2b60-426b-9cb0-82c99a12b50a.png)


## Testing
* Build the source code
```bash
go build ./cmd/syncer
```
* Run it
```bash
./syncer -h
```
- [x] Fixes #553 