### PR TITLE
Apply resource constraints to kcp instance

### DIFF
--- a/manifest/etcd.yaml
+++ b/manifest/etcd.yaml
@@ -109,6 +109,13 @@ spec:
               mountPath: /etc/etcd/tls/peer
             - name: server-certs
               mountPath: /etc/etcd/tls/server
+          resources:
+            limits:
+              cpu: '1'
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi
           command:
             - /bin/sh
             - -c

--- a/manifest/kcp.yaml
+++ b/manifest/kcp.yaml
@@ -148,6 +148,13 @@ spec:
             path: readyz
             port: 6443
             scheme: HTTPS
+        resources:
+          limits:
+            cpu: '2'
+            memory: 2Gi
+          requests:
+            cpu: '1'
+            memory: 1Gi
         volumeMounts:
         - name: etcd-certs
           mountPath: /etc/etcd/tls/server
@@ -188,6 +195,13 @@ spec:
             path: readyz
             port: 6444
             scheme: HTTPS
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
         volumeMounts:
         - name: virtual-workspaces-certs
           mountPath: /etc/kcp/tls/server


### PR DESCRIPTION
This includes:

* kcp container
* virtual-workspaces container
* 3 etcd pods

The initial goal here is to protect the infrastructure running KCP from a memory leak in KCP.  This should give us some decent head room for now.

We've actually seen node instability (i.e. memory thresholds hit on nodes) on the OSD cluster running the KCP shared service, so this is a step to try and prevent that from happening.

Signed-off-by: Kyle Lape <klape@redhat.com>