### PR TITLE
Add the WorkloadCluster name to the current context in the syncer virtual workspace

### DIFF
--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+	syncercontext "github.com/kcp-dev/kcp/pkg/virtual/syncer/context"
 	"github.com/kcp-dev/kcp/pkg/virtual/syncer/controllers/apireconciler"
 )
 
@@ -72,7 +73,8 @@ func BuildVirtualWorkspace(rootPathPrefix string, dynamicClusterClient dynamic.C
 			if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
 				return
 			}
-			apiDomainKey := dynamiccontext.APIDomainKey(clusters.ToClusterAwareKey(logicalcluster.New(parts[0]), parts[1]))
+			workloadCusterName := parts[1]
+			apiDomainKey := dynamiccontext.APIDomainKey(clusters.ToClusterAwareKey(logicalcluster.New(parts[0]), workloadCusterName))
 
 			realPath := "/"
 			if len(parts) > 2 {
@@ -95,6 +97,7 @@ func BuildVirtualWorkspace(rootPathPrefix string, dynamicClusterClient dynamic.C
 			}
 
 			completedContext = genericapirequest.WithCluster(requestContext, cluster)
+			completedContext = syncercontext.WithWorkloadClusterName(completedContext, workloadCusterName)
 			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, apiDomainKey)
 			prefixToStrip = strings.TrimSuffix(urlPath, realPath)
 			accepted = true

--- a/pkg/virtual/syncer/context/keys.go
+++ b/pkg/virtual/syncer/context/keys.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package context
+
+import (
+	"context"
+	"errors"
+)
+
+// workloadClusterNameContextKeyType is the type of the key for the request context value
+// that will carry the name of the WorkloadCluster resources with be synced with.
+type workloadClusterNameContextKeyType string
+
+// apiDomainKeyContextKey is the key for the request context value
+// that will carry the name of the WorkloadCluster resources with be synced with.
+const workloadClusterNameContextKey workloadClusterNameContextKeyType = "SyncerVirtualWorkspaceWorkloadClusterKey"
+
+// WithWorkloadClusterName adds a WorkloadCluster name to the context.
+func WithWorkloadClusterName(ctx context.Context, workloadClusterName string) context.Context {
+	return context.WithValue(ctx, workloadClusterNameContextKey, workloadClusterName)
+}
+
+// WorkloadClusterNameFrom retrieves the WorkloadCluster name key from the context, if any.
+func WorkloadClusterNameFrom(ctx context.Context) (string, error) {
+	wcn, hasWorkloadClusterName := ctx.Value(workloadClusterNameContextKey).(string)
+	if !hasWorkloadClusterName {
+		return "", errors.New("context must contain a valid non-empty WorkloadCluster name")
+	}
+	return wcn, nil
+}


### PR DESCRIPTION
## Summary

This a a pre-requisite for the implementation of transformations in the Syncer virtual workspace.
In a number of cases, especially for transformations that manage syncer-specific views of a KCP resource,
knowing the workload cluster for a given request context is important. 

## Related issue(s) or PR(s)

This is a first standalone PR, split out from the complete syncer strategies PR: https://github.com/kcp-dev/kcp/pull/1064
