### PR TITLE
Ensure push mode syncer sets kube env vars correctly on deployments

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -143,7 +143,7 @@ func main() {
 	}
 
 	var optionalSyncer *syncer.Controller
-	if manager := options.SyncerOptions.CreateSyncerManager(); manager == nil {
+	if manager := options.SyncerOptions.CreateSyncerManager(""); manager == nil {
 		klog.Info("syncer not enabled. To enable, supply --pull-mode or --push-mode")
 	} else {
 		optionalSyncer, err = syncer.NewController(

--- a/pkg/reconciler/workload/syncer/pushmanager.go
+++ b/pkg/reconciler/workload/syncer/pushmanager.go
@@ -40,11 +40,13 @@ const numSyncerThreads = 2
 
 type pushSyncerManager struct {
 	syncerCancelFuncs map[string]func()
+	externalAddress   string
 }
 
-func newPushSyncerManager() SyncerManager {
+func newPushSyncerManager(externalAddress string) SyncerManager {
 	return &pushSyncerManager{
 		syncerCancelFuncs: map[string]func(){},
+		externalAddress:   externalAddress,
 	}
 }
 
@@ -75,7 +77,7 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	kcpClusterName := logicalcluster.From(cluster)
 	klog.Infof("Starting syncer for clusterName %s to pcluster %s, resources %v", kcpClusterName, cluster.Name, groupResources)
 	syncerCtx, syncerCancel := context.WithCancel(ctx)
-	if err := syncer.StartSyncer(syncerCtx, upstream, downstream, groupResources, kcpClusterName, cluster.Name, numSyncerThreads); err != nil {
+	if err := syncer.StartManagedSyncer(syncerCtx, upstream, downstream, groupResources, kcpClusterName, cluster.Name, numSyncerThreads, m.externalAddress); err != nil {
 		klog.Errorf("error starting syncer in push mode: %v", err)
 		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error starting syncer in push mode: %v", err.Error())
 

--- a/pkg/reconciler/workload/syncer/syncer_controller_start.go
+++ b/pkg/reconciler/workload/syncer/syncer_controller_start.go
@@ -58,11 +58,11 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-func (o *Options) CreateSyncerManager() SyncerManager {
+func (o *Options) CreateSyncerManager(externalAddress string) SyncerManager {
 	if o.PullMode {
 		return newPullSyncerManager(o.SyncerImage)
 	} else if o.PushMode {
-		return newPushSyncerManager()
+		return newPushSyncerManager(externalAddress)
 	}
 
 	// No mode, no controller required

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -480,9 +480,9 @@ func (s *Server) installApiResourceController(ctx context.Context, config *rest.
 	return nil
 }
 
-func (s *Server) installWorkloadSyncerController(ctx context.Context, config *rest.Config, pclusterKubeconfig *clientcmdapi.Config) error {
+func (s *Server) installWorkloadSyncerController(ctx context.Context, config *rest.Config, pclusterKubeconfig *clientcmdapi.Config, externalAddress string) error {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "kcp-workload-syncer-controller")
-	manager := s.options.Controllers.Syncer.CreateSyncerManager()
+	manager := s.options.Controllers.Syncer.CreateSyncerManager(externalAddress)
 	if manager == nil {
 		klog.Info("syncer not enabled. To enable, supply --pull-mode or --push-mode")
 		return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -408,7 +408,7 @@ func (s *Server) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := s.installWorkloadSyncerController(ctx, controllerConfig, syncerConfig); err != nil {
+		if err := s.installWorkloadSyncerController(ctx, controllerConfig, syncerConfig, genericConfig.ExternalAddress); err != nil {
 			return err
 		}
 		if err := s.installApiResourceController(ctx, controllerConfig); err != nil {

--- a/pkg/syncer/statussyncer.go
+++ b/pkg/syncer/statussyncer.go
@@ -65,8 +65,8 @@ func NewStatusSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClu
 	}
 	toClient := toClients.Cluster(kcpClusterName)
 
-	// Register the default mutators
-	mutatorsMap := getDefaultMutators(from)
+	// Status is not currently mutated
+	mutatorsMap := mutatorGvrMap{}
 
 	return New(kcpClusterName, pclusterID, discoveryClient, fromClient, toClient, SyncUp, syncedResourceTypes, pclusterID, mutatorsMap)
 }


### PR DESCRIPTION
The push mode syncer configures itself to talk to kcp over localhost,
and the deployment mutator was using that same localhost configuration
to set env vars allowing a deployment to talk back to kcp. If the
cluster that a deployment was synced to was on a different host,
though, that deployment wouldn't be able to talk to kcp as intended.

This change ensures the push mode syncer is explicitly provided the
external address that synced deployments should be updated with rather
than extracting it from the kubeconfig the syncer uses to talk to kcp.