### PR TITLE
Simplify `kubectl kcp workspace` plugin usage and implementation

### DIFF
--- a/pkg/cliplugins/workspace/plugin/helpers.go
+++ b/pkg/cliplugins/workspace/plugin/helpers.go
@@ -17,41 +17,113 @@ limitations under the License.
 package plugin
 
 import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
 	"strings"
 
-	"k8s.io/client-go/tools/clientcmd/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/registry"
+	virtualcommandoptions "github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
+	tenancyhelpers "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
+	tenancyclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 )
 
-// prioritizedAuthInfo returns the first non-nil or non-empty AuthInfo it finds
-// from the ordred list passed in argument.
-// The first return paremeter is the index at which the returned AuthInfo was found.
-// -1 means none was found.
-func prioritizedAuthInfo(values ...*api.AuthInfo) (int, *api.AuthInfo) {
-	for i, value := range values {
-		if value == nil {
-			continue
-		}
-		value := *value
-		if value.Token != "" || value.TokenFile != "" || value.Password != "" || value.Username != "" ||
-			value.Exec != nil || value.AuthProvider != nil {
-			return i, &value
-		}
+// getWorkspaceFromInternalName retrieves the workspace with this internal name in the
+// user workspace directory, by requesting the `workspaces` virtual workspace.
+func getWorkspaceFromInternalName(ctx context.Context, workspaceInternalName string, tenancyClient tenancyclient.Interface) (*tenancyv1beta1.Workspace, error) {
+	if list, err := tenancyClient.TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + workspaceInternalName,
+	}); err != nil {
+		return nil, err
+	} else if list == nil || len(list.Items) == 0 {
+		return nil, fmt.Errorf("workspace %q is not found", workspaceInternalName)
+	} else if len(list.Items) > 1 {
+		return nil, fmt.Errorf("several workspaces with the same internal name : %q", workspaceInternalName)
+	} else {
+		return &list.Items[0], nil
 	}
-	return -1, api.NewAuthInfo()
 }
 
-// extractScopeAndName extracts the scope and workspace name from
-// workspace kubeconfig context names as they are set in workspace Kubeconfigs
-// retrieved from the virtual workspace kubeconfig sub-resource
-func extractScopeAndName(workspaceKey string) (string, string) {
-	if strings.HasPrefix(workspaceKey, registry.PersonalScope+"/") {
-		return registry.PersonalScope, strings.TrimPrefix(workspaceKey, registry.PersonalScope+"/")
-	} else if strings.HasPrefix(workspaceKey, registry.OrganizationScope+"/") {
-		return registry.OrganizationScope, strings.TrimPrefix(workspaceKey, registry.OrganizationScope+"/")
+// getWorkspaceAndBasePath gets the workspace name, org logical cluster name and the base URL for the current
+// workspace.
+func getWorkspaceAndBasePath(urlPath string) (orgClusterName, workspaceName, basePath string, err error) {
+	// get workspace from current server URL and check it point to an org or the root workspace
+	serverURL, err := url.Parse(urlPath)
+	if err != nil {
+		return "", "", "", err
 	}
-	return "", workspaceKey
+
+	possiblePrefixes := []string{
+		"/clusters/",
+		path.Join(virtualcommandoptions.DefaultRootPathPrefix, "workspaces") + "/",
+	}
+
+	var clusterName string
+	for _, prefix := range possiblePrefixes {
+		clusterIndex := strings.Index(serverURL.Path, prefix)
+		if clusterIndex < 0 {
+			continue
+		}
+		clusterName = strings.SplitN(serverURL.Path[clusterIndex+len(prefix):], "/", 2)[0]
+		basePath = serverURL.Path[:clusterIndex]
+	}
+
+	if clusterName == "" {
+		return "", "", basePath, fmt.Errorf("current cluster URL %s is not pointing to a workspace", serverURL)
+	}
+
+	var org string
+	if clusterName == tenancyhelpers.RootCluster {
+		orgClusterName = ""
+		workspaceName = tenancyhelpers.RootCluster
+	} else if org, workspaceName, err = tenancyhelpers.ParseLogicalClusterName(clusterName); err != nil {
+		return "", "", "", fmt.Errorf("unable to parse cluster name %s", clusterName)
+	} else if org == "system:" {
+		return "", "", "", fmt.Errorf("no workspaces are accessible from %s", clusterName)
+	} else if org == tenancyhelpers.RootCluster {
+		orgClusterName = tenancyhelpers.RootCluster
+	} else {
+		orgClusterName, err = tenancyhelpers.ParentClusterName(clusterName)
+		if err != nil {
+			// should never happen
+			return "", "", "", fmt.Errorf("unable to derive parent cluster name for %s", clusterName)
+		}
+	}
+
+	return orgClusterName, workspaceName, basePath, nil
+}
+
+// upToOrg derives the org workspace cluster name to operate on,
+// from a given workspace logical cluster name.
+func upToOrg(orgClusterName, workspaceName string, always bool) string {
+
+	if orgClusterName == "" && workspaceName == tenancyhelpers.RootCluster {
+		return tenancyhelpers.RootCluster
+	}
+
+	if orgClusterName == tenancyhelpers.RootCluster && !always {
+		return tenancyhelpers.EncodeOrganizationAndClusterWorkspace(tenancyhelpers.RootCluster, workspaceName)
+	}
+
+	return orgClusterName
+}
+
+func outputCurrentWorkspaceMessage(orgName, workspacePrettyName, workspaceName string, opts *Options) error {
+	if workspaceName != "" {
+		message := fmt.Sprintf("Current workspace is %q", workspacePrettyName)
+		if workspaceName != workspacePrettyName {
+			message = fmt.Sprintf("%s (an alias for %q)", message, workspaceName)
+		}
+		if orgName != "" {
+			message = fmt.Sprintf("%s in organization %q", message, orgName)
+		}
+		err := write(opts, fmt.Sprintf("%s.\n", message))
+		return err
+	}
+	return nil
 }
 
 func write(opts *Options, str string) error {

--- a/pkg/virtual/workspaces/authorization/watch.go
+++ b/pkg/virtual/workspaces/authorization/watch.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -45,7 +46,7 @@ type WatchableCache interface {
 	// RemoveWatcher removes a watcher
 	RemoveWatcher(CacheWatcher)
 	// List returns the set of workspace names the user has access to view
-	List(userInfo user.Info, selector labels.Selector) (*workspaceapi.ClusterWorkspaceList, error)
+	List(userInfo user.Info, labelSelector labels.Selector, fieldSelector fields.Selector) (*workspaceapi.ClusterWorkspaceList, error)
 }
 
 // userWorkspaceWatcher converts notifications received from the WorkspaceAuthCache to
@@ -89,7 +90,7 @@ var (
 )
 
 func NewUserWorkspaceWatcher(user user.Info, lclusterName string, clusterWorkspaceCache *workspacecache.ClusterWorkspaceCache, authCache WatchableCache, includeAllExistingWorkspaces bool, predicate kstorage.SelectionPredicate) *userWorkspaceWatcher {
-	workspaces, _ := authCache.List(user, labels.Everything())
+	workspaces, _ := authCache.List(user, labels.Everything(), fields.Everything())
 	knownWorkspaces := map[string]string{}
 	for _, workspace := range workspaces.Items {
 		knownWorkspaces[workspace.Name] = workspace.ResourceVersion

--- a/pkg/virtual/workspaces/authorization/watch_test.go
+++ b/pkg/virtual/workspaces/authorization/watch_test.go
@@ -81,7 +81,7 @@ func (w *fakeAuthCache) RemoveWatcher(watcher CacheWatcher) {
 	w.removed = append(w.removed, watcher)
 }
 
-func (w *fakeAuthCache) List(userInfo user.Info, selector labels.Selector) (*workspaceapi.ClusterWorkspaceList, error) {
+func (w *fakeAuthCache) List(userInfo user.Info, labelSelector labels.Selector, fieldSelector fields.Selector) (*workspaceapi.ClusterWorkspaceList, error) {
 	ret := &workspaceapi.ClusterWorkspaceList{}
 	if w.clusterWorkspaces != nil {
 		for i := range w.clusterWorkspaces {

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -253,8 +253,8 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 	// It breaks the API guarantees of lists.
 	// To make it correct we have to know the latest RV of the org workspace shard,
 	// and then wait for freshness relative to that RV of the lister.
-	labelSelector, _ := InternalListOptionsToSelectors(options)
-	clusterWorkspaceList, err := org.clusterWorkspaceLister.List(withoutGroupsWhenPersonal(userInfo, usePersonalScope), labelSelector)
+	labelSelector, fieldSelector := InternalListOptionsToSelectors(options)
+	clusterWorkspaceList, err := org.clusterWorkspaceLister.List(withoutGroupsWhenPersonal(userInfo, usePersonalScope), labelSelector, fieldSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +356,7 @@ func (s *REST) getClusterWorkspace(ctx context.Context, name string, options *me
 	// Filtering by applying the lister operation might not be necessary anymore
 	// when using a semi-delegated authorizer in the workspaces virtual workspace that would
 	// delegate this authorization to the main KCP instance hosting the workspaces and RBAC rules
-	obj, err := org.clusterWorkspaceLister.List(withoutGroupsWhenPersonal(userInfo, usePersonalScope), labels.Everything())
+	obj, err := org.clusterWorkspaceLister.List(withoutGroupsWhenPersonal(userInfo, usePersonalScope), labels.Everything(), fields.Everything())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -56,7 +57,7 @@ func (m *mockLister) CheckedUsers() []kuser.Info {
 	return m.checkedUsers
 }
 
-func (m *mockLister) List(user kuser.Info, _ labels.Selector) (*tenancyv1alpha1.ClusterWorkspaceList, error) {
+func (m *mockLister) List(user kuser.Info, _ labels.Selector, _ fields.Selector) (*tenancyv1alpha1.ClusterWorkspaceList, error) {
 	m.checkedUsers = append(m.checkedUsers, user)
 	return &tenancyv1alpha1.ClusterWorkspaceList{
 		Items: m.workspaces,

--- a/pkg/virtual/workspaces/util/util.go
+++ b/pkg/virtual/workspaces/util/util.go
@@ -25,16 +25,20 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	apistorage "k8s.io/apiserver/pkg/storage"
 
+	workspaceapiv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workspaceapiv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
 )
 
 // getAttrs returns labels and fields of a given object for filtering purposes.
 func getAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
-	workspaceObj, ok := obj.(*workspaceapiv1beta1.Workspace)
-	if !ok {
+	switch workspaceObj := obj.(type) {
+	case *workspaceapiv1beta1.Workspace:
+		return labels.Set(workspaceObj.Labels), workspaceToSelectableFields(workspaceObj), nil
+	case *workspaceapiv1alpha1.ClusterWorkspace:
+		return labels.Set(workspaceObj.Labels), clusterWorkspaceToSelectableFields(workspaceObj), nil
+	default:
 		return nil, nil, fmt.Errorf("not a workspace")
 	}
-	return labels.Set(workspaceObj.Labels), workspaceToSelectableFields(workspaceObj), nil
 }
 
 // MatchWorkspace returns a generic matcher for a given label and field selector.
@@ -48,6 +52,15 @@ func MatchWorkspace(label labels.Selector, field fields.Selector) apistorage.Sel
 
 // workspaceToSelectableFields returns a field set that represents the object
 func workspaceToSelectableFields(workspaceObj *workspaceapiv1beta1.Workspace) fields.Set {
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&workspaceObj.ObjectMeta, false)
+	specificFieldsSet := fields.Set{
+		"status.phase": string(workspaceObj.Status.Phase),
+	}
+	return generic.MergeFieldsSets(objectMetaFieldsSet, specificFieldsSet)
+}
+
+// clusterWorkspaceToSelectableFields returns a field set that represents the object
+func clusterWorkspaceToSelectableFields(workspaceObj *workspaceapiv1alpha1.ClusterWorkspace) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&workspaceObj.ObjectMeta, false)
 	specificFieldsSet := fields.Set{
 		"status.phase": string(workspaceObj.Status.Phase),


### PR DESCRIPTION
- **Always** derive the current workspace name and org from the server URL of the current `kubeconfig` context (instead of reading it from the current workspace kubeconfig context key). This fixes issue #678
- Store **only one** `kubeconfig` context to store the current workspace context, and one for the previous workspace (instead of the whole history of current contexts)
- Correctly manage pretty names, so that they are shown **as an alias** in the `use` or `current` commands as shown below:
```
$ kubectl kcp workspace --token=another-token create my-workspace
Workspace "my-workspace" created.
$ kubectl kcp workspace --token=user-1-token create my-workspace 
Workspace "my-workspace" created.
# It is a distinct workspace, whose org-wide name will be disambiguated. But the name requested by the user was given as an alias in the personal scope.

$ kubectl kcp workspace --token=user-1-token current
Current workspace is "my-workspace" (an alias for "my-workspace--1") in organization "default".

# Now with the org-wide ("all") scope instead of the personal scope, we directly see the workspace real, org-wide name
$ kubectl kcp workspace --token=user-1-token --scope=all current
Current workspace is "my-workspace--1" in organization "default".``` 
```

- In addition, to use a given context instead of the current context to specify the KCP server URL, no need to reset the current kubeconfig context first. You can now use the standard `--current` `kubectl` override:
```
$ kubectl kcp workspace use my-workspace
Current workspace is "my-workspace" in organization "default".
$ kubectl kcp workspace --context=root use default
Current workspace is "default" in organization "root".
``` 

More details:

For historical reasons until now the plugin used to add, inside the current `kubeconfig`, **one new context for each new current workspace** (after a "use" call), with the context name containing the name of the workspace and the related scope.
This way of storing current workspace contexts has become inconsistent with the current plugin behavior which builds the `workspaces` virtual workspace URL automatically based on the current context server URL, by extracting the current workspace logical cluster name from it.
