### PR TITLE
Rename Github Actions step to avoid conflict

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -52,13 +52,13 @@ jobs:
           chmod u+x ./kustomize
 
       - name: Get the external hostname
-        id: vars
+        id: external_hostname
         run: echo "::set-output name=external_hostname::$(kubectl get route kcp -o jsonpath='{.spec.host}')"
 
       - name: Deploy new image to CI
         id: deploy-to-ci
         run: |-
           cd manifest
-          ../kustomize edit add patch --patch='[{"op": "replace", "path": "/spec/template/spec/containers/0/env", "value": [{"name": "EXTERNAL_HOSTNAME", "value": "${{ steps.vars.outputs.external_hostname }}"}]}]' --group apps --kind Deployment --name kcp --version v1
+          ../kustomize edit add patch --patch='[{"op": "replace", "path": "/spec/template/spec/containers/0/env", "value": [{"name": "EXTERNAL_HOSTNAME", "value": "${{ steps.external_hostname.outputs.external_hostname }}"}]}]' --group apps --kind Deployment --name kcp --version v1
           ../kustomize edit set image ghcr.io/kcp-dev/kcp=ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}
           ../kustomize build . | ../kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} apply -f -


### PR DESCRIPTION
Fixes error:
The identifier 'vars' may not be used more than once within the same scope.

Signed-off-by: Kyle Lape <klape@redhat.com>