### PR TITLE
WIP: tenancy/helpers: move WorkspaceKey to pkg/server/apiexensions.go, this is not a generic helper

### DIFF
--- a/pkg/apis/tenancy/v1alpha1/helper/helper.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clusters"
 
 	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
@@ -53,18 +52,6 @@ func EncodeLogicalClusterName(workspace *tenancyapi.ClusterWorkspace) (string, e
 // an organization and workspace.
 func EncodeOrganizationAndClusterWorkspace(organization, workspace string) string {
 	return organization + separator + workspace
-}
-
-// WorkspaceKey returns a key to use when looking up a ClusterWorkspace in a lister or indexer.
-// If org is the value of OrganizationCluster, the key will be of the format
-// <OrganizationCluster>#$#<ws>. Otherwise, the key will be of the format
-// <OrganizationClsuter>_<org>#$#<ws>.
-func WorkspaceKey(org, ws string) string {
-	if org == RootCluster || (org == "" && ws == RootCluster) || strings.HasPrefix(org, LocalSystemClusterPrefix) {
-		return clusters.ToClusterAwareKey(org, ws)
-	}
-
-	return clusters.ToClusterAwareKey(EncodeOrganizationAndClusterWorkspace(RootCluster, org), ws)
 }
 
 // ParseLogicalClusterName determines the organization and workspace name from a

--- a/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
@@ -136,47 +136,6 @@ func TestParseLogicalClusterName(t *testing.T) {
 	}
 }
 
-func TestWorkspaceKey(t *testing.T) {
-	tests := []struct {
-		name string
-		org  string
-		ws   string
-		want string
-	}{
-		{
-			name: "root ws",
-			org:  "",
-			ws:   RootCluster,
-			want: RootCluster,
-		},
-		{
-			name: "fake root ws",
-			org:  "myorg",
-			ws:   RootCluster,
-			want: "root:myorg#$#root",
-		},
-		{
-			name: "org ws",
-			org:  RootCluster,
-			ws:   "myws",
-			want: "root#$#myws",
-		},
-		{
-			name: "normal ws",
-			org:  "myorg",
-			ws:   "myws",
-			want: "root:myorg#$#myws",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := WorkspaceKey(tt.org, tt.ws); got != tt.want {
-				t.Errorf("WorkspaceKey() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestParentClusterName(t *testing.T) {
 	tests := []struct {
 		clusterName string

--- a/pkg/server/apiextensions_test.go
+++ b/pkg/server/apiextensions_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1/helper"
+)
+
+func TestWorkspaceKey(t *testing.T) {
+	tests := []struct {
+		name string
+		org  string
+		ws   string
+		want string
+	}{
+		{
+			name: "org ws",
+			org:  helper.RootCluster,
+			ws:   "myws",
+			want: "root#$#myws",
+		},
+		{
+			name: "normal ws",
+			org:  "myorg",
+			ws:   "myws",
+			want: "root:myorg#$#myws",
+		},
+		{
+			name: "root ws",
+			org:  "",
+			ws:   helper.RootCluster,
+			want: helper.RootCluster,
+		},
+		{
+			name: "fake root ws",
+			org:  "myorg",
+			ws:   "root",
+			want: "root:myorg#$#root",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := workspaceKey(tt.org, tt.ws); got != tt.want {
+				t.Errorf("WorkspaceKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This helper is very workspace specific. So we should not promote reuse. Depends on the context.