### PR TITLE
e2e: wait for server to terminate on cleanup

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -256,15 +256,21 @@ func (c *kcpServer) Run(opts ...RunOption) error {
 		return err
 	}
 
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
 	c.t.Cleanup(func() {
 		// Ensure child process is killed on cleanup
 		err := cmd.Process.Kill()
 		if err != nil {
 			c.t.Errorf("Saw an error trying to kill `kcp`: %v", err)
 		}
+
+		wg.Wait()
 	})
 
 	go func() {
+		defer wg.Done()
 		defer func() { cleanupCancel() }()
 		err := cmd.Wait()
 		data := c.filterKcpLogs(&log)


### PR DESCRIPTION
This makes some pain visible, i.e. that our server does not shutdown immediately. I have looked into go routines during delayed shutdown and I see two watch servers. This is (was?) a known problem upstream that graceful termination of the apiserver does not cancel watches. @p0lyn0mial found that.

**Why we want this**: if the server binary stays up while e2e tests shut down, etcd keeps open the wal file. Golang's testing library does a `os.RemoveAll` on the test temporary dir, and that can fail (at least on Mac it does).