### PR TITLE
Adding admission plugin to validate CRDs

### DIFF
--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspacetypeexists"
 	kcpmutatingwebhook "github.com/kcp-dev/kcp/pkg/admission/mutatingwebhook"
 	workspacenamespacelifecycle "github.com/kcp-dev/kcp/pkg/admission/namespacelifecycle"
+	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdannotations"
 	kcpvalidatingwebhook "github.com/kcp-dev/kcp/pkg/admission/validatingwebhook"
 )
 
@@ -61,6 +62,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	apibinding.PluginName,
 	kcpvalidatingwebhook.PluginName,
 	kcpmutatingwebhook.PluginName,
+	reservedcrdannotations.PluginName,
 )
 
 func beforeWebhooks(recommended []string, plugins ...string) []string {
@@ -87,6 +89,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	workspacenamespacelifecycle.Register(plugins)
 	kcpvalidatingwebhook.Register(plugins)
 	kcpmutatingwebhook.Register(plugins)
+	reservedcrdannotations.Register(plugins)
 }
 
 var defaultOnPluginsInKcp = sets.NewString(
@@ -105,6 +108,7 @@ var defaultOnPluginsInKcp = sets.NewString(
 	apibinding.PluginName,
 	kcpvalidatingwebhook.PluginName,
 	kcpmutatingwebhook.PluginName,
+	reservedcrdannotations.PluginName,
 )
 
 // defaultOnKubePluginsInKube is a copy of kubeapiserveroptions.defaultOnKubePlugins.

--- a/pkg/admission/reservedcrdannotations/admission.go
+++ b/pkg/admission/reservedcrdannotations/admission.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedcrdannotations
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
+)
+
+const (
+	PluginName = "apis.kcp.dev/ReservedCRDAnnotations"
+)
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return &reservedCRDAnnotations{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+			}, nil
+		})
+}
+
+type reservedCRDAnnotations struct {
+	*admission.Handler
+}
+
+// Ensure that the required admission interfaces are implemented.
+var _ = admission.ValidationInterface(&reservedCRDAnnotations{})
+
+// Validate ensures that
+// - if the bound annotation exists that it is in the in the Shadow Workspace.
+func (o *reservedCRDAnnotations) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	if a.GetResource().GroupResource() != apiextensions.Resource("customresourcedefinitions") {
+		return nil
+	}
+
+	if a.GetKind().GroupKind() != apiextensions.Kind("CustomResourceDefinition") {
+		return nil
+	}
+	crd, ok := a.GetObject().(*apiextensions.CustomResourceDefinition)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", a.GetObject())
+	}
+
+	clusterName, err := request.ClusterNameFrom(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster from context: %w", err)
+	}
+	if clusterName == apibinding.ShadowWorkspaceName {
+		return nil
+	}
+
+	var errs []error
+	for key := range crd.GetAnnotations() {
+		comps := strings.SplitN(key, "/", 2)
+		if comps[0] == apisv1alpha1.SchemeGroupVersion.Group || strings.HasSuffix(comps[0], "."+apisv1alpha1.SchemeGroupVersion.Group) {
+			errs = append(errs, fmt.Errorf("%s is a reserved annotation", key))
+		}
+	}
+
+	if len(errs) > 0 {
+		return admission.NewForbidden(a, utilerrors.NewAggregate(errs))
+	}
+
+	return nil
+}

--- a/pkg/admission/reservedcrdannotations/admission_test.go
+++ b/pkg/admission/reservedcrdannotations/admission_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedcrdannotations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcp-dev/apimachinery/pkg/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/kcp/pkg/admission/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func createAttr(obj *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		nil,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func createAttrAPIBinding(apiBinding *apisv1alpha1.APIBinding) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(apiBinding),
+		nil,
+		apisv1alpha1.Kind("APIBinding").WithVersion("v1alpha1"),
+		"",
+		apiBinding.Name,
+		apisv1alpha1.Resource("apibindings").WithVersion("v1alpha1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func updateAttr(obj, old *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		old,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Update,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		attr        admission.Attributes
+		clusterName string
+
+		wantErr bool
+	}{
+		{
+			name: "passes create no annotation",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}),
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "fails create annotation wrong workspace",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"apis.kcp.dev/bound-crd": "true",
+					},
+				},
+			}),
+			wantErr:     true,
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "fails create some other annotation",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"abc.apis.kcp.dev/xyz": "true",
+					},
+				},
+			}),
+			wantErr:     true,
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes create annotation in some other system workspace",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"apis.kcp.dev/bound-crd": "true",
+					},
+				},
+			}),
+			clusterName: "system:bound-crds",
+		},
+		{
+			name: "fails create annotation some other system workspace",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"apis.kcp.dev/bound-crd": "true",
+					},
+				},
+			}),
+			wantErr:     true,
+			clusterName: "system:admin",
+		},
+		{
+			name: "passes not a CRD",
+			attr: createAttrAPIBinding(&apisv1alpha1.APIBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"apis.kcp.dev/bound-crd": "true",
+					},
+				},
+			}),
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes update no annotation",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}, &apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}),
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "fails update annotation wrong workspace",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"apis.kcp.dev/bound-crd": "true",
+					},
+				},
+			}, &apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}),
+			wantErr:     true,
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes update annotation correct workspace",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"apis.kcp.dev/bound-crd": "true",
+					},
+				},
+			}, &apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}),
+			clusterName: "system:bound-crds",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &reservedCRDAnnotations{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+			}
+			var ctx context.Context
+
+			require.NotEmpty(t, tt.clusterName, "clusterName must be set in this test")
+
+			ctx = request.WithCluster(context.Background(), request.Cluster{Name: logicalcluster.New(tt.clusterName)})
+			if err := o.Validate(ctx, tt.attr, nil); (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customresourcedefinition
+
+import (
+	"context"
+	"embed"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+//go:embed *.yaml
+var testFiles embed.FS
+
+func TestCustomResourceCreation(t *testing.T) {
+	t.Parallel()
+
+	server := framework.SharedKcpServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg := server.DefaultConfig(t)
+
+	kcpClients, err := clientset.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	dynamicClients, err := dynamic.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(sourceWorkspace).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(sourceWorkspace), mapper, "wildwest.dev_cowboys.yaml", testFiles)
+	if err == nil {
+		t.Errorf("Expected an error due to reserved annotation")
+	}
+}

--- a/test/e2e/customresourcedefinition/wildwest.dev_cowboys.yaml
+++ b/test/e2e/customresourcedefinition/wildwest.dev_cowboys.yaml
@@ -1,0 +1,59 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+    apis.kcp.dev/bound-crd: t
+  creationTimestamp: null
+  name: cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cowboy is part of the wild west
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CowboySpec holds the desired state of the Cowboy.
+            properties:
+              intent:
+                type: string
+            type: object
+          status:
+            description: CowboyStatus communicates the observed state of the Cowboy.
+            properties:
+              result:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
## Summary
* Validate that CRD does not have bound-crd annotation unless in the
shadow workspace

## Related issue(s)
Fixes #844 