### PR TITLE
authorization: finish removing edit+view from workspace content authz

### DIFF
--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -137,18 +137,16 @@ func (a *OrgWorkspaceAuthorizer) Authorize(ctx context.Context, attr authorizer.
 			}
 		}
 	} else {
-		verbToGroupMembership := map[string]string{
-			"admin":  "system:kcp:clusterworkspace:admin",
-			"edit":   "system:kcp:clusterworkspace:edit",
-			"view":   "system:kcp:clusterworkspace:view",
-			"access": "system:kcp:authenticated",
+		verbToGroupMembership := map[string][]string{
+			"admin":  {"system:kcp:authenticated", "system:kcp:clusterworkspace:admin"},
+			"access": {"system:kcp:authenticated"},
 		}
 
 		var (
 			errList    []error
 			reasonList []string
 		)
-		for verb, group := range verbToGroupMembership {
+		for verb, groups := range verbToGroupMembership {
 			workspaceAttr := authorizer.AttributesRecord{
 				User:            attr.GetUser(),
 				Verb:            verb,
@@ -167,7 +165,7 @@ func (a *OrgWorkspaceAuthorizer) Authorize(ctx context.Context, attr authorizer.
 				continue
 			}
 			if dec == authorizer.DecisionAllow {
-				extraGroups = append(extraGroups, group)
+				extraGroups = append(extraGroups, groups...)
 			}
 		}
 		if len(errList) > 0 {


### PR DESCRIPTION
Follow-up of https://github.com/kcp-dev/kcp/pull/726.

- removed duality between v1beta1 `Workspaces` in some virtual workspace path and the `ClusterWorkspaces` in an org. Now you can do `kubectl get workspaces` in an org
- simplified and complete kubectl plugin to implement the second section in https://docs.google.com/document/d/1XJJCr16bg22QuJnQB2W98A-djRTtrLr2JE2IWZUHzJU/edit#heading=h.nn8danthd1ys.