### PR TITLE
kube client cert auth in the proxy

### DIFF
--- a/cmd/kcp-front-proxy/filters.go
+++ b/cmd/kcp-front-proxy/filters.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/klog/v2"
+)
+
+// newRequestInfoFactory creates a new RequestInfoFactory for filters to use
+func newRequestInfoFactory() *apirequest.RequestInfoFactory {
+	apiPrefixes := sets.NewString(strings.Trim(genericapiserver.APIGroupPrefix, "/"))
+	legacyAPIPrefixes := sets.String{}
+	apiPrefixes.Insert(strings.Trim(genericapiserver.DefaultLegacyAPIPrefix, "/"))
+	legacyAPIPrefixes.Insert(strings.Trim(genericapiserver.DefaultLegacyAPIPrefix, "/"))
+
+	return &apirequest.RequestInfoFactory{
+		APIPrefixes:          apiPrefixes,
+		GrouplessAPIPrefixes: legacyAPIPrefixes,
+	}
+}
+
+// withOptionalClientCert creates a handler that verifies a request's client
+// cert if one is presented but passes through to the next handler if one is
+// not.
+func withOptionalClientCert(handler, failed http.Handler, auth authenticator.Request) http.Handler {
+	if auth == nil {
+		return handler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
+			handler.ServeHTTP(w, req)
+			return
+		}
+		resp, ok, err := auth.AuthenticateRequest(req)
+		if err != nil || !ok {
+			if err != nil {
+				klog.ErrorS(err, "Unable to authenticate the request")
+			}
+			failed.ServeHTTP(w, req)
+			return
+		}
+		req = req.WithContext(request.WithUser(req.Context(), resp.User))
+		handler.ServeHTTP(w, req)
+	})
+}
+
+func newUnauthorizedHandler() http.Handler {
+	scheme := runtime.NewScheme()
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
+	codecs := serializer.NewCodecFactory(scheme)
+	return genericapifilters.Unauthorized(codecs)
+}

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -113,6 +113,9 @@ forwards Common Name and Organizations to backend API servers in HTTP headers.
 The proxy terminates TLS and communicates with API servers via mTLS. Traffic is
 routed based on paths.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Logs.ValidateAndApply(); err != nil {
+				return err
+			}
 			if err := options.Complete(); err != nil {
 				return err
 			}
@@ -143,7 +146,7 @@ routed based on paths.`,
 			failedHandler := genericapifilters.Unauthorized(codecs)
 			handler = WithOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
 
-			var requestInfoResolver apirequest.RequestInfoResolver = NewRequestInfoResolver()
+			requestInfoResolver := NewRequestInfoResolver()
 			handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 			handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
 

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
@@ -89,7 +90,7 @@ func WithOptionalClientCert(handler, failed http.Handler, auth authenticator.Req
 			handler.ServeHTTP(w, req)
 			return
 		}
-		_, ok, err := auth.AuthenticateRequest(req)
+		resp, ok, err := auth.AuthenticateRequest(req)
 		if err != nil || !ok {
 			if err != nil {
 				klog.ErrorS(err, "Unable to authenticate the request")
@@ -97,6 +98,7 @@ func WithOptionalClientCert(handler, failed http.Handler, auth authenticator.Req
 			failed.ServeHTTP(w, req)
 			return
 		}
+		req = req.WithContext(request.WithUser(req.Context(), resp.User))
 		handler.ServeHTTP(w, req)
 	})
 }

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -117,19 +117,20 @@ routed based on paths.`,
 			if errs := options.Validate(); errs != nil {
 				return errors.NewAggregate(errs)
 			}
+
 			var handler http.Handler
 			handler, err := proxy.NewHandler(&options.Proxy)
 			if err != nil {
 				return err
 			}
 
-			var requestInfoResolver apirequest.RequestInfoResolver = NewRequestInfoResolver()
-			var authenticationInfo genericapiserver.AuthenticationInfo
 			var servingInfo *genericapiserver.SecureServingInfo
 			var loopbackClientConfig *restclient.Config
 			if err := options.SecureServing.ApplyTo(&servingInfo, &loopbackClientConfig); err != nil {
 				return err
 			}
+
+			var authenticationInfo genericapiserver.AuthenticationInfo
 			if err := options.Authentication.ApplyTo(&authenticationInfo, servingInfo); err != nil {
 				return err
 			}
@@ -138,8 +139,9 @@ routed based on paths.`,
 			metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
 			codecs := serializer.NewCodecFactory(scheme)
 			failedHandler := genericapifilters.Unauthorized(codecs)
-
 			handler = WithOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
+
+			var requestInfoResolver apirequest.RequestInfoResolver = NewRequestInfoResolver()
 			handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
 			handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
 

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -23,29 +23,19 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/authentication/authenticator"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
-	"k8s.io/apiserver/pkg/endpoints/request"
-	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	restclient "k8s.io/client-go/rest"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version"
-	"k8s.io/klog/v2"
 
 	frontproxyoptions "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/options"
 	"github.com/kcp-dev/kcp/pkg/proxy"
@@ -67,40 +57,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-}
-
-func NewRequestInfoResolver() *apirequest.RequestInfoFactory {
-	apiPrefixes := sets.NewString(strings.Trim(genericapiserver.APIGroupPrefix, "/"))
-	legacyAPIPrefixes := sets.String{}
-	apiPrefixes.Insert(strings.Trim(genericapiserver.DefaultLegacyAPIPrefix, "/"))
-	legacyAPIPrefixes.Insert(strings.Trim(genericapiserver.DefaultLegacyAPIPrefix, "/"))
-
-	return &apirequest.RequestInfoFactory{
-		APIPrefixes:          apiPrefixes,
-		GrouplessAPIPrefixes: legacyAPIPrefixes,
-	}
-}
-
-func WithOptionalClientCert(handler, failed http.Handler, auth authenticator.Request) http.Handler {
-	if auth == nil {
-		return handler
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
-			handler.ServeHTTP(w, req)
-			return
-		}
-		resp, ok, err := auth.AuthenticateRequest(req)
-		if err != nil || !ok {
-			if err != nil {
-				klog.ErrorS(err, "Unable to authenticate the request")
-			}
-			failed.ServeHTTP(w, req)
-			return
-		}
-		req = req.WithContext(request.WithUser(req.Context(), resp.User))
-		handler.ServeHTTP(w, req)
-	})
 }
 
 func NewProxyCommand(ctx context.Context) *cobra.Command {
@@ -140,15 +96,12 @@ routed based on paths.`,
 				return err
 			}
 
-			scheme := runtime.NewScheme()
-			metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
-			codecs := serializer.NewCodecFactory(scheme)
-			failedHandler := genericapifilters.Unauthorized(codecs)
-			handler = WithOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
+			failedHandler := newUnauthorizedHandler()
+			handler = withOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
 
-			requestInfoResolver := NewRequestInfoResolver()
-			handler = genericapifilters.WithRequestInfo(handler, requestInfoResolver)
-			handler = genericfilters.WithPanicRecovery(handler, requestInfoResolver)
+			requestInfoFactory := newRequestInfoFactory()
+			handler = genericapifilters.WithRequestInfo(handler, requestInfoFactory)
+			handler = genericfilters.WithPanicRecovery(handler, requestInfoFactory)
 
 			doneCh, err := servingInfo.Serve(handler, time.Second*60, ctx.Done())
 			if err != nil {

--- a/cmd/kcp-front-proxy/options/authentication.go
+++ b/cmd/kcp-front-proxy/options/authentication.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/apiserver/pkg/authentication/request/x509"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+)
+
+// Authentication wraps ClientCertAuthenticationOptions so we don't pull in
+// more auth machinery than we need with DelegatingAuthenticationOptions
+type Authentication struct {
+	ClientCert apiserveroptions.ClientCertAuthenticationOptions
+}
+
+func NewAuthentication() *Authentication {
+	return &Authentication{}
+}
+
+// ApplyTo sets up the x509 Authenticator if the client-ca-file option was passed
+func (c *Authentication) ApplyTo(authenticationInfo *genericapiserver.AuthenticationInfo, servingInfo *genericapiserver.SecureServingInfo) error {
+	clientCAProvider, err := c.ClientCert.GetClientCAContentProvider()
+	if err != nil {
+		return fmt.Errorf("unable to load client CA provider: %w", err)
+	}
+	if clientCAProvider != nil {
+		if err = authenticationInfo.ApplyClientCert(clientCAProvider, servingInfo); err != nil {
+			return fmt.Errorf("unable to assign client CA provider: %w", err)
+		}
+		authenticationInfo.Authenticator = x509.NewDynamic(clientCAProvider.VerifyOptions, x509.CommonNameUserConversion)
+	}
+	return nil
+}
+
+// AddFlags delegates to ClientCertAuthenticationOptions
+func (c *Authentication) AddFlags(fs *pflag.FlagSet) {
+	c.ClientCert.AddFlags(fs)
+}
+
+// Validate just completes the options pattern. Returns nil.
+func (c *Authentication) Validate() []error {
+	return nil
+}

--- a/cmd/kcp-front-proxy/options/authentication.go
+++ b/cmd/kcp-front-proxy/options/authentication.go
@@ -32,6 +32,7 @@ type Authentication struct {
 	ClientCert apiserveroptions.ClientCertAuthenticationOptions
 }
 
+// NewAuthentication creates a default Authentication
 func NewAuthentication() *Authentication {
 	return &Authentication{}
 }

--- a/cmd/kcp-front-proxy/options/options.go
+++ b/cmd/kcp-front-proxy/options/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/component-base/logs"
 
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
 )
@@ -31,6 +32,7 @@ type Options struct {
 	SecureServing  apiserveroptions.SecureServingOptionsWithLoopback
 	Authentication Authentication
 	Proxy          proxyoptions.Options
+	Logs           *logs.Options
 
 	RootDirectory string
 }
@@ -40,6 +42,7 @@ func NewOptions() *Options {
 		SecureServing:  *apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		Authentication: *NewAuthentication(),
 		Proxy:          *proxyoptions.NewOptions(),
+		Logs:           logs.NewOptions(),
 
 		RootDirectory: ".kcp",
 	}
@@ -55,6 +58,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.SecureServing.AddFlags(fs)
 	o.Authentication.AddFlags(fs)
 	o.Proxy.AddFlags(fs)
+
+	o.Logs.AddFlags(fs)
 
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -75,7 +75,7 @@ func ProxyHandler(p *KCPProxy, UserHeader, GroupHeader string) func(wr http.Resp
 			clientCert := r.TLS.PeerCertificates[0]
 			appendClientCertAuthHeaders(r.Header, clientCert, UserHeader, GroupHeader)
 		}
-		if klog.V(3).Enabled() {
+		if klog.V(6).Enabled() {
 			klog.Infof("%s %s (%s -> %s) ", r.Method, r.RequestURI, r.RemoteAddr, p.backend)
 		}
 		p.proxy.ServeHTTP(w, r)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -24,6 +24,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 
+	userinfo "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/klog/v2"
 )
 
@@ -71,9 +73,8 @@ func NewReverseProxy(backend, clientCert, clientKeyFile, caFile string) (*KCPPro
 // the client cert and adds them as HTTP headers to backend request.
 func ProxyHandler(p *KCPProxy, UserHeader, GroupHeader string) func(wr http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if len(r.TLS.PeerCertificates) >= 1 {
-			clientCert := r.TLS.PeerCertificates[0]
-			appendClientCertAuthHeaders(r.Header, clientCert, UserHeader, GroupHeader)
+		if u, ok := request.UserFrom(r.Context()); ok {
+			appendClientCertAuthHeaders(r.Header, u, UserHeader, GroupHeader)
 		}
 		if klog.V(6).Enabled() {
 			klog.Infof("%s %s (%s -> %s) ", r.Method, r.RequestURI, r.RemoteAddr, p.backend)
@@ -82,12 +83,10 @@ func ProxyHandler(p *KCPProxy, UserHeader, GroupHeader string) func(wr http.Resp
 	}
 }
 
-func appendClientCertAuthHeaders(header http.Header, clientCert *x509.Certificate, UserHeader, GroupHeader string) {
-	userName := clientCert.Subject.CommonName
-	header.Set(UserHeader, userName)
+func appendClientCertAuthHeaders(header http.Header, user userinfo.Info, UserHeader, GroupHeader string) {
+	header.Set(UserHeader, user.GetName())
 
-	groups := clientCert.Subject.Organization
-	for _, group := range groups {
+	for _, group := range user.GetGroups() {
 		header.Add(GroupHeader, group)
 	}
 }


### PR DESCRIPTION
## Summary
This PR wires up kube machinery for client cert auth in the front proxy.

Signed-off-by: Christopher Sams <csams@redhat.com>