### PR TITLE
5. kubectl-kcp: get rid of workspace duality and implement logical cluster path semantics

### DIFF
--- a/cmd/kubectl-workspaces/main.go
+++ b/cmd/kubectl-workspaces/main.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	goflags "flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/cliplugins/workspace/cmd"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("kubectl-kcp", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	workspaceCmd, err := cmd.NewCmdWorkspace(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// setup klog
+	fs := goflags.NewFlagSet("klog", goflags.PanicOnError)
+	klog.InitFlags(fs)
+	workspaceCmd.PersistentFlags().AddGoFlagSet(fs)
+
+	if err := workspaceCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/kubectl-ws/main.go
+++ b/cmd/kubectl-ws/main.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	goflags "flag"
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/cliplugins/workspace/cmd"
+)
+
+func main() {
+	flags := pflag.NewFlagSet("kubectl-kcp", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
+	workspaceCmd, err := cmd.NewCmdWorkspace(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// setup klog
+	fs := goflags.NewFlagSet("klog", goflags.PanicOnError)
+	klog.InitFlags(fs)
+	workspaceCmd.PersistentFlags().AddGoFlagSet(fs)
+
+	if err := workspaceCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: URL to access the workspace
+      jsonPath: .status.baseURL
+      name: URL
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -25,6 +25,10 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
+    - description: URL to access the workspace
+      jsonPath: .status.baseURL
+      name: URL
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/config/system-crds/bootstrap.go
+++ b/config/system-crds/bootstrap.go
@@ -53,6 +53,7 @@ func Bootstrap(ctx context.Context, crdClient apiextensionsclient.Interface, dis
 		{Group: tenancy.GroupName, Resource: "clusterworkspaces"},
 		{Group: tenancy.GroupName, Resource: "clusterworkspacetypes"},
 		{Group: tenancy.GroupName, Resource: "workspaceshards"},
+		{Group: tenancy.GroupName, Resource: "workspaces"},
 		{Group: apiresource.GroupName, Resource: "apiresourceimports"},
 		{Group: apiresource.GroupName, Resource: "negotiatedapiresources"},
 		{Group: workload.GroupName, Resource: "workloadclusters"},

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -43,6 +43,7 @@ var RootCluster = logicalcluster.New("root")
 // +kubebuilder:resource:scope=Cluster,categories=kcp
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`,description="Type of the workspace"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The current phase (e.g. Scheduling, Initializing, Ready)"
+// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.baseURL`,description="URL to access the workspace"
 type ClusterWorkspace struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/tenancy/v1beta1/types.go
+++ b/pkg/apis/tenancy/v1beta1/types.go
@@ -38,6 +38,7 @@ import (
 // +kubebuilder:resource:scope=Cluster,categories=kcp
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type`,description="Type of the workspace"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The current phase (e.g. Scheduling, Initializing, Ready)"
+// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.baseURL`,description="URL to access the workspace"
 type Workspace struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/cliplugins/workspace/plugin/helpers.go
+++ b/pkg/cliplugins/workspace/plugin/helpers.go
@@ -27,12 +27,37 @@ import (
 	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 
 	virtualcommandoptions "github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
-	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
 	tenancyclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 )
+
+func parseClusterURL(host string) (*url.URL, logicalcluster.LogicalCluster, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return nil, logicalcluster.LogicalCluster{}, err
+	}
+	ret := *u
+	var clusterName logicalcluster.LogicalCluster
+	for _, prefix := range []string{
+		"/clusters/",
+		path.Join(virtualcommandoptions.DefaultRootPathPrefix, "workspaces") + "/",
+	} {
+		if clusterIndex := strings.Index(u.Path, prefix); clusterIndex >= 0 {
+			clusterName = logicalcluster.New(strings.SplitN(ret.Path[clusterIndex+len(prefix):], "/", 2)[0])
+			ret.Path = ret.Path[:clusterIndex]
+			break
+		}
+	}
+	if clusterName.Empty() || !isValid(clusterName) {
+		return nil, logicalcluster.LogicalCluster{}, fmt.Errorf("current cluster URL %s is not pointing to a cluster workspace", u)
+	}
+
+	return &ret, clusterName, nil
+}
 
 // getWorkspaceFromInternalName retrieves the workspace with this internal name in the
 // user workspace directory, by requesting the `workspaces` virtual workspace.
@@ -50,79 +75,22 @@ func getWorkspaceFromInternalName(ctx context.Context, workspaceInternalName str
 	}
 }
 
-// getWorkspaceAndBasePath gets the workspace name, org logical cluster name and the base URL for the current
-// workspace.
-func getWorkspaceAndBasePath(urlPath string) (orgClusterName logicalcluster.LogicalCluster, workspaceName, basePath string, err error) {
-	// get workspace from current server URL and check it point to an org or the root workspace
-	serverURL, err := url.Parse(urlPath)
-	if err != nil {
-		return logicalcluster.LogicalCluster{}, "", "", err
-	}
-
-	possiblePrefixes := []string{
-		"/clusters/",
-		path.Join(virtualcommandoptions.DefaultRootPathPrefix, "workspaces") + "/",
-	}
-
-	var clusterName logicalcluster.LogicalCluster
-	for _, prefix := range possiblePrefixes {
-		clusterIndex := strings.Index(serverURL.Path, prefix)
-		if clusterIndex < 0 {
-			continue
-		}
-		clusterName = logicalcluster.New(strings.SplitN(serverURL.Path[clusterIndex+len(prefix):], "/", 2)[0])
-		basePath = serverURL.Path[:clusterIndex]
-	}
-
-	if !isValid(clusterName) {
-		return logicalcluster.LogicalCluster{}, "", basePath, fmt.Errorf("current cluster URL %s is not pointing to a workspace", serverURL)
-	}
-
-	parent, workspaceName := clusterName.Split()
-	if parent.String() == "system" {
-		return logicalcluster.LogicalCluster{}, "", "", fmt.Errorf("no workspaces are accessible from %s", clusterName)
-	}
-
-	return parent, workspaceName, basePath, nil
-}
-
-// upToOrg derives the org workspace cluster name to operate on,
-// from a given workspace logical cluster name.
-func upToOrg(orgClusterName logicalcluster.LogicalCluster, workspaceName string, always bool) logicalcluster.LogicalCluster {
-
-	if orgClusterName.Empty() && workspaceName == tenancyv1alpha1.RootCluster.String() {
-		return tenancyv1alpha1.RootCluster
-	}
-
-	if orgClusterName == tenancyv1alpha1.RootCluster && !always {
-		return tenancyv1alpha1.RootCluster.Join(workspaceName)
-	}
-
-	return orgClusterName
-}
-
-func outputCurrentWorkspaceMessage(orgName logicalcluster.LogicalCluster, workspacePrettyName, workspaceName string, opts *Options) error {
-	if workspaceName != "" {
-		message := fmt.Sprintf("Current workspace is %q", workspacePrettyName)
-		if workspaceName != workspacePrettyName {
-			message = fmt.Sprintf("%s (an alias for %q)", message, workspaceName)
-		}
-		if !orgName.Empty() {
-			message = fmt.Sprintf("%s in organization %q", message, orgName)
-		}
-		err := write(opts, fmt.Sprintf("%s.\n", message))
-		return err
-	}
-	return nil
-}
-
-func write(opts *Options, str string) error {
-	_, err := opts.Out.Write([]byte(str))
-	return err
-}
-
-var lclusterRegExp = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9](:[a-z0-9][a-z0-9-]*[a-z0-9])*$`)
+var lclusterRegExp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9](:[a-z][a-z0-9-]*[a-z0-9])*$`)
 
 func isValid(cluster logicalcluster.LogicalCluster) bool {
-	return lclusterRegExp.MatchString(cluster.String())
+	if !lclusterRegExp.MatchString(cluster.String()) {
+		return false
+	}
+
+	return cluster.HasPrefix(v1alpha1.RootCluster) || cluster.HasPrefix(logicalcluster.New("system"))
+}
+
+type personalClusterClient struct {
+	config *rest.Config
+}
+
+func (c *personalClusterClient) Cluster(cluster logicalcluster.LogicalCluster) tenancyclient.Interface {
+	virtualConfig := rest.CopyConfig(c.config)
+	virtualConfig.Host += path.Join("/services/workspaces", cluster.String(), "personal")
+	return tenancyclient.NewForConfigOrDie(virtualConfig)
 }

--- a/pkg/cliplugins/workspace/plugin/helpers_test.go
+++ b/pkg/cliplugins/workspace/plugin/helpers_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReCluster(t *testing.T) {
+	tests := []struct {
+		workspace string
+		valid     bool
+	}{
+		{"", false},
+
+		{"root", true},
+		{"root:foo", true},
+		{"root:foo:bar", true},
+		{"root:b1234567890123456789012345678912", true}, // the plugin does not decide about segment length, the server does
+
+		{"system", true},
+		{"system:foo", true},
+		{"system:foo:bar", true},
+
+		{"foo", false},
+		{"foo:bar", false},
+		{"root:", false},
+		{":root", false},
+		{"root::foo", false},
+		{"root:föö:bär", false},
+		{"root:bar_bar", false},
+		{"root:a", false},
+		{"root:0a", false},
+		{"root:0bar", false},
+		{"root/bar", false},
+		{"root:bar-", false},
+		{"root:-bar", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.workspace, func(t *testing.T) {
+			if got := isValid(logicalcluster.New(tt.workspace)); got != tt.valid {
+				t.Errorf("isValid(%q) = %v, want %v", tt.workspace, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestParseClusterURL(t *testing.T) {
+	tests := []struct {
+		host    string
+		url     string
+		cluster string
+		wantErr bool
+	}{
+		{host: "", wantErr: true},
+		{host: "garbgae", wantErr: true},
+		{host: "https://host/foo", wantErr: true},
+		{host: "https://host/clusters/root", url: "https://host", cluster: "root"},
+		{host: "https://host/clusters/root:foo", url: "https://host", cluster: "root:foo"},
+		{host: "https://host/clusters/system:foo", url: "https://host", cluster: "system:foo"},
+		{host: "https://host/clusters/abc:def", wantErr: true},
+		{host: "https://host/clusters/", wantErr: true},
+		{host: "https://host/clusters", wantErr: true},
+		{host: "https://host/clusters/root:foo:bar", url: "https://host", cluster: "root:foo:bar"},
+		{host: "https://host/clusters/root:foo/abc", url: "https://host", cluster: "root:foo"},
+		{host: "https://host/services/workspaces/root:foo:bar", url: "https://host", cluster: "root:foo:bar"},
+		{host: "https://host/services/workspaces/root:foo:bar/abc", url: "https://host", cluster: "root:foo:bar"},
+		{host: "https://host/services/workspaces/", wantErr: true},
+		{host: "https://host/services/workspaces", wantErr: true},
+		{host: "https://host/abc/clusters/root:foo", url: "https://host/abc", cluster: "root:foo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			gotURL, gotCluster, err := parseClusterURL(tt.host)
+			if tt.wantErr {
+				require.Error(t, err, "instead of error got %q, %q", gotURL, gotCluster)
+			} else {
+				require.NoError(t, err)
+			}
+			var gotURLStr string
+			if gotURL != nil {
+				gotURLStr = gotURL.String()
+			}
+			if gotURLStr != tt.url {
+				t.Errorf("url, _ := parseClusterURL(%q) got = %v, want %v", tt.host, gotURL, tt.url)
+			}
+			if gotCluster != logicalcluster.New(tt.cluster) {
+				t.Errorf("_, cluster := parseClusterURL(%q) got = %v, want %v", tt.host, gotCluster, tt.cluster)
+			}
+		})
+	}
+}

--- a/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
@@ -1,0 +1,721 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientgotesting "k8s.io/client-go/testing"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
+	tenancyclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	tenancyfake "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/fake"
+)
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name   string
+		config clientcmdapi.Config
+
+		existingWorkspaces []string // existing cluster workspaces
+		markReady          bool
+
+		newWorkspaceName                 string
+		newWorkspaceType                 string
+		useAfterCreation, ignoreExisting bool
+
+		expected *clientcmdapi.Config
+		wantErr  bool
+	}{
+		{
+			name: "happy case, no use",
+			config: clientcmdapi.Config{CurrentContext: "test",
+				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			newWorkspaceName: "bar",
+		},
+		{
+			name: "create, use after creation, but not ready",
+			config: clientcmdapi.Config{CurrentContext: "test",
+				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			newWorkspaceName: "bar",
+			useAfterCreation: true,
+			wantErr:          true, // not ready
+		},
+		{
+			name: "create, use after creation",
+			config: clientcmdapi.Config{CurrentContext: "test",
+				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			newWorkspaceName: "bar",
+			useAfterCreation: true,
+			markReady:        true,
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"test":                       {Cluster: "test", AuthInfo: "test"},
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "test", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test":                      {Server: "https://test/clusters/root:foo"},
+					"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo:bar"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+		},
+		{
+			name: "create, already existing",
+			config: clientcmdapi.Config{CurrentContext: "test",
+				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingWorkspaces: []string{"bar"},
+			newWorkspaceName:   "bar",
+			useAfterCreation:   true,
+			wantErr:            true,
+		},
+		{
+			name: "create, use after creation, ignore existing",
+			config: clientcmdapi.Config{CurrentContext: "test",
+				Contexts:  map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"test": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingWorkspaces: []string{"bar"},
+			newWorkspaceName:   "bar",
+			useAfterCreation:   true,
+			markReady:          true,
+			ignoreExisting:     true,
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"test":                       {Cluster: "test", AuthInfo: "test"},
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "test", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test":                      {Server: "https://test/clusters/root:foo"},
+					"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo:bar"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got *clientcmdapi.Config
+
+			cluster := tt.config.Clusters[tt.config.Contexts[tt.config.CurrentContext].Cluster]
+			u := parseURLOrDie(cluster.Server)
+			currentClusterName := logicalcluster.New(strings.TrimPrefix(u.Path, "/clusters/"))
+			u.Path = ""
+
+			objects := []runtime.Object{}
+			for _, name := range tt.existingWorkspaces {
+				objects = append(objects, &tenancyv1beta1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Spec: tenancyv1beta1.WorkspaceSpec{
+						Type: "Universal",
+					},
+					Status: tenancyv1beta1.WorkspaceStatus{
+						Phase: tenancyv1alpha1.ClusterWorkspacePhaseReady,
+						URL:   fmt.Sprintf("https://test%s", currentClusterName.Join(name).Path()),
+					},
+				})
+			}
+			client := tenancyfake.NewSimpleClientset(objects...)
+
+			if tt.markReady {
+				client.PrependReactor("create", "workspaces", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+					obj := action.(clientgotesting.CreateAction).GetObject().(*tenancyv1beta1.Workspace)
+					obj.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseReady
+					u := parseURLOrDie(u.String())
+					u.Path = currentClusterName.Join(obj.Name).Path()
+					obj.Status.URL = u.String()
+					obj.Spec.Type = tt.newWorkspaceType
+					if obj.Spec.Type == "" {
+						obj.Spec.Type = "Universal"
+					}
+					if err := client.Tracker().Create(tenancyv1beta1.SchemeGroupVersion.WithResource("workspaces"), obj, ""); err != nil {
+						return false, nil, err
+					}
+					return true, obj, nil
+				})
+			}
+
+			kc := &KubeConfig{
+				startingConfig: tt.config.DeepCopy(),
+				currentContext: tt.config.CurrentContext,
+
+				clusterClient: fakeTenancyClient{
+					t: t,
+					clients: map[logicalcluster.LogicalCluster]*tenancyfake.Clientset{
+						currentClusterName: client,
+					},
+				},
+				personalClient: fakeTenancyClient{
+					t: t,
+					clients: map[logicalcluster.LogicalCluster]*tenancyfake.Clientset{
+						currentClusterName: client,
+					},
+				},
+				modifyConfig: func(config *clientcmdapi.Config) error {
+					got = config
+					return nil
+				},
+				IOStreams: genericclioptions.NewTestIOStreamsDiscard(),
+			}
+			err := kc.CreateWorkspace(context.TODO(), tt.newWorkspaceName, tt.newWorkspaceType, tt.ignoreExisting, tt.useAfterCreation, time.Second)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if got != nil && tt.expected == nil {
+				t.Errorf("unexpected kubeconfig write")
+			} else if got == nil && tt.expected != nil {
+				t.Errorf("expected a kubeconfig write, but didn't see one")
+			} else if got != nil && !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("unexpected config, diff (expected, got): %s", cmp.Diff(tt.expected, got))
+			}
+		})
+	}
+}
+
+func TestUse(t *testing.T) {
+	tests := []struct {
+		name   string
+		config clientcmdapi.Config
+
+		existingObjects map[logicalcluster.LogicalCluster][]string
+		prettyNames     map[logicalcluster.LogicalCluster]map[string]string
+		unready         map[logicalcluster.LogicalCluster]map[string]bool // unready workspaces
+
+		param string
+
+		expected   *clientcmdapi.Config
+		wantStdout []string
+		wantErrors []string
+		wantErr    bool
+	}{
+		{
+			name: "current, context named workspace",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo:bar"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			param:      "",
+			wantStdout: []string{"Current workspace is \"root:foo:bar\""},
+		},
+		{
+			name: "current, no cluster URL",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param:      "",
+			wantStdout: []string{"Current workspace is the URL \"https://test\""},
+		},
+		{
+			name: "workspace name",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			param: "bar",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo:bar"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"root:foo:bar\""},
+		},
+		{
+			name: "workspace pretty name",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			param: "baz",
+			prettyNames: map[logicalcluster.LogicalCluster]map[string]string{
+				logicalcluster.New("root:foo"): {"bar": "baz"},
+			},
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo:bar"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"root:foo:bar\""},
+		},
+		{
+			name: "workspace name, no cluster URL",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param:   "bar",
+			wantErr: true,
+		},
+		{
+			name: "absolute name",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			prettyNames: map[logicalcluster.LogicalCluster]map[string]string{
+				logicalcluster.New("root:foo"): {"bar": "baz"},
+			},
+			param: "root:foo:bar",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo:bar"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"root:foo:bar\""},
+		},
+		{
+			name: "absolute name, no cluster URL",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param:   "root:bar",
+			wantErr: true,
+		},
+		{
+			name: "system:admin",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param: "system:admin",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/system:admin"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"system:admin\""},
+		},
+		{
+			name: "root",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param: "root",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"root\""},
+		},
+		{
+			name: "root, no cluster URL",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param:   "root",
+			wantErr: true,
+		},
+		{
+			name: "..",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo:bar"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root"): {"foo"},
+			},
+			param: "..",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo:bar"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"root:foo\""},
+		},
+		{
+			name: ".., no cluster URL",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param:   "..",
+			wantErr: true,
+		},
+		{
+			name: ".. to root",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param: "..",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			wantStdout: []string{"Current workspace is \"root\""},
+		},
+		{
+			name: ".. in root",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts:  map[string]*clientcmdapi.Context{"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"}},
+				Clusters:  map[string]*clientcmdapi.Cluster{"workspace.kcp.dev/current": {Server: "https://test/clusters/root"}},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			param:    "..",
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name: "- with existing previous context",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test2"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo:bar"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test":  {Token: "test"},
+					"test2": {Token: "test2"},
+				},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			param: "-",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test2"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo:bar"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test":  {Token: "test"},
+					"test2": {Token: "test2"},
+				},
+			},
+			wantStdout: []string{"Current workspace is \"root:foo:bar\""},
+		},
+		{
+			name: "- without existing previous context",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current": {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{"test": {Token: "test"}},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			param:   "-",
+			wantErr: true,
+		},
+		{
+			name: "- with non-cluster context",
+			config: clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "other", AuthInfo: "other"},
+					"other":                      {Cluster: "other", AuthInfo: "other"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"},
+					"other":                     {Server: "https://other/"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test":  {Token: "test"},
+					"other": {Token: "test"},
+				},
+			},
+			existingObjects: map[logicalcluster.LogicalCluster][]string{
+				logicalcluster.New("root:foo"): {"bar"},
+			},
+			param: "-",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "other", AuthInfo: "other"},
+					"workspace.kcp.dev/previous": {Cluster: "workspace.kcp.dev/previous", AuthInfo: "test"},
+					"other":                      {Cluster: "other", AuthInfo: "other"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current":  {Server: "https://test/clusters/root:foo"},
+					"workspace.kcp.dev/previous": {Server: "https://test/clusters/root:foo"},
+					"other":                      {Server: "https://other/"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test":  {Token: "test"},
+					"other": {Token: "test"},
+				},
+			},
+			wantStdout: []string{"Current workspace is the URL \"https://other/\""},
+		},
+		{
+			name: "- with non-cluster context, with non-cluster previous context",
+			config: clientcmdapi.Config{CurrentContext: "other",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "workspace.kcp.dev/current", AuthInfo: "test"},
+					"workspace.kcp.dev/previous": {Cluster: "other2", AuthInfo: "other2"},
+					"other":                      {Cluster: "other", AuthInfo: "other"},
+					"other2":                     {Cluster: "other2", AuthInfo: "other2"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"},
+					"other":                     {Server: "https://other/"},
+					"other2":                    {Server: "https://other2/"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test":   {Token: "test"},
+					"other":  {Token: "test"},
+					"other2": {Token: "test2"},
+				},
+			},
+			param: "-",
+			expected: &clientcmdapi.Config{CurrentContext: "workspace.kcp.dev/current",
+				Contexts: map[string]*clientcmdapi.Context{
+					"workspace.kcp.dev/current":  {Cluster: "other2", AuthInfo: "other2"},
+					"workspace.kcp.dev/previous": {Cluster: "other", AuthInfo: "other"},
+					"other":                      {Cluster: "other", AuthInfo: "other"},
+					"other2":                     {Cluster: "other2", AuthInfo: "other2"},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"workspace.kcp.dev/current": {Server: "https://test/clusters/root:foo"},
+					"other":                     {Server: "https://other/"},
+					"other2":                    {Server: "https://other2/"},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test":   {Token: "test"},
+					"other":  {Token: "test"},
+					"other2": {Token: "test2"},
+				},
+			},
+			wantStdout: []string{"Current workspace is the URL \"https://other2/\""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *clientcmdapi.Config
+
+			cluster := tt.config.Clusters[tt.config.Contexts[tt.config.CurrentContext].Cluster]
+			u := parseURLOrDie(cluster.Server)
+			u.Path = ""
+
+			clients := map[logicalcluster.LogicalCluster]*tenancyfake.Clientset{}
+			personalClients := map[logicalcluster.LogicalCluster]*tenancyfake.Clientset{}
+			for lcluster, names := range tt.existingObjects {
+				objs := []runtime.Object{}
+				prettyObjs := []runtime.Object{}
+				for _, name := range names {
+					obj := &tenancyv1beta1.Workspace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: name,
+						},
+						Spec: tenancyv1beta1.WorkspaceSpec{
+							Type: "Universal",
+						},
+					}
+					if !tt.unready[lcluster][name] {
+						obj.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseReady
+						obj.Status.URL = fmt.Sprintf("https://test%s", lcluster.Join(name).Path())
+					}
+					objs = append(objs, obj)
+
+					// pretty name?
+					if pretty, ok := tt.prettyNames[lcluster][name]; ok {
+						obj = obj.DeepCopy()
+						obj.Name = pretty
+					}
+					prettyObjs = append(prettyObjs, obj)
+				}
+				clients[lcluster] = tenancyfake.NewSimpleClientset(objs...)
+				personalClients[lcluster] = tenancyfake.NewSimpleClientset(prettyObjs...)
+			}
+
+			streams, _, stdout, stderr := genericclioptions.NewTestIOStreams()
+
+			kc := &KubeConfig{
+				startingConfig: tt.config.DeepCopy(),
+				currentContext: tt.config.CurrentContext,
+
+				clusterClient: fakeTenancyClient{
+					t:       t,
+					clients: clients,
+				},
+				personalClient: fakeTenancyClient{
+					t:       t,
+					clients: personalClients,
+				},
+				modifyConfig: func(config *clientcmdapi.Config) error {
+					got = config
+					return nil
+				},
+				IOStreams: streams,
+			}
+			err := kc.UseWorkspace(context.TODO(), tt.param)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			t.Logf("stdout:\n%s", stdout.String())
+			t.Logf("stderr:\n%s", stderr.String())
+
+			if got != nil && tt.expected == nil {
+				t.Errorf("unexpected kubeconfig write")
+			} else if got == nil && tt.expected != nil {
+				t.Errorf("expected a kubeconfig write, but didn't see one")
+			} else if got != nil && !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("unexpected config, diff (expected, got): %s", cmp.Diff(tt.expected, got))
+			}
+
+			for _, s := range tt.wantStdout {
+				require.Contains(t, stdout.String(), s)
+			}
+			if err != nil {
+				for _, s := range tt.wantErrors {
+					require.Contains(t, err.Error(), s)
+				}
+			}
+		})
+	}
+}
+
+func parseURLOrDie(host string) *url.URL {
+	u, err := url.Parse(host)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+type fakeTenancyClient struct {
+	t       *testing.T
+	clients map[logicalcluster.LogicalCluster]*tenancyfake.Clientset
+}
+
+func (f fakeTenancyClient) Cluster(cluster logicalcluster.LogicalCluster) tenancyclient.Interface {
+	client, ok := f.clients[cluster]
+	require.True(f.t, ok, "no client for cluster %s", cluster)
+	return client
+}

--- a/pkg/cliplugins/workspace/plugin/options.go
+++ b/pkg/cliplugins/workspace/plugin/options.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // Options provides options that will drive the update of the current context
@@ -30,6 +31,14 @@ import (
 type Options struct {
 	KubectlOverrides *clientcmd.ConfigOverrides
 	Scope            string
+
+	genericclioptions.IOStreams
+}
+
+type Config struct {
+	Scope      string
+	KubeConfig *clientcmdapi.Config
+
 	genericclioptions.IOStreams
 }
 

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -75,10 +75,18 @@ func newSystemCRDProvider(
 			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "clusterworkspaces.tenancy.kcp.dev"),
 			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "clusterworkspacetypes.tenancy.kcp.dev"),
 			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "workspaceshards.tenancy.kcp.dev"),
+
+			// the following is installed to get discovery and OpenAPI right. But it is actually
+			// served by a native rest storage, projecting the clusterworkspaces.
+			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "workspaces.tenancy.kcp.dev"),
 		),
 		orgCRDs: sets.NewString(
 			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "clusterworkspaces.tenancy.kcp.dev"),
 			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "clusterworkspacetypes.tenancy.kcp.dev"),
+
+			// the following is installed to get discovery and OpenAPI right. But it is actually
+			// served by a native rest storage, projecting the clusterworkspaces.
+			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "workspaces.tenancy.kcp.dev"),
 		),
 		universalCRDs: sets.NewString(
 			clusters.ToClusterAwareKey(SystemCRDLogicalCluster, "apiresourceimports.apiresource.kcp.dev"),

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -531,7 +531,6 @@ func (i *kcpAPIExtensionsApiextensionsV1CustomResourceDefinitionInformer) GetWit
 	}
 	if err != nil {
 		clusterName, name := clusters.SplitClusterAwareKey(name)
-		klog.Infof("GetWithQuorumReadOnCacheMiss name %q -> %s|%s", clusterName, name)
 		cws, err = i.kcpClusterClient.Cluster(clusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, name, metav1.GetOptions{})
 	}
 

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -151,6 +151,8 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 // WithWorkspaceProjection maps the personal virtual workspace "workspaces" resource into the cluster
 // workspace URL space. This means you can do `kubectl get workspaces` from an org workspace.
 func WithWorkspaceProjection(apiHandler http.Handler) http.HandlerFunc {
+	toRedirectPath := path.Join("/apis", tenancyv1beta1.SchemeGroupVersion.Group, tenancyv1beta1.SchemeGroupVersion.Version, "workspaces/")
+
 	return func(w http.ResponseWriter, req *http.Request) {
 		cluster := genericapirequest.ClusterFrom(req.Context())
 		if cluster.Name.Empty() {
@@ -158,10 +160,9 @@ func WithWorkspaceProjection(apiHandler http.Handler) http.HandlerFunc {
 			return
 		}
 
-		toRedirectPath := path.Join("/apis", tenancyv1beta1.SchemeGroupVersion.Group, tenancyv1beta1.SchemeGroupVersion.Version, "workspaces/")
 		if strings.HasPrefix(req.URL.Path, toRedirectPath) {
 			newPath := path.Join("/services/workspaces", cluster.Name.String(), "all", req.URL.Path)
-			klog.Infof("Rewriting %s -> %s", path.Join(cluster.Name.Path(), req.URL.Path), newPath)
+			klog.V(4).Infof("Rewriting %s -> %s", path.Join(cluster.Name.Path(), req.URL.Path), newPath)
 			req.URL.Path = newPath
 		}
 

--- a/pkg/virtual/workspaces/printers/printer.go
+++ b/pkg/virtual/workspaces/printers/printer.go
@@ -39,19 +39,19 @@ func AddWorkspacePrintHandlers(h kprinters.PrintHandler) {
 			Name:        "Type",
 			Type:        "string",
 			Description: "Workspace type",
-			Priority:    1,
+			Priority:    0,
 		},
 		{
 			Name:        "Phase",
 			Type:        "string",
 			Description: "Workspace phase",
-			Priority:    1,
+			Priority:    0,
 		},
 		{
 			Name:        "URL",
 			Type:        "string",
 			Description: "Workspace API Server URL",
-			Priority:    2,
+			Priority:    0,
 		},
 	}
 


### PR DESCRIPTION
Implementing UX from https://docs.google.com/document/d/1XJJCr16bg22QuJnQB2W98A-djRTtrLr2JE2IWZUHzJU/edit#heading=h.nn8danthd1ys.

- simplified and complete kubectl plugin to implement the second section in https://docs.google.com/document/d/1XJJCr16bg22QuJnQB2W98A-djRTtrLr2JE2IWZUHzJU/edit#heading=h.nn8danthd1ys.
- removed duality between v1beta1 `Workspaces` in some virtual workspace path and the `ClusterWorkspaces` in an org. Now you can do `kubectl get workspaces` in an org

Based on https://github.com/kcp-dev/kcp/pull/744.