### PR TITLE
virtual: Grant 'access' verb to user upon workspace creation

### DIFF
--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -420,7 +420,7 @@ var roleRules = map[RoleType][]rbacv1.PolicyRule{
 		},
 		{
 			Resources: []string{"clusterworkspaces/content"},
-			Verbs:     []string{"admin"},
+			Verbs:     []string{"admin", "access"},
 		},
 	},
 }

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1053,7 +1053,7 @@ func TestCreateWorkspace(t *testing.T) {
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 						{
-							Verbs:         []string{"admin"},
+							Verbs:         []string{"admin", "access"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1139,7 +1139,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 						{
-							Verbs:         []string{"admin"},
+							Verbs:         []string{"admin", "access"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1218,7 +1218,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 							APIGroups:     []string{"tenancy.kcp.dev"},
 						},
 						{
-							Verbs:         []string{"admin"},
+							Verbs:         []string{"admin", "access"},
 							ResourceNames: []string{clusterWorkspace.Name},
 							Resources:     []string{"clusterworkspaces/content"},
 							APIGroups:     []string{"tenancy.kcp.dev"},

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -231,7 +231,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 					return err == nil
 				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to get workspace1")
 
-				_, err := server.kcpClusterClient.Cluster(server.orgClusterName.Join(workspace1.Name)).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
+				_, err := vwUser1Client.Cluster(server.orgClusterName.Join(workspace1.Name)).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
 				require.NoError(t, err, "failed to list workspaces in the universal cluster")
 			},
 		},


### PR DESCRIPTION
Uses test changes from https://github.com/kcp-dev/kcp/pull/833

The `access` verb is explicitly checked in the virtual workspace server, so just give users that verb in addition to `admin` when creating a workspace on behalf of said user.

Perhaps we could modify the authorizer to check for `admin` as well as `access`, but this one-liner at least seems like a quick fix.