### PR TITLE
reconciler/workload/scheduling: remove wrong resource enqueuing avoiding optimization

### DIFF
--- a/pkg/reconciler/workload/namespace/namespace_reconcile.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile.go
@@ -127,13 +127,8 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 	}
 
 	old, new := lbls[ClusterLabel], ns.Labels[ClusterLabel]
-
-	klog.Infof("ANDY comparing %s %s|%s/%s clusterlabel %q to ns clusterlabel %q",
-		gvr.String(), lclusterName, unstr.GetNamespace(), unstr.GetName(), old, new)
-
 	if old == new {
 		// Already assigned to the right cluster.
-		klog.Infof("ANDY no-op %s %s|%s/%s", gvr.String(), lclusterName, unstr.GetNamespace(), unstr.GetName())
 		return nil
 	}
 


### PR DESCRIPTION
The namespace scheduler used `namespaceContentsEnqueuedForMap` to avoid double requeuing of resources. @ncdc found a bug of this logic that led to resources missed during reschedule of the namespace resources:

> I have a theory on the syncer flakes:
> 1. Namespace get scheduled to `cluster-x`
>     a. It’s patched
>     b. `c.namespaceContentsEnqueuedForMap[nsKey]` is set to `cluster-x`
> 2. Dynamic informer sees new deployment, ns controller `reconcileResource` is called
>     a. When it gets the ns from the cache, it’s stale (doesn’t have the cluster label yet)
>     b. It compares the deployment’s cluster label (unset) with the ns’s cluster label (unset) and returns early -> no assignment
> 3. NS informer sees updated ns (after it was patched), reconcileNamespace is called, which calls `enqueueResourcesForNamespace`, but because it was previously reconciled and the scheduling decision hasn’t changed, it returns early

`enqueueResourcesForNamespace` is a pure in-memory operation. Optimizing it away is a premature optimization. Instead we should be level-driven as much as we can. It's easy to just postpone the resource enqueuing until after the namespace cache is not stale anymore, i.e. on the next reconciliation of the namespace. This is what this PR is doing, avoiding resource scheduling with a stale namespace lister.

Note these thoughts about races:
1. after the patch of the namespace we can be sure, the namespace is requeued. When that happens, we can compare the cluster label on the resources and only enqueue those that differ. We know that those from a stale resource cache will "come back" with another resource reconcilation. By that time the namespace cache is up-to-date.
2. on the other hand, if a resource is reconciled before the namespace cache is fresh, the resource will possibly scheduling to the wrong location. But the namespace will be reconciled and will requeue this resource to fix the wrong location.
