### PR TITLE
e2e: Cleanup context use

### DIFF
--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -68,12 +68,8 @@ func TestAPIInheritance(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
-			if deadline, ok := t.Deadline(); ok {
-				withDeadline, cancel := context.WithDeadline(ctx, deadline)
-				t.Cleanup(cancel)
-				ctx = withDeadline
-			}
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -47,12 +47,8 @@ func TestCrossLogicalClusterList(t *testing.T) {
 	t.Run("Ensure cross logical cluster list works", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
-		if deadline, ok := t.Deadline(); ok {
-			withDeadline, cancel := context.WithDeadline(ctx, deadline)
-			t.Cleanup(cancel)
-			ctx = withDeadline
-		}
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		t.Cleanup(cancelFunc)
 
 		cfg := server.DefaultConfig(t)
 

--- a/test/e2e/fixtures/wildwest/bootstrap.go
+++ b/test/e2e/fixtures/wildwest/bootstrap.go
@@ -33,12 +33,8 @@ import (
 var rawCustomResourceDefinitions embed.FS
 
 func Create(t *testing.T, client apiextensionsv1client.CustomResourceDefinitionInterface, grs ...metav1.GroupResource) {
-	ctx := context.Background()
-	if deadline, ok := t.Deadline(); ok {
-		withDeadline, cancel := context.WithDeadline(ctx, deadline)
-		t.Cleanup(cancel)
-		ctx = withDeadline
-	}
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
 
 	err := configcrds.CreateFromFS(ctx, client, rawCustomResourceDefinitions, grs...)
 	require.NoError(t, err)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -87,9 +87,6 @@ func NewKcpFixture(t *testing.T, cfgs ...KcpConfig) *KcpFixture {
 	artifactDir, dataDir, err := ScratchDirs(t)
 	require.NoError(t, err, "failed to create scratch dirs: %v", err)
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
-
 	// Initialize servers from the provided configuration
 	var servers []*kcpServer
 	f.Servers = map[string]RunningServer{}
@@ -114,7 +111,7 @@ func NewKcpFixture(t *testing.T, cfgs ...KcpConfig) *KcpFixture {
 		if InProcessEnvSet() || cfgs[i].RunInProcess {
 			opts = append(opts, RunInProcess)
 		}
-		err := srv.Run(ctx, opts...)
+		err := srv.Run(opts...)
 		require.NoError(t, err)
 
 		// Wait for the server to become ready

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -280,7 +280,7 @@ type ArtifactFunc func(*testing.T, func() (runtime.Object, error))
 
 // CreateReadyCluster creates a new Cluster resource with the desired name on a
 // given server and sets it to a ready state.
-func CreateReadyCluster(t *testing.T, ctx context.Context, artifacts ArtifactFunc, kcpClient kcpclientset.Interface, pcluster RunningServer) (*workloadv1alpha1.WorkloadCluster, error) {
+func CreateReadyCluster(t *testing.T, artifacts ArtifactFunc, kcpClient kcpclientset.Interface, pcluster RunningServer) (*workloadv1alpha1.WorkloadCluster, error) {
 	config, err := pcluster.RawConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get server config: %w", err)
@@ -297,6 +297,9 @@ func CreateReadyCluster(t *testing.T, ctx context.Context, artifacts ArtifactFun
 	// in resource names, replacing it with '.' results in a name safe
 	// for use as a resource name.
 	safeClusterName := strings.Replace(pcluster.Name(), ":", ".", 1)
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
 
 	cluster, err := kcpClient.WorkloadV1alpha1().WorkloadClusters().Create(ctx, &workloadv1alpha1.WorkloadCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: safeClusterName},

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -147,12 +147,9 @@ func TestClusterController(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
-			if deadline, ok := t.Deadline(); ok {
-				withDeadline, cancel := context.WithDeadline(ctx, deadline)
-				t.Cleanup(cancel)
-				ctx = withDeadline
-			}
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
+
 			t.Log("Creating a workspace")
 			wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
@@ -197,7 +194,7 @@ func TestClusterController(t *testing.T) {
 			t.Log("Installing sink cluster...")
 			start := time.Now()
 			workloadCluster, err := framework.CreateReadyCluster(
-				t, ctx, source.Artifact, sourceKcpClusterClient.Cluster(wsClusterName), sink)
+				t, source.Artifact, sourceKcpClusterClient.Cluster(wsClusterName), sink)
 			require.NoError(t, err)
 			t.Logf("Installed sink cluster after %s", time.Since(start))
 

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -85,7 +85,7 @@ func TestNamespaceScheduler(t *testing.T) {
 				logicalServer := framework.NewFakeWorkloadServer(t, server, server.orgClusterName)
 
 				t.Log("Create a ready cluster")
-				cluster1, err := framework.CreateReadyCluster(t, ctx, server.Artifact, server.kcpClient, logicalServer)
+				cluster1, err := framework.CreateReadyCluster(t, server.Artifact, server.kcpClient, logicalServer)
 				require.NoError(t, err, "failed to create cluster1")
 
 				err = server.expect(namespace, scheduledMatcher(cluster1.Name))
@@ -137,12 +137,9 @@ func TestNamespaceScheduler(t *testing.T) {
 			t.Parallel()
 
 			start := time.Now()
-			ctx := context.Background()
-			if deadline, ok := t.Deadline(); ok {
-				withDeadline, cancel := context.WithDeadline(ctx, deadline)
-				t.Cleanup(cancel)
-				ctx = withDeadline
-			}
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
 
 			cfg := server.DefaultConfig(t)
 

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -184,12 +184,8 @@ func TestWorkspaceController(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
-			if deadline, ok := t.Deadline(); ok {
-				withDeadline, cancel := context.WithDeadline(ctx, deadline)
-				t.Cleanup(cancel)
-				ctx = withDeadline
-			}
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
 
 			server := sharedServer
 			if testCase.destructive {

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -316,12 +316,8 @@ func TestWorkspaceShardController(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
-			if deadline, ok := t.Deadline(); ok {
-				withDeadline, cancel := context.WithDeadline(ctx, deadline)
-				t.Cleanup(cancel)
-				ctx = withDeadline
-			}
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
 
 			server := sharedServer
 			if testCase.destructive {

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -606,12 +606,8 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
-			if deadline, ok := t.Deadline(); ok {
-				withDeadline, cancel := context.WithDeadline(ctx, deadline)
-				t.Cleanup(cancel)
-				ctx = withDeadline
-			}
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -151,19 +151,15 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	if deadline, ok := t.Deadline(); ok {
-		withDeadline, cancel := context.WithDeadline(ctx, deadline)
-		t.Cleanup(cancel)
-		ctx = withDeadline
-	}
-
 	server := framework.SharedKcpServer(t)
 
 	for i := range testCases {
 		testCase := testCases[i]
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
+
+			ctx, cancelFunc := context.WithCancel(context.Background())
+			t.Cleanup(cancelFunc)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 


### PR DESCRIPTION
No need to use deadline contexts, just ensure that contexts for goroutines and blocking functions have their cancel functions registered with `t.Cleanup()`.