### PR TITLE
server: send warning header to client on /clusters/<org>:<workspace> access

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -46,6 +46,8 @@ import (
 	apiserverdiscovery "k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/warning"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
 	"k8s.io/kubernetes/pkg/genericcontrolplane/aggregator"
 )
@@ -87,6 +89,15 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 		var clusterName logicalcluster.LogicalCluster
 		if path := req.URL.Path; strings.HasPrefix(path, "/clusters/") {
 			path = strings.TrimPrefix(path, "/clusters/")
+
+			// temporarily re-add the `root:` prefix and tell the use via warning headers
+			if !strings.HasPrefix(path, "*/") && !strings.HasPrefix(path, "root/") && !strings.HasPrefix(path, "root:") && !strings.HasPrefix(path, "system:") {
+				klog.Infof("%s => root:%s", path, path)
+				path = "root:" + path
+
+				warning.AddWarning(req.Context(), "", "the /clusters/<org>:<workspace> URL pattern is deprecated. Update your kubeconfig and use /clusters/root:<org>:<workspace> instead.")
+			}
+
 			i := strings.Index(path, "/")
 			if i == -1 {
 				responsewriters.ErrorNegotiated(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -30,6 +30,7 @@ import (
 	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/endpoints/filters"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/client-go/dynamic"
@@ -224,6 +225,10 @@ func (s *Server) Run(ctx context.Context) error {
 		apiHandler = WithAcceptHeader(apiHandler)
 		apiHandler = WithClusterScope(genericapiserver.DefaultBuildHandlerChain(apiHandler, c))
 		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler, unsafeServiceAccountPreAuth)
+
+		// this will be replaced in DefaultBuildHandlerChain. So at worst we get twice as many warning.
+		// But this is not harmful as the kcp warnings are not many.
+		apiHandler = filters.WithWarningRecorder(apiHandler)
 
 		// add a mux before the chain, for other handlers with their own handler chain to hook in
 		mux := http.NewServeMux()


### PR DESCRIPTION
```
$ kubectl kcp workspace create foo <- old kubectl plugin
W0329 10:22:54.753682   33759 warnings.go:70] the /clusters/<org>:<cluster> URL pattern is deprecated. Update your kubeconfig and use /clusters/root:<org>:<cluster> instead.
Workspace "foo" (type "Universal") created.
```