### PR TITLE
gh-actions: Fix relative path of kubectl command

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Get the external hostname
         id: external_hostname
-        run: echo "::set-output name=external_hostname::$(../kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} get route kcp -o jsonpath='{.spec.host}')"
+        run: echo "::set-output name=external_hostname::$(./kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} get route kcp -o jsonpath='{.spec.host}')"
 
       - name: Deploy new image to CI
         id: deploy-to-ci


### PR DESCRIPTION
This `kubectl` command has been failing for a long time, but we didn't notice because no one really relied on `EXTERNAL_HOSTNAME` being set correctly.

Signed-off-by: Kyle Lape <klape@redhat.com>