### PR TITLE
disable etcd fsync on github actions tests, fail fast if kcp binary not found and increase kcp verbosity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,11 @@ on:
 #
 # NOTE!!!
 
+env:
+  # etcd uses fsync by default, disable it for running on github actions to avoid disk contention
+  # xref: https://github.com/kcp-dev/kcp/pull/435/commits/064a517747d69c2cd8f7f8b4a595ad909e595c89
+  UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC: true
+
 jobs:
   boilerplate:
     name: boilerplate

--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -92,7 +92,7 @@ func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBy
 	cfg.ClientTLSInfo.TrustedCAFile = filepath.Join(cfg.Dir, "secrets", "ca", "cert.pem")
 	cfg.ClientTLSInfo.ClientCertAuth = true
 
-	if enableUnsafeMacE2EDisableFsyncHack, _ := strconv.ParseBool(os.Getenv("UNSAFE_MAC_E2E_HACK_DISABLE_ETCD_FSYNC")); enableUnsafeMacE2EDisableFsyncHack {
+	if enableUnsafeEtcdDisableFsyncHack, _ := strconv.ParseBool(os.Getenv("UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC")); enableUnsafeEtcdDisableFsyncHack {
 		cfg.UnsafeNoFsync = true
 	}
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -136,6 +136,11 @@ func WithLogStreaming(o *runOptions) {
 // Run runs the kcp server while the parent context is active. This call is not blocking,
 // callers should ensure that the server is Ready() before using it.
 func (c *kcpServer) Run(parentCtx context.Context, opts ...RunOption) error {
+	path, err := exec.LookPath("kcp")
+	if err != nil {
+		return err
+	}
+
 	runOpts := runOptions{}
 	for _, opt := range opts {
 		opt(&runOpts)
@@ -159,7 +164,7 @@ func (c *kcpServer) Run(parentCtx context.Context, opts ...RunOption) error {
 		<-cleanupCtx.Done()
 	})
 
-	c.t.Logf("running: %v", strings.Join(append([]string{"kcp", "start"}, c.args...), " "))
+	c.t.Logf("running: %v", strings.Join(append([]string{path, "start"}, c.args...), " "))
 
 	// run kcp start in-process for easier debugging
 	if runOpts.runInProcess {

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -108,6 +108,7 @@ func newKcpServer(t *testing.T, cfg KcpConfig, artifactDir, dataDir string) (*kc
 			"--embedded-etcd-peer-port=" + etcdPeerPort,
 			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
 			"--kubeconfig-path=admin.kubeconfig",
+			"--v=7",
 		},
 			cfg.Args...),
 		dataDir:     dataDir,


### PR DESCRIPTION
A single and embedded etcd instance should not need to fsync, this will improve the performance for CI and avoid issues with slow disks