### PR TITLE
Fix resource bootstrapping flake

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -108,7 +108,6 @@ func newKcpServer(t *testing.T, cfg KcpConfig, artifactDir, dataDir string) (*kc
 			"--embedded-etcd-peer-port=" + etcdPeerPort,
 			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
 			"--kubeconfig-path=admin.kubeconfig",
-			"--v=7",
 		},
 			cfg.Args...),
 		dataDir:     dataDir,


### PR DESCRIPTION
it never is ready

```
=== CONT  TestWorkspaceShardController/create_a_workspace_shard_referencing_credentials_without_data,_expect_to_see_status_reflect_invalid_credentials
    util.go:84: Saving test artifacts for test "TestWorkspaceShardController/create_a_workspace_shard_referencing_credentials_without_data,_expect_to_see_status_reflect_invalid_credentials" under "/home/aojea/go/src/github.com/kcp-dev/kcp/_output/TestWorkspaceShardController/create_a_workspace_shard_referencing_credentials_without_data,_expect_to_see_status_reflect_invalid_credentials/346689547".
    fixture.go:98: Starting kcp servers...
    kcp.go:168: running: /home/aojea/go/src/github.com/kcp-dev/kcp/bin/kcp start --root-directory /home/aojea/go/src/github.com/kcp-dev/kcp/_output/TestWorkspaceShardController/create_a_workspace_shard_referencing_credentials_without_data,_expect_to_see_status_reflect_invalid_credentials/346689547/data/kcp/main --secure-port=37079 --embedded-etcd-client-port=32871 --embedded-etcd-peer-port=37077 --embedded-etcd-wal-size-bytes=5000 --kubeconfig-path=admin.kubeconfig --v=7
    kcp.go:392: error contacting https://192.168.1.150:37079/readyz: an error on the server ("[+]ping ok\n[+]log ok\n[+]etcd ok\n[+]informer-sync ok\n[+]poststarthook/generic-apiserver-start-informers ok\n[+]poststarthook/priority-and-fairness-config-consumer ok\n[+]poststarthook/priority-and-fairness-filter ok\n[+]poststarthook/start-apiextensions-informers ok\n[+]poststarthook/start-apiextensions-controllers ok\n[+]poststarthook/crd-informer-synced ok\n[+]poststarthook/rbac/bootstrap-roles ok\n[+]poststarthook/priority-and-fairness-config-producer ok\n[+]poststarthook/start-cluster-authentication-info-controller ok\n[-]poststarthook/kcp-install-api-importer-controller failed: reason withheld\n[-]poststarthook/kcp-install-api-resource-controller failed: reason withheld\n[-]poststarthook/kcp-install-workspace-scheduler failed: reason withheld\n[-]poststarthook/kcp-install-namespace-scheduler failed: reason withheld\n[+]poststarthook/kcp-bootstrap-policy ok\n[-]poststarthook/kcp-start-informers failed: reason withheld\n[-]poststarthook/kcp-start-kube-namespace-controller failed: reason withheld\n[+]poststarthook/kcp-start-kube-cluster-role-aggregation-controller ok\n[+]shutdown ok\nreadyz check failed") has prevented the request from succeeding
    kcp.go:392: error contacting https://192.168.1.150:37079/livez: an error on the server ("[+]ping ok\n[+]log ok\n[+]etcd ok\n[+]poststarthook/generic-apiserver-start-informers ok\n[+]poststarthook/priority-and-fairness-config-consumer ok\n[+]poststarthook/priority-and-fairness-filter ok\n[+]poststarthook/start-apiextensions-informers ok\n[+]poststarthook/start-apiextensions-controllers ok\n[+]poststarthook/crd-informer-synced ok\n[+]poststarthook/rbac/bootstrap-roles ok\n[+]poststarthook/priority-and-fairness-config-producer ok\n[+]poststarthook/start-cluster-authentication-info-controller ok\n[-]poststarthook/kcp-install-api-importer-controller failed: reason withheld\n[-]poststarthook/kcp-install-api-resource-controller failed: reason withheld\n[-]poststarthook/kcp-install-workspace-scheduler failed: reason withheld\n[-]poststarthook/kcp-install-namespace-scheduler failed: reason withheld\n[+]poststarthook/kcp-bootstrap-policy ok\n[-]poststarthook/kcp-start-informers failed: reason withheld\n[-]poststarthook/kcp-start-kube-namespace-controller failed: reason withheld\n[+]poststarthook/kcp-start-kube-cluster-role-aggregation-controller ok\nlivez check failed") has prevented the request from succeeding
    fixture.go:122: Fixture setup failed: one or more servers did not become ready
```