### PR TITLE
Avoid trying to sync namespaces as namespaced resources.

### DIFF
--- a/pkg/syncer/status/status_controller.go
+++ b/pkg/syncer/status/status_controller.go
@@ -43,6 +43,7 @@ type Controller struct {
 
 	upstreamClient, downstreamClient       dynamic.Interface
 	upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory
+	downstreamNamespaceLister              cache.GenericLister
 
 	workloadClusterName       string
 	upstreamClusterName       logicalcluster.Name
@@ -55,10 +56,11 @@ func NewStatusSyncer(gvrs []schema.GroupVersionResource, upstreamClusterName log
 	c := &Controller{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
 
-		upstreamClient:      upstreamClient,
-		downstreamClient:    downstreamClient,
-		upstreamInformers:   upstreamInformers,
-		downstreamInformers: downstreamInformers,
+		upstreamClient:            upstreamClient,
+		downstreamClient:          downstreamClient,
+		upstreamInformers:         upstreamInformers,
+		downstreamInformers:       downstreamInformers,
+		downstreamNamespaceLister: downstreamInformers.ForResource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}).Lister(),
 
 		workloadClusterName:       workloadClusterName,
 		upstreamClusterName:       upstreamClusterName,

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -63,14 +63,13 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	}
 
 	// to upstream
-	nsInformer := c.downstreamInformers.ForResource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"})
 	nsKey := downstreamNamespace
 	if !downstreamClusterName.Empty() {
 		// If our "physical" cluster is a kcp instance (e.g. for testing purposes), it will return resources
 		// with metadata.clusterName set, which means their keys are cluster-aware, so we need to do the same here.
 		nsKey = clusters.ToClusterAwareKey(downstreamClusterName, nsKey)
 	}
-	nsObj, err := nsInformer.Lister().Get(nsKey)
+	nsObj, err := c.downstreamNamespaceLister.Get(nsKey)
 	if err != nil {
 		klog.Errorf("Error retrieving namespace %q from downstream lister: %v", nsKey, err)
 		return nil

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -235,7 +235,7 @@ func getAllGVRs(discoveryClient discovery.DiscoveryInterface, resourcesToSync ..
 	}
 	// TODO(jmprusi): Added ServiceAccounts, Configmaps and Secrets to the default syncing, but we should figure out
 	//                a way to avoid doing that: https://github.com/kcp-dev/kcp/issues/727
-	gvrstrs := sets.NewString("namespaces.v1.", "serviceaccounts.v1.", "configmaps.v1.", "secrets.v1.") // A syncer should always watch namespaces, serviceaccounts, secrets and configmaps.
+	gvrstrs := sets.NewString("serviceaccounts.v1.", "configmaps.v1.", "secrets.v1.") // A syncer should always watch serviceaccounts, secrets and configmaps.
 	for _, r := range rs {
 		// v1 -> v1.
 		// apps/v1 -> v1.apps


### PR DESCRIPTION
## Summary

After recent changes, it seems that the syncer constantly tries to sync namespace resources, as other namespaced resources, which of course is not possible.
Surely namespaces should be received by the informer and present in the informer caches, but not effectively synced by the syncer `process` functions.

Fixes #

Not sure there was an issue for this.