### PR TITLE
Fix workspace deletion e2e flake

### DIFF
--- a/pkg/reconciler/tenancy/clusterworkspacedeletion/clusterworkspace_deletion_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspacedeletion/clusterworkspace_deletion_controller.go
@@ -136,7 +136,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	var estimate *deletion.ResourcesRemainingError
 	if errors.As(err, &estimate) {
 		t := estimate.Estimate/2 + 1
-		klog.V(4).Infof("Content remaining in workspace %s, waiting %d seconds", key, t)
+		klog.V(2).Infof("Content remaining in workspace %s, waiting %d seconds", key, t)
 		c.queue.AddAfter(key, time.Duration(t)*time.Second)
 	} else {
 		// rather than wait for a full resync, re-add the workspace to the queue to be processed

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -227,6 +227,11 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				t.Logf("Ensure workspace in the org workspace is deleted")
 				require.Eventually(t, func() bool {
 					wslist, err := server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().List(ctx, metav1.ListOptions{})
+					// 404 could be returned if the org workspace is deleted.
+					if apierrors.IsNotFound(err) {
+						return true
+					}
+
 					if err != nil {
 						return false
 					}
@@ -238,7 +243,6 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				require.Eventually(t, func() bool {
 					_, err := server.rootKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, orgWorkspace.Name, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
-
 				}, wait.ForeverTestTimeout, 1*time.Second)
 			},
 		},


### PR DESCRIPTION
1. increase wait time
2. pass the test when list workspace return 404

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/950