### PR TITLE
syncer: don't default resources to sync

### DIFF
--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -39,7 +39,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
-		SyncedResourceTypes: []string{"deployments.apps"},
+		SyncedResourceTypes: []string{},
 		Logs:                logs.NewOptions(),
 	}
 }


### PR DESCRIPTION
The syncer doesn't start because by default is trying to sync a resources that doesn't exist in kcp, and the user can not disable.

```sh
$ kubectl -n kcp-system get pods
NAME                      READY   STATUS             RESTARTS     AGE
syncer-6cb4c76f8f-mq9xl   0/1     CrashLoopBackOff   1 (3s ago)   7s
$ kubectl -n kcp-system logs syncer-6cb4c76f8f-mq9xl
I0318 11:48:06.638139       1 syncer.go:66] Syncing the following resource types: [deployments.apps]
I0318 11:48:06.638801       1 specsyncer.go:73] Creating spec syncer for clusterName default:my-workspace--1 to pcluster WORKLOAD_CLUSTER_NAME, resources [deployments.apps]
E0318 11:48:06.650746       1 run.go:74] "command failed" err="The following resource types were requested to be synced, but were not found in the KCP logical cluster: [deployments.apps]"
```

Better to use sane defaults

