### PR TITLE
fix syncer image name

### DIFF
--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -23,4 +23,4 @@ jobs:
 
       # Build and push a syncer image, tagged with the commit SHA and the branch name.
       - uses: imjasonh/setup-ko@v0.4
-      - run: ko publish ./cmd/syncer -t $(git rev-parse --short "$GITHUB_SHA"),${{ github.ref_name }}
+      - run: ko publish -B ./cmd/syncer -t $(git rev-parse --short "$GITHUB_SHA"),${{ github.ref_name }}


### PR DESCRIPTION
## Summary
call `ko` with the `-B` option to prevent adding the MD5 hash of the import path to the resulting image name.
see https://github.com/google/ko#naming-images

the resulting image names will be:
* ghcr.io/kcp-dev/kcp/syncer:${git short commit sha}
* ghcr.io/kcp-dev/kcp/syncer:${git ref name} (e.g. main)

e.g. see https://github.com/geoberle/kcp/pkgs/container/kcp%2Fsyncer

## Related issue(s)
Fixes #941