### PR TITLE
Add .dockerignore file to exclude cmd/test-server from image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore server only used for e2e testing
+cmd/test-server


### PR DESCRIPTION
This is intended to unwedge the image build broken by #795