### PR TITLE
Make 'kubectl kcp workload sync' idempotent

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -183,7 +183,7 @@ func enableSyncerForWorkspace(ctx context.Context, config *rest.Config, workload
 		}
 	case err == nil:
 		//Overwrite the ownerref in case of a user changed it
-		sa.OwnerReferences = workloadClusterOwnerReferences
+		sa.ObjectMeta.OwnerReferences = workloadClusterOwnerReferences
 		if sa, err = kubeClient.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
 			return "", fmt.Errorf("failed to update ServiceAccount: %w", err)
 		}

--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -29,6 +29,8 @@ import (
 	"text/template"
 	"time"
 
+	jsonpatch "github.com/evanphx/json-patch"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,7 +42,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
-	jsonpatch "github.com/evanphx/json-patch"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	"github.com/kcp-dev/kcp/pkg/cliplugins/helpers"

--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -190,13 +190,11 @@ func enableSyncerForWorkspace(ctx context.Context, config *rest.Config, workload
 	case err == nil:
 		oldData, err := json.Marshal(corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:             sa.UID,
-				ResourceVersion: sa.ResourceVersion,
 				OwnerReferences: sa.OwnerReferences,
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to Marshal old data for ServiceAccount %s|%s/%s: %w", workloadClusterName, namespace, authResourceName, err)
+			return "", fmt.Errorf("failed to marshal old data for ServiceAccount %s|%s/%s: %w", workloadClusterName, namespace, authResourceName, err)
 		}
 
 		newData, err := json.Marshal(corev1.ServiceAccount{
@@ -207,7 +205,7 @@ func enableSyncerForWorkspace(ctx context.Context, config *rest.Config, workload
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to Marshal new data for ServiceAccount %s|%s/%s: %w", workloadClusterName, namespace, authResourceName, err)
+			return "", fmt.Errorf("failed to marshal new data for ServiceAccount %s|%s/%s: %w", workloadClusterName, namespace, authResourceName, err)
 		}
 
 		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
@@ -252,15 +250,13 @@ func enableSyncerForWorkspace(ctx context.Context, config *rest.Config, workload
 	case err == nil:
 		oldData, err := json.Marshal(rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				UID:             crb.UID,
-				ResourceVersion: crb.ResourceVersion,
 				OwnerReferences: crb.OwnerReferences,
 			},
 			Subjects: crb.Subjects,
 			RoleRef:  crb.RoleRef,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to Marshal old data for ClusterRoleBinding %s|%s: %w", workloadClusterName, authResourceName, err)
+			return "", fmt.Errorf("failed to marshal old data for ClusterRoleBinding %s|%s: %w", workloadClusterName, authResourceName, err)
 		}
 
 		newData, err := json.Marshal(rbacv1.ClusterRoleBinding{
@@ -273,7 +269,7 @@ func enableSyncerForWorkspace(ctx context.Context, config *rest.Config, workload
 			RoleRef:  roleRef,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to Marshal new data for ClusterRoleBinding %s|%s: %w", workloadClusterName, authResourceName, err)
+			return "", fmt.Errorf("failed to marshal new data for ClusterRoleBinding %s|%s: %w", workloadClusterName, authResourceName, err)
 		}
 
 		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -314,7 +314,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := sf.UpstreamServer.RawConfig()
 	require.NoError(t, err)
-	_, kubeconfigPath := writeLogicalClusterConfig(t, upstreamRawConfig, sf.WorkspaceClusterName)
+	_, kubeconfigPath := WriteLogicalClusterConfig(t, upstreamRawConfig, sf.WorkspaceClusterName)
 
 	useDeployedSyncer := len(TestConfig.PClusterKubeconfig()) > 0
 
@@ -519,10 +519,10 @@ func (sf *StartedSyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx cont
 	}
 }
 
-// writeLogicalClusterConfig creates a logical cluster config for the given config and
+// WriteLogicalClusterConfig creates a logical cluster config for the given config and
 // cluster name and writes it to the test's artifact path. Useful for configuring the
 // workspace plugin with --kubeconfig.
-func writeLogicalClusterConfig(t *testing.T, rawConfig clientcmdapi.Config, clusterName logicalcluster.LogicalCluster) (clientcmd.ClientConfig, string) {
+func WriteLogicalClusterConfig(t *testing.T, rawConfig clientcmdapi.Config, clusterName logicalcluster.LogicalCluster) (clientcmd.ClientConfig, string) {
 	logicalRawConfig := LogicalClusterRawConfig(rawConfig, clusterName)
 	artifactDir, err := CreateTempDirForTest(t, "artifacts")
 	require.NoError(t, err)

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -511,7 +511,7 @@ func NewFakeWorkloadServer(t *testing.T, server RunningServer, org logicalcluste
 	logicalClusterName := NewWorkspaceWithWorkloads(t, server, org, "Universal", false)
 	rawConfig, err := server.RawConfig()
 	require.NoError(t, err, "failed to read config for server")
-	logicalConfig, kubeconfigPath := writeLogicalClusterConfig(t, rawConfig, logicalClusterName)
+	logicalConfig, kubeconfigPath := WriteLogicalClusterConfig(t, rawConfig, logicalClusterName)
 	fakeServer := &unmanagedKCPServer{
 		name:           logicalClusterName.String(),
 		cfg:            logicalConfig,

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -197,19 +197,15 @@ func TestSyncWorkload(t *testing.T) {
 	require.NoError(t, err)
 	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, wsClusterName)
 
-	framework.RunKcpCliPlugin(t, kubeconfigPath, []string{
+	subCommand := []string{
 		"workload",
 		"sync",
 		workloadClusterName,
 		"--syncer-image",
 		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
-	})
+	}
 
-	framework.RunKcpCliPlugin(t, kubeconfigPath, []string{
-		"workload",
-		"sync",
-		workloadClusterName,
-		"--syncer-image",
-		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
-	})
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommand)
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommand)
 }

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -179,3 +179,37 @@ func toYaml(obj interface{}) string {
 	}
 	return string(b)
 }
+
+func TestSyncWorkload(t *testing.T) {
+	t.Parallel()
+
+	workloadClusterName := "test-wlc"
+	upstreamServer := framework.SharedKcpServer(t)
+
+	t.Log("Creating an organization")
+	orgClusterName := framework.NewOrganizationFixture(t, upstreamServer)
+
+	t.Log("Creating a workspace")
+	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName, "Universal")
+
+	// Write the upstream logical cluster config to disk for the workspace plugin
+	upstreamRawConfig, err := upstreamServer.RawConfig()
+	require.NoError(t, err)
+	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, wsClusterName)
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, []string{
+		"workload",
+		"sync",
+		workloadClusterName,
+		"--syncer-image",
+		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
+	})
+
+	framework.RunKcpCliPlugin(t, kubeconfigPath, []string{
+		"workload",
+		"sync",
+		workloadClusterName,
+		"--syncer-image",
+		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
+	})
+}


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dvernier@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
Avoid creating workloadcluster, sa and clusterolebinding if they already exist
Overwrite the sa, crb with the calculated values
## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/920