### PR TITLE
e2e: Remove unused constant to satisfy linter

### DIFF
--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -45,8 +45,6 @@ import (
 func TestAPIInheritance(t *testing.T) {
 	t.Parallel()
 
-	const serverName = "main"
-
 	type InheritFrom int
 	const (
 		fromRoot InheritFrom = iota


### PR DESCRIPTION
Not sure how #650 merged without the lint check failing :/