### PR TITLE
Proxy to terminate TLS and handle client cert auth

### DIFF
--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	goflags "flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/proxy"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("kcp-front-proxy", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	server := proxy.Server{}
+	cmd := &cobra.Command{
+		Use:   "kcp-front-proxy",
+		Short: "Terminate TLS and handles client cert auth for backend API servers",
+		Long: `kcp-front-proxy is a reverse proxy that accepts client certificates and
+forwards Common Name and Organizations to backend API servers in HTTP headers.
+The proxy terminates TLS and communicates with API servers via mTLS. Traffic is
+routed based on paths.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return server.Serve()
+		},
+	}
+
+	// setup klog
+	fs := goflags.NewFlagSet("klog", goflags.PanicOnError)
+	klog.InitFlags(fs)
+	cmd.PersistentFlags().AddGoFlagSet(fs)
+
+	cmd.PersistentFlags().StringVar(&server.ListenAddress, "listen-address", ":8083", "Address and port for the proxy to listen on")
+	cmd.PersistentFlags().StringVar(&server.ClientCACert, "client-ca-cert", "certs/kcp-client-ca-cert.pem", "CA cert used to validate client certs")
+	cmd.PersistentFlags().StringVar(&server.ServerCertFile, "server-cert-file", "certs/proxy-server-cert.pem", "The proxy's serving cert file")
+	cmd.PersistentFlags().StringVar(&server.ServerKeyFile, "server-key-file", "certs/proxy-server-key.pem", "The proxy's serving private key file")
+	cmd.PersistentFlags().StringVar(&server.MappingFile, "mapping-file", "", "Config file mapping paths to backends")
+
+	if err := cmd.MarkPersistentFlagRequired("mapping-file"); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
+}

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -18,8 +18,6 @@ package main
 
 import (
 	goflags "flag"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -58,10 +56,10 @@ routed based on paths.`,
 	cmd.PersistentFlags().StringVar(&server.MappingFile, "mapping-file", "", "Config file mapping paths to backends")
 
 	if err := cmd.MarkPersistentFlagRequired("mapping-file"); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		klog.Errorf("error: %v\n", err)
 	}
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		klog.Errorf("error: %v\n", err)
 	}
 }

--- a/hack/admin-ext.cnf
+++ b/hack/admin-ext.cnf
@@ -1,0 +1,2 @@
+keyUsage=digitalSignature, keyEncipherment
+extendedKeyUsage=clientAuth

--- a/hack/client-ext.cnf
+++ b/hack/client-ext.cnf
@@ -1,0 +1,2 @@
+keyUsage=digitalSignature
+extendedKeyUsage=clientAuth

--- a/hack/gen-certs.sh
+++ b/hack/gen-certs.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+SOURCE_PATH=$(readlink -f "${BASH_SOURCE[0]}")
+SOURCE_DIR=$(dirname $SOURCE_PATH)
+CERT_DIR=$(readlink -f "${SOURCE_DIR}/../certs")
+
+mkdir -p $CERT_DIR
+rm -f $CERT_DIR/*.pem
+
+# Generate a private key and self-signed cert
+make_ca () {
+    local name=$1
+    local org=${2:-KCP}
+    openssl req -x509 -nodes -newkey rsa:2048 -days 365 -keyout "$CERT_DIR/${name}-key.pem" -out "$CERT_DIR/${name}-cert.pem" -subj "/CN=${name}/O=${org}"
+}
+
+# Generate keys and certs that are signed by a CA
+make_signed_cert () {
+    local name=$1
+    local ca=$2
+    local org=${3:-KCP}
+    local type=${4:-server} # alternative is client
+
+    # Generate the private key and csr
+    openssl req -nodes -newkey rsa:2048 -keyout "$CERT_DIR/${name}-key.pem" -out "$CERT_DIR/${name}-req.pem" -subj "/CN=${name}/O=${org}"
+
+    # Sign the request
+    openssl x509 -req -in "$CERT_DIR/${name}-req.pem" -days 90 -CA "$CERT_DIR/${ca}-cert.pem" -CAkey "$CERT_DIR/${ca}-key.pem" -CAcreateserial -out "$CERT_DIR/${name}-cert.pem" -extfile "$SOURCE_DIR/${type}-ext.cnf"
+}
+
+make_ca "kcp-ca"
+make_ca "kcp-proxy-ca"
+make_ca "kcp-client-ca"
+
+# kcp server identity
+make_signed_cert "kcp-server" "kcp-ca"
+
+# kcp virtual workspace server identity
+make_signed_cert "kcp-vw-server" "kcp-ca"
+
+# kcp proxy identity for its clients
+make_signed_cert "proxy-server" "kcp-proxy-ca"
+
+# kcp proxy's identity to kcp server and virtual workspace server
+make_signed_cert "proxy-client" "kcp-ca" "KCP" "client"
+
+# An admin identity to connect to KCP or the virtual workspace server through the proxy
+make_signed_cert "admin" "kcp-client-ca" "my-admin" "client"
+
+# Delete the requests
+rm -f $CERT_DIR/*-req.pem

--- a/hack/server-ext.cnf
+++ b/hack/server-ext.cnf
@@ -1,0 +1,3 @@
+subjectAltName=DNS:*,IP:192.168.0.16
+keyUsage=digitalSignature, keyEncipherment
+extendedKeyUsage=serverAuth

--- a/pkg/proxy/doc.go
+++ b/pkg/proxy/doc.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package proxy provides a reverse proxy that accepts client certificates and
+// forwards Common Name and Organizations to backend API servers in HTTP
+// headers. The proxy terminates client TLS and communicates with API servers
+// via mTLS. Traffic is routed based on paths.
+//
+// An example configuration:
+//
+//  - path: /services/
+//    backend: https://localhost:6444
+//    backend_server_ca: certs/kcp-ca-cert.pem
+//    proxy_client_cert: certs/proxy-client-cert.pem
+//    proxy_client_key: certs/proxy-client-key.pem
+//  - path: /
+//    backend: https://localhost:6443
+//    backend_server_ca: certs/kcp-ca-cert.pem
+//    proxy_client_cert: certs/proxy-client-cert.pem
+//    proxy_client_key: certs/proxy-client-key.pem
+
+package proxy

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"k8s.io/klog/v2"
+)
+
+// KCPProxy wraps the httputil.ReverseProxy and captures the backend name.
+type KCPProxy struct {
+	proxy   *httputil.ReverseProxy
+	backend string
+}
+
+// NewReverseProxy returns a new reverse proxy where backend is the backend URL to
+// connect to, clientCert is the proxy's client cert to use to connect to it,
+// clientKeyFile is the proxy's client private key file, and caFile is the CA
+// the proxy uses to verify the backend server's cert.
+func NewReverseProxy(backend, clientCert, clientKeyFile, caFile string) (*KCPProxy, error) {
+	target, err := url.Parse(backend)
+	if err != nil {
+		return nil, err
+	}
+
+	caCert, err := ioutil.ReadFile(caFile)
+	if err != nil {
+		return nil, err
+	}
+
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	cert, err := tls.LoadX509KeyPair(clientCert, clientKeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			Certificates: []tls.Certificate{cert},
+			RootCAs:      caCertPool,
+		},
+	}
+
+	return &KCPProxy{proxy: proxy, backend: backend}, nil
+}
+
+// ProxyHandler extracts the CN as a user name and Organizations as groups from
+// the client cert and adds them as HTTP headers to backend request.
+func ProxyHandler(p *KCPProxy, UserHeader, GroupHeader string) func(wr http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if len(r.TLS.PeerCertificates) >= 1 {
+			clientCert := r.TLS.PeerCertificates[0]
+			appendClientCertAuthHeaders(r.Header, clientCert, UserHeader, GroupHeader)
+		}
+		if klog.V(3).Enabled() {
+			klog.Infof("%s %s (%s -> %s) ", r.Method, r.RequestURI, r.RemoteAddr, p.backend)
+		}
+		p.proxy.ServeHTTP(w, r)
+	}
+}
+
+func appendClientCertAuthHeaders(header http.Header, clientCert *x509.Certificate, UserHeader, GroupHeader string) {
+	userName := clientCert.Subject.CommonName
+	header.Set(UserHeader, userName)
+
+	groups := clientCert.Subject.Organization
+	for _, group := range groups {
+		header.Add(GroupHeader, group)
+	}
+}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+// Server holds the configuration for the proxy server
+type Server struct {
+	ListenAddress  string // The hostname:port for the proxy to listen on
+	ClientCACert   string // CA used to validate client certs connecting to the proxy
+	ServerCertFile string // The proxy's server cert
+	ServerKeyFile  string // The proxy's private key file
+	MappingFile    string // A yaml file containing a list of PathMappings
+}
+
+// PathMapping describes how to route traffic from a path to a backend server.
+// Each Path is registered with the DefaultServeMux with a handler that
+// delegates to the specified backend.
+type PathMapping struct {
+	Path            string `json:"path"`
+	Backend         string `json:"backend"`
+	BackendServerCA string `json:"backend_server_ca"`
+	ProxyClientCert string `json:"proxy_client_cert"`
+	ProxyClientKey  string `json:"proxy_client_key"`
+	UserHeader      string `json:"user_header,omitempty"`
+	GroupHeader     string `json:"group_header,omitempty"`
+}
+
+// Serve sets up the proxy and starts serving
+func (s *Server) Serve() error {
+	mappingData, err := ioutil.ReadFile(s.MappingFile)
+	if err != nil {
+		klog.Errorf("Couldn't read mapping file: %s", s.MappingFile)
+		return err
+	}
+
+	var mapping []PathMapping
+	if err = yaml.Unmarshal(mappingData, &mapping); err != nil {
+		return err
+	}
+
+	for _, pathCfg := range mapping {
+		klog.V(2).Infof("Adding %v", pathCfg)
+		proxy, err := NewReverseProxy(pathCfg.Backend, pathCfg.ProxyClientCert, pathCfg.ProxyClientKey, pathCfg.BackendServerCA)
+		if err != nil {
+			return err
+		}
+		userHeader := "X-Remote-User"
+		groupHeader := "X-Remote-Group"
+		if pathCfg.UserHeader != "" {
+			userHeader = pathCfg.UserHeader
+		}
+		if pathCfg.GroupHeader != "" {
+			groupHeader = pathCfg.GroupHeader
+		}
+		http.Handle(pathCfg.Path, http.HandlerFunc(ProxyHandler(proxy, userHeader, groupHeader)))
+	}
+
+	clientCACert, err := ioutil.ReadFile(s.ClientCACert)
+	if err != nil {
+		klog.Errorf("Couldn't read client CA: %s", s.ClientCACert)
+		return err
+	}
+
+	clientCACertPool := x509.NewCertPool()
+	clientCACertPool.AppendCertsFromPEM(clientCACert)
+
+	server := &http.Server{
+		Addr:    s.ListenAddress,
+		Handler: http.DefaultServeMux,
+		TLSConfig: &tls.Config{
+			ClientAuth: tls.VerifyClientCertIfGiven,
+			ClientCAs:  clientCACertPool,
+		},
+	}
+
+	klog.V(1).Infof("Listening on %s", server.Addr)
+	return server.ListenAndServeTLS(s.ServerCertFile, s.ServerKeyFile)
+}


### PR DESCRIPTION
kcp-front-proxy is a reverse proxy that accepts client certificates and forwards Common Name and Organizations to backend API servers in HTTP headers. The proxy terminates TLS and communicates with KCP and virtual workspace servers via mTLS. Traffic is routed based on paths.

The intent is to deploy the proxy in the same pod as KCP and virtual workspace server pairs.

Signed-off-by: Christopher Sams <csams@redhat.com>