### PR TITLE
e2e: Read token auth file directly from working tree

### DIFF
--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -41,7 +41,7 @@ import (
 //   $ go test -v --use-default-server
 //
 func main() {
-	commandLine := append(framework.StartKcpCommand(), framework.TestServerArgs()...)
+	commandLine := append(framework.StartKcpCommand(), framework.CommonTestServerArgs()...)
 	log.Printf("running: %v\n", strings.Join(commandLine, " "))
 
 	cmd := exec.Command(commandLine[0], commandLine[1:]...)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -19,6 +19,7 @@ package framework
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -45,19 +46,22 @@ import (
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
-// TestServerArgs returns the set of kcp args used to start a test
-// server using the token auth file from the working tree.
-func TestServerArgs() []string {
-	return TestServerArgsWithTokenAuthFile("test/e2e/framework/auth-tokens.csv")
+// TokenAuthFileForTest returns the absolute path of the auth token
+// file required by some auth tests.
+func TokenAuthFileForTest() string {
+	return filepath.Join(
+		RepositoryDir(), "test", "e2e", "framework", "auth-tokens.csv",
+	)
 }
 
-// TestServerArgsWithTokenAuthFile returns the set of kcp args used to
-// start a test server with the given token auth file.
-func TestServerArgsWithTokenAuthFile(tokenAuthFile string) []string {
+// CommonTestServerArgs returns the set of kcp args used to start a
+// test server that are common between test-managed servers and
+// servers started before a test run.
+func CommonTestServerArgs() []string {
 	return []string{
 		"--auto-publish-apis",
 		"--discovery-poll-interval=5s",
-		"--token-auth-file", tokenAuthFile,
+		"--token-auth-file", TokenAuthFileForTest(),
 		"--run-virtual-workspaces=true",
 	}
 }
@@ -104,10 +108,9 @@ func SharedKcpServer(t *testing.T) RunningServer {
 	// initializes the shared fixture before tests that rely on the
 	// fixture.
 
-	tokenAuthFile := WriteTokenAuthFile(t)
 	f := newKcpFixture(t, kcpConfig{
 		Name: serverName,
-		Args: TestServerArgsWithTokenAuthFile(tokenAuthFile),
+		Args: CommonTestServerArgs(),
 	})
 	return f.Servers[serverName]
 }

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -19,7 +19,6 @@ package framework
 import (
 	"bytes"
 	"context"
-	"embed"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -52,40 +51,6 @@ import (
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 )
-
-//go:embed *.csv
-var fs embed.FS
-
-// WriteTokenAuthFile writes the embedded token file to the current
-// test's data dir.
-//
-// Persistent servers can target the file in the source tree with
-// `--token-auth-file` and test-managed servers can target a file
-// written to a temp path. This avoids requiring a test to know the
-// location of the token file.
-//
-// TODO(marun) Is there a way to avoid embedding by determining the
-// path to the file during test execution?
-func WriteTokenAuthFile(t *testing.T) string {
-	dataDir, err := CreateTempDirForTest(t, "data")
-	require.NoError(t, err)
-
-	// This file is expected to be embedded from the package directory.
-	tokensFilename := "auth-tokens.csv"
-
-	data, err := fs.ReadFile(tokensFilename)
-	require.NoError(t, err, "error reading tokens file")
-
-	tokensPath := path.Join(dataDir, tokensFilename)
-	tokensFile, err := os.Create(tokensPath)
-	require.NoError(t, err, "failed to create tokens file")
-	defer tokensFile.Close()
-
-	_, err = tokensFile.Write(data)
-	require.NoError(t, err, "error writing tokens file")
-
-	return tokensPath
-}
 
 // Persistent mapping of test name to base temp dir used to ensure
 // artifact paths have a common root across servers for a given test.

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -473,13 +473,12 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		portStr, err := framework.GetFreePort(t)
 		require.NoError(t, err)
 
-		tokenAuthFile := framework.WriteTokenAuthFile(t)
 		server = framework.PrivateKcpServer(t,
 			"--run-controllers=false",
 			"--unsupported-run-individual-controllers=workspace-scheduler",
 			"--run-virtual-workspaces=false",
 			fmt.Sprintf("--virtual-workspace-address=https://localhost:%s", portStr),
-			"--token-auth-file", tokenAuthFile,
+			"--token-auth-file", framework.TokenAuthFileForTest(),
 		)
 
 		// write kubeconfig to disk, next to kcp kubeconfig


### PR DESCRIPTION
Now that there is a reliable way to read the file from the working
tree in a test, there is no need to write it to a temp path.