### PR TITLE
Front proxy: set sane transport defaults and enable http2 to backends

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -58,13 +58,13 @@ func NewReverseProxy(backend, clientCert, clientKeyFile, caFile string) (*KCPPro
 		return nil, err
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	proxy.Transport = &http.Transport{
-		TLSClientConfig: &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			RootCAs:      caCertPool,
-		},
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
 	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = transport
 
 	return &KCPProxy{proxy: proxy, backend: backend}, nil
 }


### PR DESCRIPTION
## Summary
This PR updates the KCP front proxy to use sane transport defaults and allow http2 to backends.

## Related issue(s)
https://github.com/kcp-dev/kcp/pull/973#issuecomment-1116990919

Signed-off-by: Christopher Sams <csams@redhat.com>