### PR TITLE
Dynamic Virtual workspace implementation

### DIFF
--- a/pkg/virtual/framework/doc.go
+++ b/pkg/virtual/framework/doc.go
@@ -19,7 +19,7 @@ limitations under the License.
 //
 // To create virtual workspaces you have to:
 //
-// - define the implementation of the VirtualWorkspaces you want to expose (for example with utilities found in the `fixedgvs` package)
+// - define the implementation of the VirtualWorkspaces you want to expose (for example with utilities found in the `fixedgvs` or `dynamic` packages)
 //
 // - define the sub-command that will expose the related CLI arguments, Bootstrap and start those VirtualWorkspaces.
 package framework

--- a/pkg/virtual/framework/dynamic/apidefinition/types.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/types.go
@@ -26,14 +26,6 @@ import (
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
 )
 
-// APIDomainKeyContextKeyType is the type of the key for the request context value
-// that will carry the API domain key.
-type APIDomainKeyContextKeyType string
-
-// APIDomainKeyContextKey is the key for the request context value
-// that will carry the API domain key.
-const APIDomainKeyContextKey APIDomainKeyContextKeyType = "VirtualWorkspaceAPIDomainLocationKey"
-
 // APIDefinition provides access to all the information needed to serve a given API resource
 type APIDefinition interface {
 	// GetAPIResourceSpec provides the API resource specification, which contains the

--- a/pkg/virtual/framework/dynamic/apidefinition/types.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/types.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apidefinition
+
+import (
+	"github.com/kcp-dev/logicalcluster"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+)
+
+// APIDomainKeyContextKeyType is the type of the key for the request context value
+// that will carry the API domain key.
+type APIDomainKeyContextKeyType string
+
+// APIDomainKeyContextKey is the key for the request context value
+// that will carry the API domain key.
+const APIDomainKeyContextKey APIDomainKeyContextKeyType = "VirtualWorkspaceAPIDomainLocationKey"
+
+// APIDefinition provides access to all the information needed to serve a given API resource
+type APIDefinition interface {
+	// GetAPIResourceSpec provides the API resource specification, which contains the
+	// API names, sub-resource definitions, and the OpenAPIv3 schema.
+	GetAPIResourceSpec() *apiresourcev1alpha1.CommonAPIResourceSpec
+
+	// GetClusterName provides the name of the logical cluster where the resource specification comes from.
+	GetClusterName() logicalcluster.Name
+
+	// GetStorage provides the REST storage used to serve the resource.
+	GetStorage() rest.Storage
+
+	// GetSubResourceStorage provides the REST storage required to serve the given sub-resource.
+	GetSubResourceStorage(subresource string) rest.Storage
+
+	// GetRequestScope provides the handlers.RequestScope required to serve the resource.
+	GetRequestScope() *handlers.RequestScope
+
+	// GetSubResourceRequestScope provides the handlers.RequestScope required to serve the given sub-resource.
+	GetSubResourceRequestScope(subresource string) *handlers.RequestScope
+}
+
+// APIDefinitionSet contains the APIDefintion objects for the APIs of an API domain.
+type APIDefinitionSet map[schema.GroupVersionResource]APIDefinition
+
+// APIDefinitionSetGetter provides access to the API definitions of a API domain, based on the API domain key.
+type APIDefinitionSetGetter interface {
+	GetAPIDefinitionSet(apiDomainKey string) (apis APIDefinitionSet, apisExist bool)
+}
+
+// CreateAPIDefinitionFunc is the type of a function which allows creating an APIDefinition
+// (with REST storage and handler Request scopes) based on the API specification logical cluster name and OpenAPI v3 schema.
+type CreateAPIDefinitionFunc func(logicalClusterName logicalcluster.Name, spec *apiresourcev1alpha1.CommonAPIResourceSpec) (APIDefinition, error)

--- a/pkg/virtual/framework/dynamic/apiserver/apiserver.go
+++ b/pkg/virtual/framework/dynamic/apiserver/apiserver.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/emicklei/go-restful"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/endpoints/discovery"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+
+	virtualcontext "github.com/kcp-dev/kcp/pkg/virtual/framework/context"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	codecs = serializer.NewCodecFactory(scheme)
+
+	// if you modify this, make sure you update the crEncoder
+	unversionedVersion = schema.GroupVersion{Group: "", Version: "v1"}
+	unversionedTypes   = []runtime.Object{
+		&metav1.Status{},
+		&metav1.WatchEvent{},
+		&metav1.APIVersions{},
+		&metav1.APIGroupList{},
+		&metav1.APIGroup{},
+		&metav1.APIResourceList{},
+	}
+)
+
+func init() {
+	// we need to add the options to empty v1
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
+
+	scheme.AddUnversionedTypes(unversionedVersion, unversionedTypes...)
+}
+
+// DynamicAPIServerExtraConfig contains additional configuration for the DynamicAPIServer
+type DynamicAPIServerExtraConfig struct {
+	APISetRetriever apidefinition.APIDefinitionSetGetter
+}
+
+// DynamicAPIServerConfig contains the configuration for the DynamicAPIServer
+type DynamicAPIServerConfig struct {
+	GenericConfig *genericapiserver.RecommendedConfig
+	ExtraConfig   DynamicAPIServerExtraConfig
+}
+
+// DynamicAPIServer contains state for a Kubernetes api server that can
+// dynamically serve resources based on an API definitions (provided by the APISetRetriever).
+type DynamicAPIServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+	APISetRetriever  apidefinition.APIDefinitionSetGetter
+}
+
+type completedConfig struct {
+	GenericConfig genericapiserver.CompletedConfig
+	ExtraConfig   *DynamicAPIServerExtraConfig
+}
+
+type CompletedConfig struct {
+	// Embed a private pointer that cannot be instantiated outside of this package.
+	*completedConfig
+}
+
+// Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
+func (c *DynamicAPIServerConfig) Complete() completedConfig {
+	cfg := completedConfig{
+		c.GenericConfig.Complete(),
+		&c.ExtraConfig,
+	}
+
+	return cfg
+}
+
+// New returns a new instance of DynamicAPIServer from the given config.
+func (c completedConfig) New(virtualWorkspaceName string, delegationTarget genericapiserver.DelegationTarget) (*DynamicAPIServer, error) {
+	genericServer, err := c.GenericConfig.New(virtualWorkspaceName+"-virtual-workspace-apiserver", delegationTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	director := genericServer.Handler.Director
+	genericServer.Handler.Director = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if vwName := r.Context().Value(virtualcontext.VirtualWorkspaceNameKey); vwName != nil {
+			if vwNameString, isString := vwName.(string); isString && vwNameString == virtualWorkspaceName {
+				director.ServeHTTP(rw, r)
+				return
+			}
+		}
+		delegatedHandler := delegationTarget.UnprotectedHandler()
+		if delegatedHandler != nil {
+			delegatedHandler.ServeHTTP(rw, r)
+		} else {
+			http.NotFoundHandler().ServeHTTP(rw, r)
+		}
+	})
+
+	s := &DynamicAPIServer{
+		GenericAPIServer: genericServer,
+		APISetRetriever:  c.ExtraConfig.APISetRetriever,
+	}
+
+	delegateHandler := delegationTarget.UnprotectedHandler()
+	if delegateHandler == nil {
+		delegateHandler = http.NotFoundHandler()
+	}
+
+	versionDiscoveryHandler := &versionDiscoveryHandler{
+		apiSetRetriever: s.APISetRetriever,
+		delegate:        delegateHandler,
+	}
+
+	groupDiscoveryHandler := &groupDiscoveryHandler{
+		apiSetRetriever: s.APISetRetriever,
+		delegate:        delegateHandler,
+	}
+
+	rootDiscoveryHandler := &rootDiscoveryHandler{
+		apiSetRetriever: s.APISetRetriever,
+		delegate:        delegateHandler,
+	}
+
+	crdHandler, err := newResourceHandler(
+		s.APISetRetriever,
+		versionDiscoveryHandler,
+		groupDiscoveryHandler,
+		rootDiscoveryHandler,
+		delegateHandler,
+		c.GenericConfig.AdmissionControl,
+		s.GenericAPIServer.Authorizer,
+		c.GenericConfig.RequestTimeout,
+		time.Duration(c.GenericConfig.MinRequestTimeout)*time.Second,
+		c.GenericConfig.MaxRequestBodyBytes,
+		s.GenericAPIServer.StaticOpenAPISpec,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	s.GenericAPIServer.Handler.GoRestfulContainer.Filter(func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		pathParts := splitPath(req.Request.URL.Path)
+		if len(pathParts) > 0 && pathParts[0] == "apis" ||
+			len(pathParts) > 1 && pathParts[0] == "api" {
+			crdHandler.ServeHTTP(resp.ResponseWriter, req.Request)
+		} else {
+			chain.ProcessFilter(req, resp)
+		}
+	})
+
+	s.GenericAPIServer.Handler.GoRestfulContainer.Add(discovery.NewLegacyRootAPIHandler(c.GenericConfig.DiscoveryAddresses, s.GenericAPIServer.Serializer, "/api").WebService())
+
+	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", crdHandler)
+	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/apis/", crdHandler)
+	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/api/v1", crdHandler)
+	s.GenericAPIServer.Handler.NonGoRestfulMux.HandlePrefix("/api/v1/", crdHandler)
+
+	// TODO(david): plug OpenAPI if necessary. For now, according to the various virtual workspace use-cases,
+	// it doesn't seem necessary.
+	// Of course this requires using the --validate=false argument with some kubectl command like kubectl apply.
+
+	return s, nil
+}

--- a/pkg/virtual/framework/dynamic/apiserver/discovery.go
+++ b/pkg/virtual/framework/dynamic/apiserver/discovery.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apiserver/pkg/endpoints/discovery"
+	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/kubernetes/pkg/genericcontrolplane/aggregator"
+
+	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+)
+
+type versionDiscoveryHandler struct {
+	apiSetRetriever apidefinition.APIDefinitionSetGetter
+	delegate        http.Handler
+}
+
+func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	pathParts := splitPath(req.URL.Path)
+	var requestedGroup string
+	var requestedVersion string
+
+	// only match /apis/<group>/<version> or /api/<version>
+	if len(pathParts) == 3 && pathParts[0] == "apis" {
+		requestedGroup = pathParts[1]
+		requestedVersion = pathParts[2]
+	} else if len(pathParts) == 2 && pathParts[0] == "api" {
+		requestedGroup = ""
+		requestedVersion = pathParts[1]
+	} else {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	ctx := req.Context()
+
+	apiDomainKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+
+	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+
+	apiResourcesForDiscovery := []metav1.APIResource{}
+
+	foundGroupVersion := false
+
+	for gvr, apiDef := range apiSet {
+		if requestedGroup != gvr.Group || requestedVersion != gvr.Version {
+			continue
+		}
+		foundGroupVersion = true
+
+		var (
+			storageVersionHash string
+			subresources       apiresourcev1alpha1.SubResources
+		)
+
+		apiResourceSpec := apiDef.GetAPIResourceSpec()
+		subresources = apiResourceSpec.SubResources
+
+		// TODO: get the list of verbs from the REST storage instance
+		verbs := metav1.Verbs([]string{"get", "list", "patch", "create", "update", "watch"})
+
+		storageVersionHash = discovery.StorageVersionHash(apiDef.GetClusterName().String(), gvr.Group, gvr.Version, apiDef.GetAPIResourceSpec().Kind)
+
+		apiResourcesForDiscovery = append(apiResourcesForDiscovery, metav1.APIResource{
+			Name:               apiResourceSpec.Plural,
+			SingularName:       apiResourceSpec.Singular,
+			Namespaced:         apiResourceSpec.Scope == apiextensionsv1.NamespaceScoped,
+			Kind:               apiResourceSpec.Kind,
+			Verbs:              verbs,
+			ShortNames:         apiResourceSpec.ShortNames,
+			Categories:         apiResourceSpec.Categories,
+			StorageVersionHash: storageVersionHash,
+		})
+
+		if subresources != nil && subresources.Contains("status") {
+			// TODO: get the list of verbs from the StatusREST storage instance
+			apiResourcesForDiscovery = append(apiResourcesForDiscovery, metav1.APIResource{
+				Name:       apiResourceSpec.Plural + "/status",
+				Namespaced: apiResourceSpec.Scope == apiextensionsv1.NamespaceScoped,
+				Kind:       apiResourceSpec.Kind,
+				Verbs:      metav1.Verbs([]string{"get", "patch", "update"}),
+			})
+		}
+
+		// TODO(david): Add scale sub-resource ???
+	}
+
+	resourceListerFunc := discovery.APIResourceListerFunc(func() []metav1.APIResource {
+		return apiResourcesForDiscovery
+	})
+
+	if !foundGroupVersion {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	discovery.NewAPIVersionHandler(codecs, schema.GroupVersion{Group: requestedGroup, Version: requestedVersion}, resourceListerFunc).ServeHTTP(w, req)
+}
+
+type groupDiscoveryHandler struct {
+	apiSetRetriever apidefinition.APIDefinitionSetGetter
+	delegate        http.Handler
+}
+
+func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	pathParts := splitPath(req.URL.Path)
+	// only match /apis/<group>
+
+	var requestedGroup string
+	if len(pathParts) == 2 && pathParts[0] == "apis" {
+		requestedGroup = pathParts[1]
+	} else if len(pathParts) == 1 && pathParts[0] == "api" {
+		requestedGroup = ""
+	} else {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	apiVersionsForDiscovery := []metav1.GroupVersionForDiscovery{}
+	versionsForDiscoveryMap := map[metav1.GroupVersion]bool{}
+
+	ctx := req.Context()
+
+	apiDomainKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+
+	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+
+	foundGroup := false
+
+	for gvr := range apiSet {
+		if requestedGroup != gvr.Group {
+			continue
+		}
+
+		foundGroup = true
+
+		gv := metav1.GroupVersion{
+			Group:   gvr.Group,
+			Version: gvr.Version,
+		}
+
+		if !versionsForDiscoveryMap[gv] {
+			versionsForDiscoveryMap[gv] = true
+			apiVersionsForDiscovery = append(apiVersionsForDiscovery, metav1.GroupVersionForDiscovery{
+				GroupVersion: gvr.GroupVersion().String(),
+				Version:      gvr.Version,
+			})
+		}
+	}
+
+	sortGroupDiscoveryByKubeAwareVersion(apiVersionsForDiscovery)
+
+	if !foundGroup {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	apiGroup := metav1.APIGroup{
+		Name:     requestedGroup,
+		Versions: apiVersionsForDiscovery,
+		// the preferred versions for a group is the first item in
+		// apiVersionsForDiscovery after it put in the right ordered
+		PreferredVersion: apiVersionsForDiscovery[0],
+	}
+
+	discovery.NewAPIGroupHandler(codecs, apiGroup).ServeHTTP(w, req)
+}
+
+type rootDiscoveryHandler struct {
+	apiSetRetriever apidefinition.APIDefinitionSetGetter
+	delegate        http.Handler
+}
+
+func (r *rootDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	apiVersionsForDiscovery := map[string][]metav1.GroupVersionForDiscovery{}
+	versionsForDiscoveryMap := map[string]map[metav1.GroupVersion]bool{}
+
+	ctx := req.Context()
+	apiDomainKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+
+	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+
+	for gvr := range apiSet {
+
+		if gvr.Group == "" {
+			// Don't include CRDs in the core ("") group in /apis discovery. They
+			// instead are in /api/v1 handled elsewhere.
+			continue
+		}
+		groupVersion := gvr.GroupVersion().String()
+
+		gv := metav1.GroupVersion{Group: gvr.Group, Version: gvr.Version}
+
+		m, ok := versionsForDiscoveryMap[gvr.Group]
+		if !ok {
+			m = make(map[metav1.GroupVersion]bool)
+		}
+
+		if !m[gv] {
+			m[gv] = true
+			groupVersions := apiVersionsForDiscovery[gvr.Group]
+			groupVersions = append(groupVersions, metav1.GroupVersionForDiscovery{
+				GroupVersion: groupVersion,
+				Version:      gvr.Version,
+			})
+			apiVersionsForDiscovery[gvr.Group] = groupVersions
+		}
+
+		versionsForDiscoveryMap[gvr.Group] = m
+	}
+
+	for _, versions := range apiVersionsForDiscovery {
+		sortGroupDiscoveryByKubeAwareVersion(versions)
+
+	}
+
+	groupList := make([]metav1.APIGroup, 0, len(apiVersionsForDiscovery))
+	for group, versions := range apiVersionsForDiscovery {
+		g := metav1.APIGroup{
+			Name:             group,
+			Versions:         versions,
+			PreferredVersion: versions[0],
+		}
+		groupList = append(groupList, g)
+	}
+	responsewriters.WriteObjectNegotiated(aggregator.DiscoveryCodecs, negotiation.DefaultEndpointRestrictions, schema.GroupVersion{}, w, req, http.StatusOK, &metav1.APIGroupList{Groups: groupList})
+}
+
+// splitPath returns the segments for a URL path.
+func splitPath(path string) []string {
+	path = strings.Trim(path, "/")
+	if path == "" {
+		return []string{}
+	}
+	return strings.Split(path, "/")
+}
+
+func sortGroupDiscoveryByKubeAwareVersion(gd []metav1.GroupVersionForDiscovery) {
+	sort.Slice(gd, func(i, j int) bool {
+		return version.CompareKubeAwareVersionStrings(gd[i].Version, gd[j].Version) > 0
+	})
+}

--- a/pkg/virtual/framework/dynamic/apiserver/discovery.go
+++ b/pkg/virtual/framework/dynamic/apiserver/discovery.go
@@ -61,7 +61,11 @@ func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 
 	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
 
-	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+	apiSet, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+	if !hasLocationKey {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
 
 	apiResourcesForDiscovery := []metav1.APIResource{}
 
@@ -148,7 +152,11 @@ func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 
 	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
 
-	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+	apiSet, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+	if !hasLocationKey {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
 
 	foundGroup := false
 
@@ -203,7 +211,11 @@ func (r *rootDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	ctx := req.Context()
 	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
 
-	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+	apiSet, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
+	if !hasLocationKey {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
 
 	for gvr := range apiSet {
 

--- a/pkg/virtual/framework/dynamic/apiserver/discovery.go
+++ b/pkg/virtual/framework/dynamic/apiserver/discovery.go
@@ -32,6 +32,7 @@ import (
 
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	dyncamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 )
 
 type versionDiscoveryHandler struct {
@@ -58,7 +59,7 @@ func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 
 	ctx := req.Context()
 
-	apiDomainKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
 
 	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
 
@@ -145,7 +146,7 @@ func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 
 	ctx := req.Context()
 
-	apiDomainKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
 
 	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
 
@@ -200,7 +201,7 @@ func (r *rootDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	versionsForDiscoveryMap := map[string]map[metav1.GroupVersion]bool{}
 
 	ctx := req.Context()
-	apiDomainKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
 
 	apiSet, _ := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
 

--- a/pkg/virtual/framework/dynamic/apiserver/doc.go
+++ b/pkg/virtual/framework/dynamic/apiserver/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package apiserver provides an APIServer that can dynamically serve resources based on an
+// API definition (CommonAPIResourceSpec) source and a Rest storage provider.
+//
+// The main interface between this package and other components is the apidefs.APIDefinition:
+//
+// - the configuration of the DynamicAPIServer contains an apidefs.APISetRetriever that allows retrieving an apidefs.APIDefinition
+// based on an api domain key and a GVR
+//
+// - the CreateServingInfoFor method can be used by external components at any time to create an apidefs.APIDefinition and
+// add it to the apidefs.APISetRetriever that has been passed to the DynamicAPIServer
+//
+// Parts of this package are highly insired from kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver
+// https://github.com/kcp-dev/kubernetes/tree/feature-logical-clusters-1.23/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver
+package apiserver

--- a/pkg/virtual/framework/dynamic/apiserver/doc.go
+++ b/pkg/virtual/framework/dynamic/apiserver/doc.go
@@ -25,6 +25,6 @@ limitations under the License.
 // - the CreateServingInfoFor method can be used by external components at any time to create an apidefs.APIDefinition and
 // add it to the apidefs.APISetRetriever that has been passed to the DynamicAPIServer
 //
-// Parts of this package are highly insired from kcp-dev/kubernetes/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver
+// Parts of this package are highly inspired from k8s.io/apiextensions-apiserver/pkg/apiserver
 // https://github.com/kcp-dev/kubernetes/tree/feature-logical-clusters-1.23/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver
 package apiserver

--- a/pkg/virtual/framework/dynamic/apiserver/handler.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler.go
@@ -131,14 +131,18 @@ func (r *resourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	locationKey := dynamiccontext.APIDomainKeyFromContext(ctx)
 
-	apiDefs, _ := r.apiSetRetriever.GetAPIDefinitionSet(locationKey)
-	apiDef, exists := apiDefs[schema.GroupVersionResource{
+	apiDefs, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(locationKey)
+	if !hasLocationKey {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	apiDef, hasAPIDef := apiDefs[schema.GroupVersionResource{
 		Group:    requestInfo.APIGroup,
 		Version:  requestInfo.APIVersion,
 		Resource: requestInfo.Resource,
 	}]
-
-	if !exists {
+	if !hasAPIDef {
 		r.delegate.ServeHTTP(w, req)
 		return
 	}

--- a/pkg/virtual/framework/dynamic/apiserver/handler.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 )
 
 // resourceHandler serves the `/apis` and `/api`` endpoints.
@@ -128,7 +129,7 @@ func (r *resourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	locationKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+	locationKey := dynamiccontext.APIDomainKeyFromContext(ctx)
 
 	apiDefs, _ := r.apiSetRetriever.GetAPIDefinitionSet(locationKey)
 	apiDef, exists := apiDefs[schema.GroupVersionResource{
@@ -143,7 +144,6 @@ func (r *resourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	apiResourceSpec := apiDef.GetAPIResourceSpec()
-	//	apiClusterName := apiDef.GetClusterName()
 
 	verb := strings.ToUpper(requestInfo.Verb)
 	resource := requestInfo.Resource

--- a/pkg/virtual/framework/dynamic/apiserver/handler.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+)
+
+// resourceHandler serves the `/apis` and `/api`` endpoints.
+type resourceHandler struct {
+	apiSetRetriever         apidefinition.APIDefinitionSetGetter
+	versionDiscoveryHandler *versionDiscoveryHandler
+	groupDiscoveryHandler   *groupDiscoveryHandler
+	rootDiscoveryHandler    *rootDiscoveryHandler
+
+	delegate http.Handler
+
+	admission admission.Interface
+
+	// so that we can do create on update.
+	authorizer authorizer.Authorizer
+
+	// request timeout we should delay storage teardown for
+	requestTimeout time.Duration
+
+	// minRequestTimeout applies to list/watch calls
+	minRequestTimeout time.Duration
+
+	// The limit on the request size that would be accepted and decoded in a write request
+	// 0 means no limit.
+	maxRequestBodyBytes int64
+}
+
+func newResourceHandler(
+	apiSetRetriever apidefinition.APIDefinitionSetGetter,
+	versionDiscoveryHandler *versionDiscoveryHandler,
+	groupDiscoveryHandler *groupDiscoveryHandler,
+	rootDiscoveryHandler *rootDiscoveryHandler,
+	delegate http.Handler,
+	admission admission.Interface,
+	authorizer authorizer.Authorizer,
+	requestTimeout time.Duration,
+	minRequestTimeout time.Duration,
+	maxRequestBodyBytes int64,
+	staticOpenAPISpec *spec.Swagger) (*resourceHandler, error) {
+	ret := &resourceHandler{
+		apiSetRetriever:         apiSetRetriever,
+		versionDiscoveryHandler: versionDiscoveryHandler,
+		groupDiscoveryHandler:   groupDiscoveryHandler,
+		rootDiscoveryHandler:    rootDiscoveryHandler,
+		delegate:                delegate,
+		admission:               admission,
+		authorizer:              authorizer,
+		requestTimeout:          requestTimeout,
+		minRequestTimeout:       minRequestTimeout,
+		maxRequestBodyBytes:     maxRequestBodyBytes,
+	}
+
+	return ret, nil
+}
+
+func (r *resourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+	requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+	if !ok {
+		responsewriters.ErrorNegotiated(
+			apierrors.NewInternalError(fmt.Errorf("no RequestInfo found in the context")),
+			codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+		)
+		return
+	}
+	if !requestInfo.IsResourceRequest {
+		pathParts := splitPath(requestInfo.Path)
+		// only match /apis/<group>/<version> or /api/<version>
+		if len(pathParts) == 3 && pathParts[0] == "apis" ||
+			len(pathParts) == 2 && pathParts[0] == "api" {
+			r.versionDiscoveryHandler.ServeHTTP(w, req)
+			return
+		}
+		// only match /apis/<group> or /api
+		if len(pathParts) == 2 && pathParts[0] == "apis" ||
+			len(pathParts) == 1 && pathParts[0] == "api" {
+			r.groupDiscoveryHandler.ServeHTTP(w, req)
+			return
+		}
+		// only match /apis
+		if len(pathParts) == 1 && pathParts[0] == "apis" {
+			r.rootDiscoveryHandler.ServeHTTP(w, req)
+			return
+		}
+
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	locationKey := ctx.Value(apidefinition.APIDomainKeyContextKey).(string)
+
+	apiDefs, _ := r.apiSetRetriever.GetAPIDefinitionSet(locationKey)
+	apiDef, exists := apiDefs[schema.GroupVersionResource{
+		Group:    requestInfo.APIGroup,
+		Version:  requestInfo.APIVersion,
+		Resource: requestInfo.Resource,
+	}]
+
+	if !exists {
+		r.delegate.ServeHTTP(w, req)
+		return
+	}
+
+	apiResourceSpec := apiDef.GetAPIResourceSpec()
+	//	apiClusterName := apiDef.GetClusterName()
+
+	verb := strings.ToUpper(requestInfo.Verb)
+	resource := requestInfo.Resource
+	subresource := requestInfo.Subresource
+	scope := metrics.CleanScope(requestInfo)
+	supportedTypes := []string{
+		string(types.JSONPatchType),
+		string(types.MergePatchType),
+	}
+
+	// HACK: Support resources of the client-go scheme the way existing clients expect it:
+	//   - Support Strategic Merge Patch (used by default on these resources by kubectl)
+	//   - Support the Protobuf content type on Create / Update resources
+	//     (by simply converting the request to the json content type),
+	//     since protobuf content type is expected to be supported in a number of client
+	//     contexts (like controller-runtime for example)
+	if clientgoscheme.Scheme.IsGroupRegistered(requestInfo.APIGroup) {
+		supportedTypes = append(supportedTypes, string(types.StrategicMergePatchType))
+		req, err := apiextensionsapiserver.ConvertProtobufRequestsToJson(verb, req, schema.GroupVersionKind{
+			Group:   requestInfo.APIGroup,
+			Version: requestInfo.APIVersion,
+			Kind:    apiResourceSpec.Kind,
+		})
+		if err != nil {
+			responsewriters.ErrorNegotiated(
+				apierrors.NewInternalError(err),
+				codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+			)
+			return
+		}
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
+		supportedTypes = append(supportedTypes, string(types.ApplyPatchType))
+	}
+
+	var handlerFunc http.HandlerFunc
+	subresources := apiResourceSpec.SubResources
+	switch {
+	case subresource == "status" && subresources != nil && subresources.Contains("status"):
+		handlerFunc = r.serveStatus(w, req, requestInfo, apiDef, supportedTypes)
+	case len(subresource) == 0:
+		handlerFunc = r.serveResource(w, req, requestInfo, apiDef, supportedTypes)
+	default:
+		responsewriters.ErrorNegotiated(
+			apierrors.NewNotFound(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Name),
+			codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+		)
+	}
+
+	if handlerFunc != nil {
+		handlerFunc = metrics.InstrumentHandlerFunc(verb, requestInfo.APIGroup, requestInfo.APIVersion, resource, subresource, scope, metrics.APIServerComponent, false, "", handlerFunc)
+		handlerFunc.ServeHTTP(w, req)
+		return
+	}
+}
+
+func (r *resourceHandler) serveResource(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, apiDef apidefinition.APIDefinition, supportedTypes []string) http.HandlerFunc {
+	requestScope := apiDef.GetRequestScope()
+	storage := apiDef.GetStorage()
+
+	switch requestInfo.Verb {
+	case "get":
+		if storage, isAble := storage.(rest.Getter); isAble {
+			return handlers.GetResource(storage, requestScope)
+		}
+	case "list":
+		if listerStorage, isAble := storage.(rest.Lister); isAble {
+			if watcherStorage, isAble := storage.(rest.Watcher); isAble {
+				forceWatch := false
+				return handlers.ListResource(listerStorage, watcherStorage, requestScope, forceWatch, r.minRequestTimeout)
+			}
+		}
+	case "watch":
+		if listerStorage, isAble := storage.(rest.Lister); isAble {
+			if watcherStorage, isAble := storage.(rest.Watcher); isAble {
+				forceWatch := true
+				return handlers.ListResource(listerStorage, watcherStorage, requestScope, forceWatch, r.minRequestTimeout)
+			}
+		}
+	case "create":
+		if storage, isAble := storage.(rest.Creater); isAble {
+			return handlers.CreateResource(storage, requestScope, r.admission)
+		}
+	case "update":
+		if storage, isAble := storage.(rest.Updater); isAble {
+			return handlers.UpdateResource(storage, requestScope, r.admission)
+		}
+	case "patch":
+		if storage, isAble := storage.(rest.Patcher); isAble {
+			return handlers.PatchResource(storage, requestScope, r.admission, supportedTypes)
+		}
+	case "delete":
+		if storage, isAble := storage.(rest.GracefulDeleter); isAble {
+			allowsOptions := true
+			return handlers.DeleteResource(storage, allowsOptions, requestScope, r.admission)
+		}
+	case "deletecollection":
+		if storage, isAble := storage.(rest.CollectionDeleter); isAble {
+			checkBody := true
+			return handlers.DeleteCollection(storage, checkBody, requestScope, r.admission)
+		}
+	}
+	responsewriters.ErrorNegotiated(
+		apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb),
+		codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+	)
+	return nil
+}
+
+func (r *resourceHandler) serveStatus(w http.ResponseWriter, req *http.Request, requestInfo *apirequest.RequestInfo, apiDef apidefinition.APIDefinition, supportedTypes []string) http.HandlerFunc {
+	requestScope := apiDef.GetSubResourceRequestScope("status")
+	storage := apiDef.GetSubResourceStorage("status")
+
+	switch requestInfo.Verb {
+	case "get":
+		if storage, isAble := storage.(rest.Getter); isAble {
+			return handlers.GetResource(storage, requestScope)
+		}
+	case "update":
+		if storage, isAble := storage.(rest.Updater); isAble {
+			return handlers.UpdateResource(storage, requestScope, r.admission)
+		}
+	case "patch":
+		if storage, isAble := storage.(rest.Patcher); isAble {
+			return handlers.PatchResource(storage, requestScope, r.admission, supportedTypes)
+		}
+	}
+	responsewriters.ErrorNegotiated(
+		apierrors.NewMethodNotSupported(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb),
+		codecs, schema.GroupVersion{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion}, w, req,
+	)
+	return nil
+}

--- a/pkg/virtual/framework/dynamic/apiserver/handler_test.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package apiserver
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -41,6 +40,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	dyncamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 )
 
 type mockedAPISetRetriever apidefinition.APIDefinitionSet
@@ -523,7 +523,7 @@ func TestRouting(t *testing.T) {
 					}
 
 					req = req.WithContext(apirequest.WithRequestInfo(
-						context.WithValue(req.Context(), apidefinition.APIDomainKeyContextKey, "domain"),
+						dyncamiccontext.WithAPIDomainKey(req.Context(), "domain"),
 						&apirequest.RequestInfo{
 							Verb:              tc.Verb,
 							Resource:          tc.Resource,

--- a/pkg/virtual/framework/dynamic/apiserver/handler_test.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler_test.go
@@ -1,0 +1,669 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	utilopenapi "k8s.io/apiserver/pkg/util/openapi"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+)
+
+type mockedAPISetRetriever apidefinition.APIDefinitionSet
+
+var _ apidefinition.APIDefinitionSetGetter = (*mockedAPISetRetriever)(nil)
+
+func (masr mockedAPISetRetriever) GetAPIDefinitionSet(apiDomainKey string) (apis apidefinition.APIDefinitionSet, apisExist bool) {
+	return apidefinition.APIDefinitionSet(masr), true
+}
+
+type mockedAPIDefinition struct {
+	apiResourceSpec *v1alpha1.CommonAPIResourceSpec
+}
+
+var _ apidefinition.APIDefinition = (*mockedAPIDefinition)(nil)
+
+func (apiDef *mockedAPIDefinition) GetAPIResourceSpec() *v1alpha1.CommonAPIResourceSpec {
+	return apiDef.apiResourceSpec
+}
+func (apiDef *mockedAPIDefinition) GetClusterName() logicalcluster.Name {
+	return logicalcluster.New("logicalClusterName")
+}
+func (apiDef *mockedAPIDefinition) GetStorage() rest.Storage {
+	return nil
+}
+func (apiDef *mockedAPIDefinition) GetSubResourceStorage(subresource string) rest.Storage {
+	return nil
+}
+func (apiDef *mockedAPIDefinition) GetRequestScope() *handlers.RequestScope {
+	return nil
+}
+func (apiDef *mockedAPIDefinition) GetSubResourceRequestScope(subresource string) *handlers.RequestScope {
+	return nil
+}
+
+func TestRouting(t *testing.T) {
+	hasSynced := false
+
+	apiSetRetriever := mockedAPISetRetriever{
+		schema.GroupVersionResource{
+			Group:    "custom",
+			Version:  "v1",
+			Resource: "customresources",
+		}: &mockedAPIDefinition{
+			apiResourceSpec: &v1alpha1.CommonAPIResourceSpec{
+				GroupVersion: v1alpha1.GroupVersion{
+					Group:   "custom",
+					Version: "v1",
+				},
+				Scope: apiextensionsv1.NamespaceScoped,
+				CustomResourceDefinitionNames: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural:   "customresources",
+					Singular: "customresource",
+					Kind:     "CustomResource",
+					ListKind: "CustomResourceList",
+				},
+			},
+		},
+		schema.GroupVersionResource{
+			Group:    "",
+			Version:  "v1",
+			Resource: "services",
+		}: &mockedAPIDefinition{
+			apiResourceSpec: &v1alpha1.CommonAPIResourceSpec{
+				GroupVersion: v1alpha1.GroupVersion{
+					Group:   "",
+					Version: "v1",
+				},
+				Scope: apiextensionsv1.NamespaceScoped,
+				CustomResourceDefinitionNames: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural:   "services",
+					Singular: "service",
+					Kind:     "Service",
+					ListKind: "ServiceList",
+				},
+			},
+		},
+	}
+
+	// note that in production we delegate to the special handler that is attached at the end of the delegation chain that checks if the server has installed all known HTTP paths before replying to the client.
+	// it returns 503 if not all registered signals have been ready (closed) otherwise it simply replies with 404.
+	// the apiextentionserver is considered to be initialized once hasCRDInformerSyncedSignal is closed.
+	//
+	// here, in this test the delegate represent the special handler and hasSync represents the signal.
+	// primarily we just want to make sure that the delegate has been called.
+	// the behaviour of the real delegate is tested elsewhere.
+	delegateCalled := false
+	delegate := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		delegateCalled = true
+		if !hasSynced {
+			http.Error(w, "", 503)
+			return
+		}
+		http.Error(w, "", 418)
+	})
+
+	versionDiscoveryHandler := &versionDiscoveryHandler{
+		apiSetRetriever: apiSetRetriever,
+		delegate:        delegate,
+	}
+	groupDiscoveryHandler := &groupDiscoveryHandler{
+		apiSetRetriever: apiSetRetriever,
+		delegate:        delegate,
+	}
+	rootDiscoveryHandler := &rootDiscoveryHandler{
+		apiSetRetriever: apiSetRetriever,
+		delegate:        delegate,
+	}
+
+	handler := &resourceHandler{
+		apiSetRetriever:         apiSetRetriever,
+		delegate:                delegate,
+		versionDiscoveryHandler: versionDiscoveryHandler,
+		groupDiscoveryHandler:   groupDiscoveryHandler,
+		rootDiscoveryHandler:    rootDiscoveryHandler,
+	}
+
+	testcases := []struct {
+		Name    string
+		Method  string
+		Path    string
+		Headers map[string]string
+		Body    io.Reader
+
+		APIGroup          string
+		APIVersion        string
+		Verb              string
+		Resource          string
+		IsResourceRequest bool
+
+		HasSynced bool
+
+		ExpectStatus         int
+		ExpectResponse       func(*testing.T, *http.Response, []byte)
+		ExpectDelegateCalled bool
+	}{
+		{
+			Name:                 "existing group discovery, presync",
+			Method:               "GET",
+			Path:                 "/apis/custom",
+			APIGroup:             "custom",
+			APIVersion:           "",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIGroup\",\"apiVersion\":\"v1\",\"name\":\"custom\",\"versions\":[{\"groupVersion\":\"custom/v1\",\"version\":\"v1\"}],\"preferredVersion\":{\"groupVersion\":\"custom/v1\",\"version\":\"v1\"}}\n",
+						string(b))
+				}
+			},
+		},
+		{
+			Name:                 "existing group discovery",
+			Method:               "GET",
+			Path:                 "/apis/custom",
+			APIGroup:             "custom",
+			APIVersion:           "",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIGroup\",\"apiVersion\":\"v1\",\"name\":\"custom\",\"versions\":[{\"groupVersion\":\"custom/v1\",\"version\":\"v1\"}],\"preferredVersion\":{\"groupVersion\":\"custom/v1\",\"version\":\"v1\"}}\n",
+						string(b))
+				}
+			},
+		},
+
+		{
+			Name:                 "nonexisting group discovery, presync",
+			Method:               "GET",
+			Path:                 "/apis/other",
+			APIGroup:             "other",
+			APIVersion:           "",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         503,
+		},
+		{
+			Name:                 "nonexisting group discovery",
+			Method:               "GET",
+			Path:                 "/apis/other",
+			APIGroup:             "other",
+			APIVersion:           "",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         418,
+		},
+
+		{
+			Name:                 "existing group version discovery, presync",
+			Method:               "GET",
+			Path:                 "/apis/custom/v1",
+			APIGroup:             "custom",
+			APIVersion:           "v1",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIResourceList\",\"apiVersion\":\"v1\",\"groupVersion\":\"custom/v1\",\"resources\":[{\"name\":\"customresources\",\"singularName\":\"customresource\",\"namespaced\":true,\"kind\":\"CustomResource\",\"verbs\":[\"get\",\"list\",\"patch\",\"create\",\"update\",\"watch\"],\"storageVersionHash\":\"ixY6U/JU9OM=\"}]}\n",
+						string(b))
+				}
+			},
+		},
+		{
+			Name:                 "existing group version discovery",
+			Method:               "GET",
+			Path:                 "/apis/custom/v1",
+			APIGroup:             "custom",
+			APIVersion:           "v1",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIResourceList\",\"apiVersion\":\"v1\",\"groupVersion\":\"custom/v1\",\"resources\":[{\"name\":\"customresources\",\"singularName\":\"customresource\",\"namespaced\":true,\"kind\":\"CustomResource\",\"verbs\":[\"get\",\"list\",\"patch\",\"create\",\"update\",\"watch\"],\"storageVersionHash\":\"ixY6U/JU9OM=\"}]}\n",
+						string(b))
+				}
+			},
+		},
+
+		{
+			Name:                 "nonexisting group version discovery, presync",
+			Method:               "GET",
+			Path:                 "/apis/other/v1",
+			APIGroup:             "other",
+			APIVersion:           "v1",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         503,
+		},
+		{
+			Name:                 "nonexisting group version discovery",
+			Method:               "GET",
+			Path:                 "/apis/other/v1",
+			APIGroup:             "other",
+			APIVersion:           "v1",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         418,
+		},
+
+		{
+			Name:                 "existing group, nonexisting version discovery, presync",
+			Method:               "GET",
+			Path:                 "/apis/custom/v2",
+			APIGroup:             "custom",
+			APIVersion:           "v2",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         503,
+		},
+		{
+			Name:                 "existing group, nonexisting version discovery",
+			Method:               "GET",
+			Path:                 "/apis/custom/v2",
+			APIGroup:             "custom",
+			APIVersion:           "v2",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         418,
+		},
+
+		{
+			Name:                 "nonexisting group, resource request, presync",
+			Method:               "GET",
+			Path:                 "/apis/custom/v2/foos",
+			APIGroup:             "custom",
+			APIVersion:           "v2",
+			Verb:                 "list",
+			Resource:             "foos",
+			HasSynced:            false,
+			IsResourceRequest:    true,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         503,
+		},
+		{
+			Name:                 "nonexisting group, resource request",
+			Method:               "GET",
+			Path:                 "/apis/custom/v2/foos",
+			APIGroup:             "custom",
+			APIVersion:           "v2",
+			Verb:                 "list",
+			Resource:             "foos",
+			HasSynced:            true,
+			IsResourceRequest:    true,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         418,
+		},
+
+		{
+			Name:                 "existing core group discovery, presync",
+			Method:               "GET",
+			Path:                 "/api",
+			APIGroup:             "",
+			APIVersion:           "",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIGroup\",\"name\":\"\",\"versions\":[{\"groupVersion\":\"v1\",\"version\":\"v1\"}],\"preferredVersion\":{\"groupVersion\":\"v1\",\"version\":\"v1\"}}\n",
+						string(b))
+				}
+			},
+		},
+		{
+			Name:                 "existing core group discovery",
+			Method:               "GET",
+			Path:                 "/api",
+			APIGroup:             "",
+			APIVersion:           "",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIGroup\",\"name\":\"\",\"versions\":[{\"groupVersion\":\"v1\",\"version\":\"v1\"}],\"preferredVersion\":{\"groupVersion\":\"v1\",\"version\":\"v1\"}}\n",
+						string(b))
+				}
+			},
+		},
+		{
+			Name:                 "existing core group version discovery, presync",
+			Method:               "GET",
+			Path:                 "/api/v1",
+			APIGroup:             "",
+			APIVersion:           "v1",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIResourceList\",\"groupVersion\":\"v1\",\"resources\":[{\"name\":\"services\",\"singularName\":\"service\",\"namespaced\":true,\"kind\":\"Service\",\"verbs\":[\"get\",\"list\",\"patch\",\"create\",\"update\",\"watch\"],\"storageVersionHash\":\"+iYBRzoiY8o=\"}]}\n",
+						string(b))
+				}
+			},
+		},
+		{
+			Name:                 "existing core group version discovery",
+			Method:               "GET",
+			Path:                 "/api/v1",
+			APIGroup:             "",
+			APIVersion:           "v1",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         200,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" && r.StatusCode == 200 {
+					require.Equal(t,
+						"{\"kind\":\"APIResourceList\",\"groupVersion\":\"v1\",\"resources\":[{\"name\":\"services\",\"singularName\":\"service\",\"namespaced\":true,\"kind\":\"Service\",\"verbs\":[\"get\",\"list\",\"patch\",\"create\",\"update\",\"watch\"],\"storageVersionHash\":\"+iYBRzoiY8o=\"}]}\n",
+						string(b))
+				}
+			},
+		},
+		{
+			Name:                 "existing core group, nonexisting version discovery, presync",
+			Method:               "GET",
+			Path:                 "/api/v2",
+			APIGroup:             "",
+			APIVersion:           "v2",
+			HasSynced:            false,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         503,
+		},
+		{
+			Name:                 "existing core group, nonexisting version discovery",
+			Method:               "GET",
+			Path:                 "/api/v2",
+			APIGroup:             "",
+			APIVersion:           "v2",
+			HasSynced:            true,
+			IsResourceRequest:    false,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         418,
+		},
+
+		{
+			Name:                 "nonexisting core group, resource request, presync",
+			Method:               "GET",
+			Path:                 "/api/v2/foos",
+			APIGroup:             "",
+			APIVersion:           "v2",
+			Verb:                 "list",
+			Resource:             "foos",
+			HasSynced:            false,
+			IsResourceRequest:    true,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         503,
+		},
+		{
+			Name:                 "nonexisting core group, resource request",
+			Method:               "GET",
+			Path:                 "/api/v2/foos",
+			APIGroup:             "",
+			APIVersion:           "v2",
+			Verb:                 "list",
+			Resource:             "foos",
+			HasSynced:            true,
+			IsResourceRequest:    true,
+			ExpectDelegateCalled: true,
+			ExpectStatus:         418,
+		},
+		{
+			Name:                 "existing group, resource request",
+			Method:               "GET",
+			Path:                 "/apis/custom/v1/customresources",
+			APIGroup:             "custom",
+			APIVersion:           "v1",
+			Verb:                 "list",
+			Resource:             "customresources",
+			HasSynced:            true,
+			IsResourceRequest:    true,
+			ExpectDelegateCalled: false,
+			ExpectStatus:         405,
+			ExpectResponse: func(t *testing.T, r *http.Response, b []byte) {
+				if r.Header.Get("Content-Type") == "application/json" {
+					require.JSONEq(t,
+						"{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"list is not supported on resources of kind \\\"customresources.custom\\\"\",\"reason\":\"MethodNotAllowed\",\"details\":{\"group\":\"custom\",\"kind\":\"customresources\"},\"code\":405}\n",
+						string(b))
+				}
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			for _, contentType := range []string{"json", "yaml", "proto", "unknown"} {
+				t.Run(contentType, func(t *testing.T) {
+					delegateCalled = false
+					hasSynced = tc.HasSynced
+
+					recorder := httptest.NewRecorder()
+
+					req := httptest.NewRequest(tc.Method, tc.Path, tc.Body)
+					for k, v := range tc.Headers {
+						req.Header.Set(k, v)
+					}
+
+					expectStatus := tc.ExpectStatus
+					switch contentType {
+					case "json":
+						req.Header.Set("Accept", "application/json")
+					case "yaml":
+						req.Header.Set("Accept", "application/yaml")
+					case "proto":
+						req.Header.Set("Accept", "application/vnd.kubernetes.protobuf, application/json")
+					case "unknown":
+						req.Header.Set("Accept", "application/vnd.kubernetes.unknown")
+						// rather than success, we'll get a not supported error
+						if expectStatus == 200 {
+							expectStatus = 406
+						}
+					default:
+						t.Fatalf("unknown content type %v", contentType)
+					}
+
+					req = req.WithContext(apirequest.WithRequestInfo(
+						context.WithValue(req.Context(), apidefinition.APIDomainKeyContextKey, "domain"),
+						&apirequest.RequestInfo{
+							Verb:              tc.Verb,
+							Resource:          tc.Resource,
+							APIGroup:          tc.APIGroup,
+							APIVersion:        tc.APIVersion,
+							IsResourceRequest: tc.IsResourceRequest,
+							Path:              tc.Path,
+						}))
+
+					handler.ServeHTTP(recorder, req)
+
+					if tc.ExpectDelegateCalled != delegateCalled {
+						t.Errorf("expected delegated called %v, got %v", tc.ExpectDelegateCalled, delegateCalled)
+					}
+					result := recorder.Result()
+					content, _ := ioutil.ReadAll(result.Body)
+					if e, a := expectStatus, result.StatusCode; e != a {
+						t.Log(string(content))
+						t.Errorf("expected %v, got %v", e, a)
+					}
+					if tc.ExpectResponse != nil {
+						tc.ExpectResponse(t, result, content)
+					}
+
+					// Make sure error responses come back with status objects in all encodings, including unknown encodings
+					if !delegateCalled && expectStatus >= 300 {
+						status := &metav1.Status{}
+
+						switch contentType {
+						// unknown accept headers fall back to json errors
+						case "json", "unknown":
+							if e, a := "application/json", result.Header.Get("Content-Type"); e != a {
+								t.Errorf("expected Content-Type %v, got %v", e, a)
+							}
+							if err := json.Unmarshal(content, status); err != nil {
+								t.Fatal(err)
+							}
+						case "yaml":
+							if e, a := "application/yaml", result.Header.Get("Content-Type"); e != a {
+								t.Errorf("expected Content-Type %v, got %v", e, a)
+							}
+							if err := yaml.Unmarshal(content, status); err != nil {
+								t.Fatal(err)
+							}
+						case "proto":
+							if e, a := "application/vnd.kubernetes.protobuf", result.Header.Get("Content-Type"); e != a {
+								t.Errorf("expected Content-Type %v, got %v", e, a)
+							}
+							if _, _, err := protobuf.NewSerializer(scheme, scheme).Decode(content, nil, status); err != nil {
+								t.Fatal(err)
+							}
+						default:
+							t.Fatalf("unknown content type %v", contentType)
+						}
+
+						if e, a := metav1.Unversioned.WithKind("Status"), status.GroupVersionKind(); e != a {
+							t.Errorf("expected %#v, got %#v", e, a)
+						}
+						if int(status.Code) != int(expectStatus) {
+							t.Errorf("expected %v, got %v", expectStatus, status.Code)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func exampleAPIResourceSpec() *v1alpha1.CommonAPIResourceSpec {
+	return &v1alpha1.CommonAPIResourceSpec{
+		GroupVersion: v1alpha1.GroupVersion{
+			Group:   "stable.example.com",
+			Version: "v1beta1",
+		},
+		CustomResourceDefinitionNames: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural: "examples", Singular: "example", Kind: "Example", ShortNames: []string{"ex"}, ListKind: "ExampleList", Categories: []string{"all"},
+		},
+		Scope: apiextensionsv1.ClusterScoped,
+		SubResources: v1alpha1.SubResources{
+			v1alpha1.SubResource{
+				Name: "status",
+			},
+		},
+	}
+}
+
+func TestBuildOpenAPIModelsForApply(t *testing.T) {
+	// This is a list of validation that we expect to work.
+	tests := []apiextensionsv1.CustomResourceValidation{
+		{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type:       "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{"num": {Type: "integer", Description: "v1beta1 num field"}},
+			},
+		},
+		{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type:         "",
+				XIntOrString: true,
+			},
+		},
+		{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"oneOf": {
+						OneOf: []apiextensionsv1.JSONSchemaProps{
+							{Type: "boolean"},
+							{Type: "string"},
+						},
+					},
+				},
+			},
+		},
+		{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"nullable": {
+						Type:     "integer",
+						Nullable: true,
+					},
+				},
+			},
+		},
+	}
+
+	spec := exampleAPIResourceSpec()
+
+	for i, test := range tests {
+		_ = spec.SetSchema(test.OpenAPIV3Schema)
+		swagger, err := buildOpenAPIV2(spec, builder.Options{V2: true, SkipFilterSchemaForKubectlOpenAPIV2Validation: true, StripValueValidation: true, StripNullable: true, AllowNonStructural: false})
+		require.NoError(t, err)
+
+		openAPIModels, err := utilopenapi.ToProtoModels(swagger)
+		if err != nil {
+			t.Fatalf("failed to convert to apply model: %v", err)
+		}
+		if openAPIModels == nil {
+			t.Fatalf("%d: failed to convert to apply model: nil", i)
+		}
+	}
+}

--- a/pkg/virtual/framework/dynamic/apiserver/serving_info.go
+++ b/pkg/virtual/framework/dynamic/apiserver/serving_info.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	structuraldefaulting "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
+	apiservervalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder"
+	"k8s.io/apiextensions-apiserver/pkg/registry/customresource/tableconvertor"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apiserver/pkg/endpoints/handlers"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"k8s.io/apiserver/pkg/endpoints/openapi"
+	"k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	utilopenapi "k8s.io/apiserver/pkg/util/openapi"
+	klog "k8s.io/klog/v2"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"k8s.io/kube-openapi/pkg/validation/strfmt"
+	"k8s.io/kube-openapi/pkg/validation/validate"
+
+	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+)
+
+var _ apidefinition.APIDefinition = (*servingInfo)(nil)
+
+// RestProviderFunc is the type of a function that builds REST storage implementations for the main resource and sub-resources, based on informations passed by the resource handler about a given API.
+type RestProviderFunc func(resource schema.GroupVersionResource, kind schema.GroupVersionKind, listKind schema.GroupVersionKind, typer runtime.ObjectTyper, tableConvertor rest.TableConvertor, namespaceScoped bool, schemaValidator *validate.SchemaValidator, subresourcesSchemaValidator map[string]*validate.SchemaValidator, structuralSchema *structuralschema.Structural) (mainStorage rest.Storage, subresourceStorages map[string]rest.Storage)
+
+// CreateServingInfoFor method can be used by external components at any time to create an APIDefinition and add it to an APISetRetriever
+func CreateServingInfoFor(genericConfig genericapiserver.CompletedConfig, logicalClusterName logicalcluster.Name, apiResourceSpec *apiresourcev1alpha1.CommonAPIResourceSpec, restProvider RestProviderFunc) (apidefinition.APIDefinition, error) {
+	equivalentResourceRegistry := runtime.NewEquivalentResourceRegistry()
+
+	v1OpenAPISchema, err := apiResourceSpec.GetSchema()
+	if err != nil {
+		return nil, err
+	}
+	internalSchema := &apiextensionsinternal.JSONSchemaProps{}
+	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(v1OpenAPISchema, internalSchema, nil); err != nil {
+		return nil, fmt.Errorf("failed converting CRD validation to internal version: %w", err)
+	}
+	structuralSchema, err := structuralschema.NewStructural(internalSchema)
+	if err != nil {
+		// This should never happen. If it does, it is a programming error.
+		utilruntime.HandleError(fmt.Errorf("failed to convert schema to structural: %w", err))
+		return nil, fmt.Errorf("the server could not properly serve the CR schema") // validation should avoid this
+	}
+
+	// we don't own structuralSchema completely, e.g. defaults are not deep-copied. So better make a copy here.
+	structuralSchema = structuralSchema.DeepCopy()
+
+	resource := schema.GroupVersionResource{Group: apiResourceSpec.GroupVersion.Group, Version: apiResourceSpec.GroupVersion.Version, Resource: apiResourceSpec.Plural}
+	kind := schema.GroupVersionKind{Group: apiResourceSpec.GroupVersion.Group, Version: apiResourceSpec.GroupVersion.Version, Kind: apiResourceSpec.Kind}
+	listKind := schema.GroupVersionKind{Group: apiResourceSpec.GroupVersion.Group, Version: apiResourceSpec.GroupVersion.Version, Kind: apiResourceSpec.ListKind}
+
+	if err := structuraldefaulting.PruneDefaults(structuralSchema); err != nil {
+		// This should never happen. If it does, it is a programming error.
+		utilruntime.HandleError(fmt.Errorf("failed to prune defaults for schema %s|%s: %w", logicalClusterName.String(), resource.String(), err))
+		return nil, fmt.Errorf("the server could not properly serve the CR schema") // validation should avoid this
+	}
+
+	s, err := buildOpenAPIV2(
+		apiResourceSpec,
+		builder.Options{
+			V2: true,
+			SkipFilterSchemaForKubectlOpenAPIV2Validation: true,
+			StripValueValidation:                          true,
+			StripNullable:                                 true,
+			AllowNonStructural:                            false})
+	if err != nil {
+		return nil, err
+	}
+
+	var modelsByGKV openapi.ModelsByGKV
+
+	openAPIModels, err := utilopenapi.ToProtoModels(s)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error building openapi models for %s: %w", kind.String(), err))
+		openAPIModels = nil
+	} else {
+		modelsByGKV, err = openapi.GetModelsByGKV(openAPIModels)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("error gathering openapi models by GKV for %s: %w", kind.String(), err))
+			modelsByGKV = nil
+		}
+	}
+	var typeConverter fieldmanager.TypeConverter = fieldmanager.DeducedTypeConverter{}
+	if openAPIModels != nil {
+		typeConverter, err = fieldmanager.NewTypeConverter(openAPIModels, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	safeConverter, unsafeConverter := &nopConverter{}, &nopConverter{}
+	if err != nil {
+		return nil, err
+	}
+
+	// In addition to Unstructured objects (Custom Resources), we also may sometimes need to
+	// decode unversioned Options objects, so we delegate to parameterScheme for such types.
+	parameterScheme := runtime.NewScheme()
+	parameterScheme.AddUnversionedTypes(schema.GroupVersion{Group: apiResourceSpec.GroupVersion.Group, Version: apiResourceSpec.GroupVersion.Version},
+		&metav1.ListOptions{},
+		&metav1.GetOptions{},
+		&metav1.DeleteOptions{},
+	)
+	parameterCodec := runtime.NewParameterCodec(parameterScheme)
+
+	equivalentResourceRegistry.RegisterKindFor(resource, "", kind)
+
+	typer := apiextensionsapiserver.NewUnstructuredObjectTyper(parameterScheme)
+	creator := apiextensionsapiserver.UnstructuredCreator{}
+
+	internalValidationSchema := &apiextensionsinternal.CustomResourceValidation{
+		OpenAPIV3Schema: internalSchema,
+	}
+	validator, _, err := apiservervalidation.NewSchemaValidator(internalValidationSchema)
+	if err != nil {
+		return nil, err
+	}
+
+	subResourcesValidators := map[string]*validate.SchemaValidator{}
+
+	if subresources := apiResourceSpec.SubResources; subresources != nil && subresources.Contains("status") {
+		var statusValidator *validate.SchemaValidator
+		equivalentResourceRegistry.RegisterKindFor(resource, "status", kind)
+		// for the status subresource, validate only against the status schema
+		if internalValidationSchema != nil && internalValidationSchema.OpenAPIV3Schema != nil && internalValidationSchema.OpenAPIV3Schema.Properties != nil {
+			if statusSchema, ok := internalValidationSchema.OpenAPIV3Schema.Properties["status"]; ok {
+				openapiSchema := &spec.Schema{}
+				if err := apiservervalidation.ConvertJSONSchemaPropsWithPostProcess(&statusSchema, openapiSchema, apiservervalidation.StripUnsupportedFormatsPostProcess); err != nil {
+					return nil, err
+				}
+				statusValidator = validate.NewSchemaValidator(openapiSchema, nil, "", strfmt.Default)
+			}
+		}
+		subResourcesValidators["status"] = statusValidator
+	}
+
+	table, err := tableconvertor.New(apiResourceSpec.ColumnDefinitions.ToCustomResourceColumnDefinitions())
+	if err != nil {
+		klog.V(2).Infof("The CRD for %s|%s has an invalid printer specification, falling back to default printing: %v", logicalClusterName.String(), kind.String(), err)
+	}
+
+	storage, subresourceStorages := restProvider(
+		resource,
+		kind,
+		listKind,
+		typer,
+		table,
+		apiResourceSpec.Scope == apiextensionsv1.NamespaceScoped,
+		validator,
+		subResourcesValidators,
+		structuralSchema,
+	)
+
+	selfLinkPrefixPrefix := path.Join("apis", apiResourceSpec.GroupVersion.Group, apiResourceSpec.GroupVersion.Version)
+	if apiResourceSpec.GroupVersion.Group == "" {
+		selfLinkPrefixPrefix = path.Join("api", apiResourceSpec.GroupVersion.Version)
+	}
+	selfLinkPrefix := ""
+	switch apiResourceSpec.Scope {
+	case apiextensionsv1.ClusterScoped:
+		selfLinkPrefix = "/" + selfLinkPrefixPrefix + "/" + apiResourceSpec.Plural + "/"
+	case apiextensionsv1.NamespaceScoped:
+		selfLinkPrefix = "/" + selfLinkPrefixPrefix + "/namespaces/"
+	}
+
+	clusterScoped := apiResourceSpec.Scope == apiextensionsv1.ClusterScoped
+
+	// CRDs explicitly do not support protobuf, but some objects returned by the API server do
+	negotiatedSerializer := apiextensionsapiserver.NewUnstructuredNegotiatedSerializer(
+		typer,
+		creator,
+		safeConverter,
+		map[string]*structuralschema.Structural{kind.Version: structuralSchema},
+		kind.GroupKind(),
+		false,
+	)
+	var standardSerializers []runtime.SerializerInfo
+	for _, s := range negotiatedSerializer.SupportedMediaTypes() {
+		if s.MediaType == runtime.ContentTypeProtobuf {
+			continue
+		}
+		standardSerializers = append(standardSerializers, s)
+	}
+
+	requestScope := &handlers.RequestScope{
+		Namer: handlers.ContextBasedNaming{
+			SelfLinker:         meta.NewAccessor(),
+			ClusterScoped:      clusterScoped,
+			SelfLinkPathPrefix: selfLinkPrefix,
+		},
+		Serializer:          negotiatedSerializer,
+		ParameterCodec:      parameterCodec,
+		StandardSerializers: standardSerializers,
+		Creater:             creator,
+		Convertor:           safeConverter,
+		Defaulter: apiextensionsapiserver.NewUnstructuredDefaulter(
+			parameterScheme,
+			map[string]*structuralschema.Structural{kind.Version: structuralSchema},
+			kind.GroupKind(),
+		),
+		Typer:                    typer,
+		UnsafeConvertor:          unsafeConverter,
+		EquivalentResourceMapper: equivalentResourceRegistry,
+		Resource:                 resource,
+		Kind:                     kind,
+		HubGroupVersion:          kind.GroupVersion(),
+		MetaGroupVersion:         metav1.SchemeGroupVersion,
+		TableConvertor:           table,
+		Authorizer:               genericConfig.Authorization.Authorizer,
+		MaxRequestBodyBytes:      genericConfig.MaxRequestBodyBytes,
+		OpenapiModels:            modelsByGKV,
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
+		if withResetFields, canGetResetFields := storage.(rest.ResetFieldsStrategy); canGetResetFields {
+			resetFields := withResetFields.GetResetFields()
+			reqScope := *requestScope
+			reqScope, err = apiextensionsapiserver.ScopeWithFieldManager(
+				typeConverter,
+				reqScope,
+				resetFields,
+				"",
+			)
+			if err != nil {
+				return nil, err
+			}
+			requestScope = &reqScope
+		} else {
+			return nil, fmt.Errorf("storage for resource %q should define GetResetFields", kind.String())
+		}
+	}
+
+	var statusScope handlers.RequestScope
+	statusStorage, statusEnabled := subresourceStorages["status"]
+	if statusEnabled {
+		// shallow copy
+		statusScope = *requestScope
+		statusScope.Subresource = "status"
+		statusScope.Namer = handlers.ContextBasedNaming{
+			SelfLinker:         meta.NewAccessor(),
+			ClusterScoped:      clusterScoped,
+			SelfLinkPathPrefix: selfLinkPrefix,
+			SelfLinkPathSuffix: "/status",
+		}
+
+		if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
+			if withResetFields, canGetResetFields := statusStorage.(rest.ResetFieldsStrategy); canGetResetFields {
+				resetFields := withResetFields.GetResetFields()
+				statusScope, err = apiextensionsapiserver.ScopeWithFieldManager(
+					typeConverter,
+					statusScope,
+					resetFields,
+					"status",
+				)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, fmt.Errorf("storage for resource %q status should define GetResetFields", kind.String())
+			}
+		}
+	}
+
+	ret := &servingInfo{
+		logicalClusterName: logicalClusterName,
+		apiResourceSpec:    apiResourceSpec,
+		storage:            storage,
+		statusStorage:      statusStorage,
+		requestScope:       requestScope,
+		statusRequestScope: &statusScope,
+	}
+
+	return ret, nil
+}
+
+// servingInfo stores enough information to serve the storage for the apiResourceSpec
+type servingInfo struct {
+	logicalClusterName logicalcluster.Name
+	apiResourceSpec    *apiresourcev1alpha1.CommonAPIResourceSpec
+
+	storage       rest.Storage
+	statusStorage rest.Storage
+
+	requestScope       *handlers.RequestScope
+	statusRequestScope *handlers.RequestScope
+}
+
+// Implement APIDefinition interface
+
+func (apiDef *servingInfo) GetAPIResourceSpec() *apiresourcev1alpha1.CommonAPIResourceSpec {
+	return apiDef.apiResourceSpec
+}
+func (apiDef *servingInfo) GetClusterName() logicalcluster.Name {
+	return apiDef.logicalClusterName
+}
+func (apiDef *servingInfo) GetStorage() rest.Storage {
+	return apiDef.storage
+}
+func (apiDef *servingInfo) GetSubResourceStorage(subresource string) rest.Storage {
+	if subresource == "status" {
+		return apiDef.statusStorage
+	}
+	return nil
+}
+func (apiDef *servingInfo) GetRequestScope() *handlers.RequestScope {
+	return apiDef.requestScope
+}
+func (apiDef *servingInfo) GetSubResourceRequestScope(subresource string) *handlers.RequestScope {
+	if subresource == "status" {
+		return apiDef.statusRequestScope
+	}
+	return nil
+}
+
+var _ runtime.ObjectConvertor = nopConverter{}
+
+type nopConverter struct{}
+
+func (u nopConverter) Convert(in, out, context interface{}) error {
+	sv, err := conversion.EnforcePtr(in)
+	if err != nil {
+		return err
+	}
+	dv, err := conversion.EnforcePtr(out)
+	if err != nil {
+		return err
+	}
+	dv.Set(sv)
+	return nil
+}
+func (u nopConverter) ConvertToVersion(in runtime.Object, gv runtime.GroupVersioner) (out runtime.Object, err error) {
+	return in, nil
+}
+func (u nopConverter) ConvertFieldLabel(gvk schema.GroupVersionKind, label, value string) (string, string, error) {
+	return label, value, nil
+}
+
+// buildOpenAPIV2 builds OpenAPI v2 for the given apiResourceSpec
+func buildOpenAPIV2(apiResourceSpec *apiresourcev1alpha1.CommonAPIResourceSpec, opts builder.Options) (*spec.Swagger, error) {
+	version := apiResourceSpec.GroupVersion.Version
+	schema, err := apiResourceSpec.GetSchema()
+	if err != nil {
+		return nil, err
+	}
+	var subResources apiextensionsv1.CustomResourceSubresources
+	for _, subResource := range apiResourceSpec.SubResources {
+		if subResource.Name == "scale" {
+			subResources.Scale = &apiextensionsv1.CustomResourceSubresourceScale{
+				SpecReplicasPath:   ".spec.replicas",
+				StatusReplicasPath: ".status.replicas",
+			}
+		}
+		if subResource.Name == "status" {
+			subResources.Status = &apiextensionsv1.CustomResourceSubresourceStatus{}
+		}
+	}
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: apiResourceSpec.GroupVersion.Group,
+			Names: apiResourceSpec.CustomResourceDefinitionNames,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name: version,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: schema,
+					},
+					Subresources: &subResources,
+				},
+			},
+			Scope: apiResourceSpec.Scope,
+		},
+	}
+	return builder.BuildOpenAPIV2(crd, version, opts)
+}

--- a/pkg/virtual/framework/dynamic/context/keys.go
+++ b/pkg/virtual/framework/dynamic/context/keys.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package context
+
+import "context"
+
+// apiDomainKeyContextKeyType is the type of the key for the request context value
+// that will carry the API domain key.
+type apiDomainKeyContextKeyType string
+
+// apiDomainKeyContextKey is the key for the request context value
+// that will carry the API domain key.
+const apiDomainKeyContextKey apiDomainKeyContextKeyType = "VirtualWorkspaceAPIDomainKey"
+
+// WithAPIDomainKey adds an API domain key to the context.
+func WithAPIDomainKey(ctx context.Context, apiDomainKey string) context.Context {
+	return context.WithValue(ctx, apiDomainKeyContextKey, apiDomainKey)
+}
+
+// APIDomainKeyFromContext retrieves the API domain key from the context, if any.
+func APIDomainKeyFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(apiDomainKeyContextKey).(string)
+	return s
+}

--- a/pkg/virtual/framework/dynamic/doc.go
+++ b/pkg/virtual/framework/dynamic/doc.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dynamic provides the types and underlying implementation
+// required to build virtual workspaces which can dynamically serve resources,
+// based on API definitions (including an OpenAPI v3 schema), and a Rest storage provider.
+//
+// Main idea
+//
+// APIs served by the virtual workspace are partitioned in API domains. Each API domain
+// is defined by an api domain key and will expose a set of APIs
+// that will be served at a dedicated URL path. API domain key is generally extracted from the URL sub-path
+// where related APIs will be exposed.
+//
+// APIs are served by an apiserver.DynamicAPIServer which is setup in the virtual workspace Register() method.
+//
+// Typical operation
+//
+// The RootPathResolver() method would usually interpret the URL sub-path, extract the API domain key from it,
+// and pass the request to the apiserver.DynamicAPIServer, along with the API domain key, if the API domain key contains APIs.
+//
+// The BootstrapAPISetManagement() method would typically create and initialize an apidefs.APISetRetriever, returned as a result,
+// and setup some logic that will call the apiserver.CreateServingInfoFor() method to add an APIDefinition
+// in the APISetRetriever on some event.
+//
+// The apidefs.APISetRetriever returned by the BootstrapAPISetManagement() method is passed to the apiserver.DynamicAPIServer during the Register() call.
+// The apiserver.DyncamicAPIServer uses it to correctly choose the appropriate apidefs.APIDefinition used to serve the request,
+// based on the context api domain key and the requested API GVR.
+package dynamic

--- a/pkg/virtual/framework/dynamic/doc.go
+++ b/pkg/virtual/framework/dynamic/doc.go
@@ -32,11 +32,11 @@ limitations under the License.
 // The RootPathResolver() method would usually interpret the URL sub-path, extract the API domain key from it,
 // and pass the request to the apiserver.DynamicAPIServer, along with the API domain key, if the API domain key contains APIs.
 //
-// The BootstrapAPISetManagement() method would typically create and initialize an apidefs.APISetRetriever, returned as a result,
+// The BootstrapAPISetManagement() method would typically create and initialize an apidefinition.APIDefinitionSetGetter, returned as a result,
 // and setup some logic that will call the apiserver.CreateServingInfoFor() method to add an APIDefinition
-// in the APISetRetriever on some event.
+// in the APIDefinitionSetGetter on some event.
 //
-// The apidefs.APISetRetriever returned by the BootstrapAPISetManagement() method is passed to the apiserver.DynamicAPIServer during the Register() call.
-// The apiserver.DyncamicAPIServer uses it to correctly choose the appropriate apidefs.APIDefinition used to serve the request,
+// The apidefinition.APIDefinitionSetGetter returned by the BootstrapAPISetManagement() method is passed to the apiserver.DynamicAPIServer during the Register() call.
+// The apiserver.DyncamicAPIServer uses it to correctly choose the appropriate apidefinition.APIDefinition used to serve the request,
 // based on the context api domain key and the requested API GVR.
 package dynamic

--- a/pkg/virtual/framework/dynamic/doc_test.go
+++ b/pkg/virtual/framework/dynamic/doc_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+
+	"github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
+)
+
+// Typical Usage of a DynamicVirtualWorkspace
+func Example() {
+
+	var someAPISetRetriever apidefinition.APIDefinitionSetGetter
+	ready := false
+
+	var _ = dynamic.DynamicVirtualWorkspace{
+
+		Name: "SomeDynamicVirtualWorkspace",
+
+		RootPathResolver: func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+			if someAPISetRetriever == nil {
+				// If the APISetRetriever is not initialized, don't accept the request
+				return
+			}
+
+			var apiDomainKey string
+
+			// Resolve the request root path, and extract API domain key from it ...
+
+			if _, exists := someAPISetRetriever.GetAPIDefinitionSet(apiDomainKey); !exists {
+				// If the APISetRetriever doesn't manage this api domain, don't accept the request
+				return
+			}
+
+			// ...
+
+			// Add the apiDomainKey to the request context before passing the request to the virtual workspace APIServer
+			completedContext = context.WithValue(requestContext, apidefinition.APIDomainKeyContextKey, apiDomainKey)
+			accepted = true
+			return
+		},
+
+		Ready: func() error {
+			if !ready {
+				return errors.New("virtual workspace controllers are not started")
+			}
+			return nil
+		},
+
+		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
+
+			// Initialize the implementation of the APISetRetriever
+
+			someAPISetRetriever = newAPISetRetriever()
+
+			// Setup some controller that will add APIDefinitions on demand
+
+			someController := setupController(func(logicalClusterName logicalcluster.Name, spec *v1alpha1.CommonAPIResourceSpec) (apidefinition.APIDefinition, error) {
+				// apiserver.CreateServingInfoFor() creates and initializes all the required information to serve an API
+				return apiserver.CreateServingInfoFor(mainConfig, logicalClusterName, spec, someRestProviderFunc)
+			})
+
+			// Start the controllers in a PostStartHook
+
+			if err := mainConfig.AddPostStartHook("SomeDynamicVirtualWorkspacePostStartHook", func(hookContext genericapiserver.PostStartHookContext) error {
+
+				// Wait for required informers to be synced
+
+				someController.Start()
+
+				ready = true
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+
+			return someAPISetRetriever, nil
+		},
+	}
+}
+
+func newAPISetRetriever() apidefinition.APIDefinitionSetGetter { return nil }
+
+type someController interface {
+	Start()
+}
+
+func setupController(createAPIDefinition apidefinition.CreateAPIDefinitionFunc) someController {
+	return nil
+}
+
+var someRestProviderFunc apiserver.RestProviderFunc

--- a/pkg/virtual/framework/dynamic/example_test.go
+++ b/pkg/virtual/framework/dynamic/example_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 )
 
 // Typical Usage of a DynamicVirtualWorkspace
@@ -58,7 +59,7 @@ func Example() {
 			// ...
 
 			// Add the apiDomainKey to the request context before passing the request to the virtual workspace APIServer
-			completedContext = context.WithValue(requestContext, apidefinition.APIDomainKeyContextKey, apiDomainKey)
+			completedContext = dynamiccontext.WithAPIDomainKey(requestContext, apiDomainKey)
 			accepted = true
 			return
 		},

--- a/pkg/virtual/framework/dynamic/register.go
+++ b/pkg/virtual/framework/dynamic/register.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	genericapiserver "k8s.io/apiserver/pkg/server"
+
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
+)
+
+// Register builds and returns a DynamicAPIServer which will serve APIs whose serving informations are provided by an APISetRetriever.
+// The APISetRetriever is returned by the virtual workspace BootstrapAPISetManagement function.
+func (vw *DynamicVirtualWorkspace) Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
+	apiSetRetriever, err := vw.BootstrapAPISetManagement(rootAPIServerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &apiserver.DynamicAPIServerConfig{
+		GenericConfig: &genericapiserver.RecommendedConfig{Config: *rootAPIServerConfig.Config, SharedInformerFactory: rootAPIServerConfig.SharedInformerFactory},
+		ExtraConfig: apiserver.DynamicAPIServerExtraConfig{
+			APISetRetriever: apiSetRetriever,
+		},
+	}
+
+	// We don't want any poststart hooks at the level of a DynamicAPIServer.
+	// In the current design, PostStartHooks are only added at the top level RootAPIServer.
+	// So let's drop the PostStartHooks from the DynamicAPIServerConfig since they are simply copied
+	// from the RootAPIServerConfig
+	cfg.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+	config := cfg.Complete()
+
+	server, err := config.New(vw.Name, delegateAPIServer)
+	if err != nil {
+		return nil, err
+	}
+
+	delegateAPIServer = server.GenericAPIServer
+
+	return delegateAPIServer, nil
+}

--- a/pkg/virtual/framework/dynamic/types.go
+++ b/pkg/virtual/framework/dynamic/types.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamic
+
+import (
+	"context"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+
+	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+)
+
+var _ framework.VirtualWorkspace = (*DynamicVirtualWorkspace)(nil)
+
+// DynamicVirtualWorkspace is an implemntation of a VirtualWorkspace which can dynamically serve resources,
+// based on API definitions (including an OpenAPI v3 schema), and a Rest storage provider.
+type DynamicVirtualWorkspace struct {
+	Name             string
+	RootPathResolver framework.RootPathResolverFunc
+	Ready            framework.ReadyFunc
+
+	// BootstrapAPISetManagement creates, initializes and returns an apidefs.APISetRetriever.
+	// Usually it would also setup some logic that will call the apiserver.CreateServingInfoFor() method
+	// to add an apidefs.APIDefinition in the apidefs.APISetRetriever on some event.
+	BootstrapAPISetManagement func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error)
+}
+
+func (vw *DynamicVirtualWorkspace) GetName() string {
+	return vw.Name
+}
+
+func (vw *DynamicVirtualWorkspace) IsReady() error {
+	return vw.Ready()
+}
+
+func (vw *DynamicVirtualWorkspace) ResolveRootPath(urlPath string, context context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+	return vw.RootPathResolver(urlPath, context)
+}


### PR DESCRIPTION
Dynamic Virtual workspace implementation that allows exposing CRD-like APIs per API domains
(one base virtual workspace URL per API domain)

Largly inspired from the current code of the `apiextensions-apiserver/pkg/apiserver`
package of the `kcp-dev/kubernetes` fork

This is a pre-requisite for https://github.com/kcp-dev/kcp/pull/754.