### PR TITLE
Syncer object mutators

### DIFF
--- a/pkg/syncer/mutators/interface.go
+++ b/pkg/syncer/mutators/interface.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mutators
 
 import (

--- a/pkg/syncer/mutators/interface.go
+++ b/pkg/syncer/mutators/interface.go
@@ -4,10 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const originalNameLabel = "syncer.kcp.dev/originalname"
-
 type Mutator interface {
 	ApplySpec(downstreamObj *unstructured.Unstructured) error
 	ApplyStatus(upstreamObj *unstructured.Unstructured) error
-	ApplyDownstreamName(downstreamObj *unstructured.Unstructured) error
 }

--- a/pkg/syncer/mutators/interface.go
+++ b/pkg/syncer/mutators/interface.go
@@ -1,0 +1,13 @@
+package mutators
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const originalNameLabel = "syncer.kcp.dev/originalname"
+
+type Mutator interface {
+	ApplySpec(downstreamObj *unstructured.Unstructured) error
+	ApplyStatus(upstreamObj *unstructured.Unstructured) error
+	ApplyDownstreamName(downstreamObj *unstructured.Unstructured) error
+}

--- a/pkg/syncer/mutators/interface_test.go
+++ b/pkg/syncer/mutators/interface_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestMutators(t *testing.T) {
+	tdm := &TestDeploymentMutator{}
+
+	deployment := appsv1.Deployment{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-deployment",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: new(int32),
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: int64(0),
+		},
+	}
+
+	// Convert to unstructured.
+	syncedObject := &unstructured.Unstructured{}
+	err := convert(&deployment, syncedObject)
+	require.NoError(t, err, "convert failed: %v", err)
+
+	// Apply mutators to the object.
+	err = tdm.ApplySpec(syncedObject)
+	require.NoError(t, err, "ApplySpec() = %v", err)
+
+	err = tdm.ApplyStatus(syncedObject)
+	require.NoError(t, err, "ApplyStatus() = %v", err)
+
+	// Convert the unstructured object back to a deployment.
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(syncedObject.UnstructuredContent(), &deployment)
+	require.NoError(t, err, "FromUnstructured() = %v", err)
+
+	desiredReplicas := int32(10)
+	if *deployment.Spec.Replicas != desiredReplicas {
+		t.Errorf("deployment.Spec.Replicas = %v, want %v", *deployment.Spec.Replicas, desiredReplicas)
+	}
+
+	if deployment.Status.ObservedGeneration != 100 {
+		t.Errorf("deployment.Status.ObservedGeneration = %v, want %v", deployment.Status.ObservedGeneration, 100)
+	}
+}
+
+type TestDeploymentMutator struct {
+}
+
+func (tdm *TestDeploymentMutator) ApplySpec(downstreamObj *unstructured.Unstructured) error {
+	// modify the spec of the downstream object, as it is a simple change, we don't need to
+	// convert it to a deployment object.
+	downstreamObj.Object["spec"] = map[string]interface{}{
+		"replicas": 10,
+	}
+	return nil
+}
+
+func (tdm *TestDeploymentMutator) ApplyStatus(upstreamObj *unstructured.Unstructured) error {
+	// modify the status of the upstream object, as it is a simple change, we don't need to
+	// convert it to a deployment object.
+	upstreamObj.Object["status"] = map[string]interface{}{
+		"observedGeneration": 100,
+	}
+	return nil
+}
+
+func convert(from interface{}, to runtime.Object) error {
+	bs, err := json.Marshal(from)
+	if err != nil {
+		return fmt.Errorf("Marshal() = %w", err)
+	}
+	if err := json.Unmarshal(bs, to); err != nil {
+		return fmt.Errorf("Unmarshal() = %w", err)
+	}
+	return nil
+}

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -173,6 +173,13 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	// Run name transformations on the downstreamObj.
 	transformName(downstreamObj, KcpToPhysicalCluster)
 
+	// Run any transformations on the object before we apply it to the downstream cluster.
+	if mutator, ok := c.mutators[gvr]; ok {
+		if err := mutator.ApplySpec(downstreamObj); err != nil {
+			return err
+		}
+	}
+
 	// TODO: wipe things like finalizers, owner-refs and any other life-cycle fields. The life-cycle
 	//       should exclusively owned by the syncer. Let's not some Kubernetes magic interfere with it.
 

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -83,7 +83,11 @@ func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClust
 	}
 	fromClient := fromClients.Cluster(kcpClusterName)
 	toClient := dynamic.NewForConfigOrDie(to)
-	return New(kcpClusterName, pclusterID, fromDiscovery, fromClient, toClient, KcpToPhysicalCluster, syncedResourceTypes, pclusterID)
+
+	// Register the default mutators
+	mutatorsMap := getDefaultMutators(from, to, kcpClusterName)
+
+	return New(kcpClusterName, pclusterID, fromDiscovery, fromClient, toClient, KcpToPhysicalCluster, syncedResourceTypes, pclusterID, mutatorsMap)
 }
 
 func (c *Controller) deleteFromDownstream(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string) error {

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -62,7 +62,11 @@ func NewStatusSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClu
 		return nil, err
 	}
 	toClient := toClients.Cluster(kcpClusterName)
-	return New(kcpClusterName, pclusterID, discoveryClient, fromClient, toClient, PhysicalClusterToKcp, syncedResourceTypes, pclusterID)
+
+	// Register the default mutators
+	mutatorsMap := getDefaultMutators(from, to, kcpClusterName)
+
+	return New(kcpClusterName, pclusterID, discoveryClient, fromClient, toClient, PhysicalClusterToKcp, syncedResourceTypes, pclusterID, mutatorsMap)
 }
 
 func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamNamespace string, downstreamObj *unstructured.Unstructured) error {

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -84,6 +84,16 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 		return err
 	}
 
+<<<<<<< HEAD
+=======
+	// Run any transformations on the object before we update the status on kcp.
+	if mutator, ok := c.mutators[gvr]; ok {
+		if err := mutator.ApplyStatus(upstreamObj); err != nil {
+			return err
+		}
+	}
+
+>>>>>>> 29bed66 (syncer: remove ApplyDownstreamName)
 	// TODO: verify that we really only update status, and not some non-status fields in ObjectMeta.
 	//       I believe to remember that we had resources where that happened.
 

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -84,8 +84,6 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 		return err
 	}
 
-<<<<<<< HEAD
-=======
 	// Run any transformations on the object before we update the status on kcp.
 	if mutator, ok := c.mutators[gvr]; ok {
 		if err := mutator.ApplyStatus(upstreamObj); err != nil {
@@ -93,7 +91,6 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 		}
 	}
 
->>>>>>> 29bed66 (syncer: remove ApplyDownstreamName)
 	// TODO: verify that we really only update status, and not some non-status fields in ObjectMeta.
 	//       I believe to remember that we had resources where that happened.
 


### PR DESCRIPTION
Adds a simple interface for registering mutators, that based on the object's GVR,  applies changes at different phases of the sync. 


 