### PR TITLE
Prepare for other types of virtuall workspaces

### DIFF
--- a/pkg/virtual/framework/fixedgvs/apiserver/apiserver.go
+++ b/pkg/virtual/framework/fixedgvs/apiserver/apiserver.go
@@ -19,11 +19,14 @@ package apiserver
 import (
 	"net/http"
 
+	"github.com/kcp-dev/logicalcluster"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	restStorage "k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -80,6 +83,18 @@ func (c completedConfig) New(virtualWorkspaceName string, groupManager discovery
 	genericServer.Handler.Director = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if vwName := r.Context().Value(virtualcontext.VirtualWorkspaceNameKey); vwName != nil {
 			if vwNameString, isString := vwName.(string); isString && vwNameString == virtualWorkspaceName {
+				// In the current KCP Kubernetes feature branch, some components (e.g.Discovery index)
+				// don't support calls without a cluster set in the request context.
+				// That's why we add a dummy cluster name here.
+				// However we don't add it for the OpenAPI v2 endpoint since, on the contrary,
+				// in our case the OpenAPI Spec will be published by the default OpenAPI Service Provider,
+				// which is served when the cluster name is empty.
+				if r.URL.Path != "/openapi/v2" {
+					context := r.Context()
+					context = genericapirequest.WithCluster(context, genericapirequest.Cluster{Name: logicalcluster.New("virtual")})
+					r = r.WithContext(context)
+				}
+
 				director.ServeHTTP(rw, r)
 				return
 			}

--- a/pkg/virtual/framework/rootapiserver/root_apiserver.go
+++ b/pkg/virtual/framework/rootapiserver/root_apiserver.go
@@ -24,8 +24,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/kcp-dev/logicalcluster"
-
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
@@ -172,15 +170,6 @@ func (c completedConfig) getRootHandlerChain(delegateAPIServer genericapiserver.
 			if accepted, prefixToStrip, context := c.resolveRootPaths(req.URL.Path, req.Context()); accepted {
 				req.URL.Path = strings.TrimPrefix(req.URL.Path, prefixToStrip)
 				req.URL.RawPath = strings.TrimPrefix(req.URL.RawPath, prefixToStrip)
-				// In the current KCP Kubernetes feature branch, some components (e.g.Discovery index)
-				// don't support calls without a cluster set in the request context.
-				// That's why we add a dummy cluster name here.
-				// However we don't add it for the OpenAPI v2 endpoint since, on the contrary,
-				// in our case the OpenAPI Spec will be published by the default OpenAPI Service Provider,
-				// which is served when the cluster name is empty.
-				if req.URL.Path != "/openapi/v2" {
-					context = genericapirequest.WithCluster(context, genericapirequest.Cluster{Name: logicalcluster.New("virtual")})
-				}
 				req = req.WithContext(context)
 				delegatedHandler := delegateAPIServer.UnprotectedHandler()
 				if delegatedHandler != nil {


### PR DESCRIPTION
## Summary

Prepare for other types of virtuall workspaces by moving an `openapiv2` special case out of the `rootapiserver`.

This PR is based on PR #1024 to which the 2 first commits belongs, so that only the last commit is really part of this PR.

## Related issue(s)

The changes in this PR were part of the work initially done in the context of PR #724 (issue  #487)