### PR TITLE
to-kubeconfig is not required, it used InCluster if not set

### DIFF
--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -67,9 +67,6 @@ func (options *Options) Validate() error {
 	if options.FromKubeconfig == "" {
 		return errors.New("--from-kubeconfig is required")
 	}
-	if options.ToKubeconfig == "" {
-		return errors.New("--to-kubeconfig is required")
-	}
 
 	return nil
 }


### PR DESCRIPTION
> 	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")

the syncer never uses the InCluster configuration because it fails validation if not set