### PR TITLE
e2e Syncer fixture

### DIFF
--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -31,13 +31,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	kubernetesclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	"github.com/kcp-dev/kcp/pkg/syncer"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
 // TestServerArgs returns the set of kcp args used to start a test
@@ -258,19 +263,84 @@ func NewWorkspaceWithWorkloads(t *testing.T, server RunningServer, orgClusterNam
 	return orgClusterName.Join(ws.Name)
 }
 
-// StartWorkspaceSyncer starts a new syncer to synchronize the identified set of
-// resource types scheduled for the given workload cluster from the upstream server
-// to the downstream server.
-func StartWorkspaceSyncer(
-	t *testing.T,
-	ctx context.Context,
-	resources sets.String,
-	workloadCluster *workloadv1alpha1.WorkloadCluster,
-	upstream, downstream RunningServer,
-) {
-	upstreamConfig := upstream.DefaultConfig(t)
-	downstreamConfig := downstream.DefaultConfig(t)
+// SyncerFixture contains the information to run a syncer fixture.
+type SyncerFixture struct {
+	RunningServer       RunningServer
+	KubeClient          kubernetes.Interface
+	WorkloadClusterName string
 
-	err := syncer.StartSyncer(ctx, upstreamConfig, downstreamConfig, resources, logicalcluster.From(workloadCluster), workloadCluster.Name, 2)
+	upstreamConfig       *rest.Config
+	downstreamConfig     *rest.Config
+	resources            sets.String
+	orgClusterName       logicalcluster.LogicalCluster
+	workspaceClusterName logicalcluster.LogicalCluster
+}
+
+// NewSyncerFixture creates a downstream server (fakeWorkloadServer), and then creates a workloadClusters on the provided upstream server
+// returns a SyncerFixture with the downstream server information, and its kubeclient.
+func NewSyncerFixture(
+	t *testing.T,
+	resources sets.String,
+	upstream RunningServer,
+	orgClusterName logicalcluster.LogicalCluster,
+	wsClusterName logicalcluster.LogicalCluster,
+) *SyncerFixture {
+	downstreamServer := NewFakeWorkloadServer(t, upstream, orgClusterName)
+
+	upstreamKcpClusterClient, err := kcpclientset.NewClusterForConfig(upstream.DefaultConfig(t))
+	require.NoError(t, err)
+
+	workloadCluster, err := CreateWorkloadCluster(t, upstream.Artifact, upstreamKcpClusterClient.Cluster(wsClusterName), downstreamServer)
+	require.NoError(t, err)
+
+	upstreamConfig := upstream.DefaultConfig(t)
+	downstreamConfig := downstreamServer.DefaultConfig(t)
+
+	downstreamKubeClient, err := kubernetesclientset.NewForConfig(downstreamConfig)
+	require.NoError(t, err)
+
+	return &SyncerFixture{
+		RunningServer:        downstreamServer,
+		KubeClient:           downstreamKubeClient,
+		upstreamConfig:       upstreamConfig,
+		downstreamConfig:     downstreamConfig,
+		resources:            resources,
+		orgClusterName:       logicalcluster.From(workloadCluster),
+		WorkloadClusterName:  workloadCluster.Name,
+		workspaceClusterName: wsClusterName,
+	}
+}
+
+// WaitForClusterReadyReason waits for the cluster to be ready with the given reason.
+func (sf *SyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx context.Context, reason string) {
+	sourceKcpClusterClient, err := kcpclient.NewClusterForConfig(sf.upstreamConfig)
+	require.NoError(t, err)
+	kcpClient := sourceKcpClusterClient.Cluster(sf.workspaceClusterName)
+
+	t.Logf("Waiting for cluster %q condition %q to have reason %q", sf.WorkloadClusterName, workloadv1alpha1.WorkloadClusterReadyCondition, reason)
+	require.Eventually(t, func() bool {
+
+		cluster, err := kcpClient.WorkloadV1alpha1().WorkloadClusters().Get(ctx, sf.WorkloadClusterName, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Error getting cluster %q: %v", sf.WorkloadClusterName, err)
+			return false
+		}
+
+		// A reason is only supplied to indicate why a cluster is 'not ready'
+		wantReady := len(reason) == 0
+		if wantReady {
+			return conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+		} else {
+			conditionReason := conditions.GetReason(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+			return conditions.IsFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition) && reason == conditionReason
+		}
+
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+	t.Logf("Cluster %q condition %s has reason %q", workloadv1alpha1.WorkloadClusterReadyCondition, sf.WorkloadClusterName, reason)
+}
+
+// Start starts the Syncer.
+func (sf *SyncerFixture) Start(t *testing.T, ctx context.Context) {
+	err := syncer.StartSyncer(ctx, sf.upstreamConfig, sf.downstreamConfig, sf.resources, sf.orgClusterName, sf.WorkloadClusterName, 2)
 	require.NoError(t, err, "syncer failed to start")
 }

--- a/test/e2e/reconciler/cluster/syncerheartbeat_test.go
+++ b/test/e2e/reconciler/cluster/syncerheartbeat_test.go
@@ -19,19 +19,11 @@ package cluster
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	workloadclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
-	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
 func TestSyncerHeartbeat(t *testing.T) {
@@ -45,53 +37,11 @@ func TestSyncerHeartbeat(t *testing.T) {
 	t.Log("Creating a workspace")
 	wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
-	t.Log("Creating a fake workload server")
-	sink := framework.NewFakeWorkloadServer(t, source, orgClusterName)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
-	sourceConfig := source.DefaultConfig(t)
-	sourceKcpClusterClient, err := kcpclient.NewClusterForConfig(sourceConfig)
-	require.NoError(t, err)
-	kcpClient := sourceKcpClusterClient.Cluster(wsClusterName)
-
-	t.Log("Creating workload cluster...")
-	workloadCluster, err := framework.CreateWorkloadCluster(t, source.Artifact, kcpClient, sink)
-	require.NoError(t, err)
-
-	waitForClusterReadyReason(t, ctx, kcpClient.WorkloadV1alpha1().WorkloadClusters(), workloadCluster.Name, workloadv1alpha1.ErrorHeartbeatMissedReason)
-
-	t.Log("Creating workspace syncer...")
-	framework.StartWorkspaceSyncer(t, ctx, sets.NewString(), workloadCluster, source, sink)
-
-	waitForClusterReadyReason(t, ctx, kcpClient.WorkloadV1alpha1().WorkloadClusters(), workloadCluster.Name, "")
-}
-
-func waitForClusterReadyReason(
-	t *testing.T,
-	ctx context.Context,
-	client workloadclient.WorkloadClusterInterface,
-	clusterName string,
-	reason string,
-) {
-	t.Logf("Waiting for cluster %q condition %q to have reason %q", clusterName, workloadv1alpha1.WorkloadClusterReadyCondition, reason)
-	require.Eventually(t, func() bool {
-		cluster, err := client.Get(ctx, clusterName, metav1.GetOptions{})
-		if err != nil {
-			t.Errorf("Error getting cluster %q: %v", clusterName, err)
-			return false
-		}
-
-		// A reason is only supplied to indicate why a cluster is 'not ready'
-		wantReady := len(reason) == 0
-		if wantReady {
-			return conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
-		} else {
-			conditionReason := conditions.GetReason(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
-			return conditions.IsFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition) && reason == conditionReason
-		}
-
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-	t.Logf("Cluster %q condition %s has reason %q", workloadv1alpha1.WorkloadClusterReadyCondition, clusterName, reason)
+	syncerFixture := framework.NewSyncerFixture(t, sets.NewString(), source, orgClusterName, wsClusterName)
+	syncerFixture.WaitForClusterReadyReason(t, ctx, workloadv1alpha1.ErrorHeartbeatMissedReason)
+	syncerFixture.Start(t, ctx)
+	syncerFixture.WaitForClusterReadyReason(t, ctx, "")
 }


### PR DESCRIPTION
## Summary

This PR adds a new SyncerFixture to replace StartWorkspaceSyncer. This will make adding a kind e2e simpler.

* This new SyncerFixture handles the creation of a downstream server (fakeWorkloadServer) and its registration into an upstream server, creating the ClusterWorkload object. Provides methods for starting the Syncer associated, and also, for waiting for the downstream cluster to be ready

* Adapts current e2e tests to use the NewSyncerFixture.
