### PR TITLE
authorization: nits

### DIFF
--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -84,13 +84,13 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 	}
 
 	// get org in the root
-	requestTopLevelOrg, ok := topLevelOrg(cluster.Name)
+	requestTopLevelOrgName, ok := topLevelOrg(cluster.Name)
 	if !ok {
 		return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
 	}
 
 	// check the org in the root exists
-	if _, err := a.clusterWorkspaceLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, requestTopLevelOrg)); err != nil {
+	if _, err := a.clusterWorkspaceLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, requestTopLevelOrgName)); err != nil {
 		if errors.IsNotFound(err) {
 			return authorizer.DecisionDeny, workspaceAccessNotPermittedReason, nil
 		}
@@ -99,8 +99,8 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 
 	if subjectCluster := attr.GetUser().GetExtra()[authserviceaccount.ClusterNameKey]; len(subjectCluster) > 0 {
 		// service account will automatically get access to its top-level org
-		subjectTopLevelOrg, ok := topLevelOrg(logicalcluster.New(subjectCluster[0]))
-		if !ok || subjectTopLevelOrg != requestTopLevelOrg {
+		subjectTopLevelOrgName, ok := topLevelOrg(logicalcluster.New(subjectCluster[0]))
+		if !ok || subjectTopLevelOrgName != requestTopLevelOrgName {
 			return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
 		}
 		return a.delegate.Authorize(ctx, attr)
@@ -117,7 +117,7 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 				APIVersion:  tenancyv1alpha1.SchemeGroupVersion.Version,
 				Resource:    "clusterworkspaces",
 				Subresource: "content",
-				Name:        requestTopLevelOrg,
+				Name:        requestTopLevelOrgName,
 
 				ResourceRequest: true,
 			}

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -35,7 +35,7 @@ import (
 	"k8s.io/client-go/tools/clusters"
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
-	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 	tenancyv1 "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 	rbacwrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/rbac"
@@ -79,7 +79,7 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 	}
 
 	// everybody authenticated has access to the root workspace
-	if cluster.Name == v1alpha1.RootCluster {
+	if cluster.Name == tenancyv1alpha1.RootCluster {
 		if sets.NewString(attr.GetUser().GetGroups()...).Has("system:authenticated") {
 			return a.delegate.Authorize(ctx, attributesWithReplacedGroups(attr, append(attr.GetUser().GetGroups(), bootstrap.SystemKcpClusterWorkspaceAccessGroup)))
 		}
@@ -114,8 +114,8 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 			workspaceAttr := authorizer.AttributesRecord{
 				User:            attr.GetUser(),
 				Verb:            attr.GetVerb(),
-				APIGroup:        v1alpha1.SchemeGroupVersion.Group,
-				APIVersion:      v1alpha1.SchemeGroupVersion.Version,
+				APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
+				APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
 				Resource:        "clusterworkspaces",
 				Subresource:     "initialize",
 				Name:            clusterWorkspace,
@@ -158,8 +158,8 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 			workspaceAttr := authorizer.AttributesRecord{
 				User:            attr.GetUser(),
 				Verb:            verb,
-				APIGroup:        v1alpha1.SchemeGroupVersion.Group,
-				APIVersion:      v1alpha1.SchemeGroupVersion.Version,
+				APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
+				APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
 				Resource:        "clusterworkspaces",
 				Subresource:     "content",
 				Name:            clusterWorkspace,


### PR DESCRIPTION
authz: use an import alias for tenancy api

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

top-level-authz: improve a name

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

I pulled these out from some draft PR that @sttts had ... figured we can merge as-is

/cc @sttts @ncdc 