### PR TITLE
clusterworkspace: admission: fix initializers check

### DIFF
--- a/pkg/admission/clusterworkspace/admission.go
+++ b/pkg/admission/clusterworkspace/admission.go
@@ -112,7 +112,7 @@ func (o *clusterWorkspace) Validate(ctx context.Context, a admission.Attributes,
 		}
 	}
 
-	if phaseOrdinal[cw.Status.Phase] > phaseOrdinal[tenancyv1alpha1.ClusterWorkspacePhaseReady] && len(cw.Status.Initializers) > 0 {
+	if phaseOrdinal[cw.Status.Phase] > phaseOrdinal[tenancyv1alpha1.ClusterWorkspacePhaseInitializing] && len(cw.Status.Initializers) > 0 {
 		return admission.NewForbidden(a, fmt.Errorf("spec.initializers must be empty for phase %s", cw.Status.Phase))
 	}
 

--- a/pkg/admission/clusterworkspace/admission_test.go
+++ b/pkg/admission/clusterworkspace/admission_test.go
@@ -151,6 +151,8 @@ func TestValidate(t *testing.T) {
 				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
 					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"a"},
+					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
+					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
 				},
 			},
 				&tenancyv1alpha1.ClusterWorkspace{


### PR DESCRIPTION
Fix bug where it was possible to transition out of Initializing with status.initializers remaining.

Fix bug in test case for this that was incorrectly passing.

Signed-off-by: Andy Goldstein <andy.goldstein@redhat.com>