### PR TITLE
e2e: Update cross logical cluster testing to use private fixture

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,7 +143,7 @@ jobs:
           ARTIFACT_DIR=/tmp/e2e \
           PATH="${PATH}:$(pwd)/bin/" \
           TEST_ARGS='-args --use-default-server' \
-          COUNT=2 \
+          COUNT=1 \
           E2E_PARALLELISM=2 \
           make test-e2e
       - uses: actions/upload-artifact@v2

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -53,7 +53,8 @@ import (
 func TestCrossLogicalClusterList(t *testing.T) {
 	t.Parallel()
 
-	server := framework.SharedKcpServer(t)
+	// This test changes global state and is not compatible with shared fixture.
+	server := framework.PrivateKcpServer(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
@@ -120,7 +121,8 @@ func TestCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	// ensure PartialObjectMetadata wildcard list works even with different CRD schemas
 	t.Parallel()
 
-	server := framework.SharedKcpServer(t)
+	// This test changes global state and is not compatible with shared fixture.
+	server := framework.PrivateKcpServer(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -58,8 +58,21 @@ func TestServerArgsWithTokenAuthFile(tokenAuthFile string) []string {
 }
 
 // KcpFixture manages the lifecycle of a set of kcp servers.
-type KcpFixture struct {
+//
+// Deprecated for use outside this package. Prefer PrivateKcpServer().
+type kcpFixture struct {
 	Servers map[string]RunningServer
+}
+
+// PrivateKcpServer returns a new kcp server fixture managing a new
+// server process that is not intended to be shared between tests.
+func PrivateKcpServer(t *testing.T, args ...string) RunningServer {
+	serverName := "main"
+	f := newKcpFixture(t, kcpConfig{
+		Name: serverName,
+		Args: args,
+	})
+	return f.Servers[serverName]
 }
 
 // SharedKcpServer returns a kcp server fixture intended to be shared
@@ -87,15 +100,16 @@ func SharedKcpServer(t *testing.T) RunningServer {
 	// fixture.
 
 	tokenAuthFile := WriteTokenAuthFile(t)
-	f := NewKcpFixture(t, KcpConfig{
+	f := newKcpFixture(t, kcpConfig{
 		Name: serverName,
 		Args: TestServerArgsWithTokenAuthFile(tokenAuthFile),
 	})
 	return f.Servers[serverName]
 }
 
-func NewKcpFixture(t *testing.T, cfgs ...KcpConfig) *KcpFixture {
-	f := &KcpFixture{}
+// Deprecated for use outside this package. Prefer PrivateKcpServer().
+func newKcpFixture(t *testing.T, cfgs ...kcpConfig) *kcpFixture {
+	f := &kcpFixture{}
 
 	artifactDir, dataDir, err := ScratchDirs(t)
 	require.NoError(t, err, "failed to create scratch dirs: %v", err)

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -70,7 +70,7 @@ type kcpServer struct {
 	t *testing.T
 }
 
-func newKcpServer(t *testing.T, cfg KcpConfig, artifactDir, dataDir string) (*kcpServer, error) {
+func newKcpServer(t *testing.T, cfg kcpConfig, artifactDir, dataDir string) (*kcpServer, error) {
 	t.Helper()
 
 	kcpListenPort, err := GetFreePort(t)

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -32,8 +32,10 @@ type RunningServer interface {
 	Artifact(t *testing.T, producer func() (runtime.Object, error))
 }
 
-// KcpConfig qualify a kcp server to start
-type KcpConfig struct {
+// kcpConfig qualify a kcp server to start
+//
+// Deprecated for use outside this package. Prefer PrivateKcpServer().
+type kcpConfig struct {
 	Name string
 	Args []string
 

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -191,9 +191,7 @@ func TestWorkspaceController(t *testing.T) {
 				// Destructive tests require their own server
 				//
 				// TODO(marun) Could the testing currently requiring destructive e2e be performed with less cost?
-				const serverName = "main"
-				f := framework.NewKcpFixture(t, framework.KcpConfig{Name: serverName})
-				server = f.Servers[serverName]
+				server = framework.PrivateKcpServer(t)
 			}
 
 			cfg := server.DefaultConfig(t)

--- a/test/e2e/reconciler/workspaceshard/controller_test.go
+++ b/test/e2e/reconciler/workspaceshard/controller_test.go
@@ -323,9 +323,7 @@ func TestWorkspaceShardController(t *testing.T) {
 				// Destructive tests require their own server
 				//
 				// TODO(marun) Could the testing currently requiring destructive e2e be performed with less cost?
-				const serverName = "main"
-				f := framework.NewKcpFixture(t, framework.KcpConfig{Name: serverName})
-				server = f.Servers[serverName]
+				server = framework.PrivateKcpServer(t)
 			}
 
 			cfg := server.DefaultConfig(t)

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -519,21 +519,14 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		portStr, err := framework.GetFreePort(t)
 		require.NoError(t, err)
 
-		serverName := "main"
 		tokenAuthFile := framework.WriteTokenAuthFile(t)
-		f := framework.NewKcpFixture(t,
-			framework.KcpConfig{
-				Name: serverName,
-				Args: []string{
-					"--run-controllers=false",
-					"--unsupported-run-individual-controllers=workspace-scheduler",
-					"--run-virtual-workspaces=false",
-					fmt.Sprintf("--virtual-workspace-address=https://localhost:%s", portStr),
-					"--token-auth-file", tokenAuthFile,
-				},
-			},
+		server = framework.PrivateKcpServer(t,
+			"--run-controllers=false",
+			"--unsupported-run-individual-controllers=workspace-scheduler",
+			"--run-virtual-workspaces=false",
+			fmt.Sprintf("--virtual-workspace-address=https://localhost:%s", portStr),
+			"--token-auth-file", tokenAuthFile,
 		)
-		server = f.Servers[serverName]
 
 		// write kubeconfig to disk, next to kcp kubeconfig
 		kcpAdminConfig, _ := server.RawConfig()


### PR DESCRIPTION
These tests operate against global state which precludes successive
invocations against shared fixture without error.

Fixes #802