### PR TITLE
e2e: Pass `t` to DefaultConfig() to allow failing on error

### DIFF
--- a/test/e2e/api_inheritance/api_inheritance_test.go
+++ b/test/e2e/api_inheritance/api_inheritance_test.go
@@ -78,9 +78,6 @@ func TestAPIInheritance(t *testing.T) {
 				ctx = withDeadline
 			}
 
-			cfg, err := server.DefaultConfig()
-			require.NoError(t, err)
-
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
 			// These are the cluster name paths (i.e. /clusters/$org:$workspace) for our two workspaces.
@@ -91,6 +88,7 @@ func TestAPIInheritance(t *testing.T) {
 				targetWorkspaceClusterName = org + ":target"
 			)
 
+			cfg := server.DefaultConfig(t)
 			apiExtensionsClients, err := apiextensionsclient.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct apiextensions client for server")
 			kcpClients, err := clientset.NewClusterForConfig(cfg)

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -107,8 +107,7 @@ func TestAuthorizer(t *testing.T) {
 
 	server := f.Servers["main"]
 
-	kcpCfg, err := server.DefaultConfig()
-	require.NoError(t, err)
+	kcpCfg := server.DefaultConfig(t)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(kcpCfg)
 	require.NoError(t, err)
 	kcpClusterClient, err := kcp.NewClusterForConfig(kcpCfg)

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -54,8 +54,7 @@ func TestCrossLogicalClusterList(t *testing.T) {
 			ctx = withDeadline
 		}
 
-		cfg, err := server.DefaultConfig()
-		require.NoError(t, err)
+		cfg := server.DefaultConfig(t)
 
 		// Until we get rid of the multiClusterClientConfigRoundTripper and replace it with scoping,
 		// make sure we don't break cross-logical cluster client listing.

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -136,9 +136,7 @@ func NewOrganizationFixture(t *testing.T, server RunningServer) (orgClusterName 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
-	cfg, err := server.DefaultConfig()
-	require.NoError(t, err, "failed to get kcp server config")
-
+	cfg := server.DefaultConfig(t)
 	clusterClient, err := kcpclientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to create kcp cluster client")
 
@@ -181,9 +179,7 @@ func NewWorkspaceFixture(t *testing.T, server RunningServer, orgClusterName stri
 	require.NoErrorf(t, err, "failed to parse organization cluster name %q", orgClusterName)
 	require.Equalf(t, rootOrg, helper.RootCluster, "expected an org cluster name, i.e. with \"%s:\" prefix", helper.RootCluster)
 
-	cfg, err := server.DefaultConfig()
-	require.NoError(t, err)
-
+	cfg := server.DefaultConfig(t)
 	clusterClient, err := kcpclientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct client for server")
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/egymgmbh/go-prefix-writer/prefixer"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	apierrors "k8s.io/apimachinery/pkg/util/errors"
@@ -277,7 +278,7 @@ func (c *kcpServer) KubeconfigPath() string {
 }
 
 // Config exposes a copy of the neutral client config for this server.
-func (c *kcpServer) DefaultConfig() (*rest.Config, error) {
+func (c *kcpServer) defaultConfig() (*rest.Config, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if c.cfg == nil {
@@ -290,6 +291,12 @@ func (c *kcpServer) DefaultConfig() (*rest.Config, error) {
 
 	config := clientcmd.NewNonInteractiveClientConfig(raw, "system:admin", nil, nil)
 	return config.ClientConfig()
+}
+
+func (c *kcpServer) DefaultConfig(t *testing.T) *rest.Config {
+	cfg, err := c.defaultConfig()
+	require.NoError(t, err)
+	return cfg
 }
 
 // RawConfig exposes a copy of the client config for this server.
@@ -314,7 +321,7 @@ func (c *kcpServer) Ready(keepMonitoring bool) error {
 		// main Ready() body, so we check before continuing that we are live
 		return fmt.Errorf("failed to wait for readiness: %w", c.ctx.Err())
 	}
-	cfg, err := c.DefaultConfig()
+	cfg, err := c.defaultConfig()
 	if err != nil {
 		return fmt.Errorf("failed to read client configuration: %w", err)
 	}
@@ -470,14 +477,14 @@ func (s *unmanagedKCPServer) RawConfig() (clientcmdapi.Config, error) {
 	return s.cfg.RawConfig()
 }
 
-func (s *unmanagedKCPServer) DefaultConfig() (*rest.Config, error) {
+func (s *unmanagedKCPServer) DefaultConfig(t *testing.T) *rest.Config {
 	raw, err := s.cfg.RawConfig()
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	config := clientcmd.NewNonInteractiveClientConfig(raw, "system:admin", nil, nil)
-	return config.ClientConfig()
+	defaultConfig, err := config.ClientConfig()
+	require.NoError(t, err)
+	return defaultConfig
 }
 
 func (s *unmanagedKCPServer) Artifact(t *testing.T, producer func() (runtime.Object, error)) {

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -28,7 +28,7 @@ type RunningServer interface {
 	Name() string
 	KubeconfigPath() string
 	RawConfig() (clientcmdapi.Config, error)
-	DefaultConfig() (*rest.Config, error)
+	DefaultConfig(t *testing.T) *rest.Config
 	Artifact(t *testing.T, producer func() (runtime.Object, error))
 }
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -165,9 +165,7 @@ func artifact(t *testing.T, server RunningServer, producer func() (runtime.Objec
 		gvk := gvks[0]
 		data.GetObjectKind().SetGroupVersionKind(gvk)
 
-		cfg, err := server.DefaultConfig() // TODO(sttts): this doesn't make sense: discovery from a random workspace
-		require.NoError(t, err, "could not get config for server %q", server.Name())
-
+		cfg := server.DefaultConfig(t) // TODO(sttts): this doesn't make sense: discovery from a random workspace
 		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 		require.NoError(t, err, "could not get discovery client for server")
 

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -178,8 +178,7 @@ func TestClusterController(t *testing.T) {
 			wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
 			// clients
-			sourceConfig, err := source.DefaultConfig()
-			require.NoError(t, err)
+			sourceConfig := source.DefaultConfig(t)
 			sourceKubeClusterClient, err := kubernetesclient.NewClusterForConfig(sourceConfig)
 			require.NoError(t, err)
 			sourceCrdClusterClient, err := apiextensionsclientset.NewClusterForConfig(sourceConfig)
@@ -193,8 +192,7 @@ func TestClusterController(t *testing.T) {
 			sourceKubeClient := sourceKubeClusterClient.Cluster(wsClusterName)
 			sourceWildwestClient := sourceWildwestClusterClient.Cluster(wsClusterName)
 
-			sinkConfig, err := sink.DefaultConfig()
-			require.NoError(t, err)
+			sinkConfig := sink.DefaultConfig(t)
 			sinkKubeClient, err := kubernetesclient.NewForConfig(sinkConfig)
 			require.NoError(t, err)
 			sinkCrdClient, err := apiextensionsclientset.NewForConfig(sinkConfig)

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -163,8 +163,7 @@ func TestIngressController(t *testing.T) {
 			clusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
 			// clients
-			sourceConfig, err := source.DefaultConfig()
-			require.NoError(t, err)
+			sourceConfig := source.DefaultConfig(t)
 			sourceKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(sourceConfig)
 			require.NoError(t, err)
 			sourceCrdClusterClient, err := apiextensionsclientset.NewClusterForConfig(sourceConfig)
@@ -175,8 +174,7 @@ func TestIngressController(t *testing.T) {
 			sourceCrdClient := sourceCrdClusterClient.Cluster(clusterName)
 			sourceKubeClient := sourceKubeClusterClient.Cluster(clusterName)
 
-			sinkConfig, err := sink.DefaultConfig()
-			require.NoError(t, err)
+			sinkConfig := sink.DefaultConfig(t)
 			sinkKubeClient, err := kubernetesclientset.NewForConfig(sinkConfig)
 			require.NoError(t, err)
 			sinkCrdClient, err := apiextensionsclientset.NewForConfig(sinkConfig)

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -183,8 +183,7 @@ func TestNamespaceScheduler(t *testing.T) {
 			require.Equal(t, 2, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
 
-			cfg, err := server.DefaultConfig()
-			require.NoError(t, err)
+			cfg := server.DefaultConfig(t)
 
 			kubeClient, err := kubernetes.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -191,8 +191,7 @@ func TestWorkspaceController(t *testing.T) {
 			)
 			require.Equal(t, 1, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
-			cfg, err := server.DefaultConfig()
-			require.NoError(t, err)
+			cfg := server.DefaultConfig(t)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -293,8 +293,7 @@ func TestWorkspaceShardController(t *testing.T) {
 			require.Equal(t, 1, len(f.Servers), "incorrect number of servers")
 			server := f.Servers[serverName]
 
-			cfg, err := server.DefaultConfig()
-			require.NoError(t, err)
+			cfg := server.DefaultConfig(t)
 
 			orgClusterName := framework.NewOrganizationFixture(t, f.Servers[serverName])
 

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -507,8 +507,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 			}
 
 			// create non-virtual clients
-			kcpConfig, err := server.DefaultConfig()
-			require.NoError(t, err)
+			kcpConfig := server.DefaultConfig(t)
 			kubeClusterClient, err := kubernetes.NewClusterForConfig(kcpConfig)
 			require.NoError(t, err, "failed to construct client for server")
 			kcpClusterClient, err := kcpclientset.NewClusterForConfig(kcpConfig)

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -167,8 +167,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
-			cfg, err := server.DefaultConfig()
-			require.NoError(t, err)
+			cfg := server.DefaultConfig(t)
 			kcpClusterClient, err := kcpclientset.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")
 			orgKcpClient := kcpClusterClient.Cluster(orgClusterName)


### PR DESCRIPTION
vs having to check the return value everywhere