### PR TITLE
cmd/kcp: add --feature-gates flag

### DIFF
--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -21,6 +21,25 @@ import (
 )
 
 var (
+	namedFlagSetOrder = []string{
+		"auditing",
+		"authentication",
+		"etcd",
+		"Embedded etcd",
+		"features",
+		"generic",
+		"logs",
+		"metrics",
+		"misc",
+		"secure serving",
+		"traces",
+		"KCP Authentication",
+		"KCP Authorization",
+		"KCP Virtual Workspaces",
+		"KCP Controllers",
+		"KCP",
+	}
+
 	allowedFlags = sets.NewString(
 		// auditing flags
 		"audit-log-batch-buffer-size",           // The size of the buffer to store events before batching and writing. Only used in batch mode.

--- a/pkg/server/options/flags_test.go
+++ b/pkg/server/options/flags_test.go
@@ -22,7 +22,23 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
 )
+
+func TestNamedFlagSetOrder(t *testing.T) {
+	fss := NewOptions().Flags()
+	var names []string
+	for name, fs := range fss.FlagSets {
+		if !fs.HasFlags() {
+			continue
+		}
+		fmt.Printf("%q,\n", name)
+		names = append(names, name)
+	}
+
+	require.Subset(t, names, namedFlagSetOrder, "namedFlagSetOrder has extra entries")
+	require.Subset(t, namedFlagSetOrder, names, "namedFlagSetOrder in incomplete")
+}
 
 func TestAllowedFlagList(t *testing.T) {
 	o := NewOptions()

--- a/pkg/server/options/genericcontrolplane.go
+++ b/pkg/server/options/genericcontrolplane.go
@@ -17,8 +17,9 @@ limitations under the License.
 package options
 
 import (
-	_ "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
+
+	_ "github.com/kcp-dev/kcp/pkg/features"
 )
 
 //

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -28,11 +29,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	cliflag "k8s.io/component-base/cli/flag"
-	_ "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/genericcontrolplane/options"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 
 	kcpadmission "github.com/kcp-dev/kcp/pkg/admission"
+	_ "github.com/kcp-dev/kcp/pkg/features"
+	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 )
 
 type Options struct {
@@ -116,6 +118,12 @@ func NewOptions() *Options {
 
 func (o *Options) Flags() cliflag.NamedFlagSets {
 	fss := filter(o.rawFlags(), allowedFlags)
+
+	// add flags that are filtered out from upstream, but overridden here with our own version
+	fs := fss.FlagSet("KCP")
+	fs.Var(kcpfeatures.NewFlagValue(), "features-gates", ""+
+		"A set of key=value pairs that describe feature gates for alpha/experimental features. "+
+		"Options are:\n"+strings.Join(kcpfeatures.KnownFeatures(), "\n")) // hide kube-only gates
 
 	fss.Order = namedFlagSetOrder
 

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -114,8 +114,12 @@ func NewOptions() *Options {
 	return o
 }
 
-func (o *Options) Flags() (fss cliflag.NamedFlagSets) {
-	return filter(o.rawFlags(), allowedFlags)
+func (o *Options) Flags() cliflag.NamedFlagSets {
+	fss := filter(o.rawFlags(), allowedFlags)
+
+	fss.Order = namedFlagSetOrder
+
+	return fss
 }
 
 func (o *Options) rawFlags() cliflag.NamedFlagSets {


### PR DESCRIPTION
Used as in kube:
- on the command line: `--feature-gates=Foo=true`
- in code: `if utilfeature.DefaultFeatureGate.Enabled(kcpfeatures.Foo)`.
- In `kcp start options`: <img width="1721" alt="Bildschirmfoto 2022-04-25 um 14 07 13" src="https://user-images.githubusercontent.com/730123/165086051-8ef71f20-f2d2-4e98-838e-4fc81d865f69.png">

