### PR TITLE
fix unknown command options for kcp

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -133,7 +133,7 @@ func main() {
 	startCmd.AddCommand(startOptionsCmd)
 	cmd.AddCommand(startCmd)
 
-	setPartialUsageAndHelpFunc(cmd, namedStartFlagSets, cols, []string{
+	setPartialUsageAndHelpFunc(startCmd, namedStartFlagSets, cols, []string{
 		"etcd-servers",
 		"run-controllers",
 		"run-virtual-workspaces",


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

- Fixed `help` and `options` commands
- Changed 
```go
setPartialUsageAndHelpFunc(cmd, namedStartFlagSets, cols, []string{
	"etcd-servers",
	"run-controllers",
	"run-virtual-workspaces",
})
  ```
to
```go
setPartialUsageAndHelpFunc(startCmd, namedStartFlagSets, cols, []string{
	"etcd-servers",
	"run-controllers",
	"run-virtual-workspaces",
})
```
	
## Testing

- Run
```bash 
kcp --help
```

- Run
```bash
kcp start --help
```

- Run
```bash
kcp options
```


## Related issue(s)

Fixes #602 