### PR TITLE
[0.3] dockerfile: Use make to build go binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,15 @@ COPY config/ config/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY third_party/ third_party/
+COPY .git/ .git/
 
-RUN mkdir bin; CGO_ENABLED=0 go build -o bin ./cmd/...
+RUN apt-get update && apt-get install -y jq && mkdir bin
+RUN CGO_ENABLED=0 make
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot
 FROM alpine:3.15
 WORKDIR /
-COPY --from=builder workspace/bin/* /
+COPY --from=builder workspace/bin/kcp-front-proxy workspace/bin/kcp workspace/bin/virtual-workspaces /
 USER 65532:65532


### PR DESCRIPTION
Upstream: https://github.com/kcp-dev/kcp/pull/850

This is required to properly get the version strings baked into the
binaries.

* .git dir is copied in to build image, but it doesn't end up in the
  shipped image.  We can follow up later to remove the need to copy over
  the whole .git dir.
* CGO_ENABLED=0 is required for alpine/distroless, so I've kept that
  here.
* Had to list out the binaries to put into the shipped image.  Using `*`
  resulted in an 800MB image!

Signed-off-by: Kyle Lape <klape@redhat.com>