### PR TITLE
Add CICD options to kubectl for external hostname discovery

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Get the external hostname
         id: external_hostname
-        run: echo "::set-output name=external_hostname::$(kubectl get route kcp -o jsonpath='{.spec.host}')"
+        run: echo "::set-output name=external_hostname::$(../kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} get route kcp -o jsonpath='{.spec.host}')"
 
       - name: Deploy new image to CI
         id: deploy-to-ci


### PR DESCRIPTION
Signed-off-by: Christopher Sams <csams@redhat.com>

## Summary
The action step that discovers the deployment's external hostname was missing some kubectl options.