### PR TITLE
Use genericConfig.ExternalAddress instead of ExternalHost

### DIFF
--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -107,9 +107,9 @@ func (s *AdminAuthentication) ApplyTo(config *genericapiserver.Config) (newToken
 	return newTokenOrEmpty, tokenHash, nil
 }
 
-func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte, externalAddress string, servingPort int) error {
+func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte) error {
 	externalCACert, _ := config.SecureServing.Cert.CurrentCertKeyContent()
-	externalKubeConfigHost := fmt.Sprintf("https://%s:%d", externalAddress, servingPort)
+	externalKubeConfigHost := fmt.Sprintf("https://%s", config.ExternalAddress)
 
 	externalAdminUserName := "admin"
 	if newToken == "" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -188,8 +188,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	servingOpts := s.options.GenericControlPlane.SecureServing
-	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, newTokenOrEmpty, tokenHash, s.options.GenericControlPlane.GenericServerRunOptions.ExternalHost, servingOpts.BindPort); err != nil {
+	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, newTokenOrEmpty, tokenHash); err != nil {
 		return err
 	}
 
@@ -205,7 +204,7 @@ func (s *Server) Run(ctx context.Context) error {
 		// the lcluster handler is a pass-through, not a delegate, so the wrapping looks weird
 		if s.options.Extra.EnableSharding {
 			clientLoader := sharding.NewClientLoader()
-			clientLoader.Add(s.options.GenericControlPlane.GenericServerRunOptions.ExternalHost, genericConfig.LoopbackClientConfig)
+			clientLoader.Add(genericConfig.ExternalAddress, genericConfig.LoopbackClientConfig)
 			apiHandler = sharding.WithSharding(apiHandler, clientLoader)
 		}
 		apiHandler = WithWildcardListWatchGuard(apiHandler)
@@ -394,7 +393,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig.Authentication, preHandlerChainMux); err != nil {
+		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig, preHandlerChainMux); err != nil {
 			return err
 		}
 	} else if err := s.installVirtualWorkspacesRedirect(ctx, preHandlerChainMux); err != nil {


### PR DESCRIPTION
The apiserver config allows the port to be added to the
`--external-hostname` option and then applies it to the `ExternalAddress`
field in the `genericConfig` (with other defaulting code in case port is
not provided).

This change uses the computed `genericConfig.ExternalAddress` instead of
trying to compute it in kcp code.

Signed-off-by: Kyle Lape <klape@redhat.com>