### PR TITLE
Adds serviceaccounts,secrets and configmaps GVRs to the default Syncer sync list

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -176,7 +176,9 @@ func getAllGVRs(discoveryClient discovery.DiscoveryInterface, resourcesToSync ..
 			return nil, err
 		}
 	}
-	gvrstrs := []string{"namespaces.v1."} // A syncer should always watch namespaces
+	// TODO(jmprusi): Added ServiceAccounts, Configmaps and Secrets to the default syncing, but we should figure out
+	//                a way to avoid doing that: https://github.com/kcp-dev/kcp/issues/727
+	gvrstrs := []string{"namespaces.v1.", "serviceaccounts.v1.", "configmaps.v1.", "secrets.v1."} // A syncer should always watch namespaces, serviceaccounts, secrets and configmaps.
 	for _, r := range rs {
 		// v1 -> v1.
 		// apps/v1 -> v1.apps


### PR DESCRIPTION
This PR adds to the default Sync list of the syncer, the GVRs of:

* Configmap
* ServiceAccounts
* Secrets

This means, that even if not specified via API imports, or "resources-to-sync" args, the syncer will sync those resources to the workloadclusters.

Pushing the discussion on how to improve the default syncing into Prototype4: https://github.com/kcp-dev/kcp/issues/727

This is related to: https://github.com/kcp-dev/kcp/issues/280