### PR TITLE
Fetch external hostname from kcp-front-proxy route.

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Get the external hostname
         id: external_hostname
-        run: echo "::set-output name=external_hostname::$(./kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} get route kcp -o jsonpath='{.spec.host}')"
+        run: echo "::set-output name=external_hostname::$(./kubectl --server=https://${{ secrets.CICD_KUBE_HOST }} --token=${{ secrets.CICD_KUBE_TOKEN }} -n ${{ secrets.CICD_KUBE_NS }} get route kcp-front-proxy -o jsonpath='{.spec.host}')"
 
       - name: Deploy new image to CI
         id: deploy-to-ci


### PR DESCRIPTION
## Summary
Deployment github action should fetch external hostname from the new `kcp-front-proxy` route.

Signed-off-by: Christopher Sams <csams@redhat.com>