### PR TITLE
Add branch name to the tag list of kcp and syncer images

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: kcp
-          tags: latest ${{ steps.vars.outputs.sha_short }}
+          tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
           containerfiles: |
             ./Dockerfile
 
@@ -39,7 +39,7 @@ jobs:
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
+          tags: ${{ steps.build-image.outputs.tags }} ${{ github.ref_name }}
           registry: ghcr.io/${{ github.repository_owner }}
           username: ${{ github.actor }}
           password: ${{ github.token }}

--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - 'release-*'
+    tags:
+    - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -19,6 +19,6 @@ jobs:
         with:
           go-version: v1.17
 
-      # Build and push a syncer image, tagged with the commit SHA.
+      # Build and push a syncer image, tagged with the commit SHA and the branch name.
       - uses: imjasonh/setup-ko@v0.4
-      - run: ko publish ./cmd/syncer -t $(git rev-parse --short "$GITHUB_SHA")
+      - run: ko publish ./cmd/syncer -t $(git rev-parse --short "$GITHUB_SHA"),${{ github.ref_name }}

--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -8,6 +8,8 @@ on:
     branches:
     - main
     - 'release-*'
+    tags:
+    - 'v*'
 
 jobs:
   syncer-image:


### PR DESCRIPTION
Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

## Summary

By adding branch names to the tags of the kcp and syncer images it is easier to consume them from other projects