### PR TITLE
Default to -v=2

### DIFF
--- a/cmd/ingress-controller/main.go
+++ b/cmd/ingress-controller/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
 
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
@@ -130,13 +131,17 @@ type Options struct {
 }
 
 func NewDefaultOptions() *Options {
+	// Default to -v=2
+	logs := logs.NewOptions()
+	logs.Config.Verbosity = config.VerbosityLevel(2)
+
 	return &Options{
 		Kubeconfig:        "",
 		Context:           "",
 		EnvoyXDSPort:      18000,
 		EnvoyListenerPort: 80,
 		Domain:            "kcp-apps.127.0.0.1.nip.io",
-		Logs:              logs.NewOptions(),
+		Logs:              logs,
 	}
 }
 

--- a/cmd/kcp-front-proxy/options/options.go
+++ b/cmd/kcp-front-proxy/options/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/pflag"
 
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
 
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
@@ -46,6 +47,9 @@ func NewOptions() *Options {
 
 		RootDirectory: ".kcp",
 	}
+
+	// Default to -v=2
+	o.Logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	// override all the things
 	o.SecureServing.BindPort = 443

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
+	"k8s.io/component-base/config"
+	"k8s.io/component-base/logs"
 	"k8s.io/component-base/term"
 
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
@@ -58,6 +60,10 @@ func main() {
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
 
 	serverOptions := options.NewOptions()
+
+	// Default to -v=2
+	serverOptions.GenericControlPlane.Logs.Config.Verbosity = config.VerbosityLevel(2)
+
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the control plane process",
@@ -102,7 +108,7 @@ func main() {
 
 	// add start named flag sets to start flags
 	namedStartFlagSets := serverOptions.Flags()
-	globalflag.AddGlobalFlags(namedStartFlagSets.FlagSet("global"), cmd.Name())
+	globalflag.AddGlobalFlags(namedStartFlagSets.FlagSet("global"), cmd.Name(), logs.SkipLoggingConfigurationFlags())
 	startFlags := startCmd.Flags()
 	for _, f := range namedStartFlagSets.FlagSets {
 		startFlags.AddFlagSet(f)

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
 
 	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
@@ -41,9 +42,13 @@ type Options struct {
 }
 
 func NewOptions() *Options {
+	// Default to -v=2
+	logs := logs.NewOptions()
+	logs.Config.Verbosity = config.VerbosityLevel(2)
+
 	return &Options{
 		SyncedResourceTypes:   []string{},
-		Logs:                  logs.NewOptions(),
+		Logs:                  logs,
 		APIImportPollInterval: 1 * time.Minute,
 	}
 }

--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/component-base/config"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
@@ -50,6 +51,10 @@ type SubCommandOptions interface {
 
 func NewCommand(errout io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	opts := options.NewOptions()
+
+	// Default to -v=2
+	opts.Logs.Config.Verbosity = config.VerbosityLevel(2)
+
 	cmd := &cobra.Command{
 		Use:   "workspaces",
 		Short: "Launch workspaces virtual workspace apiserver",


### PR DESCRIPTION
## Summary
Default to -v=2 for kcp, ingress-controller, kcp-front-proxy, virtual-workspaces (the 4 components that use logs.Options)

## Related issue(s)

Fixes #