### PR TITLE
server: Set external address based on completed serving config

### DIFF
--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -85,21 +85,21 @@ func (i *kcpClusterClientInitializer) Initialize(plugin admission.Interface) {
 }
 
 // NewExternalAddressInitializer returns an admission plugin initializer that injects
-// the external address of the shard into the admission plugin.
+// an external address provider into the admission plugin.
 func NewExternalAddressInitializer(
-	externalAddress string,
+	externalAddressProvider func() string,
 ) *externalAddressInitializer {
 	return &externalAddressInitializer{
-		externalAddress: externalAddress,
+		externalAddressProvider: externalAddressProvider,
 	}
 }
 
 type externalAddressInitializer struct {
-	externalAddress string
+	externalAddressProvider func() string
 }
 
 func (i *externalAddressInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantExternalAddress); ok {
-		wants.SetExternalAddress(i.externalAddress)
+	if wants, ok := plugin.(WantsExternalAddressProvider); ok {
+		wants.SetExternalAddressProvider(i.externalAddressProvider)
 	}
 }

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -24,7 +24,7 @@ import (
 )
 
 // WantsKcpInformers interface should be implemented by admission plugins
-// that want to have an kcp informer factory injected.
+// that want to have a kcp informer factory injected.
 type WantsKcpInformers interface {
 	SetKcpInformers(informers kcpinformers.SharedInformerFactory)
 }
@@ -41,8 +41,8 @@ type WantsKcpClusterClient interface {
 	SetKcpClusterClient(kubeClusterClient *kcpclientset.Cluster)
 }
 
-// WantExternalAddress interface should be implemented by admission plugins
-// that want to have a external shard address injected.
-type WantExternalAddress interface {
-	SetExternalAddress(externalAddress string)
+// WantsExternalAddressProvider interface should be implemented by admission plugins
+// that want to have an external address provider injected.
+type WantsExternalAddressProvider interface {
+	SetExternalAddressProvider(externalAddressProvider func() string)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -242,7 +242,9 @@ func (s *Server) Run(ctx context.Context) error {
 		kcpadmissioninitializers.NewKcpInformersInitializer(s.kcpSharedInformerFactory),
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
-		kcpadmissioninitializers.NewExternalAddressInitializer(genericConfig.ExternalAddress),
+		// The external address is provided as a function, as its value may be updated
+		// with the default secure port, when the config is later completed.
+		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return genericConfig.ExternalAddress }),
 	}
 
 	apisConfig, err := genericcontrolplane.CreateKubeAPIServerConfig(genericConfig, s.options.GenericControlPlane, s.kubeSharedInformerFactory, admissionPluginInitializers, storageFactory)

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -329,10 +329,10 @@ type WorkspaceShardExpectation func(*tenancyv1alpha1.ClusterWorkspaceShard) erro
 // ExpectWorkspaceShards sets up an Expecter in order to allow registering expectations in tests with minimal setup.
 func ExpectWorkspaceShards(ctx context.Context, t *testing.T, client kcpclientset.Interface) (RegisterWorkspaceShardExpectation, error) {
 	kcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(client, 0)
-	workspaceInformer := kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaceShards()
-	expecter := NewExpecter(workspaceInformer.Informer())
+	workspaceShardInformer := kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaceShards()
+	expecter := NewExpecter(workspaceShardInformer.Informer())
 	kcpSharedInformerFactory.Start(ctx.Done())
-	if !cache.WaitForNamedCacheSync(t.Name(), ctx.Done(), workspaceInformer.Informer().HasSynced) {
+	if !cache.WaitForNamedCacheSync(t.Name(), ctx.Done(), workspaceShardInformer.Informer().HasSynced) {
 		return nil, errors.New("failed to wait for caches to sync")
 	}
 	return func(seed *tenancyv1alpha1.ClusterWorkspaceShard, expectation WorkspaceShardExpectation) error {
@@ -341,7 +341,7 @@ func ExpectWorkspaceShards(ctx context.Context, t *testing.T, client kcpclientse
 			return err
 		}
 		return expecter.ExpectBefore(ctx, func(ctx context.Context) (done bool, err error) {
-			current, err := workspaceInformer.Lister().Get(key)
+			current, err := workspaceShardInformer.Lister().Get(key)
 			if err != nil {
 				return !apierrors.IsNotFound(err), err
 			}


### PR DESCRIPTION
## Summary

This PR makes sure the external address admission initialiser relies on a completed configuration, with the default secure serving port.

The logic is taken from the generic options completion method. While it fixes the issues below, there may be a better, more idiomatic, way to fully complete the options.

## Related issue(s)

Fixes #853 
Fixes #854