### PR TITLE
manifest: add resources to sync

### DIFF
--- a/manifest/kcp.yaml
+++ b/manifest/kcp.yaml
@@ -113,6 +113,7 @@ spec:
         - start
         - --auto-publish-apis
         - --push-mode
+        - --resources-to-sync=deployments.apps,services,ingresses.networking.k8s.io
         - --etcd-servers=https://etcd:2379
         - --etcd-keyfile=/etc/etcd/tls/server/tls.key
         - --etcd-certfile=/etc/etcd/tls/server/tls.crt


### PR DESCRIPTION
## Summary
Until push-mode is removed, default the resources to sync (and the APIs
to import) to deployments, services, ingresses.

## Related issue(s)

Fixes #