### PR TITLE
e2e: Fix broken workspacetype initializer test

### DIFF
--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -135,11 +135,11 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 					require.NoError(t, err)
 					for i, initializer := range workspace.Status.Initializers {
 						if initializer == "a" {
-							workspace.Status.Initializers = append(workspace.Status.Initializers[:i], workspace.Status.Initializers[i:]...)
+							workspace.Status.Initializers = append(workspace.Status.Initializers[:i], workspace.Status.Initializers[i+1:]...)
 							break
 						}
 					}
-					_, err = server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Update(ctx, workspace, metav1.UpdateOptions{})
+					_, err = server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().UpdateStatus(ctx, workspace, metav1.UpdateOptions{})
 					return err
 				})
 				require.NoError(t, err)
@@ -156,17 +156,18 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 					require.NoError(t, err)
 					for i, initializer := range workspace.Status.Initializers {
 						if initializer == "b" {
-							workspace.Status.Initializers = append(workspace.Status.Initializers[:i], workspace.Status.Initializers[i:]...)
+							workspace.Status.Initializers = append(workspace.Status.Initializers[:i], workspace.Status.Initializers[i+1:]...)
 							break
 						}
 					}
-					_, err = server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Update(ctx, workspace, metav1.UpdateOptions{})
+					_, err = server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().UpdateStatus(ctx, workspace, metav1.UpdateOptions{})
 					return err
 				})
 				require.NoError(t, err)
 
 				t.Logf("Expect workspace to become ready after initializers are done")
 				err = server.orgExpect(workspace, ready)
+				require.NoError(t, err, "workspace did not become ready")
 			},
 		},
 	}


### PR DESCRIPTION
I noticed that the workspacetype initializer test was taking ~50s - quadruple the runtime of any other test. Investigation revealed that the test was broken in 3 ways:

 - incorrect deletion of an element from a slice
 - using Update instead of UpdateStatus to effect a status change
 - not checking the result of a subsequent expect meant the first 2 issues were not failing the test

The extended duration of test execution was the result of the expect taking 30s before timing out, 2x5s sleeps, and the usual 10s overhead of starting a kcp server fixture.