### PR TITLE
Adding apibinding authorizer to allow service bindings ability to limit its access to exported resources

### DIFF
--- a/pkg/authorization/apibinding_authorizer.go
+++ b/pkg/authorization/apibinding_authorizer.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	clientgoinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
+
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	rbacwrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/rbac"
+	"github.com/kcp-dev/logicalcluster"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+const (
+	byWorkspaceIndex = "apiBindingAuthorizer-byWorkspace"
+)
+
+// NewAPIBindingAccessAuthorizer returns an authorizer that checks for
+func NewAPIBindingAccessAuthorizer(versionedInformers clientgoinformers.SharedInformerFactory, f kcpinformers.SharedInformerFactory, delegate authorizer.Authorizer) authorizer.Authorizer {
+	if _, found := f.Apis().V1alpha1().APIBindings().Informer().GetIndexer().GetIndexers()[byWorkspaceIndex]; !found {
+		err := f.Apis().V1alpha1().APIBindings().Informer().AddIndexers(
+			cache.Indexers{byWorkspaceIndex: func(obj interface{}) ([]string, error) {
+				return []string{logicalcluster.From(obj.(metav1.Object)).String()}, nil
+			},
+			},
+		)
+		if err != nil {
+			// nothing we can do here. But this should also never happen. We check for existence before.
+			klog.Errorf("failed to add indexer for APIBindings: %v", err)
+		}
+	}
+
+	return &apiBindingAccessAuthorizer{
+		versionedInformers: versionedInformers,
+		apiBindingIndexer:  f.Apis().V1alpha1().APIBindings().Informer().GetIndexer(),
+		delegate:           delegate,
+	}
+}
+
+type apiBindingAccessAuthorizer struct {
+	versionedInformers clientgoinformers.SharedInformerFactory
+	apiBindingIndexer  cache.Indexer
+	delegate           authorizer.Authorizer
+}
+
+func (a *apiBindingAccessAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	// Determine if resource being requested is bound.
+	// If it is bound get the workspace.
+	// request for the user in the cluster.
+
+	apiBindingAccessDenied := fmt.Sprintf("api %v.%v access is not permitted", attr.GetResource(), attr.GetAPIGroup())
+
+	// get the cluster from the ctx.
+	lcluster, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
+	}
+	klog.Errorf("here in api binding %v", lcluster)
+
+	bindingLogicalCluster, bound, err := a.getAPIBindingWorkspace(attr, lcluster)
+	if err != nil {
+		klog.Error("here unable to get API Binding Workspace")
+		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
+	}
+
+	if !bound {
+		klog.Infof("here api is not bound, delegating auth")
+		return a.delegate.Authorize(ctx, attr)
+	}
+
+	// If bound, create a rbac authorizer filtered to the cluster.
+	clusterKubeInformer := rbacwrapper.FilterInformers(bindingLogicalCluster, a.versionedInformers.Rbac().V1())
+	clusterAuthorizer := rbac.New(
+		&rbac.RoleGetter{Lister: clusterKubeInformer.Roles().Lister()},
+		&rbac.RoleBindingLister{Lister: clusterKubeInformer.RoleBindings().Lister()},
+		&rbac.ClusterRoleGetter{Lister: clusterKubeInformer.ClusterRoles().Lister()},
+		&rbac.ClusterRoleBindingLister{Lister: clusterKubeInformer.ClusterRoleBindings().Lister()},
+	)
+	dec, _, err := clusterAuthorizer.Authorize(ctx, attr)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
+	}
+
+	if dec == authorizer.DecisionAllow {
+		klog.Infof("here api is bound, APIExport Allows ")
+		return a.delegate.Authorize(ctx, attr)
+	}
+
+	return authorizer.DecisionNoOpinion, apiBindingAccessDenied, nil
+}
+
+//TODO [shawn-hurley]: this should be a helper shared.
+func (a *apiBindingAccessAuthorizer) getAPIBindingWorkspace(attr authorizer.Attributes, clusterName logicalcluster.Name) (logicalcluster.Name, bool, error) {
+	parentClusterName, hasParent := clusterName.Parent()
+	if !hasParent {
+		// APIBindings in root are not possible (they can only point to sibling workspaces).
+		return logicalcluster.New(""), false, nil
+	}
+
+	objs, err := a.apiBindingIndexer.ByIndex(byWorkspaceIndex, clusterName.String())
+	if err != nil {
+		return logicalcluster.New(""), false, err
+	}
+	for _, obj := range objs {
+		apiBinding := obj.(*apisv1alpha1.APIBinding)
+		for _, br := range apiBinding.Status.BoundResources {
+			if apiBinding.Status.BoundAPIExport.Workspace == nil {
+				// this will never happen today. But as soon as we add other reference types (like exports), this log output will remind out of necessary work here.
+				klog.Errorf("APIBinding %s has no referenced workspace", clusterName, apiBinding.Name)
+				continue
+			}
+			if br.Group == attr.GetAPIGroup() && br.Resource == attr.GetResource() {
+				return parentClusterName.Join(apiBinding.Status.BoundAPIExport.Workspace.WorkspaceName), true, nil
+			}
+		}
+	}
+	return logicalcluster.New(""), false, nil
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -175,7 +175,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.options.Authorization.ApplyTo(genericConfig, s.kubeSharedInformerFactory, s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister()); err != nil {
+	if err := s.options.Authorization.ApplyTo(genericConfig, s.kubeSharedInformerFactory, s.kcpSharedInformerFactory); err != nil {
 		return err
 	}
 	newTokenOrEmpty, tokenHash, err := s.options.AdminAuthentication.ApplyTo(genericConfig)

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestAPIBindingAuthorizer(t *testing.T) {
+	t.Parallel()
+
+	server := framework.SharedKcpServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	serviceProvider1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	consumer1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	consumer2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg := server.DefaultConfig(t)
+
+	kcpClients, err := clientset.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	dynamicClients, err := dynamic.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	serviceProviderWorkspaces := []logicalcluster.Name{serviceProvider1Workspace}
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1"}, nil, []string{"member"})
+
+	for _, serviceProviderWorkspace := range serviceProviderWorkspaces {
+		t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
+		mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(serviceProviderWorkspace).Discovery()))
+		err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+		require.NoError(t, err)
+
+		t.Logf("Create an APIExport for it")
+		cowboysAPIExport := &apisv1alpha1.APIExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "today-cowboys",
+			},
+			Spec: apisv1alpha1.APIExportSpec{
+				LatestResourceSchemas: []string{"today.cowboys.wildwest.dev"},
+			},
+		}
+		_, err = kcpClients.Cluster(serviceProviderWorkspace).ApisV1alpha1().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		//install RBAC that allows 	create/list/get/update/watch on cowboys for system:authenticated
+		t.Logf("Install RBAC for API Export")
+		clusterRole := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-systemauth",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					Verbs:     []string{rbac.VerbAll},
+					APIGroups: []string{wildwest.GroupName},
+					Resources: []string{"cowboys"},
+				},
+			},
+		}
+		_, err = kubeClusterClient.Cluster(serviceProviderWorkspace).RbacV1().ClusterRoles().Create(ctx, clusterRole, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-sytstemauth",
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind: "Group",
+					Name: "system:authenticated",
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "test-systemauth",
+			},
+		}
+		_, err = kubeClusterClient.Cluster(serviceProviderWorkspace).RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+	}
+
+	bindConsumerToProvider := func(consumerWorkspace, providerWorkspace logicalcluster.Name) {
+		t.Logf("Create an APIBinding in consumer workspace %q that points to the today-cowboys export from %q", consumerWorkspace, providerWorkspace)
+		apiBinding := &apisv1alpha1.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cowboys",
+			},
+			Spec: apisv1alpha1.APIBindingSpec{
+				Reference: apisv1alpha1.ExportReference{
+					Workspace: &apisv1alpha1.WorkspaceExportReference{
+						WorkspaceName: providerWorkspace.Base(),
+						ExportName:    "today-cowboys",
+					},
+				},
+			},
+		}
+
+		_, err = kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		t.Logf("Make sure %s API group does NOT show up in workspace %q group discovery", wildwest.GroupName, providerWorkspace)
+		groups, err := kcpClients.Cluster(providerWorkspace).Discovery().ServerGroups()
+		require.NoError(t, err, "error retrieving service provider workspace %q group discovery", providerWorkspace)
+		require.False(t, groupExists(groups, wildwest.GroupName),
+			"should not have seen %s API group in service provider workspace %q group discovery", wildwest.GroupName, providerWorkspace)
+
+		t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerWorkspace)
+		err = wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(c context.Context) (done bool, err error) {
+			groups, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerGroups()
+			if err != nil {
+				return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerWorkspace, err)
+			}
+			return groupExists(groups, wildwest.GroupName), nil
+		})
+		require.NoError(t, err)
+
+		t.Logf("Make sure cowboys API resource shows up in consumer workspace %q group version discovery", consumerWorkspace)
+		resources, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerResourcesForGroupVersion(wildwestv1alpha1.SchemeGroupVersion.String())
+		require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerWorkspace)
+		require.True(t, resourceExists(resources, "cowboys"), "consumer workspace %q discovery is missing cowboys resource", consumerWorkspace)
+
+		// User a new user in Cconsumer workspace
+		// New User
+		framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, consumerWorkspace, []string{"user-1"}, nil, []string{"admin"})
+		wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(userConfig("user-1", cfg))
+		require.NoError(t, err)
+
+		t.Logf("Make sure we can perform CRUD operations against consumer workspace %q for the bound API", consumerWorkspace)
+
+		t.Logf("Make sure list shows nothing to start")
+		cowboyClient := wildwestClusterClient.Cluster(consumerWorkspace).WildwestV1alpha1().Cowboys("default")
+		cowboys, err := cowboyClient.List(ctx, metav1.ListOptions{})
+		require.NoError(t, err, "error listing cowboys inside consumer workspace %q", consumerWorkspace)
+		require.Zero(t, len(cowboys.Items), "expected 0 cowboys inside consumer workspace %q", consumerWorkspace)
+
+		t.Logf("Create a cowboy CR in consumer workspace %q", consumerWorkspace)
+		cowboyName := fmt.Sprintf("cowboy-%s", consumerWorkspace.Base())
+		cowboy := &wildwestv1alpha1.Cowboy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cowboyName,
+				Namespace: "default",
+			},
+		}
+		_, err = cowboyClient.Create(ctx, cowboy, metav1.CreateOptions{})
+		require.NoError(t, err, "error creating cowboy in consumer workspace %q", consumerWorkspace)
+
+		t.Logf("Make sure there is 1 cowboy in consumer workspace %q", consumerWorkspace)
+		cowboys, err = cowboyClient.List(ctx, metav1.ListOptions{})
+		require.NoError(t, err, "error listing cowboys in consumer workspace %q", consumerWorkspace)
+		require.Equal(t, 1, len(cowboys.Items), "expected 1 cowboy in consumer workspace %q", consumerWorkspace)
+		require.Equal(t, cowboyName, cowboys.Items[0].Name, "unexpected name for cowboy in consumer workspace %q", consumerWorkspace)
+
+		t.Logf("Make sure that the status of cowboy can not be updated")
+		_, err = cowboyClient.UpdateStatus(ctx, &cowboys.Items[0], metav1.UpdateOptions{})
+		require.Error(t, err, "expected error updating status of cowboys")
+	}
+
+	consumersOfServiceProvider1 := []logicalcluster.Name{consumer1Workspace, consumer2Workspace}
+	for _, consumerWorkspace := range consumersOfServiceProvider1 {
+		bindConsumerToProvider(consumerWorkspace, serviceProvider1Workspace)
+	}
+
+}
+func userConfig(username string, cfg *rest.Config) *rest.Config {
+	cfgCopy := rest.CopyConfig(cfg)
+	cfgCopy.BearerToken = username + "-token"
+	return cfgCopy
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
Adding Authorizer that will check if a APIBinding exists, and if it does exist check the RBAC in the Exports Cluster, to determine if the request is allowed.
## Related issue(s)

Fixes #1013 