### PR TITLE
syncer: improve mutation + admission

### DIFF
--- a/pkg/syncer/spec/admitters/interface.go
+++ b/pkg/syncer/spec/admitters/interface.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mutators
+package admitters
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type Mutator interface {
+type Admitter interface {
 	GVR() schema.GroupVersionResource
-	Mutate(*unstructured.Unstructured) error
+	Admit(*unstructured.Unstructured) bool
 }

--- a/pkg/syncer/spec/admitters/serviceaccount_secrets.go
+++ b/pkg/syncer/spec/admitters/serviceaccount_secrets.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admitters
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+type ServiceAccountSecretAdmitter struct {
+}
+
+func (sm *ServiceAccountSecretAdmitter) GVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "secrets",
+	}
+}
+
+var _ Admitter = NewServiceAccountSecretAdmitter()
+
+func NewServiceAccountSecretAdmitter() *ServiceAccountSecretAdmitter {
+	return &ServiceAccountSecretAdmitter{}
+}
+
+// Admit determines if we should sync the object or not.
+func (sm *ServiceAccountSecretAdmitter) Admit(downstreamObj *unstructured.Unstructured) bool {
+	var secret corev1.Secret
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		downstreamObj.UnstructuredContent(),
+		&secret)
+	if err != nil {
+		klog.V(3).Infof("failed to convert from unstructured: %v", err)
+		return false
+	}
+
+	return secret.Type != corev1.SecretTypeServiceAccountToken
+}

--- a/pkg/syncer/spec/mutators/configmaps.go
+++ b/pkg/syncer/spec/mutators/configmaps.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ConfigMapMutator struct {
+}
+
+func (sm *ConfigMapMutator) GVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "configmaps",
+	}
+}
+
+var _ Mutator = NewConfigMapMutator()
+
+func NewConfigMapMutator() *ConfigMapMutator {
+	return &ConfigMapMutator{}
+}
+
+// Mutate applies the mutator changes to the object.
+func (sm *ConfigMapMutator) Mutate(downstreamObj *unstructured.Unstructured) error {
+	var configMap corev1.ConfigMap
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		downstreamObj.UnstructuredContent(),
+		&configMap)
+	if err != nil {
+		return err
+	}
+
+	if configMap.GetName() == "kube-root-ca.crt" {
+		configMap.SetName("kcp-root-ca.crt")
+	}
+
+	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&configMap)
+	if err != nil {
+		return err
+	}
+
+	// Set the changes back into the obj.
+	downstreamObj.SetUnstructuredContent(unstructured)
+
+	return nil
+}

--- a/pkg/syncer/spec/mutators/deployment.go
+++ b/pkg/syncer/spec/mutators/deployment.go
@@ -39,6 +39,8 @@ func (dm *DeploymentMutator) GVR() schema.GroupVersionResource {
 	}
 }
 
+var _ Mutator = NewDeploymentMutator(nil)
+
 func NewDeploymentMutator(upstreamURL *url.URL) *DeploymentMutator {
 	return &DeploymentMutator{
 		upstreamURL: upstreamURL,

--- a/pkg/syncer/spec/mutators/interface.go
+++ b/pkg/syncer/spec/mutators/interface.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type Mutator interface {
+	GVR() schema.GroupVersionResource
+	Mutate(*unstructured.Unstructured) error
+}

--- a/pkg/syncer/spec/mutators/secrets.go
+++ b/pkg/syncer/spec/mutators/secrets.go
@@ -17,6 +17,8 @@ limitations under the License.
 package mutators
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,7 +51,11 @@ func (sm *SecretMutator) Mutate(downstreamObj *unstructured.Unstructured) error 
 	}
 
 	// We need to transform the default kcp token into an Opaque secret, in order to avoid the pcluster to rewrite it.
-	if secret.Name == "kcp-default-token" {
+	// TODO(jmprusi): We are rewriting the name of the object into a non random one so we can reference it from the deployment transformer
+	//                but this means that means than more than one default-token-XXXX object will overwrite the same "kcp-default-token"
+	//				  object. This must be fixed.
+	if strings.Contains(secret.GetName(), "default-token-") {
+		secret.Name = "kcp-default-token"
 		secret.Type = corev1.SecretTypeOpaque
 	}
 

--- a/pkg/syncer/spec/mutators/secrets.go
+++ b/pkg/syncer/spec/mutators/secrets.go
@@ -36,6 +36,8 @@ func (sm *SecretMutator) GVR() schema.GroupVersionResource {
 	}
 }
 
+var _ Mutator = NewSecretMutator()
+
 func NewSecretMutator() *SecretMutator {
 	return &SecretMutator{}
 }

--- a/pkg/syncer/spec/mutators/serviceaccounts.go
+++ b/pkg/syncer/spec/mutators/serviceaccounts.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type ServiceAccountMutator struct {
+}
+
+func (sm *ServiceAccountMutator) GVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "serviceaccounts",
+	}
+}
+
+var _ Mutator = NewServiceAccountMutator()
+
+func NewServiceAccountMutator() *ServiceAccountMutator {
+	return &ServiceAccountMutator{}
+}
+
+// Mutate applies the mutator changes to the object.
+func (sm *ServiceAccountMutator) Mutate(downstreamObj *unstructured.Unstructured) error {
+	var serviceAccount corev1.ServiceAccount
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		downstreamObj.UnstructuredContent(),
+		&serviceAccount)
+	if err != nil {
+		return err
+	}
+
+	if serviceAccount.GetName() == "default" {
+		serviceAccount.SetName("kcp-default")
+	}
+
+	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&serviceAccount)
+	if err != nil {
+		return err
+	}
+
+	// Set the changes back into the obj.
+	downstreamObj.SetUnstructuredContent(unstructured)
+
+	return nil
+}

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -61,6 +61,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, upstreamClusterName logic
 		specmutators.NewDeploymentMutator(upstreamURL),
 		specmutators.NewSecretMutator(),
 		specmutators.NewConfigMapMutator(),
+		specmutators.NewServiceAccountMutator(),
 	}{
 		mutators[mutator.GVR()] = mutator.Mutate
 	}

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -60,6 +60,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, upstreamClusterName logic
 	for _, mutator := range []specmutators.Mutator{
 		specmutators.NewDeploymentMutator(upstreamURL),
 		specmutators.NewSecretMutator(),
+		specmutators.NewConfigMapMutator(),
 	}{
 		mutators[mutator.GVR()] = mutator.Mutate
 	}

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -344,18 +344,11 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 func transformName(syncedObject *unstructured.Unstructured) {
 	configMapGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 	serviceAccountGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
-	secretGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 
 	if syncedObject.GroupVersionKind() == configMapGVR && syncedObject.GetName() == "kube-root-ca.crt" {
 		syncedObject.SetName("kcp-root-ca.crt")
 	}
 	if syncedObject.GroupVersionKind() == serviceAccountGVR && syncedObject.GetName() == "default" {
 		syncedObject.SetName("kcp-default")
-	}
-	// TODO(jmprusi): We are rewriting the name of the object into a non random one so we can reference it from the deployment transformer
-	//                but this means that means than more than one default-token-XXXX object will overwrite the same "kcp-default-token"
-	//				  object. This must be fixed.
-	if syncedObject.GroupVersionKind() == secretGVR && strings.Contains(syncedObject.GetName(), "default-token-") {
-		syncedObject.SetName("kcp-default-token")
 	}
 }

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -255,9 +255,6 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	labels[workloadv1alpha1.InternalDownstreamClusterLabel] = c.workloadClusterName
 	downstreamObj.SetLabels(labels)
 
-	// Run name transformations on the downstreamObj.
-	transformName(downstreamObj)
-
 	// Run any transformations on the object before we apply it to the downstream cluster.
 	if mutator, ok := c.mutators[gvr]; ok {
 		if err := mutator(downstreamObj); err != nil {
@@ -338,13 +335,4 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	klog.Infof("Upserted %s %s/%s from upstream %s|%s/%s", gvr.Resource, downstreamObj.GetNamespace(), downstreamObj.GetName(), upstreamObj.GetClusterName(), upstreamObj.GetNamespace(), upstreamObj.GetName())
 
 	return nil
-}
-
-// transformName changes the object name into the desired one downstream.
-func transformName(syncedObject *unstructured.Unstructured) {
-	serviceAccountGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
-
-	if syncedObject.GroupVersionKind() == serviceAccountGVR && syncedObject.GetName() == "default" {
-		syncedObject.SetName("kcp-default")
-	}
 }

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -342,12 +342,8 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 
 // transformName changes the object name into the desired one downstream.
 func transformName(syncedObject *unstructured.Unstructured) {
-	configMapGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 	serviceAccountGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 
-	if syncedObject.GroupVersionKind() == configMapGVR && syncedObject.GetName() == "kube-root-ca.crt" {
-		syncedObject.SetName("kcp-root-ca.crt")
-	}
 	if syncedObject.GroupVersionKind() == serviceAccountGVR && syncedObject.GetName() == "default" {
 		syncedObject.SetName("kcp-default")
 	}


### PR DESCRIPTION
syncer: move secret renaming to mutation

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

syncer: add an interface for mutation

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

syncer: move configmap mutation into mutators

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

syncer: move serviceaccount mutation to mutators

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

syncer: add a concept for admission

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @jmprusi @ncdc 