### PR TITLE
admission: add SubjectAccessReview to ClusterWorkspaceType use

### DIFF
--- a/config/organization/clusterworkspacetype-use-clusterrole.yaml
+++ b/config/organization/clusterworkspacetype-use-clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:kcp:universal-clusterworkspacetype-use
+rules:
+- apiGroups: ["tenancy.kcp.dev"]
+  resources: ["clusterworkspacetypes"]
+  resourceNames: ["universal"]
+  verbs: ["use"]

--- a/config/organization/clusterworkspacetype-use-clusterrolebinding.yaml
+++ b/config/organization/clusterworkspacetype-use-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kcp:authenticated:universal-clusterworkspacetype-use
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:universal-clusterworkspacetype-use
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated

--- a/pkg/admission/helpers/authorize.go
+++ b/pkg/admission/helpers/authorize.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"time"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	"k8s.io/apiserver/pkg/server/options"
+	kubeclient "k8s.io/client-go/kubernetes"
+	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+)
+
+type AdmissionAuthorizerFactory func(clusterName string, client *kubeclient.Cluster) (authorizer.Authorizer, error)
+
+// NewAdmissionAuthorizer returns a new authorizer for use in admission plugins that delegates
+// to the kube API server via SubjectAccessReview.
+func NewAdmissionAuthorizer(clusterName string, client *kubeclient.Cluster) (authorizer.Authorizer, error) {
+	delegatingAuthorizerConfig := &authorizerfactory.DelegatingAuthorizerConfig{
+		SubjectAccessReviewClient: &clusterAwareAuthorizationV1Client{
+			AuthorizationV1Interface: client.Cluster(clusterName).AuthorizationV1(),
+			cluster:                  clusterName,
+		},
+		AllowCacheTTL:       5 * time.Minute,
+		DenyCacheTTL:        30 * time.Second,
+		WebhookRetryBackoff: options.DefaultAuthWebhookRetryBackoff(),
+	}
+
+	authz, err := delegatingAuthorizerConfig.New()
+	if err != nil {
+		klog.Errorf("error creating authorizer from delegating authorizer config: %v", err)
+		return nil, err
+	}
+
+	return authz, nil
+}
+
+// clusterAwareAuthorizationV1Client is a thin wrapper around AuthorizationV1Interface that exposes a RESTClient()
+// implementation that supports logical clusters for POST calls.
+// TODO(ncdc) replace with generated clientset wrappers that are logical cluster aware.
+type clusterAwareAuthorizationV1Client struct {
+	authorizationv1client.AuthorizationV1Interface
+	cluster string
+}
+
+// RESTClient returns a rest.Interface that supports logical clusters for POST calls.
+func (c *clusterAwareAuthorizationV1Client) RESTClient() rest.Interface {
+	return &clusterAwareRESTClient{
+		Interface: c.AuthorizationV1Interface.RESTClient(),
+		cluster:   c.cluster,
+	}
+}
+
+// clusterAwareRESTClient supports logical clusters for POST calls.
+type clusterAwareRESTClient struct {
+	rest.Interface
+	cluster string
+}
+
+// Post returns a *rest.Request for a specific logical cluster.
+func (c *clusterAwareRESTClient) Post() *rest.Request {
+	return c.Interface.Post().Cluster(c.cluster)
+}

--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -18,7 +18,9 @@ package initializers
 
 import (
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/kubernetes"
 
+	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 )
 
@@ -39,5 +41,45 @@ type kcpInformersInitializer struct {
 func (i *kcpInformersInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(WantsKcpInformers); ok {
 		wants.SetKcpInformers(i.kcpInformers)
+	}
+}
+
+// NewKubeClusterClientInitializer returns an admission plugin initializer that injects
+// a kube cluster client into admission plugins.
+func NewKubeClusterClientInitializer(
+	kubeClusterClient *kubernetes.Cluster,
+) *kubeClusterClientInitializer {
+	return &kubeClusterClientInitializer{
+		kubeClusterClient: kubeClusterClient,
+	}
+}
+
+type kubeClusterClientInitializer struct {
+	kubeClusterClient *kubernetes.Cluster
+}
+
+func (i *kubeClusterClientInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsKubeClusterClient); ok {
+		wants.SetKubeClusterClient(i.kubeClusterClient)
+	}
+}
+
+// NewKcpClusterClientInitializer returns an admission plugin initializer that injects
+// a kcp cluster client into admission plugins.
+func NewKcpClusterClientInitializer(
+	kcpClusterClient *kcpclientset.Cluster,
+) *kcpClusterClientInitializer {
+	return &kcpClusterClientInitializer{
+		kcpClusterClient: kcpClusterClient,
+	}
+}
+
+type kcpClusterClientInitializer struct {
+	kcpClusterClient *kcpclientset.Cluster
+}
+
+func (i *kcpClusterClientInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsKcpClusterClient); ok {
+		wants.SetKcpClusterClient(i.kcpClusterClient)
 	}
 }

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -17,6 +17,9 @@ limitations under the License.
 package initializers
 
 import (
+	"k8s.io/client-go/kubernetes"
+
+	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 )
 
@@ -24,4 +27,16 @@ import (
 // that want to have an kcp informer factory injected.
 type WantsKcpInformers interface {
 	SetKcpInformers(informers kcpinformers.SharedInformerFactory)
+}
+
+// WantsKubeClusterClient interface should be implemented by admission plugins
+// that want to have a kube cluster client injected.
+type WantsKubeClusterClient interface {
+	SetKubeClusterClient(kubeClusterClient *kubernetes.Cluster)
+}
+
+// WantsKcpClusterClient interface should be implemented by admission plugins
+// that want to have a kcp cluster client injected.
+type WantsKcpClusterClient interface {
+	SetKcpClusterClient(kubeClusterClient *kcpclientset.Cluster)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -215,6 +215,8 @@ func (s *Server) Run(ctx context.Context) error {
 
 	admissionPluginInitializers := []admission.PluginInitializer{
 		kcpadmissioninitializers.NewKcpInformersInitializer(s.kcpSharedInformerFactory),
+		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
+		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
 	}
 
 	apisConfig, err := genericcontrolplane.CreateKubeAPIServerConfig(genericConfig, s.options.GenericControlPlane, s.kubeSharedInformerFactory, admissionPluginInitializers, storageFactory)


### PR DESCRIPTION
Authorize ClusterWorkspace creation against a clusterworkspacetypes verb=use permission via SubjectAccessReview.

By default everybody (with org access) can create universal ClusterWorkspaces. This is done through a bootstrapped ClusterRole+Binding in every org workspace. If this is not desired, that binding could be removed on a per-org basis.