### PR TITLE
ci: Config author for commit to gitops repo

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -63,6 +63,8 @@ jobs:
       - name: Update sha and commit
         run: |-
           sed -i -e 's/tag: [0-9a-f]\{7\}/tag: ${{ needs.build.outputs.sha_short }}/' manifest/unstable-values.yaml
+          git config user.email "klape+kcp-bot@redhat.com"
+          git config user.name "KCP Bot"
           git add manifest/unstable-values.yaml
-          git commit --author="KCP Bot <klape+kcp-bot@redhat.com>" -m "Automatic update of test environment to ${{ needs.build.outputs.sha_short }}"
+          git commit -m "Automatic update of test environment to ${{ needs.build.outputs.sha_short }}"
           git push origin main


### PR DESCRIPTION
Follow up for https://github.com/kcp-dev/kcp/pull/928

Fixes this error in the [CI job](https://github.com/kcp-dev/kcp/runs/6479175167?check_suite_focus=true#step:3:43):

```Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az200-895.f5bee3wnw2gu3k5g3q4wfpt2ta.dx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.```

