### PR TITLE
kubectl-kcp: point to authInfo config instead of clone

### DIFF
--- a/pkg/cliplugins/workspace/plugin/helpers.go
+++ b/pkg/cliplugins/workspace/plugin/helpers.go
@@ -25,19 +25,21 @@ import (
 )
 
 // prioritizedAuthInfo returns the first non-nil or non-empty AuthInfo it finds
-// from the ordred list passed in argument
-func prioritizedAuthInfo(values ...*api.AuthInfo) *api.AuthInfo {
-	for _, value := range values {
+// from the ordred list passed in argument.
+// The first return paremeter is the index at which the returned AuthInfo was found.
+// -1 means none was found.
+func prioritizedAuthInfo(values ...*api.AuthInfo) (int, *api.AuthInfo) {
+	for i, value := range values {
 		if value == nil {
 			continue
 		}
 		value := *value
 		if value.Token != "" || value.TokenFile != "" || value.Password != "" || value.Username != "" ||
 			value.Exec != nil || value.AuthProvider != nil {
-			return &value
+			return i, &value
 		}
 	}
-	return api.NewAuthInfo()
+	return -1, api.NewAuthInfo()
 }
 
 // extractScopeAndName extracts the scope and workspace name from


### PR DESCRIPTION
Currently when running e.g. `kubectl kcp workspaces use my-workspace`, the context created in the user's kubeconfig will point to a new user that was cloned from the previously-active context.  This can fill a user's kubeconfig with lots of duplicate users if there are lots of workspace switches.  It also allows the authInfo to drift from the original context and the workspace-specific context, whereas they very likely need to be in sync.

This change will make the new context point to the already-existing authInfo instead of making a copy of it.

Co-authored-by: Chris Sams <csams@redhat.com>

Signed-off-by: Kyle Lape <klape@redhat.com>