### PR TITLE
Delete custom resources when apibinding is deleted

### DIFF
--- a/pkg/apis/apis/v1alpha1/types.go
+++ b/pkg/apis/apis/v1alpha1/types.go
@@ -181,8 +181,8 @@ const (
 	// has a naming conflict with other APIs.
 	NamingConflictsReason = "NamingConflicts"
 
-	// BindingResourceDeleteSuccess is a condition for APIBinding that indicates the resources relating this binding is deleted successfully
-	// when the APIBinding is deleting
+	// BindingResourceDeleteSuccess is a condition for APIBinding that indicates the resources relating this binding are deleted
+	// successfully when the APIBinding is deleting
 	BindingResourceDeleteSuccess conditionsv1alpha1.ConditionType = "BindingResourceDeleteSuccess"
 )
 

--- a/pkg/apis/apis/v1alpha1/types.go
+++ b/pkg/apis/apis/v1alpha1/types.go
@@ -180,6 +180,10 @@ const (
 	// NamingConflictsReason is a reason for the BindingUpToDate condition that at least one API coming in from the APIBinding
 	// has a naming conflict with other APIs.
 	NamingConflictsReason = "NamingConflicts"
+
+	// BindingResourceDeleteSuccess is a condition for APIBinding that indicates the resources relating this binding is deleted successfully
+	// when the APIBinding is deleting
+	BindingResourceDeleteSuccess conditionsv1alpha1.ConditionType = "BindingResourceDeleteSuccess"
 )
 
 // These are annotations for bound CRDs

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibindingdeletion
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/clusterworkspacedeletion/deletion"
+	conditionsv1alpha1 "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+const (
+	DeletionRecheckEstimateSeconds = 5
+
+	// ResourceDeletionFailedReason is the reason for condition BindingResourceDeleteSuccess that deletion of
+	// some CRs is failed
+	ResourceDeletionFailedReason = "ResourceDeletionFailed"
+
+	// ResourceRemainingReason is the reason for condition BindingResourceDeleteSuccess that some CR resource still
+	// exists when apibinding is deleting
+	ResourceRemainingReason = "SomeResourcesRemain"
+
+	// ResourceFinalizersRemainReason is the reason for condition BindingResourceDeleteSuccess that finalizers on some
+	// CRs still exist.
+	ResourceFinalizersRemainReason = "SomeFinalizersRemain"
+)
+
+type gvrDeletionMetadata struct {
+	// numRemaining is how many instances of the gvr remain
+	numRemaining int
+	// finalizersToNumRemaining maps finalizers to how many resources are stuck on them
+	finalizersToNumRemaining map[string]int
+}
+
+func (c *Controller) deleteAllCRs(ctx context.Context, apibinding *apisv1alpha1.APIBinding) error {
+
+	gvrToNumRemaining := map[schema.GroupVersionResource]int{}
+	finalizersToNumRemaining := map[string]int{}
+
+	deleteContentErrs := []error{}
+	for _, resource := range apibinding.Status.BoundResources {
+		for _, version := range resource.StorageVersions {
+			gvr := schema.GroupVersionResource{
+				Group:    resource.Group,
+				Resource: resource.Resource,
+				Version:  version,
+			}
+
+			deletionMetadata, err := c.deleteAllCR(ctx, logicalcluster.From(apibinding), gvr)
+			if err != nil {
+				deleteContentErrs = append(deleteContentErrs, err)
+			}
+
+			if deletionMetadata.numRemaining > 0 {
+				gvrToNumRemaining[gvr] = deletionMetadata.numRemaining
+				for finalizer, numRemaining := range deletionMetadata.finalizersToNumRemaining {
+					if numRemaining == 0 {
+						continue
+					}
+					finalizersToNumRemaining[finalizer] = finalizersToNumRemaining[finalizer] + numRemaining
+				}
+			}
+		}
+	}
+
+	if len(deleteContentErrs) > 0 {
+		conditions.MarkFalse(
+			apibinding,
+			apisv1alpha1.BindingResourceDeleteSuccess,
+			ResourceDeletionFailedReason,
+			conditionsv1alpha1.ConditionSeverityError,
+			utilerrors.NewAggregate(deleteContentErrs).Error(),
+		)
+
+		return utilerrors.NewAggregate(deleteContentErrs)
+	}
+
+	if len(finalizersToNumRemaining) != 0 {
+		remainingByFinalizer := []string{}
+		for finalizer, numRemaining := range finalizersToNumRemaining {
+			if numRemaining == 0 {
+				continue
+			}
+			remainingByFinalizer = append(remainingByFinalizer, fmt.Sprintf("%s in %d resource instances", finalizer, numRemaining))
+		}
+		// sort for stable updates
+		sort.Strings(remainingByFinalizer)
+		conditions.MarkFalse(
+			apibinding,
+			apisv1alpha1.BindingResourceDeleteSuccess,
+			ResourceFinalizersRemainReason,
+			conditionsv1alpha1.ConditionSeverityError,
+			fmt.Sprintf("Some content in the workspace has finalizers remaining: %s", strings.Join(remainingByFinalizer, ", ")),
+		)
+
+		return &deletion.ResourcesRemainingError{Estimate: DeletionRecheckEstimateSeconds}
+	}
+
+	if len(gvrToNumRemaining) != 0 {
+		remainingResources := []string{}
+		for gvr, numRemaining := range gvrToNumRemaining {
+			if numRemaining == 0 {
+				continue
+			}
+			remainingResources = append(remainingResources, fmt.Sprintf("%s.%s has %d resource instances", gvr.Resource, gvr.Group, numRemaining))
+		}
+		// sort for stable updates
+		sort.Strings(remainingResources)
+
+		conditions.MarkFalse(
+			apibinding,
+			apisv1alpha1.BindingResourceDeleteSuccess,
+			ResourceRemainingReason,
+			conditionsv1alpha1.ConditionSeverityError,
+			fmt.Sprintf("Some resources are remaining: %s", strings.Join(remainingResources, ", ")),
+		)
+
+		return &deletion.ResourcesRemainingError{Estimate: DeletionRecheckEstimateSeconds}
+	}
+
+	conditions.MarkTrue(apibinding, apisv1alpha1.BindingResourceDeleteSuccess)
+
+	return nil
+}
+
+func (c *Controller) deleteAllCR(ctx context.Context, clusterName logicalcluster.Name, gvr schema.GroupVersionResource) (gvrDeletionMetadata, error) {
+	partialList, err := c.metadataClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(genericapirequest.WithCluster(ctx, genericapirequest.Cluster{Name: clusterName}), metav1.ListOptions{})
+	if err != nil {
+		return gvrDeletionMetadata{}, err
+	}
+
+	deletedNamespaces := sets.String{}
+	deleteErrors := []error{}
+
+	for _, item := range partialList.Items {
+		if deletedNamespaces.Has(item.GetNamespace()) {
+			continue
+		}
+
+		// don't retry deleting the same namespace
+		deletedNamespaces.Insert(item.GetNamespace())
+		background := metav1.DeletePropagationBackground
+		opts := metav1.DeleteOptions{PropagationPolicy: &background}
+
+		// CRs always support deletecollection verb
+		if err := c.metadataClient.Resource(gvr).Namespace(item.GetNamespace()).DeleteCollection(
+			genericapirequest.WithCluster(ctx, genericapirequest.Cluster{Name: clusterName}), opts, metav1.ListOptions{}); err != nil {
+			deleteErrors = append(deleteErrors, err)
+			continue
+		}
+	}
+
+	deleteError := utilerrors.NewAggregate(deleteErrors)
+	if deleteError != nil {
+		return gvrDeletionMetadata{}, err
+	}
+
+	// list again so we know how many left resources
+	partialList, err = c.metadataClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(genericapirequest.WithCluster(ctx, genericapirequest.Cluster{Name: clusterName}), metav1.ListOptions{})
+	if err != nil {
+		return gvrDeletionMetadata{}, err
+	}
+
+	if len(partialList.Items) == 0 {
+		// we're done
+		return gvrDeletionMetadata{numRemaining: 0}, nil
+	}
+
+	// use the list to find the finalizers
+	finalizersToNumRemaining := map[string]int{}
+	for _, item := range partialList.Items {
+		for _, finalizer := range item.GetFinalizers() {
+			finalizersToNumRemaining[finalizer] = finalizersToNumRemaining[finalizer] + 1
+		}
+	}
+
+	klog.V(5).Infof("apibinding deletion controller - deleteAllCR - estimate is present - workspace: %s, gvr: %v, finalizers: %v", clusterName, gvr, finalizersToNumRemaining)
+	return gvrDeletionMetadata{
+		numRemaining:             len(partialList.Items),
+		finalizersToNumRemaining: finalizersToNumRemaining,
+	}, nil
+}

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor_test.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletor_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibindingdeletion
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	metadatafake "k8s.io/client-go/metadata/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/reconciler/tenancy/clusterworkspacedeletion/deletion"
+	conditionsv1alpha1 "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(metav1.AddMetaToScheme(scheme))
+}
+func TestAPIBindingTerminating(t *testing.T) {
+	now := metav1.Now()
+	apibinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{APIBindingFinalizer},
+		},
+		Status: apisv1alpha1.APIBindingStatus{
+			BoundResources: []apisv1alpha1.BoundAPIResource{
+				{
+					Group:           "",
+					Resource:        "pods",
+					StorageVersions: []string{"v1"},
+				},
+				{
+					Group:           "apps",
+					Resource:        "deployments",
+					StorageVersions: []string{"v1"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                    string
+		existingObject          []runtime.Object
+		metadataClientActionSet metaActionSet
+		expectErrorOnDelete     error
+		expectConditions        conditionsv1alpha1.Conditions
+	}{
+		{
+			name:           "no resource left for apibinding to delete",
+			existingObject: []runtime.Object{},
+			metadataClientActionSet: []metaAction{
+				{"pods", "list"},
+				{"pods", "list"},
+				{"deployments", "list"},
+				{"deployments", "list"},
+			},
+			expectErrorOnDelete: nil,
+			expectConditions: conditionsv1alpha1.Conditions{
+				{
+					Type:   apisv1alpha1.BindingResourceDeleteSuccess,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+		{
+			name: "some resource remaining after apibinding deletion",
+			existingObject: []runtime.Object{
+				newPartialObject("v1", "Pod", "pod1", "ns1", nil),
+				newPartialObject("apps/v1", "Deployment", "deploy1", "ns1", nil),
+			},
+			metadataClientActionSet: []metaAction{
+				{"pods", "list"},
+				{"pods", "delete-collection"},
+				{"pods", "list"},
+				{"deployments", "list"},
+				{"deployments", "delete-collection"},
+				{"deployments", "list"},
+			},
+			expectErrorOnDelete: &deletion.ResourcesRemainingError{Estimate: 5},
+			expectConditions: conditionsv1alpha1.Conditions{
+				{
+					Type:   apisv1alpha1.BindingResourceDeleteSuccess,
+					Status: v1.ConditionFalse,
+					Reason: ResourceRemainingReason,
+				},
+			},
+		},
+		{
+			name: "some resource remaining after apibinding deletion",
+			existingObject: []runtime.Object{
+				newPartialObject("v1", "Pod", "pod1", "ns1", []string{"test.kcp.io/finalizer"}),
+				newPartialObject("apps/v1", "Deployment", "deploy1", "ns1", []string{"test.kcp.io/finalizer"}),
+			},
+			metadataClientActionSet: []metaAction{
+				{"pods", "list"},
+				{"pods", "delete-collection"},
+				{"pods", "list"},
+				{"deployments", "list"},
+				{"deployments", "delete-collection"},
+				{"deployments", "list"},
+			},
+			expectErrorOnDelete: &deletion.ResourcesRemainingError{Estimate: 5},
+			expectConditions: conditionsv1alpha1.Conditions{
+				{
+					Type:   apisv1alpha1.BindingResourceDeleteSuccess,
+					Status: v1.ConditionFalse,
+					Reason: ResourceFinalizersRemainReason,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMetadataClient := metadatafake.NewSimpleMetadataClient(scheme, tt.existingObject...)
+			controller := &Controller{
+				metadataClient: mockMetadataClient,
+			}
+
+			apibindingCopy := apibinding.DeepCopy()
+
+			err := controller.deleteAllCRs(context.TODO(), apibindingCopy)
+
+			if !matchErrors(err, tt.expectErrorOnDelete) {
+				t.Errorf("expected error %q when syncing namespace, got %q", tt.expectErrorOnDelete, err)
+			}
+
+			for _, expCondition := range tt.expectConditions {
+				cond := conditions.Get(apibindingCopy, expCondition.Type)
+				if cond == nil {
+					t.Fatalf("Missing status condition %v", expCondition.Type)
+				}
+
+				if cond.Status != expCondition.Status {
+					t.Errorf("expect condition status %q, got %q for type %s", expCondition.Status, cond.Status, cond.Type)
+				}
+
+				if cond.Reason != expCondition.Reason {
+					t.Errorf("expect condition reason %q, got %q for type %s", expCondition.Reason, cond.Reason, cond.Type)
+				}
+			}
+
+			if len(mockMetadataClient.Actions()) != len(tt.metadataClientActionSet) {
+				t.Fatalf("mismatched actions, expect %d actions, got %d actions", len(tt.metadataClientActionSet), len(mockMetadataClient.Actions()))
+			}
+
+			for index, action := range mockMetadataClient.Actions() {
+				if !tt.metadataClientActionSet.match(action) {
+					t.Errorf("expect action for resource %q for verb %q but got %v", tt.metadataClientActionSet[index].resource, tt.metadataClientActionSet[index].verb, action)
+				}
+			}
+		})
+	}
+}
+
+type metaAction struct {
+	resource string
+	verb     string
+}
+
+type metaActionSet []metaAction
+
+func (m metaActionSet) match(action clienttesting.Action) bool {
+	for _, a := range m {
+		if action.Matches(a.verb, a.resource) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchError returns true if errors match, false if they don't, compares by error message only for convenience which should be sufficient for these tests
+func matchErrors(e1, e2 error) bool {
+	if e1 == nil && e2 == nil {
+		return true
+	}
+	if e1 != nil && e2 != nil {
+		return e1.Error() == e2.Error()
+	}
+	return false
+}
+
+func newPartialObject(apiversion, kind, name, namespace string, finlizers []string) *metav1.PartialObjectMetadata {
+	return &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiversion,
+			Kind:       kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: finlizers,
+		},
+	}
+}

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+func TestAPIBindingDeletion(t *testing.T) {
+	t.Parallel()
+
+	server := framework.SharedKcpServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg := server.DefaultConfig(t)
+
+	kcpClients, err := clientset.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	dynamicClients, err := dynamic.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(serviceProviderWorkspace).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Create an APIExport for it")
+	cowboysAPIExport := &apisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha1.APIExportSpec{
+			LatestResourceSchemas: []string{"today.cowboys.wildwest.dev"},
+		},
+	}
+	_, err = kcpClients.Cluster(serviceProviderWorkspace).ApisV1alpha1().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create an APIBinding in consumer workspace %q that points to the today-cowboys export from %q", consumerWorkspace, serviceProviderWorkspace)
+	apiBinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys",
+		},
+		Spec: apisv1alpha1.APIBindingSpec{
+			Reference: apisv1alpha1.ExportReference{
+				Workspace: &apisv1alpha1.WorkspaceExportReference{
+					WorkspaceName: serviceProviderWorkspace.Base(),
+					ExportName:    "today-cowboys",
+				},
+			},
+		},
+	}
+
+	_, err = kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Should have finalizer added in apibinding")
+	require.Eventually(t, func() bool {
+		apibinding, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Get(ctx, apiBinding.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		if len(apibinding.Finalizers) == 0 {
+			return false
+		}
+
+		return true
+	}, wait.ForeverTestTimeout, 1*time.Second)
+
+	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerWorkspace)
+	err = wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(c context.Context) (done bool, err error) {
+		groups, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerWorkspace, err)
+		}
+		return groupExists(groups, wildwest.GroupName), nil
+	})
+	require.NoError(t, err)
+
+	wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(cfg)
+	require.NoError(t, err)
+
+	t.Logf("Create a cowboy CR in consumer workspace %q", consumerWorkspace)
+	cowboyClient := wildwestClusterClient.Cluster(consumerWorkspace).WildwestV1alpha1().Cowboys("default")
+	cowboy := &wildwestv1alpha1.Cowboy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("cowboy-1-%s", consumerWorkspace.Base()),
+			Namespace: "default",
+		},
+	}
+	_, err = cowboyClient.Create(ctx, cowboy, metav1.CreateOptions{})
+	require.NoError(t, err, "error creating cowboy in consumer workspace %q", consumerWorkspace)
+
+	t.Logf("Create a cowboy CR with finalizer in consumer workspace %q", consumerWorkspace)
+	cowboyName := fmt.Sprintf("cowboy-2-%s", consumerWorkspace.Base())
+	cowboy = &wildwestv1alpha1.Cowboy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       cowboyName,
+			Namespace:  "default",
+			Finalizers: []string{"tenancy.kcp.dev/test-finalizer"},
+		},
+	}
+	_, err = cowboyClient.Create(ctx, cowboy, metav1.CreateOptions{})
+	require.NoError(t, err, "error creating cowboy in consumer workspace %q", consumerWorkspace)
+
+	err = kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Delete(ctx, apiBinding.Name, metav1.DeleteOptions{})
+	require.NoError(t, err)
+
+	t.Logf("There should left 1 cowboy CR in delete state")
+	require.Eventually(t, func() bool {
+		cowboys, err := cowboyClient.List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+
+		if len(cowboys.Items) != 1 {
+			return false
+		}
+
+		return !cowboys.Items[0].DeletionTimestamp.IsZero()
+	}, wait.ForeverTestTimeout, 1*time.Second)
+
+	t.Logf("apibinding should have BindingResourceDeleteSuccess with false status")
+	require.Eventually(t, func() bool {
+		apibinding, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Get(ctx, apiBinding.Name, metav1.GetOptions{})
+		if err != nil {
+			return false
+		}
+
+		return conditions.IsFalse(apibinding, apisv1alpha1.BindingResourceDeleteSuccess)
+	}, wait.ForeverTestTimeout, 1*time.Second)
+
+	t.Logf("Clean finalizer to remove the cowboy")
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cowboy, err = cowboyClient.Get(ctx, cowboyName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		cowboy.Finalizers = []string{}
+		_, err := cowboyClient.Update(ctx, cowboy, metav1.UpdateOptions{})
+		return err
+	})
+	require.NoError(t, err, "failed to update cowoby %s", cowboyName)
+
+	t.Logf("apibinding should be deleted")
+	require.Eventually(t, func() bool {
+		_, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Get(ctx, apiBinding.Name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, wait.ForeverTestTimeout, 1*time.Second)
+}

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -109,7 +109,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 		}
 
 		return true
-	}, wait.ForeverTestTimeout, 1*time.Second)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerWorkspace)
 	err = wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(c context.Context) (done bool, err error) {
@@ -162,7 +162,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 		}
 
 		return !cowboys.Items[0].DeletionTimestamp.IsZero()
-	}, wait.ForeverTestTimeout, 1*time.Second)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 	t.Logf("apibinding should have BindingResourceDeleteSuccess with false status")
 	require.Eventually(t, func() bool {
@@ -172,7 +172,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 		}
 
 		return conditions.IsFalse(apibinding, apisv1alpha1.BindingResourceDeleteSuccess)
-	}, wait.ForeverTestTimeout, 1*time.Second)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 	t.Logf("Clean finalizer to remove the cowboy")
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -190,5 +190,5 @@ func TestAPIBindingDeletion(t *testing.T) {
 	require.Eventually(t, func() bool {
 		_, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Get(ctx, apiBinding.Name, metav1.GetOptions{})
 		return apierrors.IsNotFound(err)
-	}, wait.ForeverTestTimeout, 1*time.Second)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 }

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -120,11 +120,12 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				}, wait.ForeverTestTimeout, 1*time.Second)
 
 				t.Logf("Clean finalizer to remove the configmap")
-				configmap, err = kubeClient.CoreV1().ConfigMaps(metav1.NamespaceDefault).Get(ctx, configmap.Name, metav1.GetOptions{})
-				require.NoError(t, err, "failed to get configmap in workspace %s", workspace.Name)
-
-				configmap.Finalizers = []string{}
 				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+					configmap, err = kubeClient.CoreV1().ConfigMaps(metav1.NamespaceDefault).Get(ctx, configmap.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					configmap.Finalizers = []string{}
 					_, err := kubeClient.CoreV1().ConfigMaps(metav1.NamespaceDefault).Update(ctx, configmap, metav1.UpdateOptions{})
 					return err
 				})


### PR DESCRIPTION
Signed-off-by: Jian Qiu <jqiu@redhat.com>


## Summary

add controller to delete all CRs with apibinding is deleting

followup: avoid CR creation when apibinding is deleting

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/846