### PR TITLE
WIP: Enable kube service account and token controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ replace (
 	k8s.io/kube-scheduler => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20220303133054-a8ae7563898a
 	k8s.io/kubectl => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20220303133054-a8ae7563898a
 	k8s.io/kubelet => github.com/kcp-dev/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20220303133054-a8ae7563898a
-	k8s.io/kubernetes => github.com/kcp-dev/kubernetes v0.0.0-20220303133054-a8ae7563898a
+	k8s.io/kubernetes => github.com/marun/kubernetes v0.0.0-20220311042418-82170e44a74b
 	k8s.io/legacy-cloud-providers => github.com/kcp-dev/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20220303133054-a8ae7563898a
 	k8s.io/metrics => github.com/kcp-dev/kubernetes/staging/src/k8s.io/metrics v0.0.0-20220303133054-a8ae7563898a
 	k8s.io/mount-utils => github.com/kcp-dev/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20220303133054-a8ae7563898a

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-github.com/kcp-dev/kubernetes v0.0.0-20220303133054-a8ae7563898a h1:iXSiIBQAxoFwWgVqmC3HUUc8il4pvySw/q5cSeLT3zA=
-github.com/kcp-dev/kubernetes v0.0.0-20220303133054-a8ae7563898a/go.mod h1:RpUrWJs5nq1Y6UJy/neYheNDvxH2Z0WYzP3hpAhjQyk=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20220303133054-a8ae7563898a h1:o2EKetxbqzN1Cq2AHBOd1qTDOVadkGoDLMwoA0JXyrw=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20220303133054-a8ae7563898a/go.mod h1:IpPnJRE5t3olVaut5p67N16cZkWwwU5KVFM35xCKyxM=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20220303133054-a8ae7563898a h1:zB/HKfWK0vwoxS61vbcl826Nyrk93PxAobdB3EJ/Od4=
@@ -444,11 +442,13 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-202203031
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-base v0.0.0-20220303133054-a8ae7563898a/go.mod h1:4IWNaSBE0Z02qopZW9+g2IbDAqFG+1alRB847qhaIco=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-helpers v0.0.0-20220303133054-a8ae7563898a h1:aOrIgix1j70UFc1ywVMD4oXqTeHau1qCK3PqdrRzMRw=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/component-helpers v0.0.0-20220303133054-a8ae7563898a/go.mod h1:qV12F849svAujqTL79WonkUFKUM5O4IHzh4W3leBLvY=
+github.com/kcp-dev/kubernetes/staging/src/k8s.io/controller-manager v0.0.0-20220303133054-a8ae7563898a h1:PoGwoIEY+6EYKehWR7H6O6EqCG66739SlFF3SaOrf7k=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/controller-manager v0.0.0-20220303133054-a8ae7563898a/go.mod h1:TdwiR9RY4Gk2+vANIP2oopMFcluM+dXO8P1UiVFXI2s=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/cri-api v0.0.0-20220303133054-a8ae7563898a/go.mod h1:Qls61FIA7GOKCWlPHMEWyz4zm6loDfdUyMdAss5SJe4=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/csi-translation-lib v0.0.0-20220303133054-a8ae7563898a/go.mod h1:WdK+l6XUeToWpqSTtHIg4qv61u5HDougIKQb0mGDlbQ=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20220303133054-a8ae7563898a h1:i3k85UQNn4ttLWjim0veNNaevMZpAd2fq+mcR/d8TNA=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-aggregator v0.0.0-20220303133054-a8ae7563898a/go.mod h1:eg5HTDxp1V0jlu/n7bVmP3UyDQS09fpxt8ytg1nbAsA=
+github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20220303133054-a8ae7563898a h1:ijk3bwXg3QoLBKJMOCHyQm6/loByapXzJeEXr6Gh7E8=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-controller-manager v0.0.0-20220303133054-a8ae7563898a/go.mod h1:U3g0FGkoClR+edPeq1zcTKT3eNK/ZFzZALOcy9VsGMo=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-proxy v0.0.0-20220303133054-a8ae7563898a/go.mod h1:6mEp02ABsuOeeBuUrrol78v9LYysX7Z8CZOMFlkPOOI=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20220303133054-a8ae7563898a/go.mod h1:xZnfOrGTta6rB9IWNKl82yzWKpMSUXVmyGHRilQ9kzM=
@@ -491,6 +491,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/marun/kubernetes v0.0.0-20220311042418-82170e44a74b h1:Ik6dCHp0necgJggbgosvAZbsDf2EWLTA/RHRgHuebxM=
+github.com/marun/kubernetes v0.0.0-20220311042418-82170e44a74b/go.mod h1:RpUrWJs5nq1Y6UJy/neYheNDvxH2Z0WYzP3hpAhjQyk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
@@ -779,6 +781,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1048,7 +1051,9 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
+gonum.org/v1/gonum v0.6.2 h1:4r+yNT0+8SWcOkXP+63H2zQbN+USnC73cjGUxnDF94Q=
 gonum.org/v1/gonum v0.6.2/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=

--- a/pkg/apis/tenancy/v1alpha1/helper/helper.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clusters"
 
 	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
@@ -96,4 +97,11 @@ func ParentClusterName(name string) (string, error) {
 		return RootCluster, nil
 	}
 	return EncodeOrganizationAndClusterWorkspace(RootCluster, parent), nil
+}
+
+func QualifiedObjectName(obj metav1.Object) string {
+	if len(obj.GetNamespace()) > 0 {
+		return fmt.Sprintf("%s|%s/%s", obj.GetClusterName(), obj.GetNamespace(), obj.GetName())
+	}
+	return fmt.Sprintf("%s|%s", obj.GetClusterName(), obj.GetName())
 }

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -19,6 +19,8 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io/ioutil"
 	_ "net/http/pprof"
 	"net/url"
 	"time"
@@ -34,10 +36,14 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 	"k8s.io/kubernetes/pkg/controller/namespace"
+	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
+	"k8s.io/kubernetes/pkg/serviceaccount"
 
 	configcrds "github.com/kcp-dev/kcp/config/crds"
 	configorganization "github.com/kcp-dev/kcp/config/organization"
@@ -116,6 +122,110 @@ func (s *Server) installKubeNamespaceController(ctx context.Context, config *res
 	})
 
 	return nil
+}
+
+func (s *Server) installKubeServiceAccountController(ctx context.Context, config *rest.Config) error {
+	config = rest.AddUserAgent(rest.CopyConfig(config), "service-account-controller")
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c, err := serviceaccountcontroller.NewServiceAccountsController(
+		s.kubeSharedInformerFactory.Core().V1().ServiceAccounts(),
+		s.kubeSharedInformerFactory.Core().V1().Namespaces(),
+		kubeClient,
+		serviceaccountcontroller.DefaultServiceAccountsControllerOptions(),
+	)
+	if err != nil {
+		return fmt.Errorf("error creating ServiceAccount controller: %w", err)
+	}
+
+	s.AddPostStartHook("kcp-start-kube-service-account-controller", func(hookContext genericapiserver.PostStartHookContext) error {
+		if err := s.waitForSync(hookContext.StopCh); err != nil {
+			klog.Errorf("failed to finish post-start-hook kcp-start-kube-service-account-controller: %v", err)
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		go c.Run(ctx, 1)
+		return nil
+	})
+
+	return nil
+}
+
+func (s *Server) installKubeServiceAccountTokenController(ctx context.Context, config *rest.Config) error {
+	saTokenControllerName := "serviceaccount-token"
+
+	config = rest.AddUserAgent(rest.CopyConfig(config), "tokens-controller")
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	serviceAccountKeyFile := s.options.Controllers.SAController.ServiceAccountKeyFile
+	if len(serviceAccountKeyFile) == 0 {
+		klog.Infof("Not running the service account token controller because --service-account-private-key-file is not set")
+		return nil
+	}
+	privateKey, err := keyutil.PrivateKeyFromFile(serviceAccountKeyFile)
+	if err != nil {
+		return fmt.Errorf("error reading key for service account token controller: %w", err)
+	}
+
+	var rootCA []byte
+	rootCAFile := s.options.Controllers.SAController.RootCAFile
+	if rootCAFile != "" {
+		if rootCA, err = readCA(rootCAFile); err != nil {
+			return fmt.Errorf("error parsing root-ca-file at %s: %w", rootCAFile, err)
+		}
+	} else {
+		rootCA = config.CAData
+	}
+
+	tokenGenerator, err := serviceaccount.JWTTokenGenerator(serviceaccount.LegacyIssuer, privateKey)
+	if err != nil {
+		return fmt.Errorf("failed to build token generator: %w", err)
+	}
+	controller, err := serviceaccountcontroller.NewTokensController(
+		s.kubeSharedInformerFactory.Core().V1().ServiceAccounts(),
+		s.kubeSharedInformerFactory.Core().V1().Secrets(),
+		kubeClient,
+		serviceaccountcontroller.TokensControllerOptions{
+			TokenGenerator: tokenGenerator,
+			RootCA:         rootCA,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error creating %s controller: %w", saTokenControllerName, err)
+	}
+
+	s.AddPostStartHook("kcp-start-kube-service-account-token-controller", func(hookContext genericapiserver.PostStartHookContext) error {
+		if err := s.waitForSync(hookContext.StopCh); err != nil {
+			klog.Errorf("failed to finish post-start-hook kcp-start-kube-service-account-token-controller: %v", err)
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		go controller.Run(int(s.options.Controllers.SAController.ConcurrentSATokenSyncs), ctx.Done())
+
+		return nil
+	})
+
+	return nil
+}
+
+func readCA(file string) ([]byte, error) {
+	rootCA, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := certutil.ParseCertsPEM(rootCA); err != nil {
+		return nil, err
+	}
+
+	return rootCA, err
 }
 
 func (s *Server) installNamespaceScheduler(ctx context.Context, workspaceLister tenancylisters.ClusterWorkspaceLister, clientConfig clientcmdapi.Config, server *genericapiserver.GenericAPIServer) error {

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -84,6 +84,15 @@ var (
 		"authentication-admin-token-path", // Path to which the administrative token hash should be written at startup. If this is relative, it is relative to --root-directory.
 		"kubeconfig-path",                 // Path to which the administrative kubeconfig should be written at startup.
 
+		// Kubernetes ServiceAccount Token Controller
+		"concurrent-serviceaccount-token-syncs", // The number of service account token objects that are allowed to sync concurrently. Larger number = more responsive token generation, but more CPU (and network) load
+		"service-account-private-key-file",      // Filename containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.
+		"root-ca-file",                          // If set, this root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.
+
+		// Kubernetes ServiceAccount Authentication flags
+		"service-account-key-file", // File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. The specified file can contain multiple keys, and the flag can be specified multiple times with different files. If unspecified, --tls-private-key-file is used. Must be specified when --service-account-signing-key is provided
+		"service-account-lookup",   // If true, validate ServiceAccount tokens exist in etcd as part of authentication.
+
 		// logs flags
 		"logging-format",      // Sets the log format. Permitted formats: "text".
 		"log-flush-frequency", // Maximum number of seconds between log flushes
@@ -215,5 +224,14 @@ var (
 
 		// API enablement flags
 		"runtime-config", // A set of key=value pairs that enable or disable built-in APIs. Supported options are:
+
+		// Kubernetes ServiceAccount Authentication flags
+		"service-account-api-audiences",           // Identifiers of the API. The service account token authenticator will validate that tokens used against the API are bound to at least one of these audiences.
+		"service-account-extend-token-expiration", // Turns on projected service account expiration extension during token generation, which helps safe transition from legacy token to bound service account token feature. If this flag is enabled, admission injected tokens would be extended up to 1 year to prevent unexpected failure during transition, ignoring value of service-account-max-token-expiration.
+		"service-account-issuer",                  // Identifier of the service account token issuer. The issuer will assert this identifier in "iss" claim of issued tokens. This value is a string or URI. If this option is not a valid URI per the OpenID Discovery 1.0 spec, the ServiceAccountIssuerDiscovery feature will remain disabled, even if the feature gate is set to true. It is highly recommended that this value comply with the OpenID spec: https://openid.net/specs/openid-connect-discovery-1_0.html. In practice, this means that service-account-issuer must be an https URL. It is also highly recommended that this URL be capable of serving OpenID discovery documents at {service-account-issuer}/.well-known/openid-configuration. When this flag is specified multiple times, the first is used to generate tokens and all are used to determine which issuers are accepted.
+		"service-account-jwks-uri",                // Overrides the URI for the JSON Web Key Set in the discovery doc served at /.well-known/openid-configuration. This flag is useful if the discovery docand key set are served to relying parties from a URL other than the API server's external (as auto-detected or overridden with external-hostname).
+		"service-account-key-file",                // File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. The specified file can contain multiple keys, and the flag can be specified multiple times with different files. If unspecified, --tls-private-key-file is used. Must be specified when --service-account-signing-key is provided
+		"service-account-lookup",                  // If true, validate ServiceAccount tokens exist in etcd as part of authentication.
+		"service-account-max-token-expiration",    // The maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.
 	)
 )

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -100,7 +100,7 @@ func NewOptions() *Options {
 		WithClientCert().
 		WithOIDC().
 		WithRequestHeader().
-		// WithServiceAccounts().
+		WithServiceAccounts().
 		WithTokenFile()
 	//WithWebHook()
 	o.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = []string{"embedded"}
@@ -215,6 +215,13 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 		// in Complete and not in NewOptions.
 		o.GenericControlPlane.SecureServing.Required = false
 	}
+
+	if len(o.GenericControlPlane.Authentication.ServiceAccounts.KeyFiles) == 0 {
+		o.GenericControlPlane.Authentication.ServiceAccounts.KeyFiles = []string{o.Controllers.SAController.ServiceAccountKeyFile}
+	}
+
+	// // TODO(ncdc): make this configurable
+	o.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{"https://kubernetes.default.svc.cluster.local"}
 
 	return &CompletedOptions{
 		completedOptions: &completedOptions{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -347,6 +347,14 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
+	if err := s.installKubeServiceAccountController(ctx, serverChain.GenericControlPlane.GenericAPIServer.LoopbackClientConfig); err != nil {
+		return err
+	}
+
+	if err := s.installKubeServiceAccountTokenController(ctx, serverChain.GenericControlPlane.GenericAPIServer.LoopbackClientConfig); err != nil {
+		return err
+	}
+
 	enabled := sets.NewString(s.options.Controllers.IndividuallyEnabled...)
 	if len(enabled) > 0 {
 		klog.Infof("Starting controllers individually: %v", enabled)

--- a/test/e2e/conformance/token_controller_test.go
+++ b/test/e2e/conformance/token_controller_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestServiceAccountTokenController(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	server := framework.SharedKcpServer(t)
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg, err := server.DefaultConfig()
+	require.NoError(t, err)
+
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
+	require.NoError(t, err)
+
+	orgKubeClient := kubeClusterClient.Cluster(clusterName)
+
+	namespace, err := orgKubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-sa-",
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err, "failed to create namespace")
+
+	require.Eventually(t, func() bool {
+		_, err := orgKubeClient.CoreV1().ServiceAccounts(namespace.Name).Get(ctx, "default", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false
+		} else if err != nil {
+			t.Fatalf("unexpected error retrieving service account: %v", err)
+		}
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "\"default\" service account not created in namespace %s",
+		helper.QualifiedObjectName(namespace),
+	)
+
+	var tokenSecret corev1.Secret
+	require.Eventually(t, func() bool {
+		secrets, err := orgKubeClient.CoreV1().Secrets(namespace.Name).List(ctx, metav1.ListOptions{})
+		require.NoError(t, err, "failed to list secrets")
+
+		for _, secret := range secrets.Items {
+			if secret.Annotations[corev1.ServiceAccountNameKey] == "default" {
+				tokenSecret = secret
+				return true
+			}
+		}
+		return false
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "token secret for default service account not created")
+
+	t.Logf("Token secret: %v", tokenSecret)
+
+	// Use the token to access the secret
+	// Create a namespace with the same name in a different workspace
+	// Verify that it is not possible to read the namespace in the other workspace
+}

--- a/test/e2e/framework/rsa.go
+++ b/test/e2e/framework/rsa.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+
+	"k8s.io/client-go/util/keyutil"
+)
+
+// GenerateRSAPrivateKey creates a new RSA keypair and returns the
+// private key as PEM-encoded bytes.
+func GenerateRSAPrivateKey() ([]byte, error) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, err
+	}
+	privKeyPEM, err := keyutil.MarshalPrivateKeyToPEM(rsaKey)
+	if err != nil {
+		return nil, err
+	}
+	return privKeyPEM, nil
+}


### PR DESCRIPTION
Depends on https://github.com/kcp-dev/kubernetes/pull/50. Dependency is on the personal branch for that PR until it merges.

- [ ] Check that a service account token can be used to retrieve its containing secret (token is valid, api server can verify)
- [ ] Check that a service account token can not be used to retrieve a secret in an identically named namespace in a different workspace (a token cannot be used across workspaces)