### PR TITLE
tenancy: Increase ClusterWorkspace name max length to 63 characters

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -51,14 +51,14 @@ spec:
           metadata:
             properties:
               name:
-                maxLength: 31
+                maxLength: 63
                 minLength: 1
                 not:
                   enum:
                   - root
                   - org
                   - system
-                pattern: ^[a-z]([a-z0-9-]{0,29}[a-z0-9])?$
+                pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
                 type: string
             type: object
           spec:

--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml-patch
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml-patch
@@ -2,9 +2,9 @@
   path: /spec/versions/name=v1alpha1/schema/openAPIV3Schema/properties/metadata/properties
   value:
     name:
-      pattern: "^[a-z]([a-z0-9-]{0,29}[a-z0-9])?$"
+      pattern: "^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$"
       minLength: 1
-      maxLength: 31 # half of max name length
+      maxLength: 63 # a quarter of max name length, so the workspace FQN can be a valid DNS subdomain name
       type: string
       not:
         enum:

--- a/pkg/cliplugins/workspace/plugin/helpers_test.go
+++ b/pkg/cliplugins/workspace/plugin/helpers_test.go
@@ -33,11 +33,15 @@ func TestReCluster(t *testing.T) {
 		{"root", true},
 		{"root:foo", true},
 		{"root:foo:bar", true},
-		{"root:b1234567890123456789012345678912", true}, // the plugin does not decide about segment length, the server does
 
 		{"system", true},
 		{"system:foo", true},
 		{"system:foo:bar", true},
+
+		// the plugin does not decide about segment length, the server does
+		{"root:b1234567890123456789012345678912", true},
+		{"root:test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
+		{"root:test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060:b1234567890123456789012345678912", true},
 
 		{"foo", false},
 		{"foo:bar", false},

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -56,7 +56,7 @@ import (
 )
 
 var (
-	reClusterName = regexp.MustCompile(`^([a-z]([a-z0-9-]{0,29}[a-z0-9])?:)*[a-z]([a-z0-9-]{0,29}[a-z0-9])?$`)
+	reClusterName = regexp.MustCompile(`^([a-z]([a-z0-9-]{0,61}[a-z0-9])?:)*[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
 	errorScheme = runtime.NewScheme()
 	errorCodecs = serializer.NewCodecFactory(errorScheme)

--- a/pkg/server/handler_test.go
+++ b/pkg/server/handler_test.go
@@ -48,7 +48,6 @@ func TestClusterWorkspaceNamePattern(t *testing.T) {
 }
 
 func TestReCluster(t *testing.T) {
-
 	tests := []struct {
 		cluster string
 		valid   bool
@@ -63,13 +62,15 @@ func TestReCluster(t *testing.T) {
 		{"system:foo", true},
 		{"system:foo:bar", true},
 
-		{"foo", true},
-		{"foo:bar", true},
-		{"foo:bar-bar", true},
-		{"foo:b", true},
-		{"foo:bar0", true},
-		{"foo:b123456789012345678901234567891", true},
 		{"f", true},
+		{"foo", true},
+		{"foo:b", true},
+		{"foo:bar", true},
+		{"foo:bar0", true},
+		{"foo:bar-bar", true},
+		{"foo:b123456789012345678901234567891", true},
+		{"foo:b1234567890123456789012345678912", true},
+		{"test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
 
 		{"root:", false},
 		{":root", false},
@@ -81,7 +82,7 @@ func TestReCluster(t *testing.T) {
 		{"foo/bar", false},
 		{"foo:bar-", false},
 		{"foo:-bar", false},
-		{"foo:b1234567890123456789012345678912", false},
+		{"test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060-w:b1234567890123456789012345678912", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.cluster, func(t *testing.T) {


### PR DESCRIPTION
This PR increases the maximum length for ClusterWorkspace resource names, from 31 back to 63 characters, as it used to be in KCP v0.2.0.

This enables up to 4 levels of workspace hierarchy to reach the length limit, while still composing a logical cluster FQN that's a valid DNS subdomain name: 

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

Fixes #836.
