### PR TITLE
crd bootstrap: better goroutine support

### DIFF
--- a/config/crds/bootstrap.go
+++ b/config/crds/bootstrap.go
@@ -104,19 +104,36 @@ func createSingleFromFS(ctx context.Context, client apiextensionsv1client.Custom
 		return fmt.Errorf("decoded CRD %s into incorrect type, got %T, wanted %T", gr.String(), rawCrd, &apiextensionsv1.CustomResourceDefinition{})
 	}
 
-	crdResource, err := client.Get(ctx, rawCrd.Name, metav1.GetOptions{})
+	updateNeeded := false
+	crd, err := client.Get(ctx, rawCrd.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			crd, err := client.Create(ctx, rawCrd, metav1.CreateOptions{})
+			crd, err = client.Create(ctx, rawCrd, metav1.CreateOptions{})
 			if err != nil {
-				return fmt.Errorf("error creating CRD %s: %w", gr.String(), err)
+				// If multiple post-start hooks specify the same CRD, they could race with each other, so we need to
+				// handle the scenario where another hook created this CRD after our Get() call returned not found.
+				if apierrors.IsAlreadyExists(err) {
+					// Re-get so we have the correct resourceVersion
+					crd, err = client.Get(ctx, rawCrd.Name, metav1.GetOptions{})
+					if err != nil {
+						return fmt.Errorf("error getting CRD %s: %w", gr.String(), err)
+					}
+					updateNeeded = true
+				} else {
+					return fmt.Errorf("error creating CRD %s: %w", gr.String(), err)
+				}
+			} else {
+				klog.Infof("Bootstrapped CRD %s|%v after %s", crd.GetClusterName(), gr.String(), time.Since(start).String())
 			}
-			klog.Infof("Bootstrapped CRD %s|%v after %s", crd.GetClusterName(), gr.String(), time.Since(start).String())
 		} else {
 			return fmt.Errorf("error fetching CRD %s: %w", gr.String(), err)
 		}
 	} else {
-		rawCrd.ResourceVersion = crdResource.ResourceVersion
+		updateNeeded = true
+	}
+
+	if updateNeeded {
+		rawCrd.ResourceVersion = crd.ResourceVersion
 		crd, err := client.Update(ctx, rawCrd, metav1.UpdateOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
Add support for multiple goroutines (e.g. post start hooks) that try to
install the same CRD at the same time. There was a race where one
goroutine checked for the CRD's existence, didn't find it, and proceeded
to create it. Meanwhile, another goroutine created it. Before this
change, the first goroutine would return an error ("already exists").
Now, it recognizes the existence and tries to do an update instead of
returning an error.

## Related issue(s)

Fixes #