### PR TITLE
Make namespace scheduling opt-in via label on containing workspace

### DIFF
--- a/config/organization/clusterworkspacetype-universal.yaml
+++ b/config/organization/clusterworkspacetype-universal.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   initializers:
   - initializers.tenancy.kcp.dev/universal
+  additionalWorkspaceLabels:
+    workloads.kcp.dev/schedulable: "true"

--- a/pkg/apis/tenancy/v1alpha1/helper/helper.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper.go
@@ -60,7 +60,7 @@ func EncodeOrganizationAndClusterWorkspace(organization, workspace string) strin
 // <OrganizationCluster>#$#<ws>. Otherwise, the key will be of the format
 // <OrganizationClsuter>_<org>#$#<ws>.
 func WorkspaceKey(org, ws string) string {
-	if org == RootCluster || strings.HasPrefix(org, LocalSystemClusterPrefix) {
+	if org == RootCluster || (org == "" && ws == RootCluster) || strings.HasPrefix(org, LocalSystemClusterPrefix) {
 		return clusters.ToClusterAwareKey(org, ws)
 	}
 

--- a/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
@@ -144,6 +144,18 @@ func TestWorkspaceKey(t *testing.T) {
 		want string
 	}{
 		{
+			name: "root ws",
+			org:  "",
+			ws:   RootCluster,
+			want: RootCluster,
+		},
+		{
+			name: "fake root ws",
+			org:  "myorg",
+			ws:   RootCluster,
+			want: "root:myorg#$#root",
+		},
+		{
 			name: "org ws",
 			org:  RootCluster,
 			ws:   "myws",

--- a/pkg/reconciler/namespace/scheduler_test.go
+++ b/pkg/reconciler/namespace/scheduler_test.go
@@ -147,6 +147,7 @@ func TestAssignCluster(t *testing.T) {
 			scheduler := newTestScheduler(clusters)
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default",
 					ClusterName: testLclusterName,
 					Labels:      testCase.labels,
 				},

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -292,7 +292,7 @@ func (s *Server) installNamespaceScheduler(ctx context.Context, config *rest.Con
 		dynamicClient,
 		kubeClient.DiscoveryClient,
 		kubeClient,
-		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
+		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
 		s.kcpSharedInformerFactory.Workload().V1alpha1().WorkloadClusters(),
 		s.kcpSharedInformerFactory.Workload().V1alpha1().WorkloadClusters().Lister(),
 		s.kubeSharedInformerFactory.Core().V1().Namespaces(),


### PR DESCRIPTION
Not all use of kcp will involve namespace scheduling or synchronization with a workload cluster.

One such use case involves using a logical cluster (workspace) as a workload cluster for the purposes of syncer testing. Were namespace scheduling to remain enabled for such a workspace, the cluster label of namespaces created by the syncer in that workspace would be removed (due to the cluster not existing in the workspace). Since the syncer's downstream informer filters on the presence of the label in question, the syncer would not be able to see any resources for which the namespace scheduler had removed the label. Disabling the namespace scheduler for the workspace ensures the contents of the workspace more precisely reflect how a kubernetes cluster would behave.

Unlike disabling scheduling for a namespace - where status is still set by the scheduler on the namespace - the goal here is disabling the scheduler entirely. To that end, only log messages will indicate that scheduling is disabled for the workspace.
