### PR TITLE
Create new external.kubeconfig

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -189,7 +189,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 	servingOpts := s.options.GenericControlPlane.SecureServing
-	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, newTokenOrEmpty, tokenHash, s.options.GenericControlPlane.GenericServerRunOptions.ExternalHost, servingOpts.BindPort); err != nil {
+	if err := s.options.AdminAuthentication.WriteKubeConfigs(genericConfig, newTokenOrEmpty, tokenHash, genericConfig.PublicAddress.String(), servingOpts.BindPort); err != nil {
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (s *Server) Run(ctx context.Context) error {
 		// the lcluster handler is a pass-through, not a delegate, so the wrapping looks weird
 		if s.options.Extra.EnableSharding {
 			clientLoader := sharding.NewClientLoader()
-			clientLoader.Add(s.options.GenericControlPlane.GenericServerRunOptions.ExternalHost, genericConfig.LoopbackClientConfig)
+			clientLoader.Add(genericConfig.ExternalAddress, genericConfig.LoopbackClientConfig)
 			apiHandler = sharding.WithSharding(apiHandler, clientLoader)
 		}
 		apiHandler = WithWildcardListWatchGuard(apiHandler)
@@ -394,7 +394,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig.Authentication, preHandlerChainMux); err != nil {
+		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig, preHandlerChainMux); err != nil {
 			return err
 		}
 	} else if err := s.installVirtualWorkspacesRedirect(ctx, preHandlerChainMux); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -394,7 +394,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig, preHandlerChainMux); err != nil {
+		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig.Authentication, genericConfig.ExternalAddress, preHandlerChainMux); err != nil {
 			return err
 		}
 	} else if err := s.installVirtualWorkspacesRedirect(ctx, preHandlerChainMux); err != nil {

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -39,7 +39,7 @@ type mux interface {
 	Handle(pattern string, handler http.Handler)
 }
 
-func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient kubernetesclient.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface, genericConfig *genericapiserver.Config, preHandlerChainMux mux) error {
+func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient kubernetesclient.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface, auth genericapiserver.AuthenticationInfo, externalAddress string, preHandlerChainMux mux) error {
 	// create virtual workspaces
 	extraInformerStarts, virtualWorkspaces, err := s.options.Virtual.Workspaces.NewVirtualWorkspaces(
 		virtualcommandoptions.DefaultRootPathPrefix,
@@ -66,12 +66,12 @@ func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient
 	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
 	codecs := serializer.NewCodecFactory(scheme)
 	recommendedConfig := genericapiserver.NewRecommendedConfig(codecs)
-	recommendedConfig.Authentication = genericConfig.Authentication
+	recommendedConfig.Authentication = auth
 	rootAPIServerConfig, err := virtualrootapiserver.NewRootAPIConfig(recommendedConfig, extraInformerStarts, virtualWorkspaces...)
 	if err != nil {
 		return err
 	}
-	rootAPIServerConfig.GenericConfig.ExternalAddress = genericConfig.ExternalAddress
+	rootAPIServerConfig.GenericConfig.ExternalAddress = externalAddress
 	completedRootAPIServerConfig := rootAPIServerConfig.Complete()
 	rootAPIServer, err := completedRootAPIServerConfig.New(genericapiserver.NewEmptyDelegate())
 	if err != nil {

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -109,7 +109,6 @@ func newKcpServer(t *testing.T, cfg KcpConfig, artifactDir, dataDir string) (*kc
 			"--embedded-etcd-client-port=" + etcdClientPort,
 			"--embedded-etcd-peer-port=" + etcdPeerPort,
 			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
-			"--kubeconfig-path=admin.kubeconfig",
 		},
 			cfg.Args...),
 		dataDir:     dataDir,


### PR DESCRIPTION
`external.kubeconfig` uses the `--external-hostname` option to populate the
hostname *and port*.  The generic apiserver config allows the port to be added to the
`--external-hostname`.

`admin.kubeconfig` will now always use the IP address of the locally bound
interface and the port from `--secure-port`.

`--kubeconfig-path` now points to the directory containing the kubeconfig
files.  This now means that the `admin.kubeconfig` filename cannot be
changed.

Fixes #707

Signed-off-by: Kyle Lape <klape@redhat.com>