### PR TITLE
ci: use lint make target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,10 +61,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: v1.17
-      - uses: golangci/golangci-lint-action@v2
-        with:
-          only-new-issues: true
-          args: --timeout=5m
+      - name: Run golangci-lint
+        run: make lint
 
   codegen:
     name: codegen

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ OPENSHIFT_GOIMPORTS_BIN := openshift-goimports
 OPENSHIFT_GOIMPORTS := $(TOOLS_DIR)/$(OPENSHIFT_GOIMPORTS_BIN)-$(OPENSHIFT_GOIMPORTS_VER)
 export OPENSHIFT_GOIMPORTS # so hack scripts can use it
 
+GOLANGCI_LINT_VER := v1.44.2
+GOLANGCI_LINT_BIN := golangci-lint
+GOLANGCI_LINT := $(GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
+
 all: build
 .PHONY: all
 
@@ -47,8 +51,11 @@ install:
 	go install ./cmd/...
 .PHONY: install
 
-lint:
-	golangci-lint run ./...
+$(GOLANGCI_LINT):
+	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
+
+lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run --timeout=10m ./...
 .PHONY: lint
 
 vendor: ## Vendor the dependencies


### PR DESCRIPTION
golanci-lint action job uses a custom format to annotate code within
GitHub, we can override it (forcefully) to achieve the desired output
(file and line numbers for lint issue in the output). Or we can just use
the make target directly :)

https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

fixes https://github.com/kcp-dev/kcp/issues/634

Signed-off-by: jbpratt <jbpratt78@gmail.com>
