### PR TITLE
e2e: Update ingress testing to use go run by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
           ARTIFACT_DIR=/tmp/e2e \
           PATH="${PATH}:$(pwd)/bin/" \
           TEST_ARGS='-args --use-default-server' \
-          COUNT=2 \
+          COUNT=1 \
           E2E_PARALLELISM=2 \
           make test-e2e
       - uses: actions/upload-artifact@v2

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -159,12 +159,20 @@ func RepositoryBinDir() string {
 // StartKcpCommand returns the string tokens required to start kcp in
 // the currently configured mode (direct or via `go run`).
 func StartKcpCommand() []string {
+	command := DirectOrGoRunCommand("kcp")
+	return append(command, "start")
+}
+
+// DirectOrGoRunCommand returns the string tokens required to start
+// the given executable in the currently configured mode (direct or
+// via `go run`).
+func DirectOrGoRunCommand(executableName string) []string {
 	if NoGoRunEnvSet() {
-		kcpPath := filepath.Join(RepositoryBinDir(), "kcp")
-		return []string{kcpPath, "start"}
+		cmdPath := filepath.Join(RepositoryBinDir(), executableName)
+		return []string{cmdPath}
 	} else {
-		kcpCmdPath := filepath.Join(RepositoryDir(), "cmd", "kcp")
-		return []string{"go", "run", kcpCmdPath, "start"}
+		cmdPath := filepath.Join(RepositoryDir(), "cmd", executableName)
+		return []string{"go", "run", cmdPath}
 	}
 }
 

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -261,13 +261,13 @@ func TestIngressController(t *testing.T) {
 			err = clientcmd.WriteToFile(ingressConfig, kubeconfigPath)
 			require.NoError(t, err, "failed to write kubeconfig to file")
 
-			ingressController := framework.NewAccessory(t, artifactDir,
-				filepath.Join(framework.RepositoryBinDir(), "ingress-controller"), // name
-				"ingress-controller",
+			executableName := "ingress-controller"
+			cmd := append(framework.DirectOrGoRunCommand(executableName),
 				"--kubeconfig="+kubeconfigPath,
 				"--envoy-listener-port="+envoyListenerPort,
 				"--envoy-xds-port="+xdsListenerPort,
 			)
+			ingressController := framework.NewAccessory(t, artifactDir, executableName, cmd...)
 			err = ingressController.Run(t, framework.WithLogStreaming)
 			require.NoError(t, err, "failed to start ingress controller")
 


### PR DESCRIPTION
This ensures that a test run will always be using the latest source of
the tree vs whatever binaries are in the path.