### PR TITLE
Stop apiimporter, syncer, heartbeat from fighting over the Ready condition

### DIFF
--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -105,8 +105,14 @@ type WorkloadClusterList struct {
 
 // Conditions and ConditionReasons for the kcp WorkloadCluster object.
 const (
-	// WorkloadClusterReadyCondition means the WorkloadCluster is available.
-	WorkloadClusterReadyCondition conditionsv1alpha1.ConditionType = "Ready"
+	// SyncerReady means the syncer is ready to transfer resources between KCP and the WorkloadCluster.
+	SyncerReady conditionsv1alpha1.ConditionType = "SyncerReady"
+
+	// APIImporterReady means the APIImport component is ready to import APIs from the WorkloadCluster.
+	APIImporterReady conditionsv1alpha1.ConditionType = "APIImporterReady"
+
+	// HeartbeatHealthy means the HeartbeatManager is able to contact the WorkloadCluster at a specified internval.
+	HeartbeatHealthy conditionsv1alpha1.ConditionType = "HeartbeatHealthy"
 
 	// WorkloadClusterUnknownReason documents a WorkloadCluster which readiness is unknown.
 	WorkloadClusterUnknownReason = "WorkloadClusterStatusUnknown"

--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -111,7 +111,7 @@ const (
 	// APIImporterReady means the APIImport component is ready to import APIs from the WorkloadCluster.
 	APIImporterReady conditionsv1alpha1.ConditionType = "APIImporterReady"
 
-	// HeartbeatHealthy means the HeartbeatManager is able to contact the WorkloadCluster at a specified internval.
+	// HeartbeatHealthy means the HeartbeatManager has seen a heartbeat for the WorkloadCluster within the expected interval.
 	HeartbeatHealthy conditionsv1alpha1.ConditionType = "HeartbeatHealthy"
 
 	// WorkloadClusterUnknownReason documents a WorkloadCluster which readiness is unknown.

--- a/pkg/reconciler/workload/apiimporter/apiimporter_manager.go
+++ b/pkg/reconciler/workload/apiimporter/apiimporter_manager.go
@@ -47,15 +47,6 @@ type apiImporterManager struct {
 func (m *apiImporterManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1.WorkloadCluster) error {
 	klog.Infof("reconciling cluster %q", cluster.Name)
 
-	defer conditions.SetSummary(
-		cluster,
-		conditions.WithConditions(
-			workloadv1alpha1.SyncerReady,
-			workloadv1alpha1.APIImporterReady,
-			workloadv1alpha1.HeartbeatHealthy,
-		),
-	)
-
 	logicalCluster := logicalcluster.From(cluster)
 
 	// Get client from kubeconfig

--- a/pkg/reconciler/workload/heartbeat/heartbeat_manager.go
+++ b/pkg/reconciler/workload/heartbeat/heartbeat_manager.go
@@ -36,7 +36,6 @@ type clusterManager struct {
 }
 
 func (c *clusterManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1.WorkloadCluster) error {
-
 	defer conditions.SetSummary(
 		cluster,
 		conditions.WithConditions(
@@ -51,21 +50,21 @@ func (c *clusterManager) Reconcile(ctx context.Context, cluster *workloadv1alpha
 		latestHeartbeat = cluster.Status.LastSyncerHeartbeatTime.Time
 	}
 	if latestHeartbeat.IsZero() {
-		klog.V(5).Infof("Marking Syncer %s|%s not ready due to no heartbeat", cluster.ClusterName, cluster.Name)
+		klog.V(5).Infof("Marking HeartbeatHealthy false for WorkloadCluster %s|%s due to no heartbeat", cluster.ClusterName, cluster.Name)
 		conditions.MarkFalse(cluster,
 			workloadv1alpha1.HeartbeatHealthy,
 			workloadv1alpha1.ErrorHeartbeatMissedReason,
 			conditionsapi.ConditionSeverityWarning,
 			"No heartbeat yet seen")
 	} else if time.Since(latestHeartbeat) > c.heartbeatThreshold {
-		klog.V(5).Infof("Marking Syncer %s|%s not ready due to a stale heartbeat", cluster.ClusterName, cluster.Name)
+		klog.V(5).Infof("Marking HeartbeatHealthy false for WorkloadCluster %s|%s due to a stale heartbeat", cluster.ClusterName, cluster.Name)
 		conditions.MarkFalse(cluster,
 			workloadv1alpha1.HeartbeatHealthy,
 			workloadv1alpha1.ErrorHeartbeatMissedReason,
 			conditionsapi.ConditionSeverityWarning,
 			"No heartbeat since %s", latestHeartbeat)
 	} else {
-		klog.V(5).Infof("Marking Heartbeat healthy for %s|%s", cluster.ClusterName, cluster.Name)
+		klog.V(5).Infof("Marking Heartbeat healthy true for WorkloadCluster %s|%s", cluster.ClusterName, cluster.Name)
 		conditions.MarkTrue(cluster, workloadv1alpha1.HeartbeatHealthy)
 
 		// Enqueue another check after which the heartbeat should have been updated again.

--- a/pkg/reconciler/workload/heartbeat/heartbeat_manager_test.go
+++ b/pkg/reconciler/workload/heartbeat/heartbeat_manager_test.go
@@ -61,7 +61,7 @@ func TestManager(t *testing.T) {
 			cl := &workloadv1alpha1.WorkloadCluster{
 				Status: workloadv1alpha1.WorkloadClusterStatus{
 					Conditions: []conditionsv1alpha1.Condition{{
-						Type:   workloadv1alpha1.WorkloadClusterReadyCondition,
+						Type:   workloadv1alpha1.HeartbeatHealthy,
 						Status: corev1.ConditionTrue,
 					}},
 					LastSyncerHeartbeatTime: &heartbeat,

--- a/pkg/reconciler/workload/namespace/namespace_reconcile.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile.go
@@ -40,6 +40,7 @@ import (
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -364,7 +365,7 @@ const (
 // indication of whether to enqueue the cluster in the future to respond to a
 // impending cordon event.
 func enqueueStrategyForCluster(cl *workloadv1alpha1.WorkloadCluster) (strategy clusterEnqueueStrategy, pendingCordon bool) {
-	ready := conditions.IsTrue(cl, workloadv1alpha1.WorkloadClusterReadyCondition)
+	ready := conditions.IsTrue(cl, conditionsapi.ReadyCondition)
 	cordoned := cl.Spec.EvictAfter != nil && cl.Spec.EvictAfter.Time.Before(time.Now())
 	if !ready || cordoned {
 		// An unready or cordoned cluster requires revisiting the scheduling

--- a/pkg/reconciler/workload/namespace/namespace_test.go
+++ b/pkg/reconciler/workload/namespace/namespace_test.go
@@ -27,6 +27,7 @@ import (
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -94,7 +95,7 @@ func TestEnqueueStrategyForCluster(t *testing.T) {
 				},
 			}
 			if testCase.ready {
-				conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+				conditions.MarkTrue(cluster, conditionsapi.ReadyCondition)
 			}
 			if testCase.evictAfter != nil {
 				evictAfter := metav1.NewTime(*testCase.evictAfter)

--- a/pkg/reconciler/workload/namespace/scheduler.go
+++ b/pkg/reconciler/workload/namespace/scheduler.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -90,7 +91,7 @@ func (s *namespaceScheduler) isValidCluster(lclusterName logicalcluster.LogicalC
 		return false, "", err
 	}
 	// TODO(marun) Stop duplicating these checks here and in pickCluster
-	if ready := conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition); !ready {
+	if ready := conditions.IsTrue(cluster, conditionsapi.ReadyCondition); !ready {
 		return false, "is not reporting ready", nil
 	}
 	if evictAfter := cluster.Spec.EvictAfter; evictAfter != nil && evictAfter.Time.Before(time.Now()) {
@@ -121,7 +122,7 @@ func pickCluster(allClusters []*workloadv1alpha1.WorkloadCluster, lclusterName l
 				"metadata.name", allClusters[i].Name)
 			continue
 		}
-		if !conditions.IsTrue(allClusters[i], workloadv1alpha1.WorkloadClusterReadyCondition) {
+		if !conditions.IsTrue(allClusters[i], conditionsapi.ReadyCondition) {
 			klog.V(2).InfoS("pickCluster: excluding not-ready cluster", "metadata.name", allClusters[i].Name)
 			continue
 		}

--- a/pkg/reconciler/workload/namespace/scheduler_test.go
+++ b/pkg/reconciler/workload/namespace/scheduler_test.go
@@ -30,6 +30,7 @@ import (
 	clustertools "k8s.io/client-go/tools/clusters"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -68,7 +69,7 @@ func otherClusterFixture() *clusterFixture {
 }
 
 func (f *clusterFixture) withReady() *clusterFixture {
-	conditions.MarkTrue(f.cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+	conditions.MarkTrue(f.cluster, conditionsapi.ReadyCondition)
 	return f
 }
 

--- a/pkg/reconciler/workload/syncer/pullmanager.go
+++ b/pkg/reconciler/workload/syncer/pullmanager.go
@@ -58,18 +58,18 @@ func (m *pullSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	bytes, err := clientcmd.Write(*upstreamKubeConfig)
 	if err != nil {
 		klog.Errorf("error writing kubeconfig for syncer: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error writing kubeconfig for syncer: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error writing kubeconfig for syncer: %v", err.Error())
 		return false, nil // Don't retry.
 	}
 	logicalCluster := cluster.GetClusterName()
 	if err := installSyncer(ctx, client, m.syncerImage, string(bytes), cluster.Name, logicalCluster, groupResources.List()); err != nil {
 		klog.Errorf("error installing syncer: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error installing syncer: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error installing syncer: %v", err.Error())
 		return false, nil // Don't retry.
 	}
 
 	klog.Info("syncer installing...")
-	conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+	conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 
 	return true, nil
 }
@@ -78,10 +78,10 @@ func (m *pullSyncerManager) checkHealth(ctx context.Context, cluster *workloadv1
 	logicalCluster := cluster.GetClusterName()
 	if err := healthcheckSyncer(ctx, client, logicalCluster); err != nil {
 		klog.Error("syncer not yet ready")
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.WorkloadClusterNotReadyReason, conditionsv1alpha1.ConditionSeverityInfo, "Syncer not yet ready")
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.WorkloadClusterNotReadyReason, conditionsv1alpha1.ConditionSeverityInfo, "Syncer not yet ready")
 	} else {
 		klog.Infof("started pull mode syncer for cluster %s in logical cluster %s!", cluster.Name, logicalCluster)
-		conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+		conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 	}
 	return true
 }

--- a/pkg/reconciler/workload/syncer/pushmanager.go
+++ b/pkg/reconciler/workload/syncer/pushmanager.go
@@ -61,14 +61,14 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	upstream, err := clientcmd.NewNonInteractiveClientConfig(*upstreamKubeConfig, "upstream", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
 	if err != nil {
 		klog.Errorf("error getting kcp kubeconfig: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error getting kcp kubeconfig: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error getting kcp kubeconfig: %v", err.Error())
 		return false, nil // Don't retry.
 	}
 
 	downstream, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
 	if err != nil {
 		klog.Errorf("error getting cluster kubeconfig: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error getting cluster kubeconfig: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error getting cluster kubeconfig: %v", err.Error())
 		return false, nil // Don't retry.
 	}
 
@@ -77,7 +77,7 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	syncerCtx, syncerCancel := context.WithCancel(ctx)
 	if err := syncer.StartSyncer(syncerCtx, upstream, downstream, groupResources, kcpClusterName, cluster.Name, numSyncerThreads); err != nil {
 		klog.Errorf("error starting syncer in push mode: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error starting syncer in push mode: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorStartingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error starting syncer in push mode: %v", err.Error())
 
 		syncerCancel()
 
@@ -91,7 +91,6 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	}
 
 	klog.Infof("Started push mode syncer from clusterName %s for pcluster %s", kcpClusterName, cluster.Name)
-	conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
 
 	return true, nil
 }
@@ -100,7 +99,7 @@ func (m *pushSyncerManager) checkHealth(ctx context.Context, cluster *workloadv1
 	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
 	if err != nil {
 		klog.Errorf("error getting cluster kubeconfig: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.WorkloadClusterUnknownReason, conditionsv1alpha1.ConditionSeverityError, "Error getting cluster kubeconfig: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.WorkloadClusterUnknownReason, conditionsv1alpha1.ConditionSeverityError, "Error getting cluster kubeconfig: %v", err.Error())
 		return false // Don't retry.
 	}
 
@@ -108,19 +107,19 @@ func (m *pushSyncerManager) checkHealth(ctx context.Context, cluster *workloadv1
 	restClient, err := rest.UnversionedRESTClientFor(cfg)
 	if err != nil {
 		klog.Errorf("error getting rest client: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.WorkloadClusterUnknownReason, conditionsv1alpha1.ConditionSeverityError, "Error getting rest client: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.WorkloadClusterUnknownReason, conditionsv1alpha1.ConditionSeverityError, "Error getting rest client: %v", err.Error())
 		return false // Don't retry.
 	}
 
 	_, err = restClient.Get().AbsPath("/readyz").Timeout(5 * time.Second).DoRaw(ctx)
 	if err != nil {
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.WorkloadClusterNotReadyReason, conditionsv1alpha1.ConditionSeverityError, "Error getting /readyz: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.WorkloadClusterNotReadyReason, conditionsv1alpha1.ConditionSeverityError, "Error getting /readyz: %v", err.Error())
 		return false // Don't retry.
 	}
 
 	logicalCluster := cluster.GetClusterName()
 	klog.Infof("healthy push mode syncer running for cluster %s in logical cluster %s!", cluster.Name, logicalCluster)
-	conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+	conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 
 	return true
 }

--- a/pkg/reconciler/workload/syncer/pushmanager.go
+++ b/pkg/reconciler/workload/syncer/pushmanager.go
@@ -91,6 +91,7 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	}
 
 	klog.Infof("Started push mode syncer from clusterName %s for pcluster %s", kcpClusterName, cluster.Name)
+	conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 
 	return true, nil
 }

--- a/pkg/reconciler/workload/syncer/syncer_manager.go
+++ b/pkg/reconciler/workload/syncer/syncer_manager.go
@@ -101,17 +101,26 @@ func (m *syncerManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1
 		}.String())
 	}
 
+	defer conditions.SetSummary(
+		cluster,
+		conditions.WithConditions(
+			workloadv1alpha1.SyncerReady,
+			workloadv1alpha1.APIImporterReady,
+			workloadv1alpha1.HeartbeatHealthy,
+		),
+	)
+
 	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
 	if err != nil {
 		klog.Errorf("%s: invalid kubeconfig: %v", m.name, err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.InvalidKubeConfigReason, conditionsv1alpha1.ConditionSeverityError, "Error invalid kubeconfig: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.InvalidKubeConfigReason, conditionsv1alpha1.ConditionSeverityError, "Error invalid kubeconfig: %v", err.Error())
 		return nil
 	}
 
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		klog.Errorf("%s: error creating client: %v", m.name, err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorCreatingClientReason, conditionsv1alpha1.ConditionSeverityError, "Error creating client: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorCreatingClientReason, conditionsv1alpha1.ConditionSeverityError, "Error creating client: %v", err.Error())
 		return nil
 	}
 

--- a/pkg/reconciler/workload/syncer/syncer_manager.go
+++ b/pkg/reconciler/workload/syncer/syncer_manager.go
@@ -101,15 +101,6 @@ func (m *syncerManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1
 		}.String())
 	}
 
-	defer conditions.SetSummary(
-		cluster,
-		conditions.WithConditions(
-			workloadv1alpha1.SyncerReady,
-			workloadv1alpha1.APIImporterReady,
-			workloadv1alpha1.HeartbeatHealthy,
-		),
-	)
-
 	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
 	if err != nil {
 		klog.Errorf("%s: invalid kubeconfig: %v", m.name, err)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -37,11 +37,11 @@ import (
 	"k8s.io/klog/v2"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	"github.com/kcp-dev/kcp/pkg/syncer"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -317,7 +317,7 @@ func (sf *SyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx context.Con
 	require.NoError(t, err)
 	kcpClient := sourceKcpClusterClient.Cluster(sf.workspaceClusterName)
 
-	t.Logf("Waiting for cluster %q condition %q to have reason %q", sf.WorkloadClusterName, workloadv1alpha1.WorkloadClusterReadyCondition, reason)
+	t.Logf("Waiting for cluster %q condition %q to have reason %q", sf.WorkloadClusterName, conditionsapi.ReadyCondition, reason)
 	require.Eventually(t, func() bool {
 
 		cluster, err := kcpClient.WorkloadV1alpha1().WorkloadClusters().Get(ctx, sf.WorkloadClusterName, metav1.GetOptions{})
@@ -329,14 +329,14 @@ func (sf *SyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx context.Con
 		// A reason is only supplied to indicate why a cluster is 'not ready'
 		wantReady := len(reason) == 0
 		if wantReady {
-			return conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+			return conditions.IsTrue(cluster, conditionsapi.ReadyCondition)
 		} else {
-			conditionReason := conditions.GetReason(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
-			return conditions.IsFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition) && reason == conditionReason
+			conditionReason := conditions.GetReason(cluster, conditionsapi.ReadyCondition)
+			return conditions.IsFalse(cluster, conditionsapi.ReadyCondition) && reason == conditionReason
 		}
 
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
-	t.Logf("Cluster %q condition %s has reason %q", workloadv1alpha1.WorkloadClusterReadyCondition, sf.WorkloadClusterName, reason)
+	t.Logf("Cluster %q condition %s has reason %q", conditionsapi.ReadyCondition, sf.WorkloadClusterName, reason)
 }
 
 // Start starts the Syncer.


### PR DESCRIPTION
Give each controller its own condition and make heartbeat manager responsible for setting `Ready` by accounting for all conditions via `conditions.SetSummary`

Update the namespace scheduler to depend on total readiness.

Fixes #865 