### PR TITLE
Allow optional port on --external-hostname

### DIFF
--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -22,9 +22,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
-	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
@@ -110,9 +108,9 @@ func (s *AdminAuthentication) ApplyTo(config *genericapiserver.Config) (newToken
 }
 
 // TODO(jmprusi): delete once push mode is removed.
-func (s *AdminAuthentication) GetPushModeSyncerKubeconfig(config *genericapiserver.Config, newToken string, tokenHash []byte, externalAddress string, servingPort int) (*clientcmdapi.Config, error) {
+func (s *AdminAuthentication) GetPushModeSyncerKubeconfig(config *genericapiserver.Config, newToken string, tokenHash []byte) (*clientcmdapi.Config, error) {
 	externalCACert, _ := config.SecureServing.Cert.CurrentCertKeyContent()
-	externalKubeConfigHost := fmt.Sprintf("https://%s", net.JoinHostPort(externalAddress, strconv.Itoa(int(servingPort))))
+	externalKubeConfigHost := fmt.Sprintf("https://%s", config.ExternalAddress)
 
 	externalAdminUserName := "admin"
 	if newToken == "" {
@@ -138,9 +136,9 @@ func (s *AdminAuthentication) GetPushModeSyncerKubeconfig(config *genericapiserv
 	return externalKubeConfig, nil
 }
 
-func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte, externalAddress string, servingPort int) error {
+func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte) error {
 	externalCACert, _ := config.SecureServing.Cert.CurrentCertKeyContent()
-	externalKubeConfigHost := fmt.Sprintf("https://%s:%d", externalAddress, servingPort)
+	externalKubeConfigHost := fmt.Sprintf("https://%s", config.ExternalAddress)
 
 	externalAdminUserName := "admin"
 	if newToken == "" {

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -40,7 +39,7 @@ type mux interface {
 	Handle(pattern string, handler http.Handler)
 }
 
-func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient kubernetesclient.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface, auth genericapiserver.AuthenticationInfo, preHandlerChainMux mux) error {
+func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient kubernetesclient.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface, auth genericapiserver.AuthenticationInfo, externalAddress string, preHandlerChainMux mux) error {
 	// create virtual workspaces
 	extraInformerStarts, virtualWorkspaces, err := s.options.Virtual.Workspaces.NewVirtualWorkspaces(
 		virtualcommandoptions.DefaultRootPathPrefix,
@@ -72,7 +71,7 @@ func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient
 	if err != nil {
 		return err
 	}
-	rootAPIServerConfig.GenericConfig.ExternalAddress = fmt.Sprintf("%s:%d", s.options.GenericControlPlane.GenericServerRunOptions.ExternalHost, s.options.GenericControlPlane.SecureServing.BindPort)
+	rootAPIServerConfig.GenericConfig.ExternalAddress = externalAddress
 	completedRootAPIServerConfig := rootAPIServerConfig.Complete()
 	rootAPIServer, err := completedRootAPIServerConfig.New(genericapiserver.NewEmptyDelegate())
 	if err != nil {


### PR DESCRIPTION
## Summary

kube-apiserver allows port to be part of --external-hostname, so we are
mirroring that behavior here.

## Related issue(s)

Partially fixes https://github.com/kcp-dev/kcp/issues/707

Signed-off-by: Kyle Lape <klape@redhat.com>