### PR TITLE
kubectl-kcp+server: set user-agent and version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,26 +40,26 @@ GOLANGCI_LINT_VER := v1.44.2
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
+KUBE_MAJOR_VERSION := $(shell grep "k8s.io/kubernetes v" go.mod | sed "s/.*k8s.io\/kubernetes v\([0-9]*\)\..*/\1/")
+KUBE_MINOR_VERSION := $(shell grep "k8s.io/kubernetes v" go.mod | sed "s/.*k8s.io\/kubernetes v[0-9]*\.\([0-9]*\).*/\1/")
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_DIRTY := $(shell git diff --quiet && echo 'clean' || echo 'dirty')
-GIT_VERSION := $(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null)
-BUILD_MAJOR_VERSION := $(shell echo "$(GIT_VERSION)" | sed "s/v0\.\([0-9]*\).*/\1/")
-BUILD_MINOR_VERSION := $(shell echo "$(GIT_VERSION)" | sed "s/v0\.[0-9]*\.\([0-9]*\).*/\1/")
+GIT_VERSION := $(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))+kcp
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/client-go/pkg/version.gitTreeState=${GIT_DIRTY} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/client-go/pkg/version.gitMajor=${BUILD_MAJOR_VERSION} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/client-go/pkg/version.gitMinor=${BUILD_MINOR_VERSION} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/client-go/pkg/version.buildDate=${BUILD_DATE} \
+	-X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \
+	-X k8s.io/client-go/pkg/version.gitTreeState=${GIT_DIRTY} \
+	-X k8s.io/client-go/pkg/version.gitVersion=${GIT_VERSION} \
+	-X k8s.io/client-go/pkg/version.gitMajor=${KUBE_MAJOR_VERSION} \
+	-X k8s.io/client-go/pkg/version.gitMinor=${KUBE_MINOR_VERSION} \
+	-X k8s.io/client-go/pkg/version.buildDate=${BUILD_DATE} \
 	\
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/component-base/pkg/version.gitCommit=${GIT_COMMIT} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/component-base/pkg/version.gitTreeState=${GIT_DIRTY} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/component-base/pkg/version.gitVersion=${GIT_VERSION} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/component-base/pkg/version.gitMajor=${BUILD_MAJOR_VERSION} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/component-base/pkg/version.gitMinor=${BUILD_MINOR_VERSION} \
-	-X github.com/kcp-dev/kcp/vendor/k8s.io/component-base/pkg/version.buildDate=${BUILD_DATE}
+	-X k8s.io/component-base/version.gitCommit=${GIT_COMMIT} \
+	-X k8s.io/component-base/version.gitTreeState=${GIT_DIRTY} \
+	-X k8s.io/component-base/version.gitVersion=${GIT_VERSION} \
+	-X k8s.io/component-base/version.gitMajor=${KUBE_MAJOR_VERSION} \
+	-X k8s.io/component-base/version.gitMinor=${KUBE_MINOR_VERSION} \
+	-X k8s.io/component-base/version.buildDate=${BUILD_DATE}
 all: build
 .PHONY: all
 

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -492,7 +492,14 @@ func (kc *KubeConfig) workspaceDirectoryRestConfig(contextName string, opts *Opt
 	overrides := &clientcmd.ConfigOverrides{
 		AuthInfo: authInfoOverride,
 	}
-	return clientcmd.NewDefaultClientConfig(*workpaceDirectoryAwareConfig, overrides).ClientConfig()
+
+	config, err := clientcmd.NewDefaultClientConfig(*workpaceDirectoryAwareConfig, overrides).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	config.UserAgent = rest.DefaultKubernetesUserAgent()
+	return config, nil
 }
 
 // tenancyClient returns the tenancy client set to access the workspace directory


### PR DESCRIPTION
Fixing https://github.com/kcp-dev/kcp/issues/645.

Plugin user agent: `kubectl-kcp/v0.2.3 (darwin/arm64) kubernetes/96ce0be`
Server version:
```
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v0.2.3-1-g96ce0beb59c389+kcp", GitCommit:"96ce0beb", 
GitTreeState:"clean", BuildDate:"2022-03-29T16:58:29Z", GoVersion:"go1.17.7", Compiler:"gc", Platform:"darwin/arm64"}
```
See how major and minor version are the kube ones, but the GitVersion has the `kcp` term inside. This is the same way that k3s and OpenShift servers version themselves.