### PR TITLE
use kcp namespace name for SA in-cluster configuration

### DIFF
--- a/pkg/syncer/spec/mutators/deployment.go
+++ b/pkg/syncer/spec/mutators/deployment.go
@@ -111,6 +111,10 @@ func (dm *DeploymentMutator) Mutate(downstreamObj *unstructured.Unstructured) er
 									Key:  "token",
 									Path: "token",
 								},
+								{
+									Key:  "namespace",
+									Path: "namespace",
+								},
 							},
 						},
 					},
@@ -123,19 +127,6 @@ func (dm *DeploymentMutator) Mutate(downstreamObj *unstructured.Unstructured) er
 								{
 									Key:  "ca.crt",
 									Path: "ca.crt",
-								},
-							},
-						},
-					},
-					{
-						DownwardAPI: &corev1.DownwardAPIProjection{
-							Items: []corev1.DownwardAPIVolumeFile{
-								{
-									Path: "namespace",
-									FieldRef: &corev1.ObjectFieldSelector{
-										APIVersion: "v1",
-										FieldPath:  "metadata.namespace",
-									},
 								},
 							},
 						},

--- a/pkg/syncer/spec/mutators/deployment_test.go
+++ b/pkg/syncer/spec/mutators/deployment_test.go
@@ -50,6 +50,10 @@ var kcpApiAccessVolume = corev1.Volume{
 								Key:  "token",
 								Path: "token",
 							},
+							{
+								Key:  "namespace",
+								Path: "namespace",
+							},
 						},
 					},
 				},
@@ -62,19 +66,6 @@ var kcpApiAccessVolume = corev1.Volume{
 							{
 								Key:  "ca.crt",
 								Path: "ca.crt",
-							},
-						},
-					},
-				},
-				{
-					DownwardAPI: &corev1.DownwardAPIProjection{
-						Items: []corev1.DownwardAPIVolumeFile{
-							{
-								Path: "namespace",
-								FieldRef: &corev1.ObjectFieldSelector{
-									APIVersion: "v1",
-									FieldPath:  "metadata.namespace",
-								},
 							},
 						},
 					},

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -1005,11 +1005,8 @@ func setPodSpecServiceAccount(fields ...string) unstructuredChange {
 		{"name":"kcp-api-access","projected":{
 			"defaultMode":420,
 			"sources":[
-				{"secret":{"items":[{"key":"token","path":"token"}],"name":"kcp-default-token"}},
-				{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kcp-root-ca.crt"}},
-				{"downwardAPI":{
-					"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"},"path":"namespace"}]
-				}}
+				{"secret":{"items":[{"key":"token","path":"token"},{"key":"namespace","path":"namespace"}],"name":"kcp-default-token"}},
+				{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kcp-root-ca.crt"}}
 			]
 		}}
 	]


### PR DESCRIPTION
## Summary
replaces the downstream namespace name provided via the downwards API with the namespace name from KCP
this is required for kube clients to pick up the correct in-cluster namespace name for API communication with KCP.

## Related issue(s)
#897

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>