### PR TITLE
authorization: clarify/fix service accounts and workspace initialization

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -155,6 +155,29 @@ roleRef:
   name: workspace-admin
 ```
 
+### Initializing Workspaces
+
+By default, workspaces are only accessible to a user if they are in phse `Ready`. Workspaces that are initializing
+can be access only by users that are granted `initialize` verb on the `clusterworkspaces/content` resource in the 
+parent workspace.
+
+E.g. the workspace `root:org:ws:ws` initializing user is bound to a role of the following shape in `root:org:ws`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: workspace-initalizer
+  clusterName: root:org:ws
+rules:
+- apiGroups:
+  - tenancy.kcp.dev
+  resources:
+  - clusterworkspaces/content
+  verbs:
+  - initialize
+```
+
 ## Kubernetes Bootstrap Policy authorizer
 
 The bootstrap policy authorizer works just like the local authorizer but references RBAC rules

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -125,8 +125,8 @@ a `ClusterRole` must be created in `root:org:ws` with the following shape:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: 
-  clusterName: workspace-admin
+  name: workspace-admin
+  clusterName: root:org:ws
 rules:
 - apiGroups:
   - tenancy.kcp.dev
@@ -144,7 +144,8 @@ and the user must be bound to it via a `ClusterRoleBinding` in `root:org:ws` lik
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  clusterName: adam-admin
+  name: adam-admin
+  clusterName: root:org:ws
 subjects:
 - kind: User
   name: adam

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -194,3 +194,13 @@ and work just like in a regular Kubernetes cluster.
 Note: groups added by the workspace content authorizer can be used for role bindings in that workspace.
 
 It is possible to bind to roles and cluster roles in the bootstrap policy from a local policy `RoleBinding` or `ClusterRoleBinding`.
+
+# Service Accounts
+
+Kubernetes service accounts is granted access to the workspaces they are defined in and that are ready. 
+
+E.g. a service account "default" in `root:org:ws:ws` is granted access to `root:org:ws:ws`, and through the
+workspace content authorizer it gains the `system:kcp:clusterworkspace:access` group membership.
+
+A service account can gain access (both pure access and `admin` access) to sub-workspaces defined in the workspace
+just below the workspace the service account is defined in.

--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -23,14 +23,16 @@ import (
 )
 
 const (
-	SystemKcpClusterWorkspaceAccessGroup = "system:kcp:clusterworkspace:access"
-	SystemKcpClusterWorkspaceAdminGroup  = "system:kcp:clusterworkspace:admin"
+	SystemKcpClusterWorkspaceAccessGroup     = "system:kcp:clusterworkspace:access"
+	SystemKcpClusterWorkspaceAdminGroup      = "system:kcp:clusterworkspace:admin"
+	SystemKcpClusterWorkspaceInitializeGroup = "system:kcp:clusterworkspace:initialize"
 )
 
 // ClusterRoleBindings return default rolebindings to the default roles
 func clusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	return []rbacv1.ClusterRoleBinding{
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups("system:kcp:clusterworkspace:admin").BindingOrDie(), "system:kcp:clusterworkspace:admin"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups(SystemKcpClusterWorkspaceAdminGroup).BindingOrDie(), "system:kcp:clusterworkspace:admin"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups(SystemKcpClusterWorkspaceInitializeGroup).BindingOrDie(), "system:kcp:clusterworkspace:initialize"),
 	}
 }
 


### PR DESCRIPTION
Changes:
1. give initializers admin access
2. allow service account to access/admin sub-workspaces if permission is granted
3. fix some loop-holes for service account in the authz logic

TODOs:
- [ ] add unit and e2e tests