### PR TITLE
Revert "ci: update to actions/upload-artifact@v3"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
           go-version: v1.17
       - run: make build
       - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" E2E_PARALLELISM=2 make test-e2e
-      - uses: actions/upload-artifact@v3
+      - uses: cytopia/upload-artifact-retry-action@v0.1.2
         if: ${{ always() }}
         with:
           name: e2e
@@ -123,7 +123,7 @@ jobs:
           go-version: v1.17
       - run: make build
       - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" COUNT=5 E2E_PARALLELISM=2 make test-e2e
-      - uses: actions/upload-artifact@v3
+      - uses: cytopia/upload-artifact-retry-action@v0.1.2
         if: ${{ always() }}
         with:
           name: e2e-multiiple-runs
@@ -167,7 +167,7 @@ jobs:
           kill $(cat /tmp/kcp.pid) || true
           wait $(cat /tmp/kcp.pid) || true
 
-      - uses: actions/upload-artifact@v3
+      - uses: cytopia/upload-artifact-retry-action@v0.1.2
         if: ${{ always() }}
         with:
           name: e2e-shared-server


### PR DESCRIPTION
Reverts kcp-dev/kcp#965

Because upload fails again, compare https://github.com/kcp-dev/kcp/runs/6325920274?check_suite_focus=true.