### PR TITLE
authorization: give everybody authenticated root org access

### DIFF
--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -117,6 +117,8 @@ func TestAuthorizer(t *testing.T) {
 			return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
 		}, wait.ForeverTestTimeout, time.Millisecond*100, "workspace %s didn't get ready", wsName)
 	}
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1"}, nil, []string{"member"})
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-2"}, nil, []string{"access"})
 
 	tests := map[string]func(){
 		"Users can view their own resources": func() {

--- a/test/e2e/framework/users.go
+++ b/test/e2e/framework/users.go
@@ -16,6 +16,19 @@ limitations under the License.
 
 package framework
 
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
 type User struct {
 	Name   string
 	Token  string
@@ -25,4 +38,69 @@ type User struct {
 
 var LoopbackUser User = User{
 	Name: "loopback",
+}
+
+// AdmitWorkspaceAccess create RBAC rules that allow the given users and/or groups to access the given, fully-qualified workspace, i.e.
+// the RBAC objects are create in its parent.
+func AdmitWorkspaceAccess(t *testing.T, ctx context.Context, kubeClusterClient kubernetes.ClusterInterface, orgClusterName logicalcluster.LogicalCluster, users []string, groups []string, verbs []string) {
+	parent, hasParent := orgClusterName.Parent()
+	require.True(t, hasParent, "org cluster %s should have a parent", orgClusterName)
+
+	if len(groups) > 0 {
+		t.Logf("Giving groups %v member access to workspace %q in %q", groups, orgClusterName.Base(), parent)
+	}
+	if len(users) > 0 {
+		t.Logf("Giving users %v member access to workspace %q in %q", users, orgClusterName.Base(), parent)
+	}
+
+	roleName := orgClusterName.Base() + "-" + strings.Join(verbs, "-")
+	_, err := kubeClusterClient.Cluster(parent).RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         verbs,
+				Resources:     []string{"clusterworkspaces/content"},
+				ResourceNames: []string{orgClusterName.Base()},
+				APIGroups:     []string{"tenancy.kcp.dev"},
+			},
+			{
+				Verbs:         []string{"get"},
+				Resources:     []string{"clusterworkspaces/workspace"},
+				ResourceNames: []string{orgClusterName.Base()},
+				APIGroups:     []string{"tenancy.kcp.dev"},
+			},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			APIGroup: "rbac.authorization.k8s.io",
+			Name:     roleName,
+		},
+	}
+
+	for _, group := range groups {
+		binding.Subjects = append(binding.Subjects, rbacv1.Subject{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Group",
+			Name:     group,
+		})
+	}
+	for _, user := range users {
+		binding.Subjects = append(binding.Subjects, rbacv1.Subject{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "User",
+			Name:     user,
+		})
+	}
+
+	_, err = kubeClusterClient.Cluster(parent).RbacV1().ClusterRoleBindings().Create(ctx, binding, metav1.CreateOptions{})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This is preprartion for the virtual workspace apiserver to do proper authorization, and also for users to access the root and see their org.