### PR TITLE
Fix syncer resource race

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,7 @@ jobs:
       - run: |-
           export LOG_DIR=/tmp/e2e/shared-server/artifacts &&
           mkdir -p ${LOG_DIR} &&
-          NO_GORUN=1 ./bin/test-server \
+          NO_GORUN=1 ./bin/test-server -v 2 \
           > ${LOG_DIR}/kcp.log 2>&1 &
           echo $! > /tmp/kcp.pid
 

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -42,6 +42,7 @@ import (
 //
 func main() {
 	commandLine := append(framework.StartKcpCommand(), framework.TestServerArgs()...)
+	commandLine = append(commandLine, os.Args[1:]...)
 	log.Printf("running: %v\n", strings.Join(commandLine, " "))
 
 	cmd := exec.Command(commandLine[0], commandLine[1:]...)

--- a/pkg/reconciler/workload/namespace/namespace_controller.go
+++ b/pkg/reconciler/workload/namespace/namespace_controller.go
@@ -89,7 +89,8 @@ func NewController(
 		namespaceLister: namespaceLister,
 		kubeClient:      kubeClusterClient,
 
-		namespaceContentsEnqueuedForMap: map[string]string{},
+		namespaceContentsEnqueuedForMap:     map[string]string{},
+		namespacesNeedingResourceScheduling: sets.NewString(),
 	}
 
 	clusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -151,8 +152,9 @@ type Controller struct {
 
 	// Mapping of namespace key to the last scheduling decision for
 	// which contained resources were enqueued for.
-	namespaceContentsEnqueuedForMap  map[string]string
-	namespaceContentsEnqueuedForLock sync.RWMutex
+	namespaceContentsEnqueuedForMap     map[string]string
+	namespaceContentsEnqueuedForLock    sync.RWMutex
+	namespacesNeedingResourceScheduling sets.String
 }
 
 func filterResource(obj interface{}) bool {


### PR DESCRIPTION
## Summary
Fix the following race condition:

Namespace is scheduled to a workload cluster and has its labels patched

Resource (deployment) is reconciled, but the namespace cache is not up
to date, so the deployment is not scheduled to a workload cluster
(namespace label in cache is unset)

Namespace is processed again (update event from label patch), but
because it was previously scheduled and its placement hasn't changed,
enqueueResourcesForNamespace returns without enqueuing all resources.

## Related issue(s)

Fixes #947 🤞 