### PR TITLE
Better scope management and CLI plugin cleanup

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -45,7 +45,7 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 
 	cmd := &cobra.Command{
 		Aliases:          []string{"ws", "workspaces"},
-		Use:              "workspace [--workspace-directory-server=] <current|use|list>",
+		Use:              "workspace [--scope=<personal|all>] <create|list|use|current|delete>",
 		Short:            "Manages KCP workspaces",
 		Example:          fmt.Sprintf(workspaceExample, "kubectl kcp"),
 		SilenceUsage:     true,
@@ -53,10 +53,6 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 	}
 
 	opts.BindFlags(cmd)
-	kubeconfig, err := plugin.NewKubeConfig(opts)
-	if err != nil {
-		return nil, err
-	}
 
 	useCmd := &cobra.Command{
 		Use:          "use < workspace name | - >",
@@ -64,6 +60,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		Example:      "kcp workspace use my-worspace",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(opts)
+			if err != nil {
+				return err
+			}
 			if len(args) != 1 {
 				return fmt.Errorf("The workspace name (or -) should be given")
 			}
@@ -81,6 +81,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		Example:      "kcp workspace current",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.CurrentWorkspace(c.Context(), opts); err != nil {
 				return err
 			}
@@ -94,6 +98,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		Example:      "kcp workspace list",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.ListWorkspaces(c.Context(), opts); err != nil {
 				return err
 			}
@@ -113,6 +121,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 			if err != nil {
 				return err
 			}
+			kubeconfig, err := plugin.NewKubeConfig(opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.CreateWorkspace(c.Context(), opts, args[0], useAfterCreation); err != nil {
 				return err
 			}
@@ -128,6 +140,10 @@ func NewCmdWorkspace(streams genericclioptions.IOStreams) (*cobra.Command, error
 		SilenceUsage: true,
 		Args:         cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
+			kubeconfig, err := plugin.NewKubeConfig(opts)
+			if err != nil {
+				return err
+			}
 			if err := kubeconfig.DeleteWorkspace(c.Context(), opts, args[0]); err != nil {
 				return err
 			}

--- a/pkg/cliplugins/workspace/plugin/helpers.go
+++ b/pkg/cliplugins/workspace/plugin/helpers.go
@@ -32,7 +32,8 @@ func prioritizedAuthInfo(values ...*api.AuthInfo) *api.AuthInfo {
 			continue
 		}
 		value := *value
-		if value.Token != "" || value.TokenFile != "" || value.Password != "" || value.Username != "" {
+		if value.Token != "" || value.TokenFile != "" || value.Password != "" || value.Username != "" ||
+			value.Exec != nil || value.AuthProvider != nil {
 			return &value
 		}
 	}

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -132,9 +132,6 @@ func (kc *KubeConfig) ensureWorkspaceDirectoryContextExists(options *Options) (*
 			}
 
 			scope := workspaceregistry.PersonalScope
-			if orgClusterName == tenancyhelpers.RootCluster {
-				scope = workspaceregistry.OrganizationScope
-			}
 
 			workspaceDirectoryCluster.Server = fmt.Sprintf("%s://%s:%d%s/%s/%s", currentServerURL.Scheme, currentServerURL.Hostname(), workspacecmd.SecurePortDefault, workspacebuilder.DefaultRootPathPrefix, orgClusterName, scope)
 		}

--- a/pkg/cliplugins/workspace/plugin/options.go
+++ b/pkg/cliplugins/workspace/plugin/options.go
@@ -30,6 +30,8 @@ import (
 type Options struct {
 	KubectlOverrides *clientcmd.ConfigOverrides
 	Scope            string
+	// Temporary, until we have #640 merged, in which case it should be necessary anymore
+	Port int
 	genericclioptions.IOStreams
 }
 
@@ -60,6 +62,8 @@ func (o *Options) BindFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().StringVar(&o.Scope, "scope", "personal", `The 'personal' scope shows only the workspaces you personally own, with the name you gave them at creation.
 	The 'all' scope returns all the workspaces you are allowed to see in the organization, with the disambiguated names they have inside the whole organization.`)
+
+	cmd.PersistentFlags().IntVar(&o.Port, "port", 0, `overrides the port that will be used to point to the workspace directory server. Default port is the port of the currrent kube context server.`)
 }
 
 func (o *Options) Validate() error {

--- a/pkg/cliplugins/workspace/plugin/options.go
+++ b/pkg/cliplugins/workspace/plugin/options.go
@@ -26,8 +26,7 @@ import (
 // Options provides options that will drive the update of the current context
 // on a user's KUBECONFIG based on actions done on KCP workspaces
 type Options struct {
-	WorkspaceDirectoryOverrides *clientcmd.ConfigOverrides
-	KubectlOverrides            *clientcmd.ConfigOverrides
+	KubectlOverrides *clientcmd.ConfigOverrides
 
 	genericclioptions.IOStreams
 }
@@ -35,8 +34,7 @@ type Options struct {
 // NewOptions provides an instance of Options with default values
 func NewOptions(streams genericclioptions.IOStreams) *Options {
 	return &Options{
-		WorkspaceDirectoryOverrides: &clientcmd.ConfigOverrides{},
-		KubectlOverrides:            &clientcmd.ConfigOverrides{},
+		KubectlOverrides: &clientcmd.ConfigOverrides{},
 
 		IOStreams: streams,
 	}
@@ -58,34 +56,4 @@ func (o *Options) BindFlags(cmd *cobra.Command) {
 	kubectlConfigOverrideFlags.Timeout.LongName = ""
 
 	clientcmd.BindOverrideFlags(o.KubectlOverrides, cmd.PersistentFlags(), kubectlConfigOverrideFlags)
-
-	// We also add a subset of kubeconfig-related flags related specifically to
-	// workspace directory (user workspace list). They would override the way the
-	// `workspaces` virtual workspace API server is accessed.
-	descriptionSuffix := " for workspace directory context"
-	workspaceDirectoryConfigOverrideFlags := clientcmd.RecommendedConfigOverrideFlags("workspace-directory-")
-
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.ClientCertificate.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.ClientKey.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.Impersonate.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.ImpersonateGroups.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.Password.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.Token.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.AuthOverrideFlags.Username.Description += descriptionSuffix
-
-	workspaceDirectoryConfigOverrideFlags.ContextOverrideFlags.AuthInfoName.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.ContextOverrideFlags.ClusterName.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.ContextOverrideFlags.Namespace.LongName = ""
-
-	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.APIVersion.LongName = ""
-	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.APIServer.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.CertificateAuthority.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.InsecureSkipTLSVerify.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.ClusterOverrideFlags.TLSServerName.Description += descriptionSuffix
-
-	workspaceDirectoryConfigOverrideFlags.CurrentContext.Description += descriptionSuffix
-	workspaceDirectoryConfigOverrideFlags.CurrentContext.Default = "workspace-directory"
-	workspaceDirectoryConfigOverrideFlags.Timeout.LongName = ""
-
-	clientcmd.BindOverrideFlags(o.WorkspaceDirectoryOverrides, cmd.PersistentFlags(), workspaceDirectoryConfigOverrideFlags)
 }

--- a/pkg/cliplugins/workspace/plugin/options.go
+++ b/pkg/cliplugins/workspace/plugin/options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package plugin
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -27,7 +29,7 @@ import (
 // on a user's KUBECONFIG based on actions done on KCP workspaces
 type Options struct {
 	KubectlOverrides *clientcmd.ConfigOverrides
-
+	Scope            string
 	genericclioptions.IOStreams
 }
 
@@ -35,8 +37,7 @@ type Options struct {
 func NewOptions(streams genericclioptions.IOStreams) *Options {
 	return &Options{
 		KubectlOverrides: &clientcmd.ConfigOverrides{},
-
-		IOStreams: streams,
+		IOStreams:        streams,
 	}
 }
 
@@ -56,4 +57,14 @@ func (o *Options) BindFlags(cmd *cobra.Command) {
 	kubectlConfigOverrideFlags.Timeout.LongName = ""
 
 	clientcmd.BindOverrideFlags(o.KubectlOverrides, cmd.PersistentFlags(), kubectlConfigOverrideFlags)
+
+	cmd.PersistentFlags().StringVar(&o.Scope, "scope", "personal", `The 'personal' scope shows only the workspaces you personally own, with the name you gave them at creation.
+	The 'all' scope returns all the workspaces you are allowed to see in the organization, with the disambiguated names they have inside the whole organization.`)
+}
+
+func (o *Options) Validate() error {
+	if o.Scope != "personal" && o.Scope != "all" {
+		return errors.New("The scope should be either 'personal' (default) or 'all'")
+	}
+	return nil
 }

--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -88,11 +88,6 @@ func BuildVirtualWorkspace(rootPathPrefix string, wildcardsClusterWorkspaces wor
 					return
 				}
 
-				// Do not allow the personal scope when accessing orgs as workspaces in the root logical cluster
-				if scope == virtualworkspacesregistry.PersonalScope && org == helper.RootCluster {
-					return
-				}
-
 				return true, rootPathPrefix + strings.Join(segments[:2], "/"),
 					context.WithValue(
 						context.WithValue(requestContext, virtualworkspacesregistry.WorkspacesScopeKey, scope),


### PR DESCRIPTION
- Cleanup the CLI `workspaces` plugin to:
  - remove completely the `workspace-directory` overrides
  - use the same hostname and port as the current context by default (an alternate port can still be specified through a CLI if necessary, especially if this PR is merged before #640 )  
  - have the scope be specified as a CLI arg
- Fixed an error when getting the `current` workspace on a non-org workspace
- Added (quick and dirty fix) the support of the `exec` user authentication method on the client-side.   