### PR TITLE
Remove view and edit verbs from clusterworkspace authz

### DIFF
--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -25,9 +25,7 @@ import (
 // ClusterRoleBindings return default rolebindings to the default roles
 func clusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	return []rbacv1.ClusterRoleBinding{
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups("system:kcp:clusterworkspace:edit").BindingOrDie(), "system:kcp:clusterworkspace:edit"),
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("view").Groups("system:kcp:clusterworkspace:view").BindingOrDie(), "system:kcp:clusterworkspace:view"),
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("admin").Groups("system:kcp:clusterworkspace:admin").BindingOrDie(), "system:kcp:clusterworkspace:admin"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups("system:kcp:clusterworkspace:admin").BindingOrDie(), "system:kcp:clusterworkspace:admin"),
 	}
 }
 

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -384,21 +384,10 @@ func (s *REST) getClusterWorkspace(ctx context.Context, name string, options *me
 type RoleType string
 
 const (
-	ListerRoleType RoleType = "lister"
-	OwnerRoleType  RoleType = "owner"
+	OwnerRoleType RoleType = "owner"
 )
 
-var roleRules map[RoleType][]rbacv1.PolicyRule = map[RoleType][]rbacv1.PolicyRule{
-	ListerRoleType: {
-		{
-			Verbs:     []string{"get"},
-			Resources: []string{"clusterworkspaces/workspace"},
-		},
-		{
-			Resources: []string{"clusterworkspaces/content"},
-			Verbs:     []string{"view"},
-		},
-	},
+var roleRules = map[RoleType][]rbacv1.PolicyRule{
 	OwnerRoleType: {
 		{
 			Verbs:     []string{"get", "delete"},
@@ -406,7 +395,7 @@ var roleRules map[RoleType][]rbacv1.PolicyRule = map[RoleType][]rbacv1.PolicyRul
 		},
 		{
 			Resources: []string{"clusterworkspaces/content"},
-			Verbs:     []string{"view", "edit"},
+			Verbs:     []string{"admin"},
 		},
 	},
 }
@@ -450,7 +439,7 @@ var _ = rest.Creater(&REST{})
 // since the name ( == pretty name ) requested by the user might already exist at the organization level.
 // Internal names would be <pretty name>--<suffix>.
 //
-// However when the user manages his workspaces through the personal scope, the pretty names will always be used.
+// However, when the user manages his workspaces through the personal scope, the pretty names will always be used.
 //
 // Personal pretty names and the related internal names are stored on the ClusterRoleBinding that links the
 // ClusterWorkspace-related ClusterRole with the user Subject.
@@ -467,7 +456,6 @@ var _ = rest.Creater(&REST{})
 //
 //   2. create ClusterRoleBinding owner-workspace-my-app-user-A
 //      create ClusterRole owner-workspace-my-app-user-A
-//      create ClusterRole lister-workspace-my-app-user-A  (in order to later allow sharing)
 //
 //   3. create ClusterWorkspace my-app
 //
@@ -516,7 +504,6 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	}
 
 	ownerRoleBindingName := getRoleBindingName(OwnerRoleType, workspace.Name, userInfo)
-	listerRoleBindingName := getRoleBindingName(ListerRoleType, workspace.Name, userInfo)
 
 	// First create the ClusterRoleBinding that will link the workspace cluster role with the user Subject
 	// This is created with a name unique inside the user personal scope (pretty name + userName),
@@ -546,17 +533,11 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), workspace.Name, err)
 	}
 
-	// Then create the owner and lister roles related to the given workspace.
+	// Then create the owner role related to the given workspace.
 	// Note that ResourceNames contains the workspace pretty name for now.
 	// It will be updated later on when the internal name of the workspace is known.
 	ownerClusterRole := createClusterRole(ownerRoleBindingName, workspace.Name, OwnerRoleType)
 	if _, err := org.rbacClient.ClusterRoles().Create(ctx, ownerClusterRole, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
-		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), workspace.Name, err)
-	}
-
-	listerClusterRole := createClusterRole(listerRoleBindingName, workspace.Name, ListerRoleType)
-	if _, err := org.rbacClient.ClusterRoles().Create(ctx, listerClusterRole, metav1.CreateOptions{}); err != nil && !kerrors.IsAlreadyExists(err) {
-		_ = org.rbacClient.ClusterRoles().Delete(ctx, ownerClusterRole.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), workspace.Name, err)
 	}
 
@@ -601,21 +582,6 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	ownerClusterRole.Labels[InternalNameLabel] = createdClusterWorkspace.Name
 	if _, err := org.rbacClient.ClusterRoles().Update(ctx, ownerClusterRole, metav1.UpdateOptions{}); err != nil {
 		_ = org.rbacClient.ClusterRoles().Delete(ctx, ownerClusterRole.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
-		_ = org.rbacClient.ClusterRoles().Delete(ctx, listerClusterRole.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
-		_, _, _ = s.Delete(ctx, createdClusterWorkspace.Name, nil, &metav1.DeleteOptions{GracePeriodSeconds: &zero})
-		if kerrors.IsConflict(err) {
-			return nil, kerrors.NewConflict(tenancyv1beta1.Resource("workspaces"), workspace.Name, err)
-		}
-		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), workspace.Name, err)
-	}
-
-	for i := range listerClusterRole.Rules {
-		listerClusterRole.Rules[i].ResourceNames = []string{createdClusterWorkspace.Name}
-	}
-	listerClusterRole.Labels[InternalNameLabel] = createdClusterWorkspace.Name
-	if _, err := org.rbacClient.ClusterRoles().Update(ctx, listerClusterRole, metav1.UpdateOptions{}); err != nil {
-		_ = org.rbacClient.ClusterRoles().Delete(ctx, ownerClusterRole.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
-		_ = org.rbacClient.ClusterRoles().Delete(ctx, listerClusterRole.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		_, _, _ = s.Delete(ctx, createdClusterWorkspace.Name, nil, &metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		if kerrors.IsConflict(err) {
 			return nil, kerrors.NewConflict(tenancyv1beta1.Resource("workspaces"), workspace.Name, err)

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1028,28 +1028,6 @@ func TestCreateWorkspace(t *testing.T) {
 			assert.ElementsMatch(t, crs.Items, append(testData.clusterRoles,
 				rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "lister-workspace-foo-test-user",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-						{
-							Verbs:         []string{"view"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/content"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
-				rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{
 						Name: "owner-workspace-foo-test-user",
 						Labels: map[string]string{
 							InternalNameLabel: "foo",
@@ -1063,7 +1041,7 @@ func TestCreateWorkspace(t *testing.T) {
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 						{
-							Verbs:         []string{"view", "edit"},
+							Verbs:         []string{"admin"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1143,30 +1121,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 						{
-							Verbs:         []string{"view", "edit"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/content"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", anotherUser),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-						{
-							Verbs:         []string{"view"},
+							Verbs:         []string{"admin"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1218,28 +1173,6 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 			assert.ElementsMatch(t, crs.Items, append(testData.clusterRoles,
 				rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "lister-workspace-foo-test-user",
-						Labels: map[string]string{
-							InternalNameLabel: "foo--1",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo--1"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-						{
-							Verbs:         []string{"view"},
-							ResourceNames: []string{"foo--1"},
-							Resources:     []string{"clusterworkspaces/content"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
-				rbacv1.ClusterRole{
-					ObjectMeta: metav1.ObjectMeta{
 						Name: "owner-workspace-foo-test-user",
 						Labels: map[string]string{
 							InternalNameLabel: "foo--1",
@@ -1253,7 +1186,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 						{
-							Verbs:         []string{"view", "edit"},
+							Verbs:         []string{"admin"},
 							ResourceNames: []string{"foo--1"},
 							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1323,29 +1256,6 @@ func TestCreateWorkspacePrettyNameAlreadyExists(t *testing.T) {
 				},
 			},
 			clusterRoles: []rbacv1.ClusterRole{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-						{
-							Verbs:         []string{"view"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/content"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        getRoleBindingName(OwnerRoleType, "foo", user),
@@ -1464,23 +1374,6 @@ func TestDeleteWorkspaceNotFound(t *testing.T) {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
 			},
 		},
 		apply: func(t *testing.T, storage *REST, kubeconfigSubResourceStorage *KubeconfigSubresourceREST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
@@ -1565,23 +1458,6 @@ func TestDeletePersonalWorkspaceForbiddenToUser(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							Verbs:         []string{"get", "delete"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1681,23 +1557,6 @@ func TestDeletePersonalWorkspaceForbiddenToOrgAdmin(t *testing.T) {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
 			},
 		},
 		apply: func(t *testing.T, storage *REST, kubeconfigSubResourceStorage *KubeconfigSubresourceREST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
@@ -1788,23 +1647,6 @@ func TestDeleteWorkspaceForbiddenToUser(t *testing.T) {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
 			},
 		},
 		apply: func(t *testing.T, storage *REST, kubeconfigSubResourceStorage *KubeconfigSubresourceREST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
@@ -1889,23 +1731,6 @@ func TestDeletePersonalWorkspace(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							Verbs:         []string{"get", "delete"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -2005,23 +1830,6 @@ func TestDeleteWorkspaceByOrgAdmin(t *testing.T) {
 						},
 					},
 				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
-							ResourceNames: []string{"foo"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
 			},
 		},
 		apply: func(t *testing.T, storage *REST, kubeconfigSubResourceStorage *KubeconfigSubresourceREST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
@@ -2106,23 +1914,6 @@ func TestDeletePersonalWorkspaceWithPrettyName(t *testing.T) {
 					Rules: []rbacv1.PolicyRule{
 						{
 							Verbs:         []string{"get", "delete"},
-							ResourceNames: []string{"foo--1"},
-							Resources:     []string{"clusterworkspaces/workspace"},
-							APIGroups:     []string{"tenancy.kcp.dev"},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        getRoleBindingName(ListerRoleType, "foo", user),
-						ClusterName: "root:orgName",
-						Labels: map[string]string{
-							InternalNameLabel: "foo--1",
-						},
-					},
-					Rules: []rbacv1.PolicyRule{
-						{
-							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo--1"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},

--- a/test/e2e/authorizer/resources.yaml
+++ b/test/e2e/authorizer/resources.yaml
@@ -4,58 +4,27 @@ kind: ClusterWorkspace
 metadata:
   name: workspace1
 ---
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspace
-metadata:
-  name: workspace2
----
-
-# declare user-1 to be editor
+# declare user-1 to be an admin
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: user-1-editor
+  name: user-1-admin
 subjects:
   - kind: User
     name: user-1
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: workspace1-editor
+  name: workspace1-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: workspace1-editor
+  name: workspace1-admin
 rules:
   - apiGroups: ["tenancy.kcp.dev"]
     resources: ["clusterworkspaces/content"]
     resourceNames: ["workspace1"]
-    verbs: ["edit", "view"]
----
-
-# declare user-2 to be viewer
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: user-2-viewer
-subjects:
-  - kind: User
-    name: user-2
-    apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: ClusterRole
-  name: workspace1-viewer
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: workspace1-viewer
-rules:
-  - apiGroups: ["tenancy.kcp.dev"]
-    resources: ["clusterworkspaces/content"]
-    resourceNames: ["workspace1"]
-    verbs: ["view"]
+    verbs: ["admin"]
 ---


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

This Pull Request removed both `view` and `edit` verbs from the cluster workspace authorizer. Additionally, it maps the admin to cluster admin.

## Related issue(s)

Fixes #725

## Notes

Still to be done:
* [x] Update https://github.com/kcp-dev/kcp/issues/403 with necessary information
* [x] Remove the lister PolicyRule from rest.go
* [x] Update the `owner` PolicyRule to use admin verb
* [x] Update the test if necessary

