### PR TITLE
actions: add Github's beta add-to-project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues to project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issues to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/kcp-dev/projects/1
+          github-token: ${{ secrets.GHPROJECT_TOKEN }}


### PR DESCRIPTION
Wire up https://github.com/marketplace/actions/add-to-github-projects-beta to auto-add issues to our beta project.