### PR TITLE
Ignore missing namespace on p-cluster

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -432,7 +432,7 @@ func (c *Controller) process(ctx context.Context, h holder) error {
 		nsObj, err := nsInformer.Lister().Get(nsKey)
 		if err != nil {
 			klog.Errorf("%s: error retrieving namespace %q from physical cluster lister: %v", c.name, nsKey, err)
-			return err
+			return nil
 		}
 
 		nsMeta, ok := nsObj.(metav1.Object)


### PR DESCRIPTION
If the syncer can't find a namespace on the p-cluster, it returns an err which causes a hotloop. This change should cause it to ignore the missing ns, and then the syncer will recreate it.

Signed-off-by: Christopher Sams <csams@redhat.com>