### PR TITLE
e2e: run via go-run by default, NO_GORUN=1 for opt-out from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ E2E_PARALLELISM ?= 1
 .PHONY: test-e2e
 test-e2e: WHAT ?= ./test/e2e...
 test-e2e: build
-	go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
+	NO_GORUN=1 go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
 
 .PHONY: test
 test: WHAT ?= ./...


### PR DESCRIPTION
Follow-up to #753 that hopefully addresses the cleanup problem.