### PR TITLE
virtual: Disable workspace deletion for now

### DIFF
--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -415,7 +415,11 @@ const (
 var roleRules = map[RoleType][]rbacv1.PolicyRule{
 	OwnerRoleType: {
 		{
-			Verbs:     []string{"get", "delete"},
+			Verbs: []string{
+				"get",
+				// TODO: Allow deleting workspaces after kcp supports it
+				//"delete",
+			},
 			Resources: []string{"clusterworkspaces/workspace"},
 		},
 		{
@@ -678,28 +682,33 @@ func (s *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 		Name:            internalName,
 		ResourceRequest: true,
 	}
-	if decision, _, err := authz.Authorize(ctx, deleteWorkspaceAttr); err != nil {
+	if decision, reason, err := authz.Authorize(ctx, deleteWorkspaceAttr); err != nil {
 		klog.Errorf("failed to authorize user %q to %q clusterworkspaces/workspace name %q in %s", userInfo.GetName(), "delete", internalName, orgClusterName)
 		return nil, false, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), "", fmt.Errorf("deletion in workspace %q is not allowed", orgClusterName))
 	} else if decision != authorizer.DecisionAllow {
+		klog.Errorf("user %q lacks (%s) clusterworkspaces/workspace %q permission for %q in %s: %s", userInfo.GetName(), decisions[decision], "delete", internalName, orgClusterName, reason)
+		return nil, false, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), internalName, fmt.Errorf("deletion in workspace %q is not allowed", orgClusterName))
+
+		// TODO: Uncomment the following code that allows users with admin verb on content subresource to delete after workspace deletion is more stable
+		//
 		// check for admin verb on the content
-		contentAdminAttr := authorizer.AttributesRecord{
-			User:            userInfo,
-			Verb:            "admin",
-			APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
-			APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
-			Resource:        "clusterworkspaces",
-			Subresource:     "content",
-			Name:            internalName,
-			ResourceRequest: true,
-		}
-		if decision, reason, err := authz.Authorize(ctx, contentAdminAttr); err != nil {
-			klog.Errorf("failed to authorize user %q to %q clusterworkspaces/content name %q in %s", userInfo.GetName(), "admin", internalName, orgClusterName)
-			return nil, false, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), "", fmt.Errorf("deletion in workspace %q is not allowed", orgClusterName))
-		} else if decision != authorizer.DecisionAllow {
-			klog.Errorf("user %q lacks (%s) clusterworkspaces/content %q permission and clusterworkspaces/workspace %s permission for %q in %s: %s", userInfo.GetName(), decisions[decision], "admin", "delete", internalName, orgClusterName, reason)
-			return nil, false, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), internalName, fmt.Errorf("deletion in workspace %q is not allowed", orgClusterName))
-		}
+		// contentAdminAttr := authorizer.AttributesRecord{
+		// 	User:            userInfo,
+		// 	Verb:            "admin",
+		// 	APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
+		// 	APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
+		// 	Resource:        "clusterworkspaces",
+		// 	Subresource:     "content",
+		// 	Name:            internalName,
+		// 	ResourceRequest: true,
+		// }
+		// if decision, reason, err := authz.Authorize(ctx, contentAdminAttr); err != nil {
+		// 	klog.Errorf("failed to authorize user %q to %q clusterworkspaces/content name %q in %s", userInfo.GetName(), "admin", internalName, orgClusterName)
+		// 	return nil, false, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), "", fmt.Errorf("deletion in workspace %q is not allowed", orgClusterName))
+		// } else if decision != authorizer.DecisionAllow {
+		// 	klog.Errorf("user %q lacks (%s) clusterworkspaces/content %q permission and clusterworkspaces/workspace %s permission for %q in %s: %s", userInfo.GetName(), decisions[decision], "admin", "delete", internalName, orgClusterName, reason)
+		// 	return nil, false, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), internalName, fmt.Errorf("deletion in workspace %q is not allowed", orgClusterName))
+		// }
 	}
 
 	errorToReturn := s.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Delete(ctx, internalName, *options)

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1047,7 +1047,7 @@ func TestCreateWorkspace(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							Verbs:         []string{"get", "delete"},
+							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1133,7 +1133,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							Verbs:         []string{"get", "delete"},
+							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1212,7 +1212,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							Verbs:         []string{"get", "delete"},
+							Verbs:         []string{"get"},
 							ResourceNames: []string{clusterWorkspace.Name},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1293,7 +1293,7 @@ func TestCreateWorkspacePrettyNameAlreadyExists(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							Verbs:         []string{"get", "delete"},
+							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},
@@ -1394,7 +1394,7 @@ func TestDeleteWorkspaceNotFound(t *testing.T) {
 					},
 					Rules: []rbacv1.PolicyRule{
 						{
-							Verbs:         []string{"get", "delete"},
+							Verbs:         []string{"get"},
 							ResourceNames: []string{"foo"},
 							Resources:     []string{"clusterworkspaces/workspace"},
 							APIGroups:     []string{"tenancy.kcp.dev"},

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -428,6 +428,43 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see org workspace in root")
 			},
 		},
+		{
+			name: "Should not be able to delete a workspace once it is created",
+			clientInfos: []clientInfo{
+				{
+					Token: "user-1-token",
+					Scope: "personal",
+				},
+			},
+			work: func(ctx context.Context, t *testing.T, server runningServer) {
+				vwUser1Client := server.virtualUserKcpClients[0]
+
+				createOrgMemberRoleForGroup(t, ctx, server.kubeClusterClient, server.orgClusterName, "team-1")
+
+				orgWorkspaceClient := vwUser1Client.Cluster(server.orgClusterName).TenancyV1beta1().Workspaces()
+				t.Logf("Create Workspace workspace1 in the virtual workspace")
+				var workspace1 *tenancyv1beta1.Workspace
+				require.Eventually(t, func() bool {
+					// RBAC authz uses informers and needs a moment to understand the new roles. Hence, try until successful.
+					var err error
+					workspace1, err = orgWorkspaceClient.Create(ctx, testData.workspace1.DeepCopy(), metav1.CreateOptions{})
+					if err != nil {
+						klog.Errorf("Failed to create workspace1: %v", err)
+						return false
+					}
+					return true
+				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to create workspace1")
+
+				t.Logf("Wait until informer based virtual workspace sees the new workspace")
+				require.Eventually(t, func() bool {
+					_, err := orgWorkspaceClient.Get(ctx, workspace1.Name, metav1.GetOptions{})
+					return err == nil
+				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to get workspace1")
+
+				err := orgWorkspaceClient.Delete(ctx, workspace1.Name, metav1.DeleteOptions{})
+				require.Error(t, err, "Expected workspace deletion to fail")
+			},
+		},
 	}
 
 	var server framework.RunningServer


### PR DESCRIPTION
Since workspace deletion currently leaves all resources inside that
workspace effectively orphaned, we should not allow users to delete
workspaces for now.  Admins can still delete clusterworkspaces, and we
can always add the "delete" verb to the "workspace" subresource by hand.

Signed-off-by: Kyle Lape <klape@redhat.com>