### PR TITLE
e2e: Add --use-default-server to simplify use of persistent fixture

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
       - run: |-
           ARTIFACT_DIR=/tmp/e2e \
           PATH="${PATH}:$(pwd)/bin/" \
-          TEST_ARGS="-args --kubeconfig=$(pwd)/.kcp/admin.kubeconfig" \
+          TEST_ARGS='-args --use-default-server' \
           COUNT=2 \
           E2E_PARALLELISM=2 \
           make test-e2e

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -30,15 +30,15 @@ import (
 //
 // Repeatably start a persistent test server:
 //
-//   $ rm -r .kcp/ && go run ./cmd/test-server 2>&1 | tee kcp.log
+//   $ rm -rf .kcp/ && make build && ./bin/test-server 2>&1 | tee kcp.log
 //
 // Run the e2e suite against a persistent server:
 //
-//   $ TEST_ARGS="-args --kubeconfig=$(pwd)/.kcp/admin.kubeconfig" E2E_PARALLELISM=6 make test-e2e
+//   $ TEST_ARGS='-args --use-default-server' E2E_PARALLELISM=6 make test-e2e
 //
 // Run individual tests against a persistent server:
 //
-//   $ go test -v --kubeconfig=/path/to/.kcp/admin.kubeconfig"
+//   $ go test -v --use-default-server
 //
 func main() {
 	commandLine := append(framework.StartKcpCommand(), framework.TestServerArgs()...)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -64,16 +64,17 @@ type KcpFixture struct {
 
 // SharedKcpServer returns a kcp server fixture intended to be shared
 // between tests. A persistent server will be configured if
-// `--kubeconfig` is supplied to the test runner. Otherwise a
-// test-managed server will be started. Only tests that are known to
-// be hermetic are compatible with shared fixture.
+// `--kubeconfig` or `--use-default-server` is supplied to the test
+// runner. Otherwise a test-managed server will be started. Only tests
+// that are known to be hermetic are compatible with shared fixture.
 func SharedKcpServer(t *testing.T) RunningServer {
 	serverName := "shared"
-	if len(TestConfig.KubeConfig) > 0 {
+	kubeconfig := TestConfig.Kubeconfig()
+	if len(kubeconfig) > 0 {
 		// Use a persistent server
 
-		t.Logf("shared kcp server will target the persistent kcp server identified by --kubeconfig")
-		server, err := newPersistentKCPServer(serverName, TestConfig.KubeConfig)
+		t.Logf("shared kcp server will target configuration %q", kubeconfig)
+		server, err := newPersistentKCPServer(serverName, kubeconfig)
 		require.NoError(t, err, "failed to create persistent server fixture")
 		return server
 	}

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -112,7 +112,7 @@ func createOrgMemberRoleForGroup(t *testing.T, ctx context.Context, kubeClusterC
 }
 
 func TestWorkspacesVirtualWorkspaces(t *testing.T) {
-	if len(framework.TestConfig.KubeConfig) == 0 {
+	if len(framework.TestConfig.Kubeconfig()) == 0 {
 		// Skip testing standalone when running against persistent fixture to minimize
 		// test execution cost for development.
 		t.Run("Standalone virtual workspace apiserver", func(t *testing.T) {


### PR DESCRIPTION
Rather than requiring developers to supply the qualified path to
.kcp/admin.kubeconfig to run against shared fixture, rely on the fact
that the repository root is discoverable to allow --use-default-server
to supply the same configuration.