### PR TITLE
WIP: Add APIExport virtual workspace

### DIFF
--- a/pkg/apis/apiresource/v1alpha1/common_types.go
+++ b/pkg/apis/apiresource/v1alpha1/common_types.go
@@ -35,6 +35,10 @@ type ColumnDefinition struct {
 type ColumnDefinitions []ColumnDefinition
 
 func (cd *ColumnDefinitions) ImportFromCRDVersion(crdVersion *apiextensionsv1.CustomResourceDefinitionVersion) *ColumnDefinitions {
+	return cd.ImportFromCRDAdditionalPrinterColumns(crdVersion.AdditionalPrinterColumns)
+}
+
+func (cd *ColumnDefinitions) ImportFromCRDAdditionalPrinterColumns(in []apiextensionsv1.CustomResourceColumnDefinition) *ColumnDefinitions {
 	alreadyExists := func(name string) bool {
 		for _, colDef := range *cd {
 			if colDef.Name == name {
@@ -44,7 +48,7 @@ func (cd *ColumnDefinitions) ImportFromCRDVersion(crdVersion *apiextensionsv1.Cu
 		return false
 	}
 
-	for _, apc := range crdVersion.AdditionalPrinterColumns {
+	for _, apc := range in {
 		if !alreadyExists(apc.Name) {
 			jsonPath := apc.JSONPath
 			*cd = append(*cd, ColumnDefinition{

--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -322,6 +322,20 @@ type SchemaConverter struct {
 	visited     sets.String
 }
 
+func Convert(protoSchema proto.Schema, schemaProps *apiextensionsv1.JSONSchemaProps) []error {
+	swaggerSpecDefinitionName := protoSchema.GetPath().String()
+
+	var errors []error
+	converter := &SchemaConverter{
+		schemaProps: schemaProps,
+		schemaName:  swaggerSpecDefinitionName,
+		visited:     sets.NewString(),
+		errors:      &errors,
+	}
+	protoSchema.Accept(converter)
+	return *converter.errors
+}
+
 var _ proto.SchemaVisitorArbitrary = (*SchemaConverter)(nil)
 
 func (sc *SchemaConverter) setupDescription(schema proto.Schema) {

--- a/pkg/virtual/apiexport/api_set_retriever.go
+++ b/pkg/virtual/apiexport/api_set_retriever.go
@@ -1,0 +1,177 @@
+package apiexport
+
+import (
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/kube-openapi/pkg/validation/validate"
+
+	"github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+	registry "github.com/kcp-dev/kcp/pkg/virtual/framework/forwardingregistry"
+)
+
+type apiSetRetriever struct {
+	genericConfig genericapiserver.CompletedConfig
+
+	dynamicClusterClient dynamic.ClusterInterface
+
+	getAPIExport         func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIExport, error)
+	getAPIResourceSchema func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error)
+}
+
+func (a *apiSetRetriever) GetAPIDefinitionSet(key dynamiccontext.APIDomainKey) (apis apidefinition.APIDefinitionSet, apisExist bool) {
+	parts := strings.Split(string(key), "/")
+	if len(parts) != 3 {
+		return
+	}
+
+	apiExportClusterName, apiExportName, identityHash := parts[0], parts[1], parts[2]
+	if apiExportClusterName == "" {
+		return
+	}
+	if apiExportName == "" {
+		return
+	}
+	if identityHash == "" {
+		return
+	}
+
+	clusterName := logicalcluster.New(apiExportClusterName)
+	apiExport, err := a.getAPIExport(clusterName, apiExportName)
+	if err != nil {
+		// TODO(ncdc): would be nice to expose some sort of user-visible error
+		return
+	}
+
+	if apiExport.Status.IdentityHash != identityHash {
+		// TODO(ncdc): is this right?
+		// TODO(ncdc): would be nice to expose some sort of user-visible error
+		return
+	}
+
+	apis = map[schema.GroupVersionResource]apidefinition.APIDefinition{}
+
+	for _, schemaName := range apiExport.Spec.LatestResourceSchemas {
+		apiResourceSchema, err := a.getAPIResourceSchema(clusterName, schemaName)
+		if err != nil {
+			// TODO(ncdc): would be nice to expose some sort of user-visible error
+			continue
+		}
+
+		for _, version := range apiResourceSchema.Spec.Versions {
+			gvr := schema.GroupVersionResource{
+				Group:    apiResourceSchema.Spec.Group,
+				Version:  version.Name,
+				Resource: apiResourceSchema.Spec.Names.Plural,
+			}
+
+			var subresources v1alpha1.SubResources
+			if version.Subresources.Status != nil {
+				subresources = append(subresources, v1alpha1.SubResource{Name: "status"})
+			}
+			if version.Subresources.Scale != nil {
+				subresources = append(subresources, v1alpha1.SubResource{Name: "scale"})
+			}
+
+			var columnDefinitions v1alpha1.ColumnDefinitions
+			columnDefinitions.ImportFromCRDAdditionalPrinterColumns(version.AdditionalPrinterColumns)
+
+			apiResourceSpec := &v1alpha1.CommonAPIResourceSpec{
+				GroupVersion: v1alpha1.GroupVersion{
+					Group:   gvr.Group,
+					Version: gvr.Version,
+				},
+				Scope:                         apiResourceSchema.Spec.Scope,
+				CustomResourceDefinitionNames: apiResourceSchema.Spec.Names,
+				OpenAPIV3Schema:               version.Schema,
+				SubResources:                  subresources,
+				ColumnDefinitions:             columnDefinitions,
+			}
+
+			apiDefinition, err := apiserver.CreateServingInfoFor(
+				a.genericConfig,
+				clusterName,
+				apiResourceSpec,
+				provideForwardingRestStorage(a.dynamicClusterClient, identityHash),
+			)
+			if err != nil {
+				// TODO(ncdc): would be nice to expose some sort of user-visible error
+				continue
+			}
+
+			apis[gvr] = apiDefinition
+		}
+	}
+
+	return apis, len(apis) > 0
+}
+
+func provideForwardingRestStorage(clusterClient dynamic.ClusterInterface, identityHash string) apiserver.RestProviderFunc {
+	return func(
+		resource schema.GroupVersionResource,
+		kind schema.GroupVersionKind,
+		listKind schema.GroupVersionKind,
+		typer runtime.ObjectTyper,
+		tableConvertor rest.TableConvertor,
+		namespaceScoped bool,
+		schemaValidator *validate.SchemaValidator,
+		subresourcesSchemaValidator map[string]*validate.SchemaValidator,
+		structuralSchema *structuralschema.Structural,
+	) (mainStorage rest.Storage, subresourceStorages map[string]rest.Storage) {
+		resource.Resource += ":" + identityHash
+
+		statusSchemaValidate, statusEnabled := subresourcesSchemaValidator["status"]
+
+		var statusSpec *apiextensions.CustomResourceSubresourceStatus
+		if statusEnabled {
+			statusSpec = &apiextensions.CustomResourceSubresourceStatus{}
+		}
+
+		var scaleSpec *apiextensions.CustomResourceSubresourceScale
+		// TODO(sttts): implement scale subresource
+
+		strategy := customresource.NewStrategy(
+			typer,
+			namespaceScoped,
+			kind,
+			schemaValidator,
+			statusSchemaValidate,
+			map[string]*structuralschema.Structural{resource.Version: structuralSchema},
+			statusSpec,
+			scaleSpec,
+		)
+
+		storage := registry.NewStorage(
+			resource,
+			kind,
+			listKind,
+			strategy,
+			nil,
+			tableConvertor,
+			nil,
+			clusterClient,
+			nil,
+		)
+
+		subresourceStorages = make(map[string]rest.Storage)
+		if statusEnabled {
+			subresourceStorages["status"] = storage.Status
+		}
+
+		// TODO(sttts): add scale subresource
+
+		return storage.CustomResource, subresourceStorages
+	}
+}

--- a/pkg/virtual/apiexport/builder.go
+++ b/pkg/virtual/apiexport/builder.go
@@ -1,0 +1,115 @@
+package apiexport
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clusters"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	virtualdynamic "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+const VirtualWorkspaceName string = "apiexport"
+
+func NewVirtualWorkspace(
+	rootPathPrefix string,
+	dynamicClusterClient dynamic.ClusterInterface,
+	apiExportInformer apisinformers.APIExportInformer,
+	apiResourceSchemaInformer apisinformers.APIResourceSchemaInformer,
+) framework.VirtualWorkspace {
+	virtualWorkspacePathPrefix := path.Join(rootPathPrefix, VirtualWorkspaceName)
+
+	if !strings.HasSuffix(virtualWorkspacePathPrefix, "/") {
+		virtualWorkspacePathPrefix += "/"
+	}
+
+	return &virtualdynamic.DynamicVirtualWorkspace{
+		Name: VirtualWorkspaceName,
+
+		RootPathResolver: func(path string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+			completedContext = requestContext
+
+			if !strings.HasPrefix(path, virtualWorkspacePathPrefix) {
+				return
+			}
+
+			// /services/apiexport/$cluster/$apiExport/$identity/clusters/...
+
+			withoutRootPathPrefix := strings.TrimPrefix(path, virtualWorkspacePathPrefix)
+
+			parts := strings.SplitN(withoutRootPathPrefix, "/", 4)
+			if len(parts) < 3 {
+				return
+			}
+
+			apiExportClusterName, apiExportName, identityHash := parts[0], parts[1], parts[2]
+			if apiExportClusterName == "" {
+				return
+			}
+			if apiExportName == "" {
+				return
+			}
+			if identityHash == "" {
+				return
+			}
+
+			realPath := "/"
+			if len(parts) > 3 {
+				realPath += parts[3]
+			}
+
+			cluster := genericapirequest.Cluster{Name: logicalcluster.Wildcard, Wildcard: true}
+			if strings.HasPrefix(realPath, "/clusters/") {
+				withoutClustersPrefix := strings.TrimPrefix(realPath, "/clusters/")
+				parts = strings.SplitN(withoutClustersPrefix, "/", 2)
+
+				clusterName := parts[0]
+				realPath = "/"
+				if len(parts) > 1 {
+					realPath += parts[1]
+				}
+				cluster = genericapirequest.Cluster{Name: logicalcluster.New(clusterName)}
+				if clusterName == "*" {
+					cluster.Wildcard = true
+				}
+			}
+
+			completedContext = genericapirequest.WithCluster(requestContext, cluster)
+			key := fmt.Sprintf("%s/%s/%s", apiExportClusterName, apiExportName, identityHash)
+			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, dynamiccontext.APIDomainKey(key))
+
+			prefixToStrip = strings.TrimSuffix(path, realPath)
+			accepted = true
+
+			return
+		},
+
+		Ready: func() error {
+			return nil
+		},
+
+		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
+			return &apiSetRetriever{
+				genericConfig:        mainConfig,
+				dynamicClusterClient: dynamicClusterClient,
+				getAPIExport: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIExport, error) {
+					return apiExportInformer.Lister().Get(clusters.ToClusterAwareKey(clusterName, name))
+				},
+				getAPIResourceSchema: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
+					return apiResourceSchemaInformer.Lister().Get(clusters.ToClusterAwareKey(clusterName, name))
+				},
+			}, nil
+		},
+	}
+}

--- a/pkg/virtual/framework/dynamic/apidefinition/fixtures/configmaps.yaml
+++ b/pkg/virtual/framework/dynamic/apidefinition/fixtures/configmaps.yaml
@@ -1,0 +1,45 @@
+groupVersion:
+  version: v1
+kind: ConfigMap
+openAPIV3Schema:
+  description: ConfigMap holds configuration data for pods to consume.
+  properties:
+    apiVersion:
+      description: 'APIVersion defines the versioned schema of this representation
+        of an object. Servers should convert recognized schemas to the latest internal
+        value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+      type: string
+    binaryData:
+      additionalProperties:
+        format: byte
+        type: string
+      description: BinaryData contains the binary data. Each key must consist of alphanumeric
+        characters, '-', '_' or '.'. BinaryData can contain byte sequences that are
+        not in the UTF-8 range. The keys stored in BinaryData must not overlap with
+        the ones in the Data field, this is enforced during validation process. Using
+        this field will require 1.10+ apiserver and kubelet.
+      type: object
+    data:
+      additionalProperties:
+        type: string
+      description: Data contains the configuration data. Each key must consist of
+        alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences
+        must use the BinaryData field. The keys stored in Data must not overlap with
+        the keys in the BinaryData field, this is enforced during validation process.
+      type: object
+    immutable:
+      description: Immutable, if set to true, ensures that data stored in the ConfigMap
+        cannot be updated (only object metadata can be modified). If not set to true,
+        the field can be modified at any time. Defaulted to nil.
+      type: boolean
+    kind:
+      description: 'Kind is a string value representing the REST resource this object
+        represents. Servers may infer this from the endpoint the client submits requests
+        to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+      type: string
+    metadata:
+      type: object
+  type: object
+plural: configmaps
+scope: Namespaced
+singular: configmap

--- a/pkg/virtual/framework/dynamic/apidefinition/fixtures/namespaces.yaml
+++ b/pkg/virtual/framework/dynamic/apidefinition/fixtures/namespaces.yaml
@@ -1,0 +1,83 @@
+groupVersion:
+  version: v1
+kind: Namespace
+openAPIV3Schema:
+  description: Namespace provides a scope for Names. Use of multiple namespaces is
+    optional.
+  properties:
+    apiVersion:
+      description: 'APIVersion defines the versioned schema of this representation
+        of an object. Servers should convert recognized schemas to the latest internal
+        value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+      type: string
+    kind:
+      description: 'Kind is a string value representing the REST resource this object
+        represents. Servers may infer this from the endpoint the client submits requests
+        to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+      type: string
+    metadata:
+      type: object
+    spec:
+      description: 'Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+      properties:
+        finalizers:
+          description: 'Finalizers is an opaque list of values that must be empty
+            to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/'
+          items:
+            type: string
+          type: array
+      type: object
+    status:
+      description: 'Status describes the current status of a Namespace. More info:
+        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+      properties:
+        conditions:
+          description: Represents the latest available observations of a namespace's
+            current state.
+          items:
+            description: NamespaceCondition contains details about state of namespace.
+            properties:
+              lastTransitionTime:
+                format: date-time
+                type: string
+              message:
+                type: string
+              reason:
+                type: string
+              status:
+                description: Status of the condition, one of True, False, Unknown.
+                type: string
+              type:
+                description: |-
+                  Type of namespace controller condition.
+
+                  Possible enum values:
+                   - `"NamespaceContentRemaining"` contains information about resources remaining in a namespace.
+                   - `"NamespaceDeletionContentFailure"` contains information about namespace deleter errors during deletion of resources.
+                   - `"NamespaceDeletionDiscoveryFailure"` contains information about namespace deleter errors during resource discovery.
+                   - `"NamespaceDeletionGroupVersionParsingFailure"` contains information about namespace deleter errors parsing GV for legacy types.
+                   - `"NamespaceFinalizersRemaining"` contains information about which finalizers are on resources remaining in a namespace.
+                type: string
+            required:
+            - status
+            - type
+            type: object
+          type: array
+          x-kubernetes-list-map-keys:
+          - type
+          x-kubernetes-list-type: map
+        phase:
+          description: |-
+            Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+
+            Possible enum values:
+             - `"Active"` means the namespace is available for use in the system
+             - `"Terminating"` means the namespace is undergoing graceful termination
+          type: string
+      type: object
+  type: object
+plural: namespaces
+scope: Cluster
+singular: namespace
+subResources:
+- name: status

--- a/pkg/virtual/framework/dynamic/apidefinition/fixtures/workloadclusters.yaml
+++ b/pkg/virtual/framework/dynamic/apidefinition/fixtures/workloadclusters.yaml
@@ -1,0 +1,114 @@
+groupVersion:
+  group: workload.kcp.dev
+  version: v1alpha1
+kind: WorkloadCluster
+openAPIV3Schema:
+  description: WorkloadCluster describes a member cluster capable of running workloads.
+  properties:
+    apiVersion:
+      description: 'APIVersion defines the versioned schema of this representation
+        of an object. Servers should convert recognized schemas to the latest internal
+        value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+      type: string
+    kind:
+      description: 'Kind is a string value representing the REST resource this object
+        represents. Servers may infer this from the endpoint the client submits requests
+        to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+      type: string
+    metadata:
+      type: object
+    spec:
+      description: Spec holds the desired state.
+      properties:
+        evictAfter:
+          description: EvictAfter controls cluster schedulability of new and existing
+            workloads. After the EvictAfter time, any workload scheduled to the cluster
+            will be unassigned from the cluster. By default, workloads scheduled to
+            the cluster are not evicted.
+          format: date-time
+          type: string
+        unschedulable:
+          description: Unschedulable controls cluster schedulability of new workloads.
+            By default, cluster is schedulable.
+          type: boolean
+      type: object
+    status:
+      description: Status communicates the observed state.
+      properties:
+        allocatable:
+          additionalProperties:
+            anyOf:
+            - type: integer
+            - type: string
+            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+            x-kubernetes-int-or-string: true
+          description: Allocatable represents the resources that are available for
+            scheduling.
+          type: object
+        capacity:
+          additionalProperties:
+            anyOf:
+            - type: integer
+            - type: string
+            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+            x-kubernetes-int-or-string: true
+          description: Capacity represents the total resources of the cluster.
+          type: object
+        conditions:
+          description: Current processing state of the WorkloadCluster.
+          items:
+            description: Condition defines an observation of a object operational
+              state.
+            properties:
+              lastTransitionTime:
+                description: Last time the condition transitioned from one status
+                  to another. This should be when the underlying condition changed.
+                  If that is not known, then using the time when the API field changed
+                  is acceptable.
+                format: date-time
+                type: string
+              message:
+                description: A human readable message indicating details about the
+                  transition. This field may be empty.
+                type: string
+              reason:
+                description: The reason for the condition's last transition in CamelCase.
+                  The specific API may choose whether or not this field is considered
+                  a guaranteed API. This field may not be empty.
+                type: string
+              severity:
+                description: Severity provides an explicit classification of Reason
+                  code, so the users or machines can immediately understand the current
+                  situation and act accordingly. The Severity field MUST be set only
+                  when Status=False.
+                type: string
+              status:
+                description: Status of the condition, one of True, False, Unknown.
+                type: string
+              type:
+                description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                  Many .condition.type values are consistent across resources like
+                  Available, but because arbitrary conditions can be useful (see .node.status.conditions),
+                  the ability to deconflict is important.
+                type: string
+            required:
+            - type
+            - status
+            - lastTransitionTime
+            type: object
+          type: array
+        lastSyncerHeartbeatTime:
+          description: A timestamp indicating when the syncer last reported status.
+          format: date-time
+          type: string
+        syncedResources:
+          items:
+            type: string
+          type: array
+      type: object
+  type: object
+plural: workloadclusters
+scope: Cluster
+singular: workloadcluster
+subResources:
+- name: status

--- a/pkg/virtual/framework/dynamic/apidefinition/internalapis.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/internalapis.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apidefinition
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
+	endpointsopenapi "k8s.io/apiserver/pkg/endpoints/openapi"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/util/openapi"
+	builder "k8s.io/kube-openapi/pkg/builder"
+	common "k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/util"
+
+	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/crdpuller"
+)
+
+// InternalAPI describes an API to be imported from some schemes and generated OpenAPI V2 definitions
+type InternalAPI struct {
+	names     apiextensionsv1.CustomResourceDefinitionNames
+	gv        schema.GroupVersion
+	instance  runtime.Object
+	scope     apiextensionsv1.ResourceScope
+	hasStatus bool
+}
+
+// KCPInternalAPIs provides a list of InternalAPI for the APIs that are part of the KCP scheme and will be there in every KCP workspace
+var KCPInternalAPIs = []InternalAPI{
+	{
+		names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "namespaces",
+			Singular: "namespace",
+			Kind:     "Namespace",
+		},
+		gv:        schema.GroupVersion{Group: "", Version: "v1"},
+		instance:  &corev1.Namespace{},
+		scope:     apiextensionsv1.ClusterScoped,
+		hasStatus: true,
+	},
+	{
+		names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "configmaps",
+			Singular: "configmap",
+			Kind:     "ConfigMap",
+		},
+		gv:       schema.GroupVersion{Group: "", Version: "v1"},
+		instance: &corev1.ConfigMap{},
+		scope:    apiextensionsv1.NamespaceScoped,
+	},
+	{
+		names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "secrets",
+			Singular: "secret",
+			Kind:     "Secret",
+		},
+		gv:       schema.GroupVersion{Group: "", Version: "v1"},
+		instance: &corev1.Secret{},
+		scope:    apiextensionsv1.NamespaceScoped,
+	},
+	{
+		names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "serviceaccounts",
+			Singular: "serviceaccount",
+			Kind:     "ServiceAccount",
+		},
+		gv:       schema.GroupVersion{Group: "", Version: "v1"},
+		instance: &corev1.ServiceAccount{},
+		scope:    apiextensionsv1.NamespaceScoped,
+	},
+}
+
+func ImportInternalAPIs(schemes []*runtime.Scheme, openAPIDefinitionsGetters []common.GetOpenAPIDefinitions, defs ...InternalAPI) ([]*apiresourcev1alpha1.CommonAPIResourceSpec, error) {
+	config := genericapiserver.DefaultOpenAPIConfig(func(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
+		result := make(map[string]common.OpenAPIDefinition)
+
+		for _, openAPIDefinitionsGetter := range openAPIDefinitionsGetters {
+			for key, val := range openAPIDefinitionsGetter(ref) {
+				result[key] = val
+			}
+			for key, val := range openAPIDefinitionsGetter(ref) {
+				result[key] = val
+			}
+		}
+
+		return result
+	}, endpointsopenapi.NewDefinitionNamer(schemes...))
+
+	var canonicalTypeNames []string
+	for _, def := range defs {
+		canonicalTypeNames = append(canonicalTypeNames, util.GetCanonicalTypeName(def.instance))
+	}
+	swagger, err := builder.BuildOpenAPIDefinitionsForResources(config, canonicalTypeNames...)
+	if err != nil {
+		return nil, err
+	}
+	swagger.Info.Version = "1.0"
+	models, err := openapi.ToProtoModels(swagger)
+	if err != nil {
+		return nil, err
+	}
+
+	modelsByGKV, err := endpointsopenapi.GetModelsByGKV(models)
+	if err != nil {
+		return nil, err
+	}
+
+	var apis []*apiresourcev1alpha1.CommonAPIResourceSpec
+	for _, def := range defs {
+		gvk := def.gv.WithKind(def.names.Kind)
+		var schemaProps apiextensionsv1.JSONSchemaProps
+		errs := crdpuller.Convert(modelsByGKV[gvk], &schemaProps)
+		if len(errs) > 0 {
+			return nil, errors.NewAggregate(errs)
+		}
+		spec := &apiresourcev1alpha1.CommonAPIResourceSpec{
+			GroupVersion:                  apiresourcev1alpha1.GroupVersion(gvk.GroupVersion()),
+			Scope:                         def.scope,
+			CustomResourceDefinitionNames: def.names,
+		}
+		if def.hasStatus {
+			spec.SubResources = append(spec.SubResources, apiresourcev1alpha1.SubResource{
+				Name: apiresourcev1alpha1.StatusSubResourceName,
+			})
+		}
+		if err := spec.SetSchema(&schemaProps); err != nil {
+			return nil, err
+		}
+
+		apis = append(apis, spec)
+	}
+	return apis, nil
+}

--- a/pkg/virtual/framework/dynamic/apidefinition/internalapis.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/internalapis.go
@@ -95,9 +95,6 @@ func ImportInternalAPIs(schemes []*runtime.Scheme, openAPIDefinitionsGetters []c
 			for key, val := range openAPIDefinitionsGetter(ref) {
 				result[key] = val
 			}
-			for key, val := range openAPIDefinitionsGetter(ref) {
-				result[key] = val
-			}
 		}
 
 		return result

--- a/pkg/virtual/framework/dynamic/apidefinition/internalapis_test.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/internalapis_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apidefinition
+
+import (
+	"embed"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	common "k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	k8sopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	kcpopenapi "github.com/kcp-dev/kcp/pkg/openapi"
+)
+
+//go:embed fixtures/*.yaml
+var embeddedResources embed.FS
+
+func TestImportInternalAPIs(t *testing.T) {
+	apisToImport := []InternalAPI{
+		{
+			names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "namespaces",
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+			gv:        schema.GroupVersion{Group: "", Version: "v1"},
+			instance:  &corev1.Namespace{},
+			scope:     apiextensionsv1.ClusterScoped,
+			hasStatus: true,
+		},
+		{
+			names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "configmaps",
+				Singular: "configmap",
+				Kind:     "ConfigMap",
+			},
+			gv:       schema.GroupVersion{Group: "", Version: "v1"},
+			instance: &corev1.ConfigMap{},
+			scope:    apiextensionsv1.NamespaceScoped,
+		},
+		{
+			names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   "workloadclusters",
+				Singular: "workloadcluster",
+				Kind:     "WorkloadCluster",
+			},
+			gv:        schema.GroupVersion{Group: "workload.kcp.dev", Version: "v1alpha1"},
+			instance:  &v1alpha1.WorkloadCluster{},
+			scope:     apiextensionsv1.ClusterScoped,
+			hasStatus: true,
+		},
+	}
+	tenancyScheme := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(tenancyScheme)
+	require.NoError(t, err)
+	importedAPISpecs, err := ImportInternalAPIs(
+		[]*runtime.Scheme{legacyscheme.Scheme, tenancyScheme},
+		[]common.GetOpenAPIDefinitions{k8sopenapi.GetOpenAPIDefinitions, kcpopenapi.GetOpenAPIDefinitions},
+		apisToImport...)
+	require.NoError(t, err)
+	require.Len(t, importedAPISpecs, 3)
+	for _, importedAPISpec := range importedAPISpecs {
+		expectedContent, err := embeddedResources.ReadFile(path.Join("fixtures", importedAPISpec.Plural+".yaml"))
+		require.NoError(t, err)
+		actualContent, err := yaml.Marshal(importedAPISpec)
+		require.NoError(t, err)
+		assert.Equal(t, string(expectedContent), string(actualContent))
+	}
+}

--- a/pkg/virtual/framework/dynamic/apidefinition/types.go
+++ b/pkg/virtual/framework/dynamic/apidefinition/types.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 )
 
 // APIDefinition provides access to all the information needed to serve a given API resource
@@ -53,7 +54,7 @@ type APIDefinitionSet map[schema.GroupVersionResource]APIDefinition
 
 // APIDefinitionSetGetter provides access to the API definitions of a API domain, based on the API domain key.
 type APIDefinitionSetGetter interface {
-	GetAPIDefinitionSet(apiDomainKey string) (apis APIDefinitionSet, apisExist bool)
+	GetAPIDefinitionSet(key dynamiccontext.APIDomainKey) (apis APIDefinitionSet, apisExist bool)
 }
 
 // CreateAPIDefinitionFunc is the type of a function which allows creating an APIDefinition

--- a/pkg/virtual/framework/dynamic/apiserver/discovery.go
+++ b/pkg/virtual/framework/dynamic/apiserver/discovery.go
@@ -59,7 +59,7 @@ func (r *versionDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Req
 
 	ctx := req.Context()
 
-	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
+	apiDomainKey := dyncamiccontext.APIDomainKeyFrom(ctx)
 
 	apiSet, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
 	if !hasLocationKey {
@@ -150,7 +150,7 @@ func (r *groupDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reque
 
 	ctx := req.Context()
 
-	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
+	apiDomainKey := dyncamiccontext.APIDomainKeyFrom(ctx)
 
 	apiSet, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
 	if !hasLocationKey {
@@ -209,7 +209,7 @@ func (r *rootDiscoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Reques
 	versionsForDiscoveryMap := map[string]map[metav1.GroupVersion]bool{}
 
 	ctx := req.Context()
-	apiDomainKey := dyncamiccontext.APIDomainKeyFromContext(ctx)
+	apiDomainKey := dyncamiccontext.APIDomainKeyFrom(ctx)
 
 	apiSet, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(apiDomainKey)
 	if !hasLocationKey {

--- a/pkg/virtual/framework/dynamic/apiserver/handler.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler.go
@@ -129,7 +129,7 @@ func (r *resourceHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	locationKey := dynamiccontext.APIDomainKeyFromContext(ctx)
+	locationKey := dynamiccontext.APIDomainKeyFrom(ctx)
 
 	apiDefs, hasLocationKey := r.apiSetRetriever.GetAPIDefinitionSet(locationKey)
 	if !hasLocationKey {

--- a/pkg/virtual/framework/dynamic/apiserver/handler_test.go
+++ b/pkg/virtual/framework/dynamic/apiserver/handler_test.go
@@ -47,7 +47,7 @@ type mockedAPISetRetriever apidefinition.APIDefinitionSet
 
 var _ apidefinition.APIDefinitionSetGetter = (*mockedAPISetRetriever)(nil)
 
-func (masr mockedAPISetRetriever) GetAPIDefinitionSet(apiDomainKey string) (apis apidefinition.APIDefinitionSet, apisExist bool) {
+func (masr mockedAPISetRetriever) GetAPIDefinitionSet(key dyncamiccontext.APIDomainKey) (apis apidefinition.APIDefinitionSet, apisExist bool) {
 	return apidefinition.APIDefinitionSet(masr), true
 }
 

--- a/pkg/virtual/framework/dynamic/context/keys.go
+++ b/pkg/virtual/framework/dynamic/context/keys.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package context
 
-import "context"
+import (
+	"context"
+)
 
 // apiDomainKeyContextKeyType is the type of the key for the request context value
 // that will carry the API domain key.
@@ -26,13 +28,18 @@ type apiDomainKeyContextKeyType string
 // that will carry the API domain key.
 const apiDomainKeyContextKey apiDomainKeyContextKeyType = "VirtualWorkspaceAPIDomainKey"
 
+// APIDomainKey is a string key identifying the API domain serving a kube-like API surface. Depending
+// on the dynamic virtual workspace, the structure of the key will vary. The APIDomainKey is usually
+// derived from URL path segments.
+type APIDomainKey string
+
 // WithAPIDomainKey adds an API domain key to the context.
-func WithAPIDomainKey(ctx context.Context, apiDomainKey string) context.Context {
+func WithAPIDomainKey(ctx context.Context, apiDomainKey APIDomainKey) context.Context {
 	return context.WithValue(ctx, apiDomainKeyContextKey, apiDomainKey)
 }
 
-// APIDomainKeyFromContext retrieves the API domain key from the context, if any.
-func APIDomainKeyFromContext(ctx context.Context) string {
-	s, _ := ctx.Value(apiDomainKeyContextKey).(string)
-	return s
+// APIDomainKeyFrom retrieves the API domain key from the context, if any.
+func APIDomainKeyFrom(ctx context.Context) APIDomainKey {
+	adk, _ := ctx.Value(apiDomainKeyContextKey).(APIDomainKey)
+	return adk
 }

--- a/pkg/virtual/framework/dynamic/example_test.go
+++ b/pkg/virtual/framework/dynamic/example_test.go
@@ -47,7 +47,7 @@ func Example() {
 				return
 			}
 
-			var apiDomainKey string
+			var apiDomainKey dynamiccontext.APIDomainKey
 
 			// Resolve the request root path and extract the API domain key from it
 

--- a/pkg/virtual/framework/forwardingregistry/rest_test.go
+++ b/pkg/virtual/framework/forwardingregistry/rest_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kcp-dev/logicalcluster"
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -50,15 +51,15 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/forwardingregistry"
 )
 
-type mockedClientGetter struct {
-	*fake.FakeDynamicClient
+type mockedClusterClient struct {
+	client *fake.FakeDynamicClient
 }
 
-func (mcg *mockedClientGetter) GetDynamicClient(ctx context.Context) (dynamic.Interface, error) {
-	return mcg.FakeDynamicClient, nil
+func (mcg *mockedClusterClient) Cluster(cluster logicalcluster.Name) dynamic.Interface {
+	return mcg.client
 }
 
-func newStorage(t *testing.T, clientGetter forwardingregistry.ClientGetter, patchConflictRetryBackoff *wait.Backoff) customresource.CustomResourceStorage {
+func newStorage(t *testing.T, clusterClient dynamic.ClusterInterface, patchConflictRetryBackoff *wait.Backoff) customresource.CustomResourceStorage {
 	groupResource := schema.GroupResource{Group: "mygroup.example.com", Resource: "noxus"}
 	gvr := groupResource.WithVersion("v1beta1")
 	groupVersion := gvr.GroupVersion()
@@ -105,7 +106,7 @@ func newStorage(t *testing.T, clientGetter forwardingregistry.ClientGetter, patc
 		nil,
 		table,
 		nil,
-		clientGetter,
+		clusterClient,
 		patchConflictRetryBackoff)
 }
 
@@ -134,8 +135,9 @@ func createResource(namespace, name string) *unstructured.Unstructured {
 
 func TestGet(t *testing.T) {
 	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
-	storage := newStorage(t, &mockedClientGetter{fakeClient}, nil)
+	storage := newStorage(t, &mockedClusterClient{fakeClient}, nil)
 	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 
 	_, err := storage.CustomResource.Get(ctx, "foo", &metav1.GetOptions{})
 	require.EqualError(t, err, "noxus.mygroup.example.com \"foo\" not found")
@@ -151,8 +153,9 @@ func TestGet(t *testing.T) {
 func TestList(t *testing.T) {
 	resources := []runtime.Object{createResource("default", "foo"), createResource("default", "foo2")}
 	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), resources...)
-	storage := newStorage(t, &mockedClientGetter{fakeClient}, nil)
+	storage := newStorage(t, &mockedClusterClient{fakeClient}, nil)
 	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 
 	result, err := storage.CustomResource.List(ctx, &internalversion.ListOptions{})
 	require.NoError(t, err)
@@ -171,8 +174,9 @@ func TestWatch(t *testing.T) {
 	fakeWatcher := watch.NewFake()
 	defer fakeWatcher.Stop()
 	fakeClient.PrependWatchReactor("noxus", kubernetestesting.DefaultWatchReactor(fakeWatcher, nil))
-	storage := newStorage(t, &mockedClientGetter{fakeClient}, nil)
+	storage := newStorage(t, &mockedClusterClient{fakeClient}, nil)
 	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 
 	watchedError := &v1.Status{
 		Status:  "Failure",
@@ -267,8 +271,9 @@ func TestUpdate(t *testing.T) {
 	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
 	fakeClient.PrependReactor("update", "noxus", updateReactor(fakeClient))
 
-	storage := newStorage(t, &mockedClientGetter{fakeClient}, nil)
+	storage := newStorage(t, &mockedClusterClient{fakeClient}, nil)
 	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 	updated := resource.DeepCopy()
 
 	newReplicas, _, err := unstructured.NestedInt64(updated.UnstructuredContent(), "spec", "replicas")
@@ -325,8 +330,9 @@ func TestStatusUpdate(t *testing.T) {
 	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme(), resource)
 	fakeClient.PrependReactor("update", "noxus", updateReactor(fakeClient))
 
-	storage := newStorage(t, &mockedClientGetter{fakeClient}, nil)
+	storage := newStorage(t, &mockedClusterClient{fakeClient}, nil)
 	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 	statusUpdated := resource.DeepCopy()
 	if err := unstructured.SetNestedField(statusUpdated.UnstructuredContent(), int64(10), "status", "availableReplicas"); err != nil {
 		require.NoError(t, err)
@@ -360,9 +366,10 @@ func TestPatch(t *testing.T) {
 
 	backoff := retry.DefaultRetry
 	backoff.Steps = 5
-	storage := newStorage(t, &mockedClientGetter{fakeClient}, &backoff)
+	storage := newStorage(t, &mockedClusterClient{fakeClient}, &backoff)
 	ctx := request.WithNamespace(context.Background(), "default")
 	ctx = request.WithRequestInfo(ctx, &request.RequestInfo{Verb: "patch"})
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 
 	patcher := func(ctx context.Context, newObj, oldObj runtime.Object) (runtime.Object, error) {
 		updated := oldObj.DeepCopyObject().(*unstructured.Unstructured)

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -25,6 +25,7 @@ import (
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/virtual/apiexport"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	workspacesoptions "github.com/kcp-dev/kcp/pkg/virtual/workspaces/options"
@@ -72,6 +73,9 @@ func (o *Options) NewVirtualWorkspaces(
 	}
 	extraInformers = append(extraInformers, inf...)
 	workspaces = append(workspaces, vws...)
+
+	vw := apiexport.NewVirtualWorkspace(rootPathPrefix, dynamicClusterClient, wildcardKcpInformers.Apis().V1alpha1().APIExports(), wildcardKcpInformers.Apis().V1alpha1().APIResourceSchemas())
+	workspaces = append(workspaces, vw)
 
 	return extraInformers, workspaces, nil
 }


### PR DESCRIPTION
## Summary
Add a virtual workspace for APIExports so API providers can consume only instances of their exported schemas by group+resource+identity.

## Related issue(s)

#981 