### PR TITLE
Enable the RootCACertPublisher

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -356,6 +356,10 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := s.installRootCAConfigMapController(ctx, serverChain.GenericControlPlane.GenericAPIServer.LoopbackClientConfig); err != nil {
+		return err
+	}
+
 	enabled := sets.NewString(s.options.Controllers.IndividuallyEnabled...)
 	if len(enabled) > 0 {
 		klog.Infof("Starting controllers individually: %v", enabled)

--- a/test/e2e/authorizer/rootcacertconfigmap_test.go
+++ b/test/e2e/authorizer/rootcacertconfigmap_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+const DefaultRootCACertConfigmap = "kube-root-ca.crt"
+
+func TestRootCACertConfigmap(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	server := framework.SharedKcpServer(t)
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg := server.DefaultConfig(t)
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
+	require.NoError(t, err)
+
+	kubeClient := kubeClusterClient.Cluster(clusterName)
+
+	t.Log("Creating namespace")
+	namespace, err := kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-sa-",
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create namespace")
+
+	t.Log("Waiting for default configmap to be created")
+	require.Eventually(t, func() bool {
+		configmap, err := kubeClient.CoreV1().ConfigMaps(namespace.Name).Get(ctx, DefaultRootCACertConfigmap, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		}
+		require.NoError(t, err, "failed to get configmap")
+
+		if v, ok := configmap.Data["ca.crt"]; ok {
+			if len(v) > 0 {
+				return true
+			}
+		}
+
+		return false
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "default CACert configmap not created")
+}


### PR DESCRIPTION
In order to get the ServiceAccounts working we will need to handle the `kube-root-ca.crt` configmap that contains the k8s CA certificate.

This PR wires the kube `rootCACert` controller into KCP.

Todo
- [x] Merge the PR that makes the RootCACertPublisher multi-workspace aware (https://github.com/kcp-dev/kubernetes/pull/49)
~~- [ ] Bump the Kubernetes version (https://github.com/kcp-dev/kcp/pull/671)~~
