### PR TITLE
specsyncer: fix when logging namespace creation

### DIFF
--- a/pkg/syncer/specsyncer.go
+++ b/pkg/syncer/specsyncer.go
@@ -136,8 +136,9 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 			klog.Errorf("Error while creating namespace %q: %v", downstreamNamespace, err)
 			return err
 		}
+	} else {
+		klog.Infof("Created downstream namespace %s for upstream namespace %s|%s", downstreamNamespace, c.upstreamClusterName, upstreamObj.GetNamespace())
 	}
-	klog.Infof("Created downstream namespace %s for upstream namespace %s|%s", downstreamNamespace, c.upstreamClusterName, upstreamObj.GetNamespace())
 
 	return nil
 }


### PR DESCRIPTION
## Summary
Fix it so we only log that we created a downstream namespace when we
actually did, instead of every time ensureDownstreamNamespaceExists
returns successfully.

## Related issue(s)

Fixes #