### PR TITLE
kubectl-kcp: fix user-agent regression

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -89,6 +89,7 @@ func NewKubeConfig(opts *Options) (*KubeConfig, error) {
 
 	clusterConfig := rest.CopyConfig(config)
 	clusterConfig.Host = u.String()
+	clusterConfig.UserAgent = rest.DefaultKubernetesUserAgent()
 	clusterClient, err := tenancyclient.NewClusterForConfig(clusterConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It got lost in some recent PR, leading to ugly warnings on the console of the client.

@csams worth to pick into the release branch?