### PR TITLE
Add front proxy

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -74,5 +74,7 @@ jobs:
         run: |-
           cd manifest
           ../kustomize edit add patch --patch='[{"op": "replace", "path": "/spec/template/spec/containers/0/env", "value": [{"name": "EXTERNAL_HOSTNAME", "value": "${{ steps.external_hostname.outputs.external_hostname }}"}]}]' --group apps --kind Deployment --name kcp --version v1
+          ../kustomize edit add patch --patch='[{"op": "replace", "path": "/spec/host", "value": "${{ steps.external_hostname.outputs.external_hostname }}"}]' --group route.openshift.io --kind Route --name kcp-front-proxy --version v1
+          ../kustomize edit add patch --patch='[{"op": "replace", "path": "/spec/dnsNames/0", "value": "${{ steps.external_hostname.outputs.external_hostname }}"}]' --group cert-manager.io --kind Certificate --name kcp-front-proxy --version v1
           ../kustomize edit set image ghcr.io/kcp-dev/kcp=ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}
           ../kustomize build . | ../kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} apply -f -

--- a/manifest/etcd.yaml
+++ b/manifest/etcd.yaml
@@ -2,6 +2,54 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
+  name: etcd-client-ca
+spec:
+  isCA: true
+  commonName: etcd-client-bootstrap
+  secretName: etcd-client-bootstrap-secret
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: etcd-peer-ca
+spec:
+  isCA: true
+  commonName: etcd-peer-bootstrap
+  secretName: etcd-peer-bootstrap-secret
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-client-issuer
+spec:
+  ca:
+    secretName: etcd-client-bootstrap-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: etcd-peer-issuer
+spec:
+  ca:
+    secretName: etcd-peer-bootstrap-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
   name: etcd
 spec:
   secretName: etcd-cert
@@ -29,7 +77,7 @@ spec:
   ipAddresses:
     - 0.0.0.0
   issuerRef:
-    name: kcp
+    name: etcd-client-issuer
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -60,7 +108,7 @@ spec:
   ipAddresses:
     - 0.0.0.0
   issuerRef:
-    name: kcp
+    name: etcd-peer-issuer
 ---
 apiVersion: v1
 kind: Service

--- a/manifest/etcd.yaml
+++ b/manifest/etcd.yaml
@@ -53,12 +53,11 @@ metadata:
   name: etcd
 spec:
   secretName: etcd-cert
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
   subject:
     organizations:
       - redhat
-  isCA: false
   privateKey:
     algorithm: RSA
     encoding: PKCS1
@@ -85,12 +84,11 @@ metadata:
   name: etcd-peer
 spec:
   secretName: etcd-peer-cert
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
   subject:
     organizations:
       - redhat
-  isCA: false
   privateKey:
     algorithm: RSA
     encoding: PKCS1

--- a/manifest/issuer.yaml
+++ b/manifest/issuer.yaml
@@ -1,6 +1,6 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: kcp
+  name: kcp-pki-bootstrap
 spec:
   selfSigned: {}

--- a/manifest/kcp-front-proxy.yaml
+++ b/manifest/kcp-front-proxy.yaml
@@ -103,8 +103,8 @@ metadata:
   name: kcp-front-proxy-virtual-workspaces-client-cert
 spec:
   secretName: kcp-front-proxy-virtual-workspaces-client-cert
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
   subject:
     organizations:
       - redhat

--- a/manifest/kcp-front-proxy.yaml
+++ b/manifest/kcp-front-proxy.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kcp-front-proxy
+spec:
+  host: kcp
+  port:
+    targetPort: 8443
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: kcp-front-proxy
+    weight: 100
+  wildcardPolicy: None
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-front-proxy-issuer
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: kcp-front-proxy-issuer-account-key
+    solvers:
+    - http01:
+        ingress:
+          serviceType: ClusterIP
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-front-proxy
+spec:
+  secretName: kcp-front-proxy-cert
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  subject:
+    organizations:
+      - redhat
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+  dnsNames:
+    - "kcp"
+  issuerRef:
+    name: kcp-front-proxy-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-client-ca
+spec:
+  isCA: true
+  commonName: kcp-client-ca
+  secretName: kcp-client-ca
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-client-issuer
+spec:
+  ca:
+    secretName: kcp-client-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-front-proxy-kcp-client-cert
+spec:
+  secretName: kcp-front-proxy-kcp-client-cert
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  subject:
+    organizations:
+      - redhat
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - client auth
+  dnsNames:
+    - "kcp-front-proxy"
+  issuerRef:
+    name: kcp-requestheader-client-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-front-proxy-virtual-workspaces-client-cert
+spec:
+  secretName: kcp-front-proxy-virtual-workspaces-client-cert
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  subject:
+    organizations:
+      - redhat
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - client auth
+  dnsNames:
+    - "kcp-front-proxy"
+  issuerRef:
+    name: kcp-requestheader-client-issuer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kcp-front-proxy
+spec:
+  ports:
+    - protocol: TCP
+      name: kcp-front-proxy
+      port: 8443
+      targetPort: 8443
+  selector:
+    app: kcp-front-proxy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kcp-front-proxy-config
+data:
+  path-mapping.yaml: |
+    - path: /services/
+      backend: https://kcp:6444
+      backend_server_ca: /etc/virtual-workspaces/tls/ca.crt
+      proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls/virtual-workspaces/tls.crt
+      proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls/virtual-workspaces/tls.key
+    - path: /
+      backend: https://kcp:6443
+      backend_server_ca: /etc/kcp/tls/ca.crt
+      proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls/kcp/tls.crt
+      proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls/kcp/tls.key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kcp-front-proxy
+  labels:
+    app: kcp-front-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kcp-front-proxy
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: kcp-front-proxy
+    spec:
+      containers:
+      - name: kcp-front-proxy
+        image: ghcr.io/kcp-dev/kcp:latest
+        ports:
+        - containerPort: 8443
+        command:
+        - /kcp-front-proxy
+        args:
+        - --secure-port=8443
+        - --tls-private-key-file=/etc/kcp-front-proxy/tls/tls.key
+        - --tls-cert-file=/etc/kcp-front-proxy/tls/tls.crt
+        - --client-ca-file=/etc/kcp-front-proxy/client/tls/ca.crt
+        - --mapping-file=/etc/kcp-front-proxy/config/path-mapping.yaml
+        - --v=6
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: livez
+            port: 8443
+            scheme: HTTPS
+          initialDelaySeconds: 45
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: readyz
+            port: 8443
+            scheme: HTTPS
+        volumeMounts:
+        - name: kcp-front-proxy-cert
+          mountPath: /etc/kcp-front-proxy/tls
+        - name: kcp-front-proxy-config
+          mountPath: /etc/kcp-front-proxy/config
+        - name: kcp-client-ca
+          mountPath: /etc/kcp-front-proxy/client/tls
+        - name: kcp-ca
+          mountPath: /etc/kcp/tls
+        - name: kcp-virtual-workspaces-ca
+          mountPath: /etc/virtual-workspaces/tls
+        - name: kcp-front-proxy-kcp-client-cert
+          mountPath: /etc/kcp-front-proxy/requestheader-client/tls/kcp
+        - name: kcp-front-proxy-virtual-workspaces-client-cert
+          mountPath: /etc/kcp-front-proxy/requestheader-client/tls/virtual-workspaces
+      volumes:
+      - name: kcp-front-proxy-cert
+        secret:
+          secretName: kcp-front-proxy-cert
+      - name: kcp-client-ca
+        secret:
+          secretName: kcp-client-ca
+          items:
+            - key: ca.crt
+              path: ca.crt
+      - name: kcp-ca
+        secret:
+          secretName: kcp-cert
+          items:
+            - key: ca.crt
+              path: ca.crt
+      - name: kcp-virtual-workspaces-ca
+        secret:
+          secretName: kcp-virtual-workspaces-cert
+          items:
+            - key: ca.crt
+              path: ca.crt
+      - name: kcp-front-proxy-kcp-client-cert
+        secret:
+          secretName: kcp-front-proxy-kcp-client-cert
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      - name: kcp-front-proxy-virtual-workspaces-client-cert
+        secret:
+          secretName: kcp-front-proxy-virtual-workspaces-client-cert
+          items:
+            - key: tls.crt
+              path: tls.crt
+            - key: tls.key
+              path: tls.key
+      - name: kcp-front-proxy-config
+        configMap:
+          name: kcp-front-proxy-config
+          items:
+            - key: "path-mapping.yaml"
+              path: "path-mapping.yaml"

--- a/manifest/kcp.yaml
+++ b/manifest/kcp.yaml
@@ -18,12 +18,11 @@ metadata:
   name: kcp-virtual-workspaces
 spec:
   secretName: kcp-virtual-workspaces-cert
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
   subject:
     organizations:
       - redhat
-  isCA: false
   privateKey:
     algorithm: RSA
     encoding: PKCS1
@@ -91,12 +90,11 @@ metadata:
   name: kcp
 spec:
   secretName: kcp-cert
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
   subject:
     organizations:
       - redhat
-  isCA: false
   privateKey:
     algorithm: RSA
     encoding: PKCS1

--- a/manifest/kcp.yaml
+++ b/manifest/kcp.yaml
@@ -30,14 +30,60 @@ spec:
     size: 2048
   usages:
     - server auth
-    - client auth
   dnsNames:
     - kcp
-    - "*openshiftapps.com"
-  ipAddresses:
-    - 0.0.0.0
+    - localhost
+    - "*.openshiftapps.com"
   issuerRef:
-    name: kcp
+    name: kcp-server-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-ca
+spec:
+  isCA: true
+  commonName: kcp-ca
+  secretName: kcp-ca
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-requestheader-client-ca
+spec:
+  isCA: true
+  commonName: kcp-requestheader-client-ca
+  secretName: kcp-requestheader-client-ca
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-server-issuer
+spec:
+  ca:
+    secretName: kcp-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-requestheader-client-issuer
+spec:
+  ca:
+    secretName: kcp-requestheader-client-ca
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -57,15 +103,12 @@ spec:
     size: 2048
   usages:
     - server auth
-    - client auth
   dnsNames:
     - kcp
     - localhost
-    - "*openshiftapps.com"
-  ipAddresses:
-    - 0.0.0.0
+    - "*.openshiftapps.com"
   issuerRef:
-    name: kcp
+    name: kcp-server-issuer
 ---
 apiVersion: v1
 kind: Service
@@ -117,6 +160,9 @@ spec:
         - --etcd-cafile=/etc/etcd/tls/server/ca.crt
         - --tls-private-key-file=/etc/kcp/tls/server/tls.key
         - --tls-cert-file=/etc/kcp/tls/server/tls.crt
+        - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client/ca.crt
+        - --requestheader-username-headers=X-Remote-User
+        - --requestheader-group-headers=X-Remote-Group
         - --root-directory=/etc/kcp/config
         - --run-virtual-workspaces=false
         - --virtual-workspace-address=https://$(EXTERNAL_HOSTNAME)
@@ -159,6 +205,8 @@ spec:
           mountPath: /etc/etcd/tls/server
         - name: kcp-certs
           mountPath: /etc/kcp/tls/server
+        - name: kcp-requestheader-client-ca
+          mountPath: /etc/kcp/tls/requestheader-client
         - name: kubeconfig
           mountPath: /etc/kcp/config
       - name: virtual-workspaces
@@ -177,6 +225,9 @@ spec:
           --authentication-skip-lookup
           --tls-private-key-file=/etc/kcp/tls/server/tls.key
           --tls-cert-file=/etc/kcp/tls/server/tls.crt
+          --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client/ca.crt
+          --requestheader-username-headers=X-Remote-User
+          --requestheader-group-headers=X-Remote-Group
           --secure-port=6444
         livenessProbe:
           failureThreshold: 3
@@ -204,6 +255,8 @@ spec:
         volumeMounts:
         - name: virtual-workspaces-certs
           mountPath: /etc/kcp/tls/server
+        - name: kcp-requestheader-client-ca
+          mountPath: /etc/kcp/tls/requestheader-client
         - name: kubeconfig
           mountPath: /etc/kcp/config
       volumes:
@@ -216,6 +269,12 @@ spec:
       - name: virtual-workspaces-certs
         secret:
           secretName: kcp-virtual-workspaces-cert
+      - name: kcp-requestheader-client-ca
+        secret:
+          secretName: kcp-requestheader-client-ca
+          items:
+          - key: ca.crt
+            path: ca.crt
       - name: kubeconfig
         persistentVolumeClaim:
           claimName: kcp

--- a/manifest/kustomization.yaml
+++ b/manifest/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - etcd.yaml
 - issuer.yaml
 - kcp.yaml
+- kcp-front-proxy.yaml


### PR DESCRIPTION
This adds the front proxy into the topology of the deployment manifest.

Instead of terminating TLS at the ingress router, it will instead terminate at the front proxy, and the proxy will route requests to either KCP or the virtual workspaces process.

This also leverages cert-manager to add the ability to authenticate using a certificate.  Groups will be assigned using the organizations listed on the cert.