### PR TITLE
virtual: authorize clusterworkspacetype use

### DIFF
--- a/pkg/admission/apibinding/apibinding_admission.go
+++ b/pkg/admission/apibinding/apibinding_admission.go
@@ -32,9 +32,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	kcpadmissionhelpers "github.com/kcp-dev/kcp/pkg/admission/helpers"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
 )
 
 const (
@@ -46,7 +46,7 @@ func Register(plugins *admission.Plugins) {
 		func(_ io.Reader) (admission.Interface, error) {
 			return &apiBindingAdmission{
 				Handler:          admission.NewHandler(admission.Create, admission.Update),
-				createAuthorizer: kcpadmissionhelpers.NewAdmissionAuthorizer,
+				createAuthorizer: delegated.NewDelegatedAuthorizer,
 			}, nil
 		})
 }
@@ -55,7 +55,7 @@ type apiBindingAdmission struct {
 	*admission.Handler
 	kubeClusterClient *kubernetes.Cluster
 
-	createAuthorizer kcpadmissionhelpers.AdmissionAuthorizerFactory
+	createAuthorizer delegated.DelegatedAuthorizerFactory
 }
 
 // Ensure that the required admission interfaces are implemented.

--- a/pkg/admission/apibinding/apibinding_admission_test.go
+++ b/pkg/admission/apibinding/apibinding_admission_test.go
@@ -245,7 +245,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			o := &apiBindingAdmission{
 				Handler: admission.NewHandler(admission.Create, admission.Update),
-				createAuthorizer: func(clusterName string, client *kubernetes.Cluster) (authorizer.Authorizer, error) {
+				createAuthorizer: func(clusterName string, client kubernetes.ClusterInterface) (authorizer.Authorizer, error) {
 					return &fakeAuthorizer{
 						tc.authzDecision,
 						tc.authzError,

--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -571,7 +571,7 @@ func TestValidate(t *testing.T) {
 			o := &clusterWorkspaceTypeExists{
 				Handler:    admission.NewHandler(admission.Create, admission.Update),
 				typeLister: fakeClusterWorkspaceTypeLister(tt.types),
-				createAuthorizer: func(clusterName string, client *kubernetes.Cluster) (authorizer.Authorizer, error) {
+				createAuthorizer: func(clusterName string, client kubernetes.ClusterInterface) (authorizer.Authorizer, error) {
 					return &fakeAuthorizer{
 						tt.authzDecision,
 						tt.authzError,

--- a/pkg/authorization/delegated/authorizer.go
+++ b/pkg/authorization/delegated/authorizer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package helpers
+package delegated
 
 import (
 	"time"
@@ -28,11 +28,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type AdmissionAuthorizerFactory func(clusterName string, client *kubeclient.Cluster) (authorizer.Authorizer, error)
+type DelegatedAuthorizerFactory func(clusterName string, client kubeclient.ClusterInterface) (authorizer.Authorizer, error)
 
-// NewAdmissionAuthorizer returns a new authorizer for use in admission plugins that delegates
+// NewDelegatedAuthorizer returns a new authorizer for use in e.g. admission plugins that delegates
 // to the kube API server via SubjectAccessReview.
-func NewAdmissionAuthorizer(clusterName string, client *kubeclient.Cluster) (authorizer.Authorizer, error) {
+func NewDelegatedAuthorizer(clusterName string, client kubeclient.ClusterInterface) (authorizer.Authorizer, error) {
 	delegatingAuthorizerConfig := &authorizerfactory.DelegatingAuthorizerConfig{
 		SubjectAccessReviewClient: &clusterAwareAuthorizationV1Client{
 			AuthorizationV1Interface: client.Cluster(clusterName).AuthorizationV1(),

--- a/pkg/virtual/workspaces/options/options.go
+++ b/pkg/virtual/workspaces/options/options.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
@@ -60,11 +59,8 @@ func (o *Workspaces) NewVirtualWorkspaces(
 	wildcardKubeInformers informers.SharedInformerFactory,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
 ) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
-	rootKubeClient := kubeClusterClient.Cluster(helper.RootCluster)
-	rootKcpClient := kcpClusterClient.Cluster(helper.RootCluster)
-
 	virtualWorkspaces := []framework.VirtualWorkspace{
-		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), rootKcpClient, rootKubeClient, kcpClusterClient, kubeClusterClient),
+		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient),
 	}
 	return nil, virtualWorkspaces, nil
 }

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -32,8 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -191,6 +194,9 @@ func applyTest(t *testing.T, test TestDescription) {
 		crbInformer:           crbInformer,
 		clusterWorkspaceCache: nil,
 		rootReviewer:          test.rootReviewer,
+		delegatedAuthz: func(clusterName string, client kubernetes.ClusterInterface) (authorizer.Authorizer, error) {
+			return authorizerfactory.NewAlwaysAllowAuthorizer(), nil
+		},
 	}
 	kubeconfigSubresourceStorage := KubeconfigSubresourceREST{
 		mainRest:             &storage,


### PR DESCRIPTION
Fixes https://github.com/kcp-dev/kcp/issues/716

We had that in ClusterWorkspaceTypeExists admission. But because the virtual-workspace apiserver creates as admin, that did not apply. Also impersonation would not work because users cannot create ClusterWorkspaces in the org workspace.