### PR TITLE
Remove stty dependency.

### DIFF
--- a/cmd/crd-puller/pull-crds.go
+++ b/cmd/crd-puller/pull-crds.go
@@ -32,7 +32,6 @@ import (
 )
 
 func main() {
-	help.FitTerminal()
 	cmd := &cobra.Command{
 		Use:        "pull-crds",
 		Aliases:    []string{},
@@ -70,7 +69,10 @@ func main() {
 			return nil
 		},
 	}
+
 	cmd.Flags().String("kubeconfig", ".kubeconfig", "kubeconfig file used to contact the cluster.")
+
+	help.FitTerminal(cmd.OutOrStdout())
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -41,8 +41,6 @@ const numThreads = 2
 const resyncPeriod = 10 * time.Hour
 
 func main() {
-	help.FitTerminal()
-
 	options := NewDefaultOptions()
 
 	cmd := &cobra.Command{
@@ -114,6 +112,8 @@ func main() {
 	}
 
 	options.BindFlags(cmd.Flags())
+
+	help.FitTerminal(cmd.OutOrStdout())
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -35,8 +35,6 @@ import (
 )
 
 func main() {
-	help.FitTerminal()
-
 	cmd := &cobra.Command{
 		Use:   "kcp",
 		Short: "Kube for Control Plane (KCP)",
@@ -138,6 +136,8 @@ func main() {
 		"run-controllers",
 		"run-virtual-workspaces",
 	})
+
+	help.FitTerminal(cmd.OutOrStdout())
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
-	github.com/wayneashleyberry/terminal-dimensions v1.0.0
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/multierr v1.7.0
 	google.golang.org/grpc v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,6 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
-github.com/wayneashleyberry/terminal-dimensions v1.0.0 h1:LawtS1nqKjAfqrmKOzkcrDLAjSzh38lEhC401JPjQVA=
-github.com/wayneashleyberry/terminal-dimensions v1.0.0/go.mod h1:PW2XrtV6KmKOPhuf7wbtcmw1/IFnC39mryRET2XbxeE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=

--- a/pkg/cmd/help/doc.go
+++ b/pkg/cmd/help/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 package help
 
 import (
+	"io"
 	"regexp"
 	"strings"
 	"unicode"
@@ -24,7 +25,8 @@ import (
 	"github.com/MakeNowJust/heredoc"
 	"github.com/muesli/reflow/wordwrap"
 	"github.com/spf13/cobra"
-	terminal "github.com/wayneashleyberry/terminal-dimensions"
+
+	"k8s.io/component-base/term"
 )
 
 var reEmptyLine = regexp.MustCompile(`(?m)([\w[:punct:]])[ ]*\n([\w[:punct:]])`)
@@ -35,12 +37,13 @@ func Doc(s string) string {
 	return s
 }
 
-func FitTerminal() {
+func FitTerminal(out io.Writer) {
+	cols, _, err := term.TerminalSize(out)
+	if err != nil {
+		cols = 80
+	}
+
 	cobra.AddTemplateFunc("trimTrailingWhitespaces", func(s string) string {
-		w, err := terminal.Width()
-		if err != nil {
-			w = 80
-		}
-		return strings.TrimRightFunc(wordwrap.String(s, int(w)), unicode.IsSpace)
+		return strings.TrimRightFunc(wordwrap.String(s, cols), unicode.IsSpace)
 	})
 }


### PR DESCRIPTION
## Summary

There is already internal code to detect the terminal width, so we don't
need to carry a dependency that does it by exec'ing stty.

Signed-off-by: James Peach <jpeach@cloudflare.com>