### PR TITLE
Ensure push-mode syncer is provided a parseable external url

### DIFF
--- a/pkg/reconciler/workload/syncer/pushmanager.go
+++ b/pkg/reconciler/workload/syncer/pushmanager.go
@@ -40,13 +40,13 @@ const numSyncerThreads = 2
 
 type pushSyncerManager struct {
 	syncerCancelFuncs map[string]func()
-	externalAddress   string
+	externalURL       string
 }
 
-func newPushSyncerManager(externalAddress string) SyncerManager {
+func newPushSyncerManager(externalURL string) SyncerManager {
 	return &pushSyncerManager{
 		syncerCancelFuncs: map[string]func(){},
-		externalAddress:   externalAddress,
+		externalURL:       externalURL,
 	}
 }
 
@@ -77,7 +77,7 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	kcpClusterName := logicalcluster.From(cluster)
 	klog.Infof("Starting syncer for clusterName %s to pcluster %s, resources %v", kcpClusterName, cluster.Name, groupResources)
 	syncerCtx, syncerCancel := context.WithCancel(ctx)
-	if err := syncer.StartManagedSyncer(syncerCtx, upstream, downstream, groupResources, kcpClusterName, cluster.Name, numSyncerThreads, m.externalAddress); err != nil {
+	if err := syncer.StartManagedSyncer(syncerCtx, upstream, downstream, groupResources, kcpClusterName, cluster.Name, numSyncerThreads, m.externalURL); err != nil {
 		klog.Errorf("error starting syncer in push mode: %v", err)
 		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error starting syncer in push mode: %v", err.Error())
 

--- a/pkg/reconciler/workload/syncer/syncer_controller_start.go
+++ b/pkg/reconciler/workload/syncer/syncer_controller_start.go
@@ -58,11 +58,11 @@ func (o *Options) Validate() error {
 	return nil
 }
 
-func (o *Options) CreateSyncerManager(externalAddress string) SyncerManager {
+func (o *Options) CreateSyncerManager(externalURL string) SyncerManager {
 	if o.PullMode {
 		return newPullSyncerManager(o.SyncerImage)
 	} else if o.PushMode {
-		return newPushSyncerManager(externalAddress)
+		return newPushSyncerManager(externalURL)
 	}
 
 	// No mode, no controller required

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -480,9 +480,9 @@ func (s *Server) installApiResourceController(ctx context.Context, config *rest.
 	return nil
 }
 
-func (s *Server) installWorkloadSyncerController(ctx context.Context, config *rest.Config, pclusterKubeconfig *clientcmdapi.Config, externalAddress string) error {
+func (s *Server) installWorkloadSyncerController(ctx context.Context, config *rest.Config, pclusterKubeconfig *clientcmdapi.Config, externalURL string) error {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "kcp-workload-syncer-controller")
-	manager := s.options.Controllers.Syncer.CreateSyncerManager(externalAddress)
+	manager := s.options.Controllers.Syncer.CreateSyncerManager(externalURL)
 	if manager == nil {
 		klog.Info("syncer not enabled. To enable, supply --pull-mode or --push-mode")
 		return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -408,7 +408,8 @@ func (s *Server) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := s.installWorkloadSyncerController(ctx, controllerConfig, syncerConfig, genericConfig.ExternalAddress); err != nil {
+		externalURL := fmt.Sprintf("https://%s", genericConfig.ExternalAddress)
+		if err := s.installWorkloadSyncerController(ctx, controllerConfig, syncerConfig, externalURL); err != nil {
 			return err
 		}
 		if err := s.installApiResourceController(ctx, controllerConfig); err != nil {

--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -67,8 +67,8 @@ func deepEqualApartFromStatus(oldObj, newObj interface{}) bool {
 
 const specSyncerAgent = "kcp#spec-syncer/v0.0.0"
 
-// TODO(marun) Update this function to not accept externalAddress when push-mode syncer management goes away.
-func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClusterName logicalcluster.LogicalCluster, pclusterID string, externalAddress string) (*Controller, error) {
+// TODO(marun) Update this function to not accept externalURL when push-mode syncer management goes away.
+func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClusterName logicalcluster.LogicalCluster, pclusterID string, externalURL string) (*Controller, error) {
 	from = rest.CopyConfig(from)
 	from.UserAgent = specSyncerAgent
 	to = rest.CopyConfig(to)
@@ -88,16 +88,16 @@ func NewSpecSyncer(from, to *rest.Config, syncedResourceTypes []string, kcpClust
 	fromClient := fromClients.Cluster(kcpClusterName)
 	toClient := dynamic.NewForConfigOrDie(to)
 
-	if externalAddress == "" {
-		externalAddress = from.Host
+	if externalURL == "" {
+		externalURL = from.Host
 	}
-	externalURL, err := url.Parse(externalAddress)
+	parsedExternalURL, err := url.Parse(externalURL)
 	if err != nil {
 		return nil, err
 	}
 
 	// Register the default mutators
-	mutatorsMap := getDefaultMutators(externalURL)
+	mutatorsMap := getDefaultMutators(parsedExternalURL)
 
 	return New(kcpClusterName, pclusterID, fromDiscovery, fromClient, toClient, SyncDown, syncedResourceTypes, pclusterID, mutatorsMap)
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -69,16 +69,16 @@ const SyncDown SyncDirection = "down"
 const SyncUp SyncDirection = "up"
 
 // TODO(marun) Remove this function and rename startSyncer to StartSyncer once push-mode syncer management goes away.
-func StartManagedSyncer(ctx context.Context, upstream, downstream *rest.Config, resources sets.String, kcpClusterName logicalcluster.LogicalCluster, pcluster string, numSyncerThreads int, externalAddress string) error {
-	return startSyncer(ctx, upstream, downstream, resources, kcpClusterName, pcluster, numSyncerThreads, externalAddress)
+func StartManagedSyncer(ctx context.Context, upstream, downstream *rest.Config, resources sets.String, kcpClusterName logicalcluster.LogicalCluster, pcluster string, numSyncerThreads int, externalURL string) error {
+	return startSyncer(ctx, upstream, downstream, resources, kcpClusterName, pcluster, numSyncerThreads, externalURL)
 }
 
 func StartSyncer(ctx context.Context, upstream, downstream *rest.Config, resources sets.String, kcpClusterName logicalcluster.LogicalCluster, pcluster string, numSyncerThreads int) error {
 	return startSyncer(ctx, upstream, downstream, resources, kcpClusterName, pcluster, numSyncerThreads, "")
 }
 
-func startSyncer(ctx context.Context, upstream, downstream *rest.Config, resources sets.String, kcpClusterName logicalcluster.LogicalCluster, pcluster string, numSyncerThreads int, externalAddress string) error {
-	specSyncer, err := NewSpecSyncer(upstream, downstream, resources.List(), kcpClusterName, pcluster, externalAddress)
+func startSyncer(ctx context.Context, upstream, downstream *rest.Config, resources sets.String, kcpClusterName logicalcluster.LogicalCluster, pcluster string, numSyncerThreads int, externalURL string) error {
+	specSyncer, err := NewSpecSyncer(upstream, downstream, resources.List(), kcpClusterName, pcluster, externalURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#832 provided the syncer the external address of kcp with the expectation that the syncer would parse out the host and port for use in deployment mutation. The missing detail was that url.Parse returns empty string and no error if the url string it is provided doesn't have a prefix like https://. Fixing that should fix the syncer but manual testing is required because there is no e2e coverage of this code path.