### PR TITLE
kubectl-kcp: fix logic to derive the orgClusterName

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -44,7 +44,7 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 	opts := plugin.NewOptions(streams)
 
 	cmd := &cobra.Command{
-		Aliases:          []string{"ws"},
+		Aliases:          []string{"ws", "workspaces"},
 		Use:              "workspace [--workspace-directory-server=] <current|use|list>",
 		Short:            "Manages KCP workspaces",
 		Example:          fmt.Sprintf(workspaceExample, "kubectl kcp"),


### PR DESCRIPTION
`kubectl kcp workspaces` now operates on the following org:

- when in the root, the org is the root
- when in an org, the org is the same org
- when in a non-org, the org is the parent.

Also adding a `workspaces` alias to the subcommand, and removing the confusion `'all'` scope output from current workspace. The latter needs another design session probably, but removing at least removes the confusion for now.

Closes #630.