### PR TITLE
Rename workspaces to clusterworkspaces

### DIFF
--- a/pkg/apis/tenancy/v1alpha1/helper/helper.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper.go
@@ -45,12 +45,12 @@ func EncodeLogicalClusterName(workspace *tenancyapi.ClusterWorkspace) (string, e
 		}
 		orgName = name
 	}
-	return EncodeOrganizationAndWorkspace(orgName, workspace.Name), nil
+	return EncodeOrganizationAndClusterWorkspace(orgName, workspace.Name), nil
 }
 
-// EncodeOrganizationAndWorkspace determines the logical cluster name for
+// EncodeOrganizationAndClusterWorkspace determines the logical cluster name for
 // an organization and workspace.
-func EncodeOrganizationAndWorkspace(organization, workspace string) string {
+func EncodeOrganizationAndClusterWorkspace(organization, workspace string) string {
 	return organization + separator + workspace
 }
 
@@ -63,7 +63,7 @@ func WorkspaceKey(org, ws string) string {
 		return clusters.ToClusterAwareKey(org, ws)
 	}
 
-	return clusters.ToClusterAwareKey(EncodeOrganizationAndWorkspace(RootCluster, org), ws)
+	return clusters.ToClusterAwareKey(EncodeOrganizationAndClusterWorkspace(RootCluster, org), ws)
 }
 
 // ParseLogicalClusterName determines the organization and workspace name from a
@@ -95,5 +95,5 @@ func ParentClusterName(name string) (string, error) {
 	if parent == RootCluster {
 		return RootCluster, nil
 	}
-	return EncodeOrganizationAndWorkspace(RootCluster, parent), nil
+	return EncodeOrganizationAndClusterWorkspace(RootCluster, parent), nil
 }

--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -25,9 +25,9 @@ import (
 // ClusterRoleBindings return default rolebindings to the default roles
 func clusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	return []rbacv1.ClusterRoleBinding{
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups("system:kcp:workspace:edit").BindingOrDie(), "system:kcp:workspace:edit"),
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("view").Groups("system:kcp:workspace:view").BindingOrDie(), "system:kcp:workspace:view"),
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("admin").Groups("system:kcp:workspace:admin").BindingOrDie(), "system:kcp:workspace:admin"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups("system:kcp:clusterworkspace:edit").BindingOrDie(), "system:kcp:clusterworkspace:edit"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("view").Groups("system:kcp:clusterworkspace:view").BindingOrDie(), "system:kcp:clusterworkspace:view"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("admin").Groups("system:kcp:clusterworkspace:admin").BindingOrDie(), "system:kcp:clusterworkspace:admin"),
 	}
 }
 

--- a/pkg/reconciler/clusterworkspacetypebootstrap/bootstrap_reconcile.go
+++ b/pkg/reconciler/clusterworkspacetypebootstrap/bootstrap_reconcile.go
@@ -57,7 +57,7 @@ func (c *controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.C
 	if err != nil {
 		return err
 	}
-	wsClusterName := helper.EncodeOrganizationAndWorkspace(org, workspace.Name)
+	wsClusterName := helper.EncodeOrganizationAndClusterWorkspace(org, workspace.Name)
 	klog.Infof("Bootstrapping resources for org workspace %s, logical cluster %s", workspace.Name, wsClusterName)
 	bootstrapCtx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second*30)) // to not block the controller
 	defer cancel()

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -115,7 +115,7 @@ func (c *inheritanceCRDLister) ListWithContext(ctx context.Context, selector lab
 				switch {
 				case err == nil:
 					inheriting = true
-					inheritFrom = helper.EncodeOrganizationAndWorkspace(orgName, wsName)
+					inheritFrom = helper.EncodeOrganizationAndClusterWorkspace(orgName, wsName)
 				case apierrors.IsNotFound(err):
 					// A NotFound error is ok. It means we can't inherit but we should still proceed below to list.
 				default:
@@ -246,7 +246,7 @@ func (c *inheritanceCRDLister) GetWithContext(ctx context.Context, name string) 
 			return nil, err
 		}
 
-		sourceWorkspaceCRDKey = clusters.ToClusterAwareKey(helper.EncodeOrganizationAndWorkspace(org, workspace.Spec.InheritFrom), name)
+		sourceWorkspaceCRDKey = clusters.ToClusterAwareKey(helper.EncodeOrganizationAndClusterWorkspace(org, workspace.Spec.InheritFrom), name)
 	}
 	// Try to get the inherited CRD
 	crd, err = c.crdLister.Get(sourceWorkspaceCRDKey)

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -317,7 +317,7 @@ var roleRules map[RoleType][]rbacv1.PolicyRule = map[RoleType][]rbacv1.PolicyRul
 			Resources: []string{"workspaces"},
 		},
 		{
-			Resources: []string{"workspaces/content"},
+			Resources: []string{"clusterworkspaces/content"},
 			Verbs:     []string{"view"},
 		},
 	},
@@ -327,7 +327,7 @@ var roleRules map[RoleType][]rbacv1.PolicyRule = map[RoleType][]rbacv1.PolicyRul
 			Resources: []string{"workspaces"},
 		},
 		{
-			Resources: []string{"workspaces/content"},
+			Resources: []string{"clusterworkspaces/content"},
 			Verbs:     []string{"view", "edit"},
 		},
 	},

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	informers "k8s.io/client-go/informers"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -743,7 +743,7 @@ func TestCreateWorkspace(t *testing.T) {
 						{
 							Verbs:         []string{"view"},
 							ResourceNames: []string{"foo"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -765,7 +765,7 @@ func TestCreateWorkspace(t *testing.T) {
 						{
 							Verbs:         []string{"view", "edit"},
 							ResourceNames: []string{"foo"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -835,7 +835,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 						{
 							Verbs:         []string{"view", "edit"},
 							ResourceNames: []string{"foo"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -857,7 +857,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 						{
 							Verbs:         []string{"view"},
 							ResourceNames: []string{"foo"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -922,7 +922,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 						{
 							Verbs:         []string{"view"},
 							ResourceNames: []string{"foo--1"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -944,7 +944,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 						{
 							Verbs:         []string{"view", "edit"},
 							ResourceNames: []string{"foo--1"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -1020,7 +1020,7 @@ func TestCreateWorkspacePrettyNameAlreadyExists(t *testing.T) {
 						{
 							Verbs:         []string{"view"},
 							ResourceNames: []string{"foo"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},
@@ -1042,7 +1042,7 @@ func TestCreateWorkspacePrettyNameAlreadyExists(t *testing.T) {
 						{
 							Verbs:         []string{"view", "edit"},
 							ResourceNames: []string{"foo"},
-							Resources:     []string{"workspaces/content"},
+							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 					},

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -130,9 +130,9 @@ func TestAuthorizer(t *testing.T) {
 			KcpClient:  orgKcpClient,
 			Dynamic:    orgDynamicClient,
 		},
-		"user-1": newUserClient(t, "user-1", helper.EncodeOrganizationAndWorkspace(org, "workspace1"), kcpCfg),
-		"user-2": newUserClient(t, "user-2", helper.EncodeOrganizationAndWorkspace(org, "workspace1"), kcpCfg),
-		"user-3": newUserClient(t, "user-3", helper.EncodeOrganizationAndWorkspace(org, "workspace1"), kcpCfg),
+		"user-1": newUserClient(t, "user-1", helper.EncodeOrganizationAndClusterWorkspace(org, "workspace1"), kcpCfg),
+		"user-2": newUserClient(t, "user-2", helper.EncodeOrganizationAndClusterWorkspace(org, "workspace1"), kcpCfg),
+		"user-3": newUserClient(t, "user-3", helper.EncodeOrganizationAndClusterWorkspace(org, "workspace1"), kcpCfg),
 	}
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(orgKcpClient.Discovery()))

--- a/test/e2e/authorizer/resources.yaml
+++ b/test/e2e/authorizer/resources.yaml
@@ -30,7 +30,7 @@ metadata:
   name: workspace1-editor
 rules:
   - apiGroups: ["tenancy.kcp.dev"]
-    resources: ["workspaces/content"]
+    resources: ["clusterworkspaces/content"]
     resourceNames: ["workspace1"]
     verbs: ["edit", "view"]
 ---
@@ -55,7 +55,7 @@ metadata:
   name: workspace1-viewer
 rules:
   - apiGroups: ["tenancy.kcp.dev"]
-    resources: ["workspaces/content"]
+    resources: ["clusterworkspaces/content"]
     resourceNames: ["workspace1"]
     verbs: ["view"]
 ---

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -138,7 +138,7 @@ func NewOrganizationFixture(t *testing.T, server RunningServer) (orgClusterName 
 		return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to wait for organization workspace %s to become ready", org.Name)
 
-	return helper.EncodeOrganizationAndWorkspace(helper.RootCluster, org.Name)
+	return helper.EncodeOrganizationAndClusterWorkspace(helper.RootCluster, org.Name)
 }
 
 func NewWorkspaceFixture(t *testing.T, server RunningServer, orgClusterName string, workspaceType string) (clusterName string) {
@@ -183,5 +183,5 @@ func NewWorkspaceFixture(t *testing.T, server RunningServer, orgClusterName stri
 		return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to wait for workspace %s:%s to become ready", orgName, ws.Name)
 
-	return helper.EncodeOrganizationAndWorkspace(orgName, ws.Name)
+	return helper.EncodeOrganizationAndClusterWorkspace(orgName, ws.Name)
 }

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -123,7 +123,7 @@ func TestWorkspaceController(t *testing.T) {
 				t.Logf("Expect workspace to be scheduled to the shard with the base URL stored in the credentials")
 				_, orgName, err := helper.ParseLogicalClusterName(workspace.ClusterName)
 				require.NoError(t, err, "failed to parse logical cluster name of workspace")
-				workspaceClusterName := helper.EncodeOrganizationAndWorkspace(orgName, workspace.Name)
+				workspaceClusterName := helper.EncodeOrganizationAndClusterWorkspace(orgName, workspace.Name)
 				err = server.orgExpect(workspace, func(workspace *tenancyv1alpha1.ClusterWorkspace) error {
 					if err := scheduled(bostonShard.Name)(workspace); err != nil {
 						return err


### PR DESCRIPTION
This Pull Request has been opened as a supplementary part of https://github.com/kcp-dev/kcp/issues/606.

When creating clusterroles, kubectl requires a valid resource, hence the change from `workspaces` to `clusterworkspaces` with `content` subresource.

Fixes #606
