### PR TITLE
[0.3] Stop apiimporter, syncer, heartbeat from fighting over the Ready condition

### DIFF
--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -105,8 +105,14 @@ type WorkloadClusterList struct {
 
 // Conditions and ConditionReasons for the kcp WorkloadCluster object.
 const (
-	// WorkloadClusterReadyCondition means the WorkloadCluster is available.
-	WorkloadClusterReadyCondition conditionsv1alpha1.ConditionType = "Ready"
+	// SyncerReady means the syncer is ready to transfer resources between KCP and the WorkloadCluster.
+	SyncerReady conditionsv1alpha1.ConditionType = "SyncerReady"
+
+	// APIImporterReady means the APIImport component is ready to import APIs from the WorkloadCluster.
+	APIImporterReady conditionsv1alpha1.ConditionType = "APIImporterReady"
+
+	// HeartbeatHealthy means the HeartbeatManager is able to contact the WorkloadCluster at a specified internval.
+	HeartbeatHealthy conditionsv1alpha1.ConditionType = "HeartbeatHealthy"
 
 	// WorkloadClusterUnknownReason documents a WorkloadCluster which readiness is unknown.
 	WorkloadClusterUnknownReason = "WorkloadClusterStatusUnknown"

--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -111,7 +111,7 @@ const (
 	// APIImporterReady means the APIImport component is ready to import APIs from the WorkloadCluster.
 	APIImporterReady conditionsv1alpha1.ConditionType = "APIImporterReady"
 
-	// HeartbeatHealthy means the HeartbeatManager is able to contact the WorkloadCluster at a specified internval.
+	// HeartbeatHealthy means the HeartbeatManager has seen a heartbeat for the WorkloadCluster within the expected interval.
 	HeartbeatHealthy conditionsv1alpha1.ConditionType = "HeartbeatHealthy"
 
 	// WorkloadClusterUnknownReason documents a WorkloadCluster which readiness is unknown.

--- a/pkg/reconciler/workload/apiimporter/apiimporter_manager.go
+++ b/pkg/reconciler/workload/apiimporter/apiimporter_manager.go
@@ -47,15 +47,6 @@ type apiImporterManager struct {
 func (m *apiImporterManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1.WorkloadCluster) error {
 	klog.Infof("reconciling cluster %q", cluster.Name)
 
-	defer conditions.SetSummary(
-		cluster,
-		conditions.WithConditions(
-			workloadv1alpha1.SyncerReady,
-			workloadv1alpha1.APIImporterReady,
-			workloadv1alpha1.HeartbeatHealthy,
-		),
-	)
-
 	logicalCluster := logicalcluster.From(cluster)
 
 	// Get client from kubeconfig

--- a/pkg/reconciler/workload/heartbeat/heartbeat_manager.go
+++ b/pkg/reconciler/workload/heartbeat/heartbeat_manager.go
@@ -36,7 +36,6 @@ type clusterManager struct {
 }
 
 func (c *clusterManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1.WorkloadCluster) error {
-
 	defer conditions.SetSummary(
 		cluster,
 		conditions.WithConditions(
@@ -51,21 +50,21 @@ func (c *clusterManager) Reconcile(ctx context.Context, cluster *workloadv1alpha
 		latestHeartbeat = cluster.Status.LastSyncerHeartbeatTime.Time
 	}
 	if latestHeartbeat.IsZero() {
-		klog.V(5).Infof("Marking Syncer %s|%s not ready due to no heartbeat", cluster.ClusterName, cluster.Name)
+		klog.V(5).Infof("Marking HeartbeatHealthy false for WorkloadCluster %s|%s due to no heartbeat", cluster.ClusterName, cluster.Name)
 		conditions.MarkFalse(cluster,
 			workloadv1alpha1.HeartbeatHealthy,
 			workloadv1alpha1.ErrorHeartbeatMissedReason,
 			conditionsapi.ConditionSeverityWarning,
 			"No heartbeat yet seen")
 	} else if time.Since(latestHeartbeat) > c.heartbeatThreshold {
-		klog.V(5).Infof("Marking Syncer %s|%s not ready due to a stale heartbeat", cluster.ClusterName, cluster.Name)
+		klog.V(5).Infof("Marking HeartbeatHealthy false for WorkloadCluster %s|%s due to a stale heartbeat", cluster.ClusterName, cluster.Name)
 		conditions.MarkFalse(cluster,
 			workloadv1alpha1.HeartbeatHealthy,
 			workloadv1alpha1.ErrorHeartbeatMissedReason,
 			conditionsapi.ConditionSeverityWarning,
 			"No heartbeat since %s", latestHeartbeat)
 	} else {
-		klog.V(5).Infof("Marking Heartbeat healthy for %s|%s", cluster.ClusterName, cluster.Name)
+		klog.V(5).Infof("Marking Heartbeat healthy true for WorkloadCluster %s|%s", cluster.ClusterName, cluster.Name)
 		conditions.MarkTrue(cluster, workloadv1alpha1.HeartbeatHealthy)
 
 		// Enqueue another check after which the heartbeat should have been updated again.

--- a/pkg/reconciler/workload/heartbeat/heartbeat_manager_test.go
+++ b/pkg/reconciler/workload/heartbeat/heartbeat_manager_test.go
@@ -61,7 +61,7 @@ func TestManager(t *testing.T) {
 			cl := &workloadv1alpha1.WorkloadCluster{
 				Status: workloadv1alpha1.WorkloadClusterStatus{
 					Conditions: []conditionsv1alpha1.Condition{{
-						Type:   workloadv1alpha1.WorkloadClusterReadyCondition,
+						Type:   workloadv1alpha1.HeartbeatHealthy,
 						Status: corev1.ConditionTrue,
 					}},
 					LastSyncerHeartbeatTime: &heartbeat,

--- a/pkg/reconciler/workload/namespace/namespace_reconcile.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile.go
@@ -40,6 +40,7 @@ import (
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -364,7 +365,7 @@ const (
 // indication of whether to enqueue the cluster in the future to respond to a
 // impending cordon event.
 func enqueueStrategyForCluster(cl *workloadv1alpha1.WorkloadCluster) (strategy clusterEnqueueStrategy, pendingCordon bool) {
-	ready := conditions.IsTrue(cl, workloadv1alpha1.WorkloadClusterReadyCondition)
+	ready := conditions.IsTrue(cl, conditionsapi.ReadyCondition)
 	cordoned := cl.Spec.EvictAfter != nil && cl.Spec.EvictAfter.Time.Before(time.Now())
 	if !ready || cordoned {
 		// An unready or cordoned cluster requires revisiting the scheduling

--- a/pkg/reconciler/workload/namespace/namespace_test.go
+++ b/pkg/reconciler/workload/namespace/namespace_test.go
@@ -27,6 +27,7 @@ import (
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -94,7 +95,7 @@ func TestEnqueueStrategyForCluster(t *testing.T) {
 				},
 			}
 			if testCase.ready {
-				conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+				conditions.MarkTrue(cluster, conditionsapi.ReadyCondition)
 			}
 			if testCase.evictAfter != nil {
 				evictAfter := metav1.NewTime(*testCase.evictAfter)

--- a/pkg/reconciler/workload/namespace/scheduler.go
+++ b/pkg/reconciler/workload/namespace/scheduler.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -90,7 +91,7 @@ func (s *namespaceScheduler) isValidCluster(lclusterName logicalcluster.LogicalC
 		return false, "", err
 	}
 	// TODO(marun) Stop duplicating these checks here and in pickCluster
-	if ready := conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition); !ready {
+	if ready := conditions.IsTrue(cluster, conditionsapi.ReadyCondition); !ready {
 		return false, "is not reporting ready", nil
 	}
 	if evictAfter := cluster.Spec.EvictAfter; evictAfter != nil && evictAfter.Time.Before(time.Now()) {
@@ -121,7 +122,7 @@ func pickCluster(allClusters []*workloadv1alpha1.WorkloadCluster, lclusterName l
 				"metadata.name", allClusters[i].Name)
 			continue
 		}
-		if !conditions.IsTrue(allClusters[i], workloadv1alpha1.WorkloadClusterReadyCondition) {
+		if !conditions.IsTrue(allClusters[i], conditionsapi.ReadyCondition) {
 			klog.V(2).InfoS("pickCluster: excluding not-ready cluster", "metadata.name", allClusters[i].Name)
 			continue
 		}

--- a/pkg/reconciler/workload/namespace/scheduler_test.go
+++ b/pkg/reconciler/workload/namespace/scheduler_test.go
@@ -30,6 +30,7 @@ import (
 	clustertools "k8s.io/client-go/tools/clusters"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -68,7 +69,7 @@ func otherClusterFixture() *clusterFixture {
 }
 
 func (f *clusterFixture) withReady() *clusterFixture {
-	conditions.MarkTrue(f.cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+	conditions.MarkTrue(f.cluster, conditionsapi.ReadyCondition)
 	return f
 }
 

--- a/pkg/reconciler/workload/syncer/pullmanager.go
+++ b/pkg/reconciler/workload/syncer/pullmanager.go
@@ -58,18 +58,18 @@ func (m *pullSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	bytes, err := clientcmd.Write(*upstreamKubeConfig)
 	if err != nil {
 		klog.Errorf("error writing kubeconfig for syncer: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error writing kubeconfig for syncer: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error writing kubeconfig for syncer: %v", err.Error())
 		return false, nil // Don't retry.
 	}
 	logicalCluster := cluster.GetClusterName()
 	if err := installSyncer(ctx, client, m.syncerImage, string(bytes), cluster.Name, logicalCluster, groupResources.List()); err != nil {
 		klog.Errorf("error installing syncer: %v", err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error installing syncer: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorInstallingSyncerReason, conditionsv1alpha1.ConditionSeverityError, "Error installing syncer: %v", err.Error())
 		return false, nil // Don't retry.
 	}
 
 	klog.Info("syncer installing...")
-	conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+	conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 
 	return true, nil
 }
@@ -78,10 +78,10 @@ func (m *pullSyncerManager) checkHealth(ctx context.Context, cluster *workloadv1
 	logicalCluster := cluster.GetClusterName()
 	if err := healthcheckSyncer(ctx, client, logicalCluster); err != nil {
 		klog.Error("syncer not yet ready")
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.WorkloadClusterNotReadyReason, conditionsv1alpha1.ConditionSeverityInfo, "Syncer not yet ready")
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.WorkloadClusterNotReadyReason, conditionsv1alpha1.ConditionSeverityInfo, "Syncer not yet ready")
 	} else {
 		klog.Infof("started pull mode syncer for cluster %s in logical cluster %s!", cluster.Name, logicalCluster)
-		conditions.MarkTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+		conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 	}
 	return true
 }

--- a/pkg/reconciler/workload/syncer/pushmanager.go
+++ b/pkg/reconciler/workload/syncer/pushmanager.go
@@ -93,6 +93,7 @@ func (m *pushSyncerManager) update(ctx context.Context, cluster *workloadv1alpha
 	}
 
 	klog.Infof("Started push mode syncer from clusterName %s for pcluster %s", kcpClusterName, cluster.Name)
+	conditions.MarkTrue(cluster, workloadv1alpha1.SyncerReady)
 
 	return true, nil
 }

--- a/pkg/reconciler/workload/syncer/syncer_manager.go
+++ b/pkg/reconciler/workload/syncer/syncer_manager.go
@@ -101,17 +101,26 @@ func (m *syncerManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1
 		}.String())
 	}
 
+	defer conditions.SetSummary(
+		cluster,
+		conditions.WithConditions(
+			workloadv1alpha1.SyncerReady,
+			workloadv1alpha1.APIImporterReady,
+			workloadv1alpha1.HeartbeatHealthy,
+		),
+	)
+
 	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
 	if err != nil {
 		klog.Errorf("%s: invalid kubeconfig: %v", m.name, err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.InvalidKubeConfigReason, conditionsv1alpha1.ConditionSeverityError, "Error invalid kubeconfig: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.InvalidKubeConfigReason, conditionsv1alpha1.ConditionSeverityError, "Error invalid kubeconfig: %v", err.Error())
 		return nil
 	}
 
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		klog.Errorf("%s: error creating client: %v", m.name, err)
-		conditions.MarkFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition, workloadv1alpha1.ErrorCreatingClientReason, conditionsv1alpha1.ConditionSeverityError, "Error creating client: %v", err.Error())
+		conditions.MarkFalse(cluster, workloadv1alpha1.SyncerReady, workloadv1alpha1.ErrorCreatingClientReason, conditionsv1alpha1.ConditionSeverityError, "Error creating client: %v", err.Error())
 		return nil
 	}
 

--- a/pkg/reconciler/workload/syncer/syncer_manager.go
+++ b/pkg/reconciler/workload/syncer/syncer_manager.go
@@ -101,15 +101,6 @@ func (m *syncerManager) Reconcile(ctx context.Context, cluster *workloadv1alpha1
 		}.String())
 	}
 
-	defer conditions.SetSummary(
-		cluster,
-		conditions.WithConditions(
-			workloadv1alpha1.SyncerReady,
-			workloadv1alpha1.APIImporterReady,
-			workloadv1alpha1.HeartbeatHealthy,
-		),
-	)
-
 	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(cluster.Spec.KubeConfig))
 	if err != nil {
 		klog.Errorf("%s: invalid kubeconfig: %v", m.name, err)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -31,13 +31,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	kubernetesclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	"github.com/kcp-dev/kcp/pkg/syncer"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
 // TestServerArgs returns the set of kcp args used to start a test
@@ -258,19 +263,84 @@ func NewWorkspaceWithWorkloads(t *testing.T, server RunningServer, orgClusterNam
 	return orgClusterName.Join(ws.Name)
 }
 
-// StartWorkspaceSyncer starts a new syncer to synchronize the identified set of
-// resource types scheduled for the given workload cluster from the upstream server
-// to the downstream server.
-func StartWorkspaceSyncer(
-	t *testing.T,
-	ctx context.Context,
-	resources sets.String,
-	workloadCluster *workloadv1alpha1.WorkloadCluster,
-	upstream, downstream RunningServer,
-) {
-	upstreamConfig := upstream.DefaultConfig(t)
-	downstreamConfig := downstream.DefaultConfig(t)
+// SyncerFixture contains the information to run a syncer fixture.
+type SyncerFixture struct {
+	RunningServer       RunningServer
+	KubeClient          kubernetes.Interface
+	WorkloadClusterName string
 
-	err := syncer.StartSyncer(ctx, upstreamConfig, downstreamConfig, resources, logicalcluster.From(workloadCluster), workloadCluster.Name, 2)
+	upstreamConfig       *rest.Config
+	downstreamConfig     *rest.Config
+	resources            sets.String
+	orgClusterName       logicalcluster.LogicalCluster
+	workspaceClusterName logicalcluster.LogicalCluster
+}
+
+// NewSyncerFixture creates a downstream server (fakeWorkloadServer), and then creates a workloadClusters on the provided upstream server
+// returns a SyncerFixture with the downstream server information, and its kubeclient.
+func NewSyncerFixture(
+	t *testing.T,
+	resources sets.String,
+	upstream RunningServer,
+	orgClusterName logicalcluster.LogicalCluster,
+	wsClusterName logicalcluster.LogicalCluster,
+) *SyncerFixture {
+	downstreamServer := NewFakeWorkloadServer(t, upstream, orgClusterName)
+
+	upstreamKcpClusterClient, err := kcpclientset.NewClusterForConfig(upstream.DefaultConfig(t))
+	require.NoError(t, err)
+
+	workloadCluster, err := CreateWorkloadCluster(t, upstream.Artifact, upstreamKcpClusterClient.Cluster(wsClusterName), downstreamServer)
+	require.NoError(t, err)
+
+	upstreamConfig := upstream.DefaultConfig(t)
+	downstreamConfig := downstreamServer.DefaultConfig(t)
+
+	downstreamKubeClient, err := kubernetesclientset.NewForConfig(downstreamConfig)
+	require.NoError(t, err)
+
+	return &SyncerFixture{
+		RunningServer:        downstreamServer,
+		KubeClient:           downstreamKubeClient,
+		upstreamConfig:       upstreamConfig,
+		downstreamConfig:     downstreamConfig,
+		resources:            resources,
+		orgClusterName:       logicalcluster.From(workloadCluster),
+		WorkloadClusterName:  workloadCluster.Name,
+		workspaceClusterName: wsClusterName,
+	}
+}
+
+// WaitForClusterReadyReason waits for the cluster to be ready with the given reason.
+func (sf *SyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx context.Context, reason string) {
+	sourceKcpClusterClient, err := kcpclient.NewClusterForConfig(sf.upstreamConfig)
+	require.NoError(t, err)
+	kcpClient := sourceKcpClusterClient.Cluster(sf.workspaceClusterName)
+
+	t.Logf("Waiting for cluster %q condition %q to have reason %q", sf.WorkloadClusterName, workloadv1alpha1.WorkloadClusterReadyCondition, reason)
+	require.Eventually(t, func() bool {
+
+		cluster, err := kcpClient.WorkloadV1alpha1().WorkloadClusters().Get(ctx, sf.WorkloadClusterName, metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("Error getting cluster %q: %v", sf.WorkloadClusterName, err)
+			return false
+		}
+
+		// A reason is only supplied to indicate why a cluster is 'not ready'
+		wantReady := len(reason) == 0
+		if wantReady {
+			return conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+		} else {
+			conditionReason := conditions.GetReason(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+			return conditions.IsFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition) && reason == conditionReason
+		}
+
+	}, wait.ForeverTestTimeout, time.Millisecond*100)
+	t.Logf("Cluster %q condition %s has reason %q", workloadv1alpha1.WorkloadClusterReadyCondition, sf.WorkloadClusterName, reason)
+}
+
+// Start starts the Syncer.
+func (sf *SyncerFixture) Start(t *testing.T, ctx context.Context) {
+	err := syncer.StartSyncer(ctx, sf.upstreamConfig, sf.downstreamConfig, sf.resources, sf.orgClusterName, sf.WorkloadClusterName, 2)
 	require.NoError(t, err, "syncer failed to start")
 }

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -37,11 +37,11 @@ import (
 	"k8s.io/klog/v2"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	"github.com/kcp-dev/kcp/pkg/syncer"
+	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
@@ -317,7 +317,7 @@ func (sf *SyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx context.Con
 	require.NoError(t, err)
 	kcpClient := sourceKcpClusterClient.Cluster(sf.workspaceClusterName)
 
-	t.Logf("Waiting for cluster %q condition %q to have reason %q", sf.WorkloadClusterName, workloadv1alpha1.WorkloadClusterReadyCondition, reason)
+	t.Logf("Waiting for cluster %q condition %q to have reason %q", sf.WorkloadClusterName, conditionsapi.ReadyCondition, reason)
 	require.Eventually(t, func() bool {
 
 		cluster, err := kcpClient.WorkloadV1alpha1().WorkloadClusters().Get(ctx, sf.WorkloadClusterName, metav1.GetOptions{})
@@ -329,14 +329,14 @@ func (sf *SyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx context.Con
 		// A reason is only supplied to indicate why a cluster is 'not ready'
 		wantReady := len(reason) == 0
 		if wantReady {
-			return conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
+			return conditions.IsTrue(cluster, conditionsapi.ReadyCondition)
 		} else {
-			conditionReason := conditions.GetReason(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
-			return conditions.IsFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition) && reason == conditionReason
+			conditionReason := conditions.GetReason(cluster, conditionsapi.ReadyCondition)
+			return conditions.IsFalse(cluster, conditionsapi.ReadyCondition) && reason == conditionReason
 		}
 
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
-	t.Logf("Cluster %q condition %s has reason %q", workloadv1alpha1.WorkloadClusterReadyCondition, sf.WorkloadClusterName, reason)
+	t.Logf("Cluster %q condition %s has reason %q", conditionsapi.ReadyCondition, sf.WorkloadClusterName, reason)
 }
 
 // Start starts the Syncer.

--- a/test/e2e/reconciler/cluster/syncerheartbeat_test.go
+++ b/test/e2e/reconciler/cluster/syncerheartbeat_test.go
@@ -19,19 +19,11 @@ package cluster
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/require"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	workloadclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
-	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
 func TestSyncerHeartbeat(t *testing.T) {
@@ -45,53 +37,11 @@ func TestSyncerHeartbeat(t *testing.T) {
 	t.Log("Creating a workspace")
 	wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
 
-	t.Log("Creating a fake workload server")
-	sink := framework.NewFakeWorkloadServer(t, source, orgClusterName)
-
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
-	sourceConfig := source.DefaultConfig(t)
-	sourceKcpClusterClient, err := kcpclient.NewClusterForConfig(sourceConfig)
-	require.NoError(t, err)
-	kcpClient := sourceKcpClusterClient.Cluster(wsClusterName)
-
-	t.Log("Creating workload cluster...")
-	workloadCluster, err := framework.CreateWorkloadCluster(t, source.Artifact, kcpClient, sink)
-	require.NoError(t, err)
-
-	waitForClusterReadyReason(t, ctx, kcpClient.WorkloadV1alpha1().WorkloadClusters(), workloadCluster.Name, workloadv1alpha1.ErrorHeartbeatMissedReason)
-
-	t.Log("Creating workspace syncer...")
-	framework.StartWorkspaceSyncer(t, ctx, sets.NewString(), workloadCluster, source, sink)
-
-	waitForClusterReadyReason(t, ctx, kcpClient.WorkloadV1alpha1().WorkloadClusters(), workloadCluster.Name, "")
-}
-
-func waitForClusterReadyReason(
-	t *testing.T,
-	ctx context.Context,
-	client workloadclient.WorkloadClusterInterface,
-	clusterName string,
-	reason string,
-) {
-	t.Logf("Waiting for cluster %q condition %q to have reason %q", clusterName, workloadv1alpha1.WorkloadClusterReadyCondition, reason)
-	require.Eventually(t, func() bool {
-		cluster, err := client.Get(ctx, clusterName, metav1.GetOptions{})
-		if err != nil {
-			t.Errorf("Error getting cluster %q: %v", clusterName, err)
-			return false
-		}
-
-		// A reason is only supplied to indicate why a cluster is 'not ready'
-		wantReady := len(reason) == 0
-		if wantReady {
-			return conditions.IsTrue(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
-		} else {
-			conditionReason := conditions.GetReason(cluster, workloadv1alpha1.WorkloadClusterReadyCondition)
-			return conditions.IsFalse(cluster, workloadv1alpha1.WorkloadClusterReadyCondition) && reason == conditionReason
-		}
-
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-	t.Logf("Cluster %q condition %s has reason %q", workloadv1alpha1.WorkloadClusterReadyCondition, clusterName, reason)
+	syncerFixture := framework.NewSyncerFixture(t, sets.NewString(), source, orgClusterName, wsClusterName)
+	syncerFixture.WaitForClusterReadyReason(t, ctx, workloadv1alpha1.ErrorHeartbeatMissedReason)
+	syncerFixture.Start(t, ctx)
+	syncerFixture.WaitForClusterReadyReason(t, ctx, "")
 }


### PR DESCRIPTION
Backports fix in #864 for a hotloop.  Requires testing fixture changes from #861.