### PR TITLE
make signal handling consistent

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -17,17 +17,16 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"time"
 
 	"github.com/spf13/pflag"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/tools/clientcmd"
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
@@ -75,8 +74,7 @@ func (o *options) Validate() error {
 
 func main() {
 	// Setup signal handler for a cleaner shutdown
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Kill, os.Interrupt)
-	defer cancel()
+	ctx := genericapiserver.SetupSignalContext()
 
 	fs := pflag.NewFlagSet("cluster-controller", pflag.ContinueOnError)
 	options := bindOptions(fs)

--- a/cmd/virtual-workspaces/main.go
+++ b/cmd/virtual-workspaces/main.go
@@ -33,13 +33,13 @@ import (
 )
 
 func main() {
-	stopCh := genericapiserver.SetupSignalHandler()
+	ctx := genericapiserver.SetupSignalContext()
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
-	command := NewVirtualWorkspaceApiServerCommand(stopCh)
+	command := NewVirtualWorkspaceApiServerCommand(ctx.Done())
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## The Updates
Consistent Signal handling methods
*  changed signal.NotifyContext() and genericapiserver.SetupSignalHandler() to genericapiserver.SetupSignalContext()

- [x] Fixes #552 