### PR TITLE
image: Add entrypoint to container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # Ignore server only used for e2e testing
 cmd/test-server
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,10 @@ RUN CGO_ENABLED=0 make
 FROM alpine:3.15
 WORKDIR /
 COPY --from=builder workspace/bin/kcp-front-proxy workspace/bin/kcp workspace/bin/virtual-workspaces /
+RUN mkdir -p /data && \
+    chown 65532:65532 /data
 USER 65532:65532
+WORKDIR /data
+VOLUME /data
+ENTRYPOINT ["/kcp"]
+CMD ["start"]


### PR DESCRIPTION
* Ignore local ./bin for container image builds
* add .kcp directory to container image

Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Related issue(s)

Fixes #1019