### PR TITLE
Add GitVersion in kcp version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY third_party/ third_party/
 
-RUN mkdir bin; CGO_ENABLED=0 go build -o bin ./cmd/...
+RUN mkdir bin; CGO_ENABLED=0 go build -ldflags "-X k8s.io/component-base/version.gitVersion=v1.23.4" -o bin ./cmd/...
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Knative is expecting a real version and not a placeholder to run.

See https://github.com/knative/pkg/blob/80c511aa340f678c7449e1cc360d43b168a140aa/version/version.go#L52

--

The other way to fix it is to remove this check in knative. But I don't think it will be accepted.