### PR TITLE
[0.3] Fix git version string returned by kcp server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ KUBE_MAJOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path 
 KUBE_MINOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output | sed "s/v[0-9]*\.\([0-9]*\).*/\1/")
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 GIT_DIRTY := $(shell git diff --quiet && echo 'clean' || echo 'dirty')
-GIT_VERSION := $(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))+kcp
+GIT_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output)+kcp-$(shell git describe --tags --match='v*' --abbrev=14 "$(GIT_COMMIT)^{commit}" 2>/dev/null || echo v0.0.0-$(GIT_COMMIT))
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := \
 	-X k8s.io/client-go/pkg/version.gitCommit=${GIT_COMMIT} \


### PR DESCRIPTION
Upstream: https://github.com/kcp-dev/kcp/pull/859

Was using kcp version, but instead needs to use kube version followed by kcp
version.

Signed-off-by: Kyle Lape <klape@redhat.com>