### PR TITLE
Add helpers in `CommonAPIResourceSpec`

### DIFF
--- a/pkg/apis/apiresource/v1alpha1/common_types.go
+++ b/pkg/apis/apiresource/v1alpha1/common_types.go
@@ -62,6 +62,24 @@ func (cd *ColumnDefinitions) ImportFromCRDVersion(crdVersion *apiextensionsv1.Cu
 	return cd
 }
 
+func (cds *ColumnDefinitions) ToCustomResourceColumnDefinitions() []apiextensionsv1.CustomResourceColumnDefinition {
+	var crdcds []apiextensionsv1.CustomResourceColumnDefinition
+	for _, cd := range *cds {
+		if cd.JSONPath == nil {
+			continue
+		}
+		crdcds = append(crdcds, apiextensionsv1.CustomResourceColumnDefinition{
+			Name:        cd.Name,
+			Type:        cd.Type,
+			Format:      cd.Format,
+			Description: cd.Description,
+			Priority:    cd.Priority,
+			JSONPath:    *cd.JSONPath,
+		})
+	}
+	return crdcds
+}
+
 type SubResource struct {
 	Name string `json:"name"`
 }
@@ -98,6 +116,15 @@ func (sr *SubResources) ImportFromCRDVersion(crdVersion *apiextensionsv1.CustomR
 		}
 	}
 	return sr
+}
+
+func (sr *SubResources) Contains(name string) bool {
+	for _, r := range *sr {
+		if r.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 type GroupVersion struct {

--- a/pkg/reconciler/apis/apiresource/negotiation.go
+++ b/pkg/reconciler/apis/apiresource/negotiation.go
@@ -637,20 +637,7 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 		}
 	}
 
-	var crColumnDefinitions []apiextensionsv1.CustomResourceColumnDefinition
-	for _, columDefinition := range negotiatedApiResource.Spec.ColumnDefinitions {
-		if columDefinition.JSONPath == nil {
-			continue
-		}
-		crColumnDefinitions = append(crColumnDefinitions, apiextensionsv1.CustomResourceColumnDefinition{
-			Name:        columDefinition.Name,
-			Type:        columDefinition.Type,
-			Format:      columDefinition.Format,
-			Description: columDefinition.Description,
-			Priority:    columDefinition.Priority,
-			JSONPath:    *columDefinition.JSONPath,
-		})
-	}
+	crColumnDefinitions := negotiatedApiResource.Spec.ColumnDefinitions.ToCustomResourceColumnDefinitions()
 
 	crdVersion := apiextensionsv1.CustomResourceDefinitionVersion{
 		Name:    gvr.Version,

--- a/pkg/reconciler/workload/apiexport/apiresourceschema.go
+++ b/pkg/reconciler/workload/apiexport/apiresourceschema.go
@@ -63,16 +63,6 @@ func toAPIResourceSchema(r *v1alpha1.NegotiatedAPIResource, name string) *apisv1
 			schema.Spec.Versions[0].Subresources.Status = &apiextensionsv1.CustomResourceSubresourceStatus{}
 		}
 	}
-	for _, c := range r.Spec.CommonAPIResourceSpec.ColumnDefinitions {
-		if c.JSONPath == nil {
-			continue
-		}
-		schema.Spec.Versions[0].AdditionalPrinterColumns = append(schema.Spec.Versions[0].AdditionalPrinterColumns, apiextensionsv1.CustomResourceColumnDefinition{
-			Name:        c.Name,
-			Description: c.Description,
-			Type:        c.Type,
-			JSONPath:    *c.JSONPath,
-		})
-	}
+	schema.Spec.Versions[0].AdditionalPrinterColumns = r.Spec.CommonAPIResourceSpec.ColumnDefinitions.ToCustomResourceColumnDefinitions()
 	return schema
 }


### PR DESCRIPTION
## Summary

This PR add helpers to the `CommonAPIResourceSpec` to make the conversion to `CustomResource` objects easier.

This PR is based on PR #1023 to which the first commit belongs, so that only the last commit is really part of this PR.

## Related issue(s)

The changes in this PR were part of the work initially done in the context of PR #724 (issue  #487)