### PR TITLE
Enable CI/CD for release branches

### DIFF
--- a/.github/workflows/ci-docs-only.yaml
+++ b/.github/workflows/ci-docs-only.yaml
@@ -4,7 +4,9 @@ name: CI
 # always return true.
 on:
   pull_request:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
     paths:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
   pull_request:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
     paths-ignore:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -7,13 +7,14 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
 
 jobs:
   kcp-image:
     if: github.repository_owner == 'kcp-dev'
     name: Build and Publish KCP Image
+    environment: unstable
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -5,7 +5,9 @@ permissions:
 
 on:
   push:
-    branches: ["main"]
+    branches:
+    - main
+    - 'release-*'
 
 jobs:
   syncer-image:


### PR DESCRIPTION
Start using Github Action Environments so the `CICD_KUBE_*` environment
variables can be set depending on which deployment environment (i.e.
stable/unstable) is targeted.

Signed-off-by: Kyle Lape <klape@redhat.com>