### PR TITLE
e2e: Enable multiple test servers to run without port conflict

### DIFF
--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -30,7 +30,7 @@ import (
 //
 // Repeatably start a persistent test server:
 //
-//   $ rm -rf .kcp/ && make build && ./bin/test-server 2>&1 | tee kcp.log
+//   $ rm -rf .kcp/ && go run ./cmd/test-server 2>&1 | tee kcp.log
 //
 // Run the e2e suite against a persistent server:
 //
@@ -41,7 +41,11 @@ import (
 //   $ go test -v --use-default-server
 //
 func main() {
-	commandLine := append(framework.StartKcpCommand(), framework.TestServerArgs()...)
+	args, err := framework.TestServerArgsForConcurrent()
+	if err != nil {
+		log.Fatalf("failed to retrieve server args: %v", err)
+	}
+	commandLine := append(framework.StartKcpCommand(), args...)
 	log.Printf("running: %v\n", strings.Join(commandLine, " "))
 
 	cmd := exec.Command(commandLine[0], commandLine[1:]...)
@@ -49,7 +53,7 @@ func main() {
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -40,19 +41,22 @@ import (
 	"github.com/kcp-dev/kcp/pkg/syncer"
 )
 
-// TestServerArgs returns the set of kcp args used to start a test
-// server using the token auth file from the working tree.
-func TestServerArgs() []string {
-	return TestServerArgsWithTokenAuthFile("test/e2e/framework/auth-tokens.csv")
+// TokenAuthFileForTest returns the absolute path of the auth token
+// file required by some auth tests.
+func TokenAuthFileForTest() string {
+	return filepath.Join(
+		RepositoryDir(), "test", "e2e", "framework", "auth-tokens.csv",
+	)
 }
 
-// TestServerArgsWithTokenAuthFile returns the set of kcp args used to
-// start a test server with the given token auth file.
-func TestServerArgsWithTokenAuthFile(tokenAuthFile string) []string {
+// CommonTestServerArgs returns the set of kcp args used to start a
+// test server that are common between test-managed servers and
+// servers started before a test run.
+func CommonTestServerArgs() []string {
 	return []string{
 		"--auto-publish-apis",
 		"--discovery-poll-interval=5s",
-		"--token-auth-file", tokenAuthFile,
+		"--token-auth-file", TokenAuthFileForTest(),
 		"--run-virtual-workspaces=true",
 	}
 }
@@ -99,10 +103,9 @@ func SharedKcpServer(t *testing.T) RunningServer {
 	// initializes the shared fixture before tests that rely on the
 	// fixture.
 
-	tokenAuthFile := WriteTokenAuthFile(t)
 	f := newKcpFixture(t, kcpConfig{
 		Name: serverName,
-		Args: TestServerArgsWithTokenAuthFile(tokenAuthFile),
+		Args: CommonTestServerArgs(),
 	})
 	return f.Servers[serverName]
 }

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -61,6 +61,31 @@ func CommonTestServerArgs() []string {
 	}
 }
 
+// TestServerArgsForConcurrent returns the set of kcp args used to
+// start a test server that will run concurrently with other test
+// servers. The etcd and server ports are randomized to ensure that
+// multiple servers can run in parallel without explicit port
+// configuration.
+func TestServerArgsForConcurrent() ([]string, error) {
+	etcdClientPort, err := GetMaybeFreePort()
+	if err != nil {
+		return nil, err
+	}
+	etcdPeerPort, err := GetMaybeFreePort()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(CommonTestServerArgs(),
+		"--embedded-etcd-client-port="+etcdClientPort,
+		"--embedded-etcd-peer-port="+etcdPeerPort,
+
+		// Ensure kcp picks a random port to serve securely on
+		"--experimental-bind-free-port=true",
+		"--secure-port=0",
+	), nil
+}
+
 // KcpFixture manages the lifecycle of a set of kcp servers.
 //
 // Deprecated for use outside this package. Prefer PrivateKcpServer().

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -19,7 +19,6 @@ package framework
 import (
 	"bytes"
 	"context"
-	"embed"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -52,40 +51,6 @@ import (
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 )
-
-//go:embed *.csv
-var fs embed.FS
-
-// WriteTokenAuthFile writes the embedded token file to the current
-// test's data dir.
-//
-// Persistent servers can target the file in the source tree with
-// `--token-auth-file` and test-managed servers can target a file
-// written to a temp path. This avoids requiring a test to know the
-// location of the token file.
-//
-// TODO(marun) Is there a way to avoid embedding by determining the
-// path to the file during test execution?
-func WriteTokenAuthFile(t *testing.T) string {
-	dataDir, err := CreateTempDirForTest(t, "data")
-	require.NoError(t, err)
-
-	// This file is expected to be embedded from the package directory.
-	tokensFilename := "auth-tokens.csv"
-
-	data, err := fs.ReadFile(tokensFilename)
-	require.NoError(t, err, "error reading tokens file")
-
-	tokensPath := path.Join(dataDir, tokensFilename)
-	tokensFile, err := os.Create(tokensPath)
-	require.NoError(t, err, "failed to create tokens file")
-	defer tokensFile.Close()
-
-	_, err = tokensFile.Write(data)
-	require.NoError(t, err, "error writing tokens file")
-
-	return tokensPath
-}
 
 // Persistent mapping of test name to base temp dir used to ensure
 // artifact paths have a common root across servers for a given test.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -240,6 +240,26 @@ func GetFreePort(t *testing.T) (string, error) {
 	}
 }
 
+// GetMaybeFreePort returns a port that was free right before being
+// returned to the caller. This is good enough for interactive use
+// where process start could be trivially retried, but GetFreePort
+// should be preferred for parallel use cases where there may be
+// contention for port allocation.
+func GetMaybeFreePort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+
+	defer l.Close()
+	return fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port), nil
+}
+
 type ArtifactFunc func(*testing.T, func() (runtime.Object, error))
 
 // CreateWorkloadCluster creates a new WorkloadCluster resource with

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -519,13 +519,12 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		portStr, err := framework.GetFreePort(t)
 		require.NoError(t, err)
 
-		tokenAuthFile := framework.WriteTokenAuthFile(t)
 		server = framework.PrivateKcpServer(t,
 			"--run-controllers=false",
 			"--unsupported-run-individual-controllers=workspace-scheduler",
 			"--run-virtual-workspaces=false",
 			fmt.Sprintf("--virtual-workspace-address=https://localhost:%s", portStr),
-			"--token-auth-file", tokenAuthFile,
+			"--token-auth-file", framework.TokenAuthFileForTest(),
 		)
 
 		// write kubeconfig to disk, next to kcp kubeconfig


### PR DESCRIPTION
Randomizing the ports configured for a given test server invocation
allows multiple servers to run concurrently without conflict. This is
useful when developing in parallel with multiple branches (e.g. with
git-worktree) and invoking tests with `--use-default-server`.