### PR TITLE
Sync from multiple workspaces

### DIFF
--- a/pkg/syncer/shared/finalizer.go
+++ b/pkg/syncer/shared/finalizer.go
@@ -36,8 +36,8 @@ const (
 	SyncerFinalizerNamePrefix = "workloads.kcp.dev/syncer-"
 )
 
-func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersionResource, upstreamClient dynamic.Interface, upstreamNamespace, workloadClusterName string, logicalClusterName logicalcluster.Name, resourceName string) error {
-	upstreamObj, err := upstreamClient.Resource(gvr).Namespace(upstreamNamespace).Get(ctx, resourceName, metav1.GetOptions{})
+func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersionResource, upstreamClient dynamic.ClusterInterface, upstreamNamespace, workloadClusterName string, logicalClusterName logicalcluster.Name, resourceName string) error {
+	upstreamObj, err := upstreamClient.Cluster(logicalClusterName).Resource(gvr).Namespace(upstreamNamespace).Get(ctx, resourceName, metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -77,7 +77,7 @@ func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersion
 	upstreamObj.SetLabels(upstreamLabels)
 	// - End of block to be removed once the virtual workspace syncer is integrated -
 
-	if _, err := upstreamClient.Resource(gvr).Namespace(upstreamObj.GetNamespace()).Update(ctx, upstreamObj, metav1.UpdateOptions{}); err != nil {
+	if _, err := upstreamClient.Cluster(logicalClusterName).Resource(gvr).Namespace(upstreamObj.GetNamespace()).Update(ctx, upstreamObj, metav1.UpdateOptions{}); err != nil {
 		klog.Errorf("Failed updating after removing the finalizers of resource %s|%s/%s: %v", logicalClusterName, upstreamNamespace, upstreamObj.GetName(), err)
 		return err
 	}

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -46,16 +46,17 @@ type Controller struct {
 
 	mutators mutatorGvrMap
 
-	upstreamClient, downstreamClient       dynamic.Interface
+	upstreamClient                         dynamic.ClusterInterface
+	downstreamClient                       dynamic.Interface
 	upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory
 
-	workloadClusterName       string
-	upstreamClusterName       logicalcluster.Name
-	advancedSchedulingEnabled bool
+	workloadClusterName               string
+	workloadClusterLogicalClusterName logicalcluster.Name
+	advancedSchedulingEnabled         bool
 }
 
-func NewSpecSyncer(gvrs []schema.GroupVersionResource, upstreamClusterName logicalcluster.Name, workloadClusterName string, upstreamURL *url.URL, advancedSchedulingEnabled bool,
-	upstreamClient, downstreamClient dynamic.Interface, upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory) (*Controller, error) {
+func NewSpecSyncer(gvrs []schema.GroupVersionResource, workloadClusterLogicalClusterName logicalcluster.Name, workloadClusterName string, upstreamURL *url.URL, advancedSchedulingEnabled bool,
+	upstreamClient dynamic.ClusterInterface, downstreamClient dynamic.Interface, upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory) (*Controller, error) {
 	deploymentMutator := specmutators.NewDeploymentMutator(upstreamURL)
 	secretMutator := specmutators.NewSecretMutator()
 
@@ -72,9 +73,9 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, upstreamClusterName logic
 		upstreamInformers:   upstreamInformers,
 		downstreamInformers: downstreamInformers,
 
-		workloadClusterName:       workloadClusterName,
-		upstreamClusterName:       upstreamClusterName,
-		advancedSchedulingEnabled: advancedSchedulingEnabled,
+		workloadClusterName:               workloadClusterName,
+		workloadClusterLogicalClusterName: workloadClusterLogicalClusterName,
+		advancedSchedulingEnabled:         advancedSchedulingEnabled,
 	}
 
 	for _, gvr := range gvrs {
@@ -96,7 +97,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, upstreamClusterName logic
 				c.AddToQueue(gvr, obj)
 			},
 		})
-		klog.InfoS("Set up informer", "clusterName", upstreamClusterName, "pcluster", workloadClusterName, "gvr", gvr.String())
+		klog.InfoS("Set up informer", "clusterName", workloadClusterLogicalClusterName, "pcluster", workloadClusterName, "gvr", gvr.String())
 	}
 
 	return &c, nil

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -143,7 +143,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		return err
 	}
 
-	upstreamInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(upstreamDynamicClient.Cluster(cfg.KCPClusterName), resyncPeriod, metav1.NamespaceAll, func(o *metav1.ListOptions) {
+	upstreamInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(upstreamDynamicClient.Cluster(logicalcluster.Wildcard), resyncPeriod, metav1.NamespaceAll, func(o *metav1.ListOptions) {
 		o.LabelSelector = workloadv1alpha1.InternalClusterResourceStateLabelPrefix + cfg.WorkloadClusterName + "=" + string(workloadv1alpha1.ResourceStateSync)
 	})
 	downstreamInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(downstreamDynamicClient, resyncPeriod, metav1.NamespaceAll, func(o *metav1.ListOptions) {
@@ -194,14 +194,14 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		return err
 	}
 	specSyncer, err := spec.NewSpecSyncer(gvrs, cfg.KCPClusterName, cfg.WorkloadClusterName, upstreamURL, advancedSchedulingEnabled,
-		upstreamDynamicClient.Cluster(cfg.KCPClusterName), downstreamDynamicClient, upstreamInformers, downstreamInformers)
+		upstreamDynamicClient, downstreamDynamicClient, upstreamInformers, downstreamInformers)
 	if err != nil {
 		return err
 	}
 
 	klog.Infof("Creating status syncer for clusterName %s from pcluster %s, resources %v", cfg.KCPClusterName, cfg.WorkloadClusterName, resources)
 	statusSyncer, err := status.NewStatusSyncer(gvrs, cfg.KCPClusterName, cfg.WorkloadClusterName, advancedSchedulingEnabled,
-		upstreamDynamicClient.Cluster(cfg.KCPClusterName), downstreamDynamicClient, upstreamInformers, downstreamInformers)
+		upstreamDynamicClient, downstreamDynamicClient, upstreamInformers, downstreamInformers)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -243,6 +243,14 @@ func TestScheduling(t *testing.T) {
 				"state.internal.workloads.kcp.dev/" + workloadClusterName: "Sync",
 			},
 		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+		},
 	}, metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -252,6 +260,14 @@ func TestScheduling(t *testing.T) {
 			Name: "second",
 			Labels: map[string]string{
 				"state.internal.workloads.kcp.dev/" + workloadClusterName: "Sync",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
 			},
 		},
 	}, metav1.CreateOptions{})
@@ -273,6 +289,11 @@ func TestScheduling(t *testing.T) {
 		}
 		return true
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
+
+	syncedServicesYaml, err := yaml.Marshal(downstreamServices)
+	require.NoError(t, err)
+	t.Logf("Synced services:\n%s", syncedServicesYaml)
+
 	require.Len(t, downstreamServices.Items, 2)
 
 	names := sets.NewString()

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -18,6 +18,8 @@ package cluster
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -68,7 +70,7 @@ func TestScheduling(t *testing.T) {
 	_, err = kubeClusterClient.Cluster(secondUserClusterName).CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	require.Error(t, err)
 
-	workloadClusterName := "workloadcluster"
+	workloadClusterName := fmt.Sprintf("workloadcluster-%d", +rand.Intn(1000000))
 	t.Logf("Creating a WorkloadCluster and syncer in %s", negotiationClusterName)
 	syncerFixture := framework.SyncerFixture{
 		ResourcesToSync:      sets.NewString("services"),


### PR DESCRIPTION
This PR builds on top of the basic Syncer virtual workspace PR( [#1111](https://github.com/kcp-dev/kcp/pull/1111)), and introduce the required Syncer changes to allow syncers (wire to the syncer virtual workspace) to sync from mltiple workspaces having consistent APIs.

Only the 2 last commits add on top of PR [#1111](https://github.com/kcp-dev/kcp/pull/1111)

## Test instructions:

- Start KCP:
```bash
./bin/kcp start --auto-publish-apis --feature-gates KCPLocationAPI=true

```

- Export KCP kubeconfig:
```bash
export KUBECONFIG=$(pwd)/.kcp/admin.kubeconfig
```

- Create a `negotiation` workspace:
```bash
kubectl ws create negotiation --enter
```

- Prepare for the Syncer installation:
```
kubectl kcp workload sync us-west1 --replicas=0 --resources=ingresses.networking.k8s.io,deployments.apps,services --syncer-image=syncer > us-west1-syncer.yaml
```

- Apply the syncer manifest to the us-west1 physical cluster:
```
kubectl --kubeconfig contrib/demo/clusters/kind/us-west1.kubeconfig apply -f us-west1-syncer.yaml
```

- Start the syncer locally:
```bash
./bin/syncer --workload-cluster-name us-west1 --from-kubeconfig ${KUBECONFIG} --from-context system:admin --from-cluster root:default:negotiation --to-kubeconfig contrib/demo/clusters/kind/us-west1.kubeconfig --resources="deployments.apps" --resources="services"
```

- Create an APIExport in the negotiation domain:
```bash
kubectl apply -f - << EOF
apiVersion: apis.kcp.dev/v1alpha1
kind: APIExport
metadata:
    name: kubernetes
spec:
EOF
```

- Create a location in the negotiation workspace
```bash
kubectl apply -f - << EOF
apiVersion: scheduling.kcp.dev/v1alpha1
kind: Location
metadata:
    name: us-west1
    labels:
        foo: "42"
spec:
    resource:
        group: workload.kcp.dev
        version: v1alpha1
        resource: workloadclusters
EOF
```

- Create a `user1` workspace and label the default namespace standard resources to have the synced:
```bash
kubectl ws ..
kubectl ws create user1 --enter

kubectl label configmap/kube-root-ca.crt state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
kubectl label $(kubectl get secrets -o name | grep default-token) state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
kubectl label serviceaccount default state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
```

- Create a binding in user1 workspace to the APIExport in the negotiation workspace: 
```bash
kubectl apply -f - << EOF
apiVersion: apis.kcp.dev/v1alpha1
kind: APIBinding
metadata:
    name: kubernetes
spec:
    reference:
        workspace:
            name: negotiation
            exportName: kubernetes
EOF
```

- Create a deployment and label it:
```bash
kubectl apply -f contrib/examples/ingress-demo/full-example.yaml
kubectl label deployment httpecho state.internal.workloads.kcp.dev/us-west1="Sync" --overwrite
```

- See the deployment has been synced to the physical cluster:
```bash
kubectl --kubeconfig contrib/demo/clusters/kind/us-west1.kubeconfig get deployments --all-namespaces
```

- Create a `user2` workspace and a binding inside:
```bash
kubectl ws ..
kubectl ws create user2 --enter

kubectl label configmap/kube-root-ca.crt state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
kubectl label $(kubectl get secrets -o name | grep default-token) state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
kubectl label serviceaccount default state.internal.workloads.kcp.dev/us-west1=Sync --overwrite

kubectl apply -f - << EOF
apiVersion: apis.kcp.dev/v1alpha1
kind: APIBinding
metadata:
    name: kubernetes
spec:
    reference:
        workspace:
            name: negotiation
            exportName: kubernetes
EOF
```

- Create and label a distinct deployment in user2 workspace:
```bash
kubectl apply -f contrib/examples/deployment.yaml
kubectl label deployment example state.internal.workloads.kcp.dev/us-west1="Sync" --overwrite

kubectl label configmap/kube-root-ca.crt state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
kubectl label $(kubectl get secrets -o name | grep default-token) state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
kubectl label serviceaccount default state.internal.workloads.kcp.dev/us-west1=Sync --overwrite
```

- See that the same syncer is syncing deployments in both `user1` and `user2` workspaces.
You should see the corresponding deployments in 2 distinct hashed namespaces on the physical cluster:
```bash
kubectl --kubeconfig contrib/demo/clusters/kind/us-west1.kubeconfig get deployments --all-namespaces
```

- Now you can scale deployments (from KCP) of either `user1` or `user2` workspaces and verify in the kind cluster that they are correctly synced by the single multi-workspace syncer.


