### PR TITLE
e2e: Update shared-server job to run twice

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
           ARTIFACT_DIR=/tmp/e2e \
           PATH="${PATH}:$(pwd)/bin/" \
           TEST_ARGS="-args --kubeconfig=$(pwd)/.kcp/admin.kubeconfig" \
-          COUNT=1 \
+          COUNT=2 \
           E2E_PARALLELISM=2 \
           make test-e2e
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This validates that the e2e tests can run repeatedly without error
against a shared server. Important for local development and testing.