### PR TITLE
e2e: unify make-build bin/ dir and e2e search path for binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ E2E_PARALLELISM ?= 1
 
 .PHONY: test-e2e
 test-e2e: WHAT ?= ./test/e2e...
-test-e2e: install
+test-e2e: build
 	go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
 
 .PHONY: test

--- a/test/e2e/framework/accessory.go
+++ b/test/e2e/framework/accessory.go
@@ -77,7 +77,7 @@ func (a *Accessory) Run(t *testing.T, opts ...RunOption) error {
 	cmd := exec.CommandContext(ctx, a.cmd, a.args...)
 
 	a.t.Logf("running: %v", strings.Join(cmd.Args, " "))
-	logFile, err := os.Create(filepath.Join(a.artifactDir, fmt.Sprintf("%s.log", a.cmd)))
+	logFile, err := os.Create(filepath.Join(a.artifactDir, fmt.Sprintf("%s.log", a.name)))
 	if err != nil {
 		cleanupCancel()
 		return fmt.Errorf("could not create log file: %w", err)

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -126,13 +127,17 @@ func WithLogStreaming(o *runOptions) {
 	o.streamLogs = true
 }
 
+// RepositoryBinDir returns the absolute path of <repo-dir>/bin. That's where `make build` produces our binaries.
+func RepositoryBinDir() string {
+	_, sourceFile, _, _ := goruntime.Caller(0)
+	repoDir := filepath.Join(filepath.Dir(sourceFile), "..", "..", "..")
+	return filepath.Join(repoDir, "bin")
+}
+
 // Run runs the kcp server while the parent context is active. This call is not blocking,
 // callers should ensure that the server is Ready() before using it.
 func (c *kcpServer) Run(opts ...RunOption) error {
-	path, err := exec.LookPath("kcp")
-	if err != nil {
-		return err
-	}
+	path := filepath.Join(RepositoryBinDir(), "kcp")
 
 	runOpts := runOptions{}
 	for _, opt := range opts {

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -262,7 +262,7 @@ func TestIngressController(t *testing.T) {
 			require.NoError(t, err, "failed to write kubeconfig to file")
 
 			ingressController := framework.NewAccessory(t, artifactDir,
-				"ingress-controller", // name
+				filepath.Join(framework.RepositoryBinDir(), "ingress-controller"), // name
 				"ingress-controller",
 				"--kubeconfig="+kubeconfigPath,
 				"--envoy-listener-port="+envoyListenerPort,


### PR DESCRIPTION
How many times did I miss that I have to `go install` instead of `make build` to run an e2e test via `go test`. This is probably the reason for half of the times where we I added `RunInProcess: true` to the fixture because without the test behaves differently in Goland than via `make test-e2e`. This PR unifies that by basing both on `<repo-dir>/bin`.