### PR TITLE
kubectl-kcp: add ws alias for workspace

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -44,6 +44,7 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 	opts := plugin.NewOptions(streams)
 
 	cmd := &cobra.Command{
+		Aliases:          []string{"ws"},
 		Use:              "workspace [--workspace-directory-server=] <current|use|list>",
 		Short:            "Manages KCP workspaces",
 		Example:          fmt.Sprintf(workspaceExample, "kubectl kcp"),


### PR DESCRIPTION
Add `ws` as an alias for the `workspace` command.

mentioned in https://github.com/kcp-dev/kcp/issues/633

Signed-off-by: jbpratt <jbpratt78@gmail.com>
