### PR TITLE
e2e: Switch to test-managed syncer and update syncer-dependent tests to use shared fixture

### DIFF
--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -139,7 +139,7 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 			return err
 		}
 	}
-	klog.Infof("Created downstream namespace %s for upstream namespace %s|%s", downstreamNamespace, c.upstreamClusterName, upstreamObj.GetName())
+	klog.Infof("Created downstream namespace %s for upstream namespace %s|%s", downstreamNamespace, c.upstreamClusterName, upstreamObj.GetNamespace())
 
 	return nil
 }

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -83,7 +83,7 @@ func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClust
 	}
 	fromClient := fromClients.Cluster(kcpClusterName)
 	toClient := dynamic.NewForConfigOrDie(to)
-	return New(kcpClusterName, pclusterID, fromDiscovery, fromClient, toClient, KcpToPhysicalCluster, syncedResourceTypes, pclusterID)
+	return New(kcpClusterName, pclusterID, fromDiscovery, fromClient, toClient, SyncDown, syncedResourceTypes, pclusterID)
 }
 
 func (c *Controller) deleteFromDownstream(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) error {
@@ -167,7 +167,7 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	downstreamObj.SetOwnerReferences(ownerReferences)
 
 	// Run name transformations on the downstreamObj.
-	transformName(downstreamObj, KcpToPhysicalCluster)
+	transformName(downstreamObj, SyncDown)
 
 	// TODO: wipe things like finalizers, owner-refs and any other life-cycle fields. The life-cycle
 	//       should exclusively owned by the syncer. Let's not some Kubernetes magic interfere with it.

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -62,7 +62,7 @@ func NewStatusSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClu
 		return nil, err
 	}
 	toClient := toClients.Cluster(kcpClusterName)
-	return New(kcpClusterName, pclusterID, discoveryClient, fromClient, toClient, PhysicalClusterToKcp, syncedResourceTypes, pclusterID)
+	return New(kcpClusterName, pclusterID, discoveryClient, fromClient, toClient, SyncUp, syncedResourceTypes, pclusterID)
 }
 
 func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamNamespace string, downstreamObj *unstructured.Unstructured) error {
@@ -72,7 +72,7 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 	upstreamObj.SetNamespace(upstreamNamespace)
 
 	// Run name transformations on upstreamObj
-	transformName(upstreamObj, PhysicalClusterToKcp)
+	transformName(upstreamObj, SyncUp)
 
 	existing, err := c.toClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, upstreamObj.GetName(), metav1.GetOptions{})
 	if err != nil {

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -50,14 +50,14 @@ const (
 	syncerApplyManager = "syncer"
 )
 
-// Direction indicates which direction data is flowing for this particular syncer
-type Direction string
+// SyncDirection indicates which direction data is flowing for this particular syncer
+type SyncDirection string
 
-// KcpToPhysicalCluster indicates a syncer watches resources on KCP and applies the spec to the target cluster
-const KcpToPhysicalCluster Direction = "down"
+// SyncDown indicates a syncer watches resources on KCP and applies the spec to the target cluster
+const SyncDown SyncDirection = "down"
 
-// PhysicalClusterToKcp indicates a syncer watches resources on the target cluster and applies the status to KCP
-const PhysicalClusterToKcp Direction = "up"
+// SyncUp indicates a syncer watches resources on the target cluster and applies the status to KCP
+const SyncUp SyncDirection = "up"
 
 func StartSyncer(ctx context.Context, upstream, downstream *rest.Config, resources sets.String, kcpClusterName, pcluster string, numSyncerThreads int) error {
 	specSyncer, err := NewSpecSyncer(upstream, downstream, resources.List(), kcpClusterName, pcluster)
@@ -87,14 +87,14 @@ type Controller struct {
 
 	upsertFn  UpsertFunc
 	deleteFn  DeleteFunc
-	direction Direction
+	direction SyncDirection
 
 	upstreamClusterName string
 	syncerNamespace     string
 }
 
 // New returns a new syncer Controller syncing spec from "from" to "to".
-func New(kcpClusterName, pcluster string, fromDiscovery discovery.DiscoveryInterface, fromClient, toClient dynamic.Interface, direction Direction, syncedResourceTypes []string, pclusterID string) (*Controller, error) {
+func New(kcpClusterName, pcluster string, fromDiscovery discovery.DiscoveryInterface, fromClient, toClient dynamic.Interface, direction SyncDirection, syncedResourceTypes []string, pclusterID string) (*Controller, error) {
 	controllerName := string(direction) + "--" + kcpClusterName + "--" + pcluster
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-"+controllerName)
 
@@ -107,7 +107,7 @@ func New(kcpClusterName, pcluster string, fromDiscovery discovery.DiscoveryInter
 		syncerNamespace:     os.Getenv(SyncerNamespaceKey),
 	}
 
-	if direction == KcpToPhysicalCluster {
+	if direction == SyncDown {
 		c.upsertFn = c.applyToDownstream
 		c.deleteFn = c.deleteFromDownstream
 	} else {
@@ -130,7 +130,7 @@ func New(kcpClusterName, pcluster string, fromDiscovery discovery.DiscoveryInter
 		fromInformers.ForResource(*gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) { c.AddToQueue(*gvr, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				if c.direction == KcpToPhysicalCluster {
+				if c.direction == SyncDown {
 					if !deepEqualApartFromStatus(oldObj, newObj) {
 						c.AddToQueue(*gvr, newObj)
 					}
@@ -256,7 +256,7 @@ func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}
 	if len(metaObj.GetNamespace()) > 0 {
 		qualifiedName = metaObj.GetNamespace() + "/" + qualifiedName
 	}
-	if c.direction == KcpToPhysicalCluster {
+	if c.direction == SyncDown {
 		qualifiedName = metaObj.GetClusterName() + "|" + qualifiedName
 	}
 	klog.Infof("Syncer %s: adding %s %s to queue", c.name, gvr, qualifiedName)
@@ -355,7 +355,7 @@ func (c *Controller) process(ctx context.Context, h holder) error {
 	)
 
 	// Determine toNamespace
-	if c.direction == KcpToPhysicalCluster {
+	if c.direction == SyncDown {
 		// Convert the clusterName and namespace to a single string for toNamespace
 		l := NamespaceLocator{
 			LogicalCluster: h.clusterName,
@@ -444,16 +444,16 @@ func (c *Controller) process(ctx context.Context, h holder) error {
 // transformName changes the object name into the desired one based on the Direction:
 // - if the object is a configmap it handles the "kube-root-ca.crt" name mapping
 // - if the object is a serviceaccount it handles the "default" name mapping
-func transformName(syncedObject *unstructured.Unstructured, direction Direction) {
+func transformName(syncedObject *unstructured.Unstructured, direction SyncDirection) {
 	switch direction {
-	case KcpToPhysicalCluster:
+	case SyncDown:
 		if syncedObject.GetKind() == "ConfigMap" && syncedObject.GetName() == "kube-root-ca.crt" {
 			syncedObject.SetName("kcp-root-ca.crt")
 		}
 		if syncedObject.GetKind() == "ServiceAccount" && syncedObject.GetName() == "default" {
 			syncedObject.SetName("kcp-default")
 		}
-	case PhysicalClusterToKcp:
+	case SyncUp:
 		if syncedObject.GetKind() == "ConfigMap" && syncedObject.GetName() == "kcp-root-ca.crt" {
 			syncedObject.SetName("kube-root-ca.crt")
 		}

--- a/pkg/syncer/syncer_test.go
+++ b/pkg/syncer/syncer_test.go
@@ -26,11 +26,11 @@ func TestTransformName(t *testing.T) {
 	for _, c := range []struct {
 		desc         string
 		syncedobject *unstructured.Unstructured
-		direction    Direction
+		direction    SyncDirection
 		expectedName string
 	}{{
 		desc:      "Sync kube-root-ca.crt configmap from KCP to a Pcluster",
-		direction: KcpToPhysicalCluster,
+		direction: SyncDown,
 		syncedobject: &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"kind":       "ConfigMap",
@@ -45,7 +45,7 @@ func TestTransformName(t *testing.T) {
 	},
 		{
 			desc:      "Sync kcp-root-ca.crt configmap from Pcluster to a KCP",
-			direction: PhysicalClusterToKcp,
+			direction: SyncUp,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ConfigMap",
@@ -60,7 +60,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync default serviceaccount from KCP to a Pcluster",
-			direction: KcpToPhysicalCluster,
+			direction: SyncDown,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ServiceAccount",
@@ -75,7 +75,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync kcp-default serviceaccount from Pcluster to a KCP",
-			direction: PhysicalClusterToKcp,
+			direction: SyncUp,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ServiceAccount",
@@ -90,7 +90,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync arbitrary serviceaccount from Pcluster to a KCP",
-			direction: PhysicalClusterToKcp,
+			direction: SyncUp,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ServiceAccount",
@@ -105,7 +105,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync arbitrary serviceaccount from KCP to a Pcluster",
-			direction: KcpToPhysicalCluster,
+			direction: SyncDown,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ServiceAccount",
@@ -120,7 +120,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync arbitrary configmap from Pcluster to a KCP",
-			direction: PhysicalClusterToKcp,
+			direction: SyncUp,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ConfigMap",
@@ -135,7 +135,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync arbitrary configmap from KCP to a Pcluster",
-			direction: KcpToPhysicalCluster,
+			direction: SyncDown,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "ConfigMap",
@@ -150,7 +150,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync deployment from KCP to a Pcluster",
-			direction: KcpToPhysicalCluster,
+			direction: SyncDown,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "Deployment",
@@ -165,7 +165,7 @@ func TestTransformName(t *testing.T) {
 		},
 		{
 			desc:      "Sync deployment from Pcluster to KCP",
-			direction: PhysicalClusterToKcp,
+			direction: SyncUp,
 			syncedobject: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"kind":       "Deployment",

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -465,6 +465,22 @@ func newPersistentKCPServer(name, kubeconfigPath string) (RunningServer, error) 
 	}, nil
 }
 
+// NewFakeWorkloadServer creates a workspace in the provided server and org
+// and creates a server fixture for the logical cluster that results.
+func NewFakeWorkloadServer(t *testing.T, server RunningServer, org string) RunningServer {
+	logicalClusterName := NewWorkspaceWithWorkloads(t, server, org, "Universal", false)
+
+	serverKubeConfig, err := server.RawConfig()
+	require.NoError(t, err, "failed to read config for server")
+
+	logicalConfig := LogicalClusterConfig(&serverKubeConfig, logicalClusterName)
+
+	return &unmanagedKCPServer{
+		name: logicalClusterName,
+		cfg:  logicalConfig,
+	}
+}
+
 func (s *unmanagedKCPServer) Name() string {
 	return s.name
 }


### PR DESCRIPTION
Switch to test-managed syncer to enable syncer-requiring tests to use shared fixture.