### PR TITLE
e2e: Switch to DefaultConfig() function from Config("system:admin") 

### DIFF
--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -80,7 +80,7 @@ func TestAPIInheritance(t *testing.T) {
 				ctx = withDeadline
 			}
 
-			cfg, err := server.Config("system:admin")
+			cfg, err := server.DefaultConfig()
 			require.NoError(t, err)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -107,7 +107,7 @@ func TestAuthorizer(t *testing.T) {
 
 	server := f.Servers["main"]
 
-	kcpCfg, err := server.Config("system:admin")
+	kcpCfg, err := server.DefaultConfig()
 	require.NoError(t, err)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(kcpCfg)
 	require.NoError(t, err)

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -54,7 +54,7 @@ func TestCrossLogicalClusterList(t *testing.T) {
 			ctx = withDeadline
 		}
 
-		cfg, err := server.Config("system:admin")
+		cfg, err := server.DefaultConfig()
 		require.NoError(t, err)
 
 		// Until we get rid of the multiClusterClientConfigRoundTripper and replace it with scoping,

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -136,7 +136,7 @@ func NewOrganizationFixture(t *testing.T, server RunningServer) (orgClusterName 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
-	cfg, err := server.Config("system:admin")
+	cfg, err := server.DefaultConfig()
 	require.NoError(t, err, "failed to get kcp server config")
 
 	clusterClient, err := kcpclientset.NewClusterForConfig(cfg)
@@ -181,7 +181,7 @@ func NewWorkspaceFixture(t *testing.T, server RunningServer, orgClusterName stri
 	require.NoErrorf(t, err, "failed to parse organization cluster name %q", orgClusterName)
 	require.Equalf(t, rootOrg, helper.RootCluster, "expected an org cluster name, i.e. with \"%s:\" prefix", helper.RootCluster)
 
-	cfg, err := server.Config("system:admin")
+	cfg, err := server.DefaultConfig()
 	require.NoError(t, err)
 
 	clusterClient, err := kcpclientset.NewClusterForConfig(cfg)

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -425,7 +425,7 @@ func loadKubeConfig(kubeconfigPath string) (clientcmd.ClientConfig, error) {
 		return nil, fmt.Errorf("failed to load admin kubeconfig: %w", err)
 	}
 
-	return clientcmd.NewNonInteractiveClientConfig(*rawConfig, "root", nil, nil), nil
+	return clientcmd.NewNonInteractiveClientConfig(*rawConfig, "system:admin", nil, nil), nil
 }
 
 type unmanagedKCPServer struct {

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -270,8 +270,8 @@ func (c *kcpServer) KubeconfigPath() string {
 	return c.kubeconfigPath
 }
 
-// Config exposes a copy of the client config for this server.
-func (c *kcpServer) Config(context string) (*rest.Config, error) {
+// Config exposes a copy of the neutral client config for this server.
+func (c *kcpServer) DefaultConfig() (*rest.Config, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.cfg == nil {
@@ -282,7 +282,7 @@ func (c *kcpServer) Config(context string) (*rest.Config, error) {
 		return nil, err
 	}
 
-	config := clientcmd.NewNonInteractiveClientConfig(raw, context, nil, nil)
+	config := clientcmd.NewNonInteractiveClientConfig(raw, "system:admin", nil, nil)
 	return config.ClientConfig()
 }
 
@@ -308,7 +308,7 @@ func (c *kcpServer) Ready(keepMonitoring bool) error {
 		// main Ready() body, so we check before continuing that we are live
 		return fmt.Errorf("failed to wait for readiness: %w", c.ctx.Err())
 	}
-	cfg, err := c.Config("system:admin")
+	cfg, err := c.DefaultConfig()
 	if err != nil {
 		return fmt.Errorf("failed to read client configuration: %w", err)
 	}
@@ -464,13 +464,13 @@ func (s *unmanagedKCPServer) RawConfig() (clientcmdapi.Config, error) {
 	return s.cfg.RawConfig()
 }
 
-func (s *unmanagedKCPServer) Config(context string) (*rest.Config, error) {
+func (s *unmanagedKCPServer) DefaultConfig() (*rest.Config, error) {
 	raw, err := s.cfg.RawConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	config := clientcmd.NewNonInteractiveClientConfig(raw, context, nil, nil)
+	config := clientcmd.NewNonInteractiveClientConfig(raw, "system:admin", nil, nil)
 	return config.ClientConfig()
 }
 

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -28,7 +28,7 @@ type RunningServer interface {
 	Name() string
 	KubeconfigPath() string
 	RawConfig() (clientcmdapi.Config, error)
-	Config(context string) (*rest.Config, error)
+	DefaultConfig() (*rest.Config, error)
 	Artifact(t *testing.T, producer func() (runtime.Object, error))
 }
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -165,7 +165,7 @@ func artifact(t *testing.T, server RunningServer, producer func() (runtime.Objec
 		gvk := gvks[0]
 		data.GetObjectKind().SetGroupVersionKind(gvk)
 
-		cfg, err := server.Config("system:admin") // TODO(sttts): this doesn't make sense: discovery from a random workspace
+		cfg, err := server.DefaultConfig() // TODO(sttts): this doesn't make sense: discovery from a random workspace
 		require.NoError(t, err, "could not get config for server %q", server.Name())
 
 		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -178,7 +178,7 @@ func TestClusterController(t *testing.T) {
 			wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
 			// clients
-			sourceConfig, err := source.Config("system:admin")
+			sourceConfig, err := source.DefaultConfig()
 			require.NoError(t, err)
 			sourceKubeClusterClient, err := kubernetesclient.NewClusterForConfig(sourceConfig)
 			require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestClusterController(t *testing.T) {
 			sourceKubeClient := sourceKubeClusterClient.Cluster(wsClusterName)
 			sourceWildwestClient := sourceWildwestClusterClient.Cluster(wsClusterName)
 
-			sinkConfig, err := sink.Config("system:admin")
+			sinkConfig, err := sink.DefaultConfig()
 			require.NoError(t, err)
 			sinkKubeClient, err := kubernetesclient.NewForConfig(sinkConfig)
 			require.NoError(t, err)

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -163,7 +163,7 @@ func TestIngressController(t *testing.T) {
 			clusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
 			// clients
-			sourceConfig, err := source.Config("system:admin")
+			sourceConfig, err := source.DefaultConfig()
 			require.NoError(t, err)
 			sourceKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(sourceConfig)
 			require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestIngressController(t *testing.T) {
 			sourceCrdClient := sourceCrdClusterClient.Cluster(clusterName)
 			sourceKubeClient := sourceKubeClusterClient.Cluster(clusterName)
 
-			sinkConfig, err := sink.Config("system:admin")
+			sinkConfig, err := sink.DefaultConfig()
 			require.NoError(t, err)
 			sinkKubeClient, err := kubernetesclientset.NewForConfig(sinkConfig)
 			require.NoError(t, err)

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -183,7 +183,7 @@ func TestNamespaceScheduler(t *testing.T) {
 			require.Equal(t, 2, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
 
-			cfg, err := server.Config("system:admin")
+			cfg, err := server.DefaultConfig()
 			require.NoError(t, err)
 
 			kubeClient, err := kubernetes.NewClusterForConfig(cfg)

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -191,7 +191,7 @@ func TestWorkspaceController(t *testing.T) {
 			)
 			require.Equal(t, 1, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
-			cfg, err := server.Config("system:admin")
+			cfg, err := server.DefaultConfig()
 			require.NoError(t, err)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -293,7 +293,7 @@ func TestWorkspaceShardController(t *testing.T) {
 			require.Equal(t, 1, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
 
-			cfg, err := server.Config("system:admin")
+			cfg, err := server.DefaultConfig()
 			require.NoError(t, err)
 
 			orgClusterName := framework.NewOrganizationFixture(t, f.Servers[serverName])

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -373,7 +373,7 @@ func TestWorkspacesVirtualWorkspaces(t *testing.T) {
 				virtualWorkspaceExpectations = append(virtualWorkspaceExpectations, expecter)
 			}
 
-			kcpCfg, err := server.Config("system:admin")
+			kcpCfg, err := server.DefaultConfig()
 			require.NoError(t, err)
 
 			kubeClusterClient, err := kubernetes.NewClusterForConfig(kcpCfg)

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -167,7 +167,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
-			cfg, err := server.Config("system:admin")
+			cfg, err := server.DefaultConfig()
 			require.NoError(t, err)
 			kcpClusterClient, err := kcpclientset.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")


### PR DESCRIPTION
Stop requiring tests to supply the correct context (e.g. `Config("system:admin")`) to retrieve server configuration. Switch to using DefaultConfig() which hides that detail.