### PR TITLE
Forbid kcp.dev CRD groups outside system:system-crds

### DIFF
--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -48,6 +48,7 @@ import (
 	kcpmutatingwebhook "github.com/kcp-dev/kcp/pkg/admission/mutatingwebhook"
 	workspacenamespacelifecycle "github.com/kcp-dev/kcp/pkg/admission/namespacelifecycle"
 	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdannotations"
+	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdgroups"
 	kcpvalidatingwebhook "github.com/kcp-dev/kcp/pkg/admission/validatingwebhook"
 )
 
@@ -63,6 +64,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	kcpvalidatingwebhook.PluginName,
 	kcpmutatingwebhook.PluginName,
 	reservedcrdannotations.PluginName,
+	reservedcrdgroups.PluginName,
 )
 
 func beforeWebhooks(recommended []string, plugins ...string) []string {
@@ -90,6 +92,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	kcpvalidatingwebhook.Register(plugins)
 	kcpmutatingwebhook.Register(plugins)
 	reservedcrdannotations.Register(plugins)
+	reservedcrdgroups.Register(plugins)
 }
 
 var defaultOnPluginsInKcp = sets.NewString(
@@ -109,6 +112,7 @@ var defaultOnPluginsInKcp = sets.NewString(
 	kcpvalidatingwebhook.PluginName,
 	kcpmutatingwebhook.PluginName,
 	reservedcrdannotations.PluginName,
+	reservedcrdgroups.PluginName,
 )
 
 // defaultOnKubePluginsInKube is a copy of kubeapiserveroptions.defaultOnKubePlugins.

--- a/pkg/admission/reservedcrdgroups/admission.go
+++ b/pkg/admission/reservedcrdgroups/admission.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedcrdgroups
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+const (
+	PluginName = "kcp.dev/ReservedCRDGroups"
+)
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return &reservedCRDGroups{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+			}, nil
+		})
+}
+
+type reservedCRDGroups struct {
+	*admission.Handler
+}
+
+// Ensure that the required admission interfaces are implemented.
+var _ = admission.ValidationInterface(&reservedCRDGroups{})
+
+// Ensure that CRDs in *.kcp.dev group are ony created inside system:system-crds workspace
+func (o *reservedCRDGroups) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	if a.GetResource().GroupResource() != apiextensions.Resource("customresourcedefinitions") {
+		return nil
+	}
+
+	if a.GetKind().GroupKind() != apiextensions.Kind("CustomResourceDefinition") {
+		return nil
+	}
+	crd, ok := a.GetObject().(*apiextensions.CustomResourceDefinition)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", a.GetObject())
+	}
+
+	clusterName, err := request.ClusterNameFrom(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster from context: %w", err)
+	}
+	if clusterName.String() == "system:system-crds" {
+		return nil
+	}
+
+	if strings.HasSuffix(crd.Spec.Group, "kcp.dev") {
+		return admission.NewForbidden(a, fmt.Errorf("%s is a reserved group", crd.Spec.Group))
+	}
+	return nil
+}

--- a/pkg/admission/reservedcrdgroups/admission.go
+++ b/pkg/admission/reservedcrdgroups/admission.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	PluginName = "kcp.dev/ReservedCRDGroups"
+	PluginName                  = "kcp.dev/ReservedCRDGroups"
+	SystemCRDLogicalClusterName = "system:system-crds"
 )
 
 func Register(plugins *admission.Plugins) {
@@ -65,7 +66,7 @@ func (o *reservedCRDGroups) Validate(ctx context.Context, a admission.Attributes
 	if err != nil {
 		return fmt.Errorf("failed to retrieve cluster from context: %w", err)
 	}
-	if clusterName.String() == "system:system-crds" {
+	if clusterName.String() == SystemCRDLogicalClusterName {
 		return nil
 	}
 

--- a/pkg/admission/reservedcrdgroups/admission_test.go
+++ b/pkg/admission/reservedcrdgroups/admission_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedcrdgroups
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/kcp/pkg/admission/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func createAttr(obj *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		nil,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func createAttrAPIBinding(apiBinding *apisv1alpha1.APIBinding) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(apiBinding),
+		nil,
+		apisv1alpha1.Kind("APIBinding").WithVersion("v1alpha1"),
+		"",
+		apiBinding.Name,
+		apisv1alpha1.Resource("apibindings").WithVersion("v1alpha1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func updateAttr(obj, old *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		old,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Update,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		attr        admission.Attributes
+		clusterName string
+
+		wantErr bool
+	}{
+		{
+			name: "passes create reserved group in system crd logical cluster",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "foo.kcp.dev",
+				},
+			}),
+			clusterName: "system:system-crds",
+		},
+		{
+			name: "fails create reserved group outside of system crd logical cluster",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "foo.kcp.dev",
+				},
+			}),
+			wantErr:     true,
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes create non-reserved group outside of system crd logical cluster",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "foo.dev",
+				},
+			}),
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes not a CRD",
+			attr: createAttrAPIBinding(&apisv1alpha1.APIBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}),
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes update reserved group in system crd logical cluster",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "foo.kcp.dev",
+				},
+			},
+				&apiextensions.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: apiextensions.CustomResourceDefinitionSpec{
+						Group: "foo.dev",
+					},
+				}),
+			clusterName: "system:system-crds",
+		},
+		{
+			name: "fails update reserved group outside of system crd logical cluster",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "foo.kcp.dev",
+				},
+			},
+				&apiextensions.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: apiextensions.CustomResourceDefinitionSpec{
+						Group: "foo.dev",
+					},
+				}),
+			wantErr:     true,
+			clusterName: "root:org:ws",
+		},
+		{
+			name: "passes update non-reserved group outside of system crd logical cluster",
+			attr: updateAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "bar.dev",
+				},
+			},
+				&apiextensions.CustomResourceDefinition{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+					},
+					Spec: apiextensions.CustomResourceDefinitionSpec{
+						Group: "foo.dev",
+					},
+				}),
+			clusterName: "root:org:ws",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &reservedCRDGroups{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+			}
+			var ctx context.Context
+
+			require.NotEmpty(t, tt.clusterName, "clusterName must be set in this test")
+
+			ctx = request.WithCluster(context.Background(), request.Cluster{Name: logicalcluster.New(tt.clusterName)})
+			if err := o.Validate(ctx, tt.attr, nil); (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/server/apiextensions_test.go
+++ b/pkg/server/apiextensions_test.go
@@ -19,8 +19,9 @@ package server
 import (
 	"testing"
 
-	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdgroups"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdgroups"
 )
 
 func TestSystemCRDsLogicalClusterName(t *testing.T) {

--- a/pkg/server/apiextensions_test.go
+++ b/pkg/server/apiextensions_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdgroups"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemCRDsLogicalClusterName(t *testing.T) {
+	require.Equal(t, SystemCRDLogicalCluster.String(), reservedcrdgroups.SystemCRDLogicalClusterName, "reservedcrdgroups admission check should match SystemCRDLogicalCluster")
+}

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -59,4 +59,9 @@ func TestCustomResourceCreation(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected an error due to reserved annotation")
 	}
+
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(sourceWorkspace), mapper, "wildwest.kcp.dev_cowboys.yaml", testFiles)
+	if err == nil {
+		t.Errorf("Expected an error due to reserved group")
+	}
 }

--- a/test/e2e/customresourcedefinition/wildwest.kcp.dev_cowboys.yaml
+++ b/test/e2e/customresourcedefinition/wildwest.kcp.dev_cowboys.yaml
@@ -1,0 +1,58 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: cowboys.wildwest.kcp.dev
+spec:
+  group: wildwest.kcp.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cowboy is part of the wild west
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CowboySpec holds the desired state of the Cowboy.
+            properties:
+              intent:
+                type: string
+            type: object
+          status:
+            description: CowboyStatus communicates the observed state of the Cowboy.
+            properties:
+              result:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>

## Summary

Adds an admission plugin that ensures *.kcp.dev CRDs are only allowed in system:system-crds.

## Related issue(s)

Fixes #772