### PR TITLE
0. ingress-controller: fix race leading to too many leaves when informers are stale

### DIFF
--- a/pkg/reconciler/workload/ingresssplitter/ingresssplitter_controller.go
+++ b/pkg/reconciler/workload/ingresssplitter/ingresssplitter_controller.go
@@ -77,13 +77,14 @@ func NewController(
 			if !ok {
 				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 				if !ok {
-					runtime.HandleError(fmt.Errorf("unexpected boject type: %T", obj))
+					runtime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
 					return
 				}
 
 				ingress, ok = tombstone.Obj.(*networkingv1.Ingress)
 				if !ok {
-					runtime.HandleError(fmt.Errorf("unexpected boject type: %T", obj))
+					runtime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
+					return
 				}
 			}
 

--- a/pkg/reconciler/workload/ingresssplitter/ingresssplitter_controller.go
+++ b/pkg/reconciler/workload/ingresssplitter/ingresssplitter_controller.go
@@ -232,7 +232,7 @@ func (c *Controller) ingressesFromService(obj interface{}) {
 	// One Service can be referenced by 0..n Ingresses, so we need to enqueue all the related ingreses.
 	for _, ingress := range ingresses.List() {
 		klog.Infof("tracked service %q triggered Ingress %q reconciliation", service.Name, ingress)
-		c.enqueue(&ingress)
+		c.queue.Add(ingress)
 	}
 }
 


### PR DESCRIPTION
ingress-controller used generated-name, i.e. without any guarantee that there is only one leaf per workload cluster. Moreover, the controller didn't delete the leaves that are too many. Finally, the e2e test waits for exactly one 🤷‍♂️ 

This PR switches to `<root-name>-<cluster-name>`.

Also: revert 034f5c4f0 which was wrong. The list is a string list.