### PR TITLE
Allow several virtual workspace commands

### DIFF
--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/version"
@@ -41,13 +42,8 @@ import (
 	"github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework"
 	virtualrootapiserver "github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 )
-
-type SubCommandOptions interface {
-	NewVirtualWorkspaces() ([]virtualrootapiserver.InformerStart, []framework.VirtualWorkspace, error)
-}
 
 func NewCommand(errout io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	opts := options.NewOptions()
@@ -99,6 +95,12 @@ func Run(o *options.Options, stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
+
+	dynamicClusterClient, err := dynamic.NewClusterForConfig(kubeClientConfig)
+	if err != nil {
+		return err
+	}
+
 	wildcardKubeClient := kubeClusterClient.Cluster(logicalcluster.Wildcard)
 	wildcardKubeInformers := kubeinformers.NewSharedInformerFactory(wildcardKubeClient, 10*time.Minute)
 	kcpClusterClient, err := kcpclient.NewClusterForConfig(kubeClientConfig)
@@ -109,7 +111,7 @@ func Run(o *options.Options, stopCh <-chan struct{}) error {
 	wildcardKcpInformers := kcpinformer.NewSharedInformerFactory(wildcardKcpClient, 10*time.Minute)
 
 	// create apiserver
-	extraInformerStarts, virtualWorkspaces, err := o.Workspaces.NewVirtualWorkspaces(o.RootPathPrefix, kubeClusterClient, kcpClusterClient, wildcardKubeInformers, wildcardKcpInformers)
+	extraInformerStarts, virtualWorkspaces, err := o.VirtualWorkspaces.NewVirtualWorkspaces(o.RootPathPrefix, kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKubeInformers, wildcardKcpInformers)
 	if err != nil {
 		return err
 	}

--- a/cmd/virtual-workspaces/options/options.go
+++ b/cmd/virtual-workspaces/options/options.go
@@ -29,7 +29,7 @@ import (
 	genericapiserveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/component-base/logs"
 
-	workspacesoptions "github.com/kcp-dev/kcp/pkg/virtual/workspaces/options"
+	virtualworkspacesoptions "github.com/kcp-dev/kcp/pkg/virtual/options"
 )
 
 // DefaultRootPathPrefix is basically constant forever, or we risk a breaking change. The
@@ -47,7 +47,7 @@ type Options struct {
 	Authentication genericapiserveroptions.DelegatingAuthenticationOptions
 	Logs           logs.Options
 
-	Workspaces workspacesoptions.Workspaces
+	VirtualWorkspaces virtualworkspacesoptions.Options
 }
 
 func NewOptions() *Options {
@@ -60,7 +60,7 @@ func NewOptions() *Options {
 		Authentication: *genericapiserveroptions.NewDelegatingAuthenticationOptions(),
 		Logs:           *logs.NewOptions(),
 
-		Workspaces: *workspacesoptions.NewWorkspaces(),
+		VirtualWorkspaces: *virtualworkspacesoptions.NewOptions(),
 	}
 
 	opts.SecureServing.ServerCert.CertKey.CertFile = filepath.Join(".", ".kcp", "apiserver.crt")
@@ -74,7 +74,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	o.SecureServing.AddFlags(flags)
 	o.Authentication.AddFlags(flags)
 	o.Logs.AddFlags(flags)
-	o.Workspaces.AddFlags(flags, "")
+	o.VirtualWorkspaces.AddFlags(flags)
 
 	flags.StringVar(&o.KubeconfigFile, "kubeconfig", o.KubeconfigFile, ""+
 		"The kubeconfig file of the KCP instance that hosts workspaces.")
@@ -85,7 +85,7 @@ func (o *Options) Validate() error {
 	errs := []error{}
 	errs = append(errs, o.SecureServing.Validate()...)
 	errs = append(errs, o.Authentication.Validate()...)
-	errs = append(errs, o.Workspaces.Validate("")...)
+	errs = append(errs, o.VirtualWorkspaces.Validate()...)
 
 	if len(o.KubeconfigFile) == 0 {
 		errs = append(errs, fmt.Errorf("--kubeconfig is required for this command"))

--- a/pkg/server/options/virtual.go
+++ b/pkg/server/options/virtual.go
@@ -22,14 +22,12 @@ import (
 
 	"github.com/spf13/pflag"
 
-	workspacesoptions "github.com/kcp-dev/kcp/pkg/virtual/workspaces/options"
+	virtualworkspacesoptions "github.com/kcp-dev/kcp/pkg/virtual/options"
 )
 
-const virtualWorkspacesFlagPrefix = "virtual-workspaces-"
-
 type Virtual struct {
-	Workspaces workspacesoptions.Workspaces
-	Enabled    bool
+	VirtualWorkspaces virtualworkspacesoptions.Options
+	Enabled           bool
 
 	// ExternalVirtualWorkspaceAddress holds a URL to redirect to for stand-alone virtual workspaces.
 	ExternalVirtualWorkspaceAddress string
@@ -37,7 +35,7 @@ type Virtual struct {
 
 func NewVirtual() *Virtual {
 	return &Virtual{
-		Workspaces: *workspacesoptions.NewWorkspaces(),
+		VirtualWorkspaces: *virtualworkspacesoptions.NewOptions(),
 
 		Enabled: true,
 	}
@@ -47,7 +45,7 @@ func (v *Virtual) Validate() []error {
 	var errs []error
 
 	if v.Enabled {
-		errs = append(errs, v.Workspaces.Validate(virtualWorkspacesFlagPrefix)...)
+		errs = append(errs, v.VirtualWorkspaces.Validate()...)
 
 		if v.ExternalVirtualWorkspaceAddress != "" {
 			errs = append(errs, fmt.Errorf("--virtual-workspace-address must be empty if virtual workspaces run in-process"))
@@ -66,7 +64,7 @@ func (v *Virtual) Validate() []error {
 }
 
 func (v *Virtual) AddFlags(fs *pflag.FlagSet) {
-	v.Workspaces.AddFlags(fs, virtualWorkspacesFlagPrefix)
+	v.VirtualWorkspaces.AddFlags(fs)
 
 	fs.BoolVar(&v.Enabled, "run-virtual-workspaces", v.Enabled, "Run the virtual workspace apiservers in-process")
 	fs.StringVar(&v.ExternalVirtualWorkspaceAddress, "virtual-workspace-address", v.ExternalVirtualWorkspaceAddress, "Address of a stand-alone virtual workspace apiserver (without the /services path)")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -459,7 +459,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, kcpClusterClient, genericConfig.Authentication, genericConfig.ExternalAddress, preHandlerChainMux); err != nil {
+		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, dynamicClusterClient, kcpClusterClient, genericConfig.Authentication, genericConfig.ExternalAddress, preHandlerChainMux); err != nil {
 			return err
 		}
 	} else if err := s.installVirtualWorkspacesRedirect(ctx, preHandlerChainMux); err != nil {

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic"
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
@@ -39,11 +40,12 @@ type mux interface {
 	Handle(pattern string, handler http.Handler)
 }
 
-func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient kubernetesclient.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface, auth genericapiserver.AuthenticationInfo, externalAddress string, preHandlerChainMux mux) error {
+func (s *Server) installVirtualWorkspaces(ctx context.Context, kubeClusterClient kubernetesclient.ClusterInterface, dynamicClusterClient dynamic.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface, auth genericapiserver.AuthenticationInfo, externalAddress string, preHandlerChainMux mux) error {
 	// create virtual workspaces
-	extraInformerStarts, virtualWorkspaces, err := s.options.Virtual.Workspaces.NewVirtualWorkspaces(
+	extraInformerStarts, virtualWorkspaces, err := s.options.Virtual.VirtualWorkspaces.NewVirtualWorkspaces(
 		virtualcommandoptions.DefaultRootPathPrefix,
 		kubeClusterClient,
+		dynamicClusterClient,
 		kcpClusterClient,
 		s.kubeSharedInformerFactory,
 		s.kcpSharedInformerFactory,


### PR DESCRIPTION
## Summary

Allow several virtual workspace commands, in addition to the only existing one (`workspaces`).

## Related issue(s)

The changes in this PR were part of the work initially done in the context of PR https://github.com/kcp-dev/kcp/pull/724 (issue https://github.com/kcp-dev/kcp/issues/487)
