### PR TITLE
Move `TEST_ARGS` for `make test-e2e` to after the package list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ E2E_PARALLELISM ?= 1
 .PHONY: test-e2e
 test-e2e: WHAT ?= ./test/e2e...
 test-e2e: install
-	go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(TEST_ARGS) $(WHAT)
+	go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
 
 .PHONY: test
 test: WHAT ?= ./...


### PR DESCRIPTION
This enables the use of `-args [custom args]` and `-- [custom args]`, which have to appear after the package list.
