### PR TITLE
e2e: Add new shared server ci job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,3 +124,34 @@ jobs:
         with:
           name: e2e-artifacts
           path: /tmp/e2e/**/artifacts/
+
+  e2e-shared-server:
+    name: e2e-shared-server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.17
+      - run: make build
+      - run: |-
+          export LOG_DIR=/tmp/e2e/shared-server/artifacts &&
+          mkdir -p ${LOG_DIR} &&
+          ./bin/kcp start \
+          --discovery-poll-interval=5s \
+          --token-auth-file=test/e2e/framework/auth-tokens.csv \
+          --auto-publish-apis \
+          --run-virtual-workspaces=true \
+          > ${LOG_DIR}/kcp.log 2>&1 &
+      - run: |-
+          ARTIFACT_DIR=/tmp/e2e \
+          PATH="${PATH}:$(pwd)/bin/" \
+          TEST_ARGS="-args --kubeconfig=$(pwd)/.kcp/admin.kubeconfig" \
+          COUNT=1 \
+          E2E_PARALLELISM=2 \
+          make test-e2e
+      - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: e2e-artifacts
+          path: /tmp/e2e/**/artifacts/


### PR DESCRIPTION
The job runs tests twice to ensure tests don't interfere with one another when using shared fixture.
