### PR TITLE
[0.3] manifest: Add explicit port number to external hostname

### DIFF
--- a/.github/workflows/ci-docs-only.yaml
+++ b/.github/workflows/ci-docs-only.yaml
@@ -4,7 +4,9 @@ name: CI
 # always return true.
 on:
   pull_request:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
     paths:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
   pull_request:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
     paths-ignore:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -13,7 +13,7 @@ jobs:
   kcp-image:
     if: github.repository_owner == 'kcp-dev'
     name: Build and Publish KCP Image
-    environment: unstable
+    environment: stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -7,13 +7,14 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
 
 jobs:
   kcp-image:
     if: github.repository_owner == 'kcp-dev'
     name: Build and Publish KCP Image
+    environment: unstable
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -5,7 +5,9 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
 
 jobs:
   syncer-image:

--- a/manifest/kcp.yaml
+++ b/manifest/kcp.yaml
@@ -122,7 +122,7 @@ spec:
         - --root-directory=/etc/kcp/config
         - --run-virtual-workspaces=false
         - --virtual-workspace-address=https://$(EXTERNAL_HOSTNAME)
-        - --external-hostname=$(EXTERNAL_HOSTNAME)
+        - --external-hostname=$(EXTERNAL_HOSTNAME):443
         - --oidc-issuer-url=https://sso.redhat.com/auth/realms/redhat-external
         - --oidc-client-id=rhoas-cli-prod
         - --oidc-groups-claim=org_id


### PR DESCRIPTION
If port is not present in external hostname, the --secure-port value is
used instead.

Signed-off-by: Kyle Lape <klape@redhat.com>