### PR TITLE
cleanup ClusterRoleBinding on failed workspace creation

### DIFF
--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -595,6 +595,7 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	}
 	if err != nil {
 		_ = s.kubeClusterClient.Cluster(orgClusterName).RbacV1().ClusterRoles().Delete(ctx, ownerClusterRole.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
+		_ = s.kubeClusterClient.Cluster(orgClusterName).RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Name, metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		return nil, err
 	}
 

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -71,15 +71,16 @@ func (m *mockLister) List(user kuser.Info, _ labels.Selector, _ fields.Selector)
 }
 
 type TestData struct {
-	clusterRoles        []rbacv1.ClusterRole
-	clusterRoleBindings []rbacv1.ClusterRoleBinding
-	clusterWorkspaces   []tenancyv1alpha1.ClusterWorkspace
-	workspaceLister     *mockLister
-	user                kuser.Info
-	scope               string
-	reviewer            *workspaceauth.Reviewer
-	rootReviewer        *workspaceauth.Reviewer
-	orgName             logicalcluster.Name
+	clusterRoles           []rbacv1.ClusterRole
+	clusterRoleBindings    []rbacv1.ClusterRoleBinding
+	clusterWorkspaces      []tenancyv1alpha1.ClusterWorkspace
+	workspaceCreationError error
+	workspaceLister        *mockLister
+	user                   kuser.Info
+	scope                  string
+	reviewer               *workspaceauth.Reviewer
+	rootReviewer           *workspaceauth.Reviewer
+	orgName                logicalcluster.Name
 }
 
 type TestDescription struct {
@@ -111,6 +112,11 @@ func applyTest(t *testing.T, test TestDescription) {
 				return false, nil, errors.NewAlreadyExists(schema.GroupResource{}, workspace.Name)
 			}
 		}
+
+		if test.workspaceCreationError != nil {
+			return true, nil, test.workspaceCreationError
+		}
+
 		workspace = workspace.DeepCopy()
 		if workspace.Name == "" && workspace.GenerateName != "" {
 			workspace.Name = fmt.Sprintf("%s%4x", workspace.GenerateName, rand.Uint32()&65535)
@@ -1330,6 +1336,62 @@ func TestCreateWorkspacePrettyNameAlreadyExists(t *testing.T) {
 			require.NoError(t, err)
 			wsList := workspaceList.(*tenancyv1alpha1.ClusterWorkspaceList)
 			assert.ElementsMatch(t, wsList.Items, testData.clusterWorkspaces)
+		},
+	}
+	applyTest(t, test)
+}
+
+func TestCreateWorkspaceWithClusterWorkspaceCreationError(t *testing.T) {
+	user := &kuser.DefaultInfo{
+		Name:   "test-user",
+		UID:    "test-uid",
+		Groups: []string{"test-group"},
+	}
+	test := TestDescription{
+		TestData: TestData{
+			user:                   user,
+			scope:                  PersonalScope,
+			orgName:                logicalcluster.New("root:orgName"),
+			workspaceCreationError: errors.NewBadRequest("something bad happened"),
+			reviewer: workspaceauth.NewReviewer(&mockSubjectLocator{
+				subjects: map[string]map[string][]rbacv1.Subject{
+					"use/tenancy.kcp.dev/v1alpha1/clusterworkspacetypes": {
+						"universal": rbacGroups("test-group"),
+					},
+				},
+			}),
+			rootReviewer: workspaceauth.NewReviewer(&mockSubjectLocator{
+				subjects: map[string]map[string][]rbacv1.Subject{
+					"access/tenancy.kcp.dev/v1alpha1/clusterworkspaces/content": {
+						"orgName": rbacGroups("test-group"),
+					},
+					"member/tenancy.kcp.dev/v1alpha1/clusterworkspaces/content": {
+						"orgName": rbacGroups("test-group"),
+					},
+				},
+			}),
+		},
+		apply: func(t *testing.T, storage *REST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
+			newWorkspace := tenancyv1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			}
+			response, err := storage.Create(ctx, &newWorkspace, nil, &metav1.CreateOptions{})
+			require.Nil(t, response)
+
+			crbList, err := kubeClient.Tracker().List(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"), "")
+			require.NoError(t, err)
+			crbs := crbList.(*rbacv1.ClusterRoleBindingList)
+			assert.Empty(t, crbs.Items)
+			crList, err := kubeClient.Tracker().List(rbacv1.SchemeGroupVersion.WithResource("clusterroles"), rbacv1.SchemeGroupVersion.WithKind("ClusterRole"), "")
+			require.NoError(t, err)
+			crs := crList.(*rbacv1.ClusterRoleList)
+			assert.Empty(t, crs.Items)
+			workspaceList, err := kcpClient.Tracker().List(tenancyv1alpha1.SchemeGroupVersion.WithResource("clusterworkspaces"), tenancyv1alpha1.SchemeGroupVersion.WithKind("ClusterWorkspace"), "")
+			require.NoError(t, err)
+			wsList := workspaceList.(*tenancyv1alpha1.ClusterWorkspaceList)
+			assert.Empty(t, wsList.Items)
 		},
 	}
 	applyTest(t, test)

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1378,6 +1378,7 @@ func TestCreateWorkspaceWithClusterWorkspaceCreationError(t *testing.T) {
 				},
 			}
 			response, err := storage.Create(ctx, &newWorkspace, nil, &metav1.CreateOptions{})
+			require.EqualError(t, err, "something bad happened")
 			require.Nil(t, response)
 
 			crbList, err := kubeClient.Tracker().List(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"), "")


### PR DESCRIPTION
## Summary
Delete the `ClusterRoleBinding` that is left behind when a `ClusterWorkspace` creation fails late.

## Related issue(s)
Fixes #977

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>