### PR TITLE
Add kubectl kcp crd snapshot command

### DIFF
--- a/cmd/kubectl-kcp/main.go
+++ b/cmd/kubectl-kcp/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 
+	crdcmd "github.com/kcp-dev/kcp/pkg/cliplugins/crd/cmd"
 	workloadcmd "github.com/kcp-dev/kcp/pkg/cliplugins/workload/cmd"
 	workspacecmd "github.com/kcp-dev/kcp/pkg/cliplugins/workspace/cmd"
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
@@ -72,6 +73,9 @@ func main() {
 		os.Exit(1)
 	}
 	root.AddCommand(workloadCmd)
+
+	crdCmd := crdcmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root.AddCommand(crdCmd)
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/pkg/apis/apis/v1alpha1/crd_to_apiresourceschema.go
+++ b/pkg/apis/apis/v1alpha1/crd_to_apiresourceschema.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// CRDToAPIResourceSchema converts a CustomResourceDefinition to an APIResourceSchema. The name of the returned
+// APIResourceSchema is in the form of <prefix>.<crd.Name>.
+func CRDToAPIResourceSchema(crd *apiextensionsv1.CustomResourceDefinition, prefix string) (*APIResourceSchema, error) {
+	name := prefix + "." + crd.Name
+
+	if msgs := validation.IsDNS1123Subdomain(name); len(msgs) > 0 {
+		var errs []error
+
+		for _, msg := range msgs {
+			errs = append(errs, field.Invalid(field.NewPath("metadata", "name"), name, msg))
+		}
+
+		return nil, errors.NewAggregate(errs)
+	}
+
+	apiResourceSchema := &APIResourceSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: prefix + "." + crd.Name,
+		},
+		Spec: APIResourceSchemaSpec{
+			Group: crd.Spec.Group,
+			Names: crd.Spec.Names,
+			Scope: crd.Spec.Scope,
+		},
+	}
+
+	for i := range crd.Spec.Versions {
+		crdVersion := crd.Spec.Versions[i]
+
+		apiResourceVersion := APIResourceVersion{
+			Name:                     crdVersion.Name,
+			Served:                   crdVersion.Served,
+			Storage:                  crdVersion.Storage,
+			Deprecated:               crdVersion.Deprecated,
+			DeprecationWarning:       crdVersion.DeprecationWarning,
+			AdditionalPrinterColumns: crdVersion.AdditionalPrinterColumns,
+		}
+
+		if crdVersion.Schema != nil && crdVersion.Schema.OpenAPIV3Schema != nil {
+			if err := apiResourceVersion.SetSchema(crdVersion.Schema.OpenAPIV3Schema); err != nil {
+				return nil, fmt.Errorf("error converting schema for version %q: %w", crdVersion.Name, err)
+			}
+		}
+
+		if crdVersion.Subresources != nil {
+			apiResourceVersion.Subresources = *crdVersion.Subresources
+		}
+
+		apiResourceSchema.Spec.Versions = append(apiResourceSchema.Spec.Versions, apiResourceVersion)
+	}
+
+	return apiResourceSchema, nil
+}

--- a/pkg/cliplugins/crd/cmd/cmd.go
+++ b/pkg/cliplugins/crd/cmd/cmd.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/kcp-dev/kcp/pkg/cliplugins/crd/plugin"
+)
+
+var (
+	crdExample = `
+	# Convert a CRD in a yaml file to an APIResourceSchema. For a CRD named widgets.example.io, and a prefix value of
+	# 'today', the new APIResourceSchema's name will be today.widgets.example.io.
+	%[1]s crd snapshot -f crd.yaml --prefix 2022-05-07 > api-resource-schema.yaml
+
+	# Convert a CRD from STDIN
+	kubectl get crd foo -o yaml | %[1]s crd snapshot -f - --prefix today > output.yaml
+`
+)
+
+// New provides a command for crd operations.
+func New(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "crd",
+		Short:            "CRD related operations",
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	snapshotOptions := plugin.NewOptions(streams)
+
+	snapshotCommand := &cobra.Command{
+		Use:          "snapshot -f FILE --prefix PREFIX",
+		Short:        "Snapshot a CRD and convert it to an APIResourceSchema",
+		Example:      fmt.Sprintf(crdExample, "kubectl kcp"),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := snapshotOptions.Validate(); err != nil {
+				return err
+			}
+
+			return plugin.NewCRDSnapshot(snapshotOptions).Execute()
+		},
+	}
+
+	snapshotOptions.BindFlags(snapshotCommand)
+
+	cmd.AddCommand(snapshotCommand)
+
+	return cmd
+}

--- a/pkg/cliplugins/crd/plugin/options.go
+++ b/pkg/cliplugins/crd/plugin/options.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Options for the crd commands.
+type Options struct {
+	KubectlOverrides *clientcmd.ConfigOverrides
+
+	genericclioptions.IOStreams
+
+	Filename     string
+	Prefix       string
+	OutputFormat string
+}
+
+// NewOptions provides an instance of Options with default values
+func NewOptions(streams genericclioptions.IOStreams) *Options {
+	return &Options{
+		KubectlOverrides: &clientcmd.ConfigOverrides{},
+		IOStreams:        streams,
+		OutputFormat:     "yaml",
+	}
+}
+
+// BindFlags binds the arguments common to all sub-commands,
+// to the corresponding main command flags
+func (o *Options) BindFlags(cmd *cobra.Command) {
+	// We add only a subset of kubeconfig-related flags to the plugin.
+	// All those with with LongName == "" will be ignored.
+	kubectlConfigOverrideFlags := clientcmd.RecommendedConfigOverrideFlags("")
+	kubectlConfigOverrideFlags.AuthOverrideFlags.ClientCertificate.LongName = ""
+	kubectlConfigOverrideFlags.AuthOverrideFlags.ClientKey.LongName = ""
+	kubectlConfigOverrideFlags.AuthOverrideFlags.Impersonate.LongName = ""
+	kubectlConfigOverrideFlags.AuthOverrideFlags.ImpersonateGroups.LongName = ""
+	kubectlConfigOverrideFlags.ContextOverrideFlags.AuthInfoName.LongName = ""
+	kubectlConfigOverrideFlags.ContextOverrideFlags.ClusterName.LongName = ""
+	kubectlConfigOverrideFlags.ContextOverrideFlags.Namespace.LongName = ""
+	kubectlConfigOverrideFlags.Timeout.LongName = ""
+
+	clientcmd.BindOverrideFlags(o.KubectlOverrides, cmd.PersistentFlags(), kubectlConfigOverrideFlags)
+
+	cmd.Flags().StringVarP(&o.Filename, "filename", "f", o.Filename, "Path to a file containing the CRD to convert to an APIResourceSchema, or - for stdin")
+	cmd.Flags().StringVar(&o.Prefix, "prefix", o.Prefix, "Prefix to use for the APIResourceSchema's name, before <resource>.<group>")
+	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", o.OutputFormat, "Output format. Valid values are 'json' and 'yaml'")
+}
+
+func (o *Options) Validate() error {
+	var errs []error
+
+	if o.Filename == "" {
+		errs = append(errs, fmt.Errorf("--filename is required"))
+	}
+
+	if o.Prefix == "" {
+		errs = append(errs, fmt.Errorf("--prefix is required"))
+	}
+
+	if o.OutputFormat != "json" && o.OutputFormat != "yaml" {
+		errs = append(errs, fmt.Errorf("invalid value %q for --output; valid values are json, yaml", o.OutputFormat))
+	}
+
+	return errors.NewAggregate(errs)
+}

--- a/pkg/cliplugins/crd/plugin/snapshot.go
+++ b/pkg/cliplugins/crd/plugin/snapshot.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+type CRDSnapshot struct {
+	options *Options
+}
+
+func NewCRDSnapshot(opts *Options) *CRDSnapshot {
+	return &CRDSnapshot{
+		options: opts,
+	}
+}
+
+func (c *CRDSnapshot) Execute() error {
+	var (
+		in  io.Reader
+		err error
+	)
+
+	if c.options.Filename == "-" {
+		in = c.options.In
+	} else {
+		f, err := os.Open(c.options.Filename)
+		if err != nil {
+			return fmt.Errorf("error opening %s: %w", c.options.Filename, err)
+		}
+
+		defer f.Close()
+
+		in = f
+	}
+
+	data, err := ioutil.ReadAll(in)
+	if err != nil {
+		return fmt.Errorf("error reading: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	if err := apisv1alpha1.AddToScheme(scheme); err != nil {
+		return err
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+
+	decoded, _, err := codecs.UniversalDecoder(apiextensionsv1.SchemeGroupVersion).Decode(data, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	crd, ok := decoded.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return fmt.Errorf("unexpected type for CRD %T", decoded)
+	}
+
+	apiResourceSchema, err := apisv1alpha1.CRDToAPIResourceSchema(crd, c.options.Prefix)
+	if err != nil {
+		return fmt.Errorf("error converting CRD: %w", err)
+	}
+
+	var mediaType string
+	switch c.options.OutputFormat {
+	case "json":
+		mediaType = runtime.ContentTypeJSON
+	case "yaml":
+		mediaType = runtime.ContentTypeYAML
+	default:
+		return fmt.Errorf("unsupported output format %q", c.options.OutputFormat)
+	}
+
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		return fmt.Errorf("unsupported media type %q", mediaType)
+	}
+
+	encoder := codecs.EncoderForVersion(info.Serializer, apisv1alpha1.SchemeGroupVersion)
+
+	out, err := runtime.Encode(encoder, apiResourceSchema)
+	if err != nil {
+		return fmt.Errorf("error converting CRD to an APIResourceSchema: %w", err)
+	}
+
+	fmt.Fprintln(c.options.Out, string(out))
+
+	return nil
+}

--- a/pkg/cliplugins/crd/plugin/snapshot_test.go
+++ b/pkg/cliplugins/crd/plugin/snapshot_test.go
@@ -1,0 +1,423 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestExecute(t *testing.T) {
+	streams, stdin, stdout, _ := genericclioptions.NewTestIOStreams()
+
+	opts := NewOptions(streams)
+	opts.Prefix = "testing"
+	opts.Filename = "-"
+
+	c := NewCRDSnapshot(opts)
+
+	n, err := stdin.WriteString(endpointsYAML)
+	require.NoError(t, err)
+	require.Equal(t, len(endpointsYAML), n)
+
+	err = c.Execute()
+	require.NoError(t, err)
+
+	require.Empty(t, cmp.Diff(expectedYAML, strings.Trim(stdout.String(), "\n")))
+}
+
+var endpointsYAML = `
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: endpoints.core
+spec:
+  group: ""
+  names:
+    kind: Endpoints
+    listKind: EndpointsList
+    plural: endpoints
+    singular: endpoints
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'Endpoints is a collection of endpoints that implement the actual service. Example:   Name: "mysvc",   Subsets: [     {       Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],       Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]     },     {       Addresses: [{"ip": "10.10.3.3"}],       Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]     },  ]'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          subsets:
+            description: The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
+            items:
+              description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+              properties:
+                addresses:
+                  description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+                  items:
+                    description: EndpointAddress is a tuple that describes single IP address.
+                    properties:
+                      hostname:
+                        description: The Hostname of this endpoint
+                        type: string
+                      ip:
+                        description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                        type: string
+                      nodeName:
+                        description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                        type: string
+                      targetRef:
+                        description: Reference to object providing the endpoint.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                notReadyAddresses:
+                  description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+                  items:
+                    description: EndpointAddress is a tuple that describes single IP address.
+                    properties:
+                      hostname:
+                        description: The Hostname of this endpoint
+                        type: string
+                      ip:
+                        description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                        type: string
+                      nodeName:
+                        description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                        type: string
+                      targetRef:
+                        description: Reference to object providing the endpoint.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                ports:
+                  description: Port numbers available on the related IP addresses.
+                  items:
+                    description: EndpointPort is a tuple that describes a single port.
+                    properties:
+                      appProtocol:
+                        description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                        type: string
+                      name:
+                        description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+                        type: string
+                      port:
+                        description: The port number of the endpoint.
+                        format: int32
+                        type: integer
+                      protocol:
+                        default: TCP
+                        description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  type: array
+              type: object
+            type: array
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+`
+
+var expectedYAML = `apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  creationTimestamp: null
+  name: testing.endpoints.core
+spec:
+  group: ""
+  names:
+    kind: Endpoints
+    listKind: EndpointsList
+    plural: endpoints
+    singular: endpoints
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      description: 'Endpoints is a collection of endpoints that implement the actual
+        service. Example:   Name: "mysvc",   Subsets: [     {       Addresses: [{"ip":
+        "10.10.1.1"}, {"ip": "10.10.2.2"}],       Ports: [{"name": "a", "port": 8675},
+        {"name": "b", "port": 309}]     },     {       Addresses: [{"ip": "10.10.3.3"}],       Ports:
+        [{"name": "a", "port": 93}, {"name": "b", "port": 76}]     },  ]'
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        subsets:
+          description: The set of all endpoints is the union of all subsets. Addresses
+            are placed into subsets according to the IPs they share. A single address
+            with multiple ports, some of which are ready and some of which are not
+            (because they come from different containers) will result in the address
+            being displayed in different subsets for the different ports. No address
+            will appear in both Addresses and NotReadyAddresses in the same subset.
+            Sets of addresses and ports that comprise a service.
+          items:
+            description: 'EndpointSubset is a group of addresses with a common set
+              of ports. The expanded set of endpoints is the Cartesian product of
+              Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"},
+              {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name":
+              "b", "port": 309}]   } The resulting set of endpoints can be viewed
+              as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309,
+              10.10.2.2:309 ]'
+            properties:
+              addresses:
+                description: IP addresses which offer the related ports that are marked
+                  as ready. These endpoints should be considered safe for load balancers
+                  and clients to utilize.
+                items:
+                  description: EndpointAddress is a tuple that describes single IP
+                    address.
+                  properties:
+                    hostname:
+                      description: The Hostname of this endpoint
+                      type: string
+                    ip:
+                      description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8),
+                        link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24).
+                        IPv6 is also accepted but not fully supported on all platforms.
+                        Also, certain kubernetes components, like kube-proxy, are
+                        not IPv6 ready. TODO: This should allow hostname or IP, See
+                        #4447.'
+                      type: string
+                    nodeName:
+                      description: 'Optional: Node hosting this endpoint. This can
+                        be used to determine endpoints local to a node.'
+                      type: string
+                    targetRef:
+                      description: Reference to object providing the endpoint.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                  required:
+                  - ip
+                  type: object
+                type: array
+              notReadyAddresses:
+                description: IP addresses which offer the related ports but are not
+                  currently marked as ready because they have not yet finished starting,
+                  have recently failed a readiness check, or have recently failed
+                  a liveness check.
+                items:
+                  description: EndpointAddress is a tuple that describes single IP
+                    address.
+                  properties:
+                    hostname:
+                      description: The Hostname of this endpoint
+                      type: string
+                    ip:
+                      description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8),
+                        link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24).
+                        IPv6 is also accepted but not fully supported on all platforms.
+                        Also, certain kubernetes components, like kube-proxy, are
+                        not IPv6 ready. TODO: This should allow hostname or IP, See
+                        #4447.'
+                      type: string
+                    nodeName:
+                      description: 'Optional: Node hosting this endpoint. This can
+                        be used to determine endpoints local to a node.'
+                      type: string
+                    targetRef:
+                      description: Reference to object providing the endpoint.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                  required:
+                  - ip
+                  type: object
+                type: array
+              ports:
+                description: Port numbers available on the related IP addresses.
+                items:
+                  description: EndpointPort is a tuple that describes a single port.
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and http://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                        Field can be enabled with ServiceAppProtocol feature gate.
+                      type: string
+                    name:
+                      description: The name of this port.  This must match the 'name'
+                        field in the corresponding ServicePort. Must be a DNS_LABEL.
+                        Optional only if one port is defined.
+                      type: string
+                    port:
+                      description: The port number of the endpoint.
+                      format: int32
+                      type: integer
+                    protocol:
+                      default: TCP
+                      description: The IP protocol for this port. Must be UDP, TCP,
+                        or SCTP. Default is TCP.
+                      type: string
+                  required:
+                  - port
+                  type: object
+                type: array
+            type: object
+          type: array
+      type: object
+    served: true
+    storage: true
+    subresources: {}`


### PR DESCRIPTION
## Summary
Add a new command, `kubectl kcp crd snapshot`, to make it easy to convert.

```
	crdExample = `
	# Convert a CRD in a yaml file to an APIResourceSchema. For a CRD named widgets.example.io, and a prefix value of
	# 'today', the new APIResourceSchema's name will be today.widgets.example.io.
	%[1]s crd snapshot -f crd.yaml --prefix 2022-05-07 > api-resource-schema.yaml
	# Convert a CRD from STDIN
	%[1]s crd snapshot -f - --prefix today > output.yaml
```

## Related issue(s)

Fixes #