### PR TITLE
Fix make test-e2e WHAT so that it works by using WHAT-TESTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,7 +176,7 @@ jobs:
           kind get kubeconfig > /tmp/kind-kubeconfig
           ARTIFACT_DIR=/tmp/e2e \
           PATH="${PATH}:$(pwd)/bin/" \
-          TEST_ARGS="-args --use-default-kcp-server --syncer-image=$(cat /tmp/syncer-image) --kcp-test-image=$(cat /tmp/kcp-test-image) --pcluster-kubeconfig=/tmp/kind-kubeconfig" \
+          TEST_ARGS="./test/e2e... -args --use-default-kcp-server --syncer-image=$(cat /tmp/syncer-image) --kcp-test-image=$(cat /tmp/kcp-test-image) --pcluster-kubeconfig=/tmp/kind-kubeconfig" \
           COUNT=2 \
           E2E_PARALLELISM=2 \
           make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ COUNT ?= 1
 E2E_PARALLELISM ?= 1
 
 .PHONY: test-e2e
-test-e2e: WHAT ?= ./test/e2e...
+test-e2e: WHAT-TESTS ?= ./test/e2e...
 test-e2e: build
-	NO_GORUN=1 go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
+	NO_GORUN=1 go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT-TESTS) $(TEST_ARGS)
 
 .PHONY: test
 test: WHAT ?= ./...

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ COUNT ?= 1
 E2E_PARALLELISM ?= 1
 
 .PHONY: test-e2e
-test-e2e: WHAT-TESTS ?= ./test/e2e...
+test-e2e: TEST_ARGS ?= ./test/e2e...
 test-e2e: build
-	NO_GORUN=1 go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT-TESTS) $(TEST_ARGS)
+	NO_GORUN=1 go test -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(TEST_ARGS)
 
 .PHONY: test
 test: WHAT ?= ./...


### PR DESCRIPTION
Signed-off-by: Chris Ahl <cahl@redhat.com>

## Summary
`make test-e2e` is broken if `WHAT` parameter is passed.

With this fix, you would need to run with `WHAT-TESTS` instead of `WHAT`
```
make test-e2e WHAT-TESTS=./test/e2e/syncer...
```

## Related issue(s)

Fixes #1089