### PR TITLE
api: Enables the binding of APIs in protected groups

### DIFF
--- a/pkg/apis/apis/v1alpha1/types.go
+++ b/pkg/apis/apis/v1alpha1/types.go
@@ -163,6 +163,9 @@ const (
 	// APIExportNotFoundReason is a reason for the APIExportValid condition that the referenced APIExport is not found.
 	APIExportNotFoundReason = "APIExportNotFound"
 
+	// APIResourceSchemaInvalidReason is a reason for the InitialBindingCompleted and BindingUpToDate conditions when one of generated CRD is invalid.
+	APIResourceSchemaInvalidReason = "APIResourceSchemaInvalid"
+
 	// InternalErrorReason is a reason used by multiple conditions that something went wrong.
 	InternalErrorReason = "InternalError"
 

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -199,6 +199,7 @@ func TestReconcileBinding(t *testing.T) {
 		wantBoundAPIExport                      bool
 		wantInitialBindingComplete              bool
 		wantInitialBindingCompleteInternalError bool
+		wantInitialBindingCompleteSchemaInvalid bool
 		wantPhaseBound                          bool
 		wantBoundResources                      []apisv1alpha1.BoundAPIResource
 		wantNamingConflict                      bool
@@ -252,7 +253,7 @@ func TestReconcileBinding(t *testing.T) {
 			getCRDError:                             apierrors.NewNotFound(schema.GroupResource{}, ""),
 			wantCreateCRD:                           true,
 			createCRDError:                          apierrors.NewInvalid(apiextensionsv1.Kind("CustomResourceDefinition"), "todaywidgetsuid", field.ErrorList{field.Forbidden(field.NewPath("foo"), "details")}),
-			wantInitialBindingCompleteInternalError: true,
+			wantInitialBindingCompleteSchemaInvalid: true,
 			wantError:                               false,
 		},
 		"create CRD fails - other error": {
@@ -615,6 +616,15 @@ func TestReconcileBinding(t *testing.T) {
 					Status:   corev1.ConditionFalse,
 					Severity: conditionsv1alpha1.ConditionSeverityError,
 					Reason:   apisv1alpha1.InternalErrorReason,
+				})
+			}
+
+			if tc.wantInitialBindingCompleteSchemaInvalid {
+				requireConditionMatches(t, tc.apiBinding, &conditionsv1alpha1.Condition{
+					Type:     apisv1alpha1.InitialBindingCompleted,
+					Status:   corev1.ConditionFalse,
+					Severity: conditionsv1alpha1.ConditionSeverityError,
+					Reason:   apisv1alpha1.APIResourceSchemaInvalidReason,
 				})
 			}
 		})

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
+)
+
+func TestProtectedAPI(t *testing.T) {
+	t.Parallel()
+
+	server := framework.SharedKcpServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	providerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg := server.DefaultConfig(t)
+
+	kcpClients, err := clientset.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	dynamicClients, err := dynamic.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", providerWorkspace)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(providerWorkspace).Discovery()))
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(providerWorkspace), mapper, "apiresourceschema_tlsroutes.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Create an APIExport for it")
+	cowboysAPIExport := &apisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gateway-api",
+		},
+		Spec: apisv1alpha1.APIExportSpec{
+			LatestResourceSchemas: []string{"latest.tlsroutes.gateway.networking.k8s.io"},
+		},
+	}
+	_, err = kcpClients.Cluster(providerWorkspace).ApisV1alpha1().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Create an APIBinding in consumer workspace %q that points to the gateway-api export from %q", consumerWorkspace, providerWorkspace)
+	apiBinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gateway-api",
+		},
+		Spec: apisv1alpha1.APIBindingSpec{
+			Reference: apisv1alpha1.ExportReference{
+				Workspace: &apisv1alpha1.WorkspaceExportReference{
+					WorkspaceName: providerWorkspace.Base(),
+					ExportName:    "gateway-api",
+				},
+			},
+		},
+	}
+
+	_, err = kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	t.Logf("Make sure APIBinding %q in workspace %q is completed and up-to-date", apiBinding.Name, consumerWorkspace)
+	require.Eventually(t, func() bool {
+		b, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Get(ctx, apiBinding.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		return conditions.IsTrue(b, apisv1alpha1.InitialBindingCompleted) &&
+			conditions.IsTrue(b, apisv1alpha1.BindingUpToDate)
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "APIBinding %q in workspace %q did not complete", apiBinding.Name, consumerWorkspace)
+
+	t.Logf("Make sure gateway API resource shows up in workspace %q group version discovery", consumerWorkspace)
+	resources, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1alpha2")
+	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerWorkspace)
+	require.True(t, resourceExists(resources, "tlsroutes"), "consumer workspace %q discovery is missing tlsroutes resource", consumerWorkspace)
+}

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -18,7 +18,6 @@ package apibinding
 
 import (
 	"context"
-	"embed"
 	"fmt"
 	"testing"
 	"time"
@@ -41,9 +40,6 @@ import (
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
-
-//go:embed *.yaml
-var testFiles embed.FS
 
 func TestAPIBinding(t *testing.T) {
 	t.Parallel()
@@ -224,22 +220,4 @@ func TestAPIBinding(t *testing.T) {
 
 	t.Logf("Verify that consumer workspace 3 (%q) bound to service provider workspace 2 (%q) wildcard list works", consumer3Workspace, serviceProvider2Workspace)
 	verifyWildcardList(consumer3Workspace, 1)
-}
-
-func groupExists(list *metav1.APIGroupList, group string) bool {
-	for _, g := range list.Groups {
-		if g.Name == group {
-			return true
-		}
-	}
-	return false
-}
-
-func resourceExists(list *metav1.APIResourceList, resource string) bool {
-	for _, r := range list.APIResources {
-		if r.Name == resource {
-			return true
-		}
-	}
-	return false
 }

--- a/test/e2e/apibinding/apiresourceschema_tlsroutes.yaml
+++ b/test/e2e/apibinding/apiresourceschema_tlsroutes.yaml
@@ -1,0 +1,479 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/891
+    gateway.networking.k8s.io/bundle-version: v0.5.0-dev
+    gateway.networking.k8s.io/channel: stable
+  name: latest.tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        description: "The TLSRoute resource is similar to TCPRoute, but can be configured
+        to match against TLS-specific metadata. This allows more flexibility in
+        matching streams for a given TLS listener. \n If you need to forward traffic
+        to a single target for a TLS listener, you could choose to use a TCPRoute
+        with a TLS listener."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TLSRoute.
+            properties:
+              hostnames:
+                description: "Hostnames defines a set of SNI names that should match
+                against the SNI attribute of TLS ClientHello message in TLS handshake.
+                This matches the RFC 1123 definition of a hostname with 2 notable
+                exceptions: \n 1. IPs are not allowed in SNI names per RFC 6066.
+                2. A hostname may be prefixed with a wildcard label (`*.`). The
+                wildcard    label must appear by itself as the first label. \n If
+                a hostname is specified by both the Listener and TLSRoute, there
+                must be at least one intersecting hostname for the TLSRoute to be
+                attached to the Listener. For example: \n * A Listener with `test.example.com`
+                as the hostname matches TLSRoutes   that have either not specified
+                any hostnames, or have specified at   least one of `test.example.com`
+                or `*.example.com`. * A Listener with `*.example.com` as the hostname
+                matches TLSRoutes   that have either not specified any hostnames
+                or have specified at least   one hostname that matches the Listener
+                hostname. For example,   `test.example.com` and `*.example.com`
+                would both match. On the other   hand, `example.com` and `test.example.net`
+                would not match. \n If both the Listener and TLSRoute have specified
+                hostnames, any TLSRoute hostnames that do not match the Listener
+                hostname MUST be ignored. For example, if a Listener specified `*.example.com`,
+                and the TLSRoute specified `test.example.com` and `test.example.net`,
+                `test.example.net` must not be considered for a match. \n If both
+                the Listener and TLSRoute have specified hostnames, and none match
+                with the criteria above, then the TLSRoute is not accepted. The
+                implementation must raise an 'Accepted' Condition with a status
+                of `False` in the corresponding RouteParentStatus. \n Support: Core"
+                items:
+                  description: "Hostname is the fully qualified domain name of a network
+                  host. This matches the RFC 1123 definition of a hostname with
+                  2 notable exceptions: \n 1. IPs are not allowed. 2. A hostname
+                  may be prefixed with a wildcard label (`*.`). The wildcard    label
+                  must appear by itself as the first label. \n Hostname can be \"precise\"
+                  which is a domain name without the terminating dot of a network
+                  host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain
+                  name prefixed with a single wildcard label (e.g. `*.example.com`).
+                  \n Note that as per RFC1035 and RFC1123, a *label* must consist
+                  of lower case alphanumeric characters or '-', and must start and
+                  end with an alphanumeric character. No other punctuation is allowed."
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                maxItems: 16
+                type: array
+              parentRefs:
+                description: "ParentRefs references the resources (usually Gateways)
+                that a Route wants to be attached to. Note that the referenced parent
+                resource needs to allow this for the attachment to be complete.
+                For Gateways, that means the Gateway needs to allow attachment from
+                Routes of this kind and namespace. \n The only kind of parent resource
+                with \"Core\" support is Gateway. This API may be extended in the
+                future to support additional kinds of parent resources such as one
+                of the route kinds. \n It is invalid to reference an identical parent
+                more than once. It is valid to reference multiple distinct sections
+                within the same parent resource, such as 2 Listeners within a Gateway.
+                \n It is possible to separately reference multiple distinct objects
+                that may be collapsed by an implementation. For example, some implementations
+                may choose to merge compatible Gateway Listeners together. If that
+                is the case, the list of routes attached to those resources should
+                also be merged."
+                items:
+                  description: "ParentReference identifies an API object (usually
+                  a Gateway) that can be considered a parent of this resource (usually
+                  a route). The only kind of parent resource with \"Core\" support
+                  is Gateway. This API may be extended in the future to support
+                  additional kinds of parent resources, such as HTTPRoute. \n The
+                  API object must be valid in the cluster; the Group and Kind must
+                  be registered in the cluster for this reference to be valid."
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: "Group is the group of the referent. \n Support:
+                      Core"
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: "Kind is kind of the referent. \n Support: Core
+                      (Gateway) Support: Custom (Other Resources)"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: "Name is the name of the referent. \n Support:
+                      Core"
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "Namespace is the namespace of the referent. When
+                      unspecified (or empty string), this refers to the local namespace
+                      of the Route. \n Support: Core"
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    sectionName:
+                      description: "SectionName is the name of a section within the
+                      target resource. In the following resources, SectionName is
+                      interpreted as the following: \n * Gateway: Listener Name.
+                      When both Port (experimental) and SectionName are specified,
+                      the name and port of the selected listener must match both
+                      specified values. \n Implementations MAY choose to support
+                      attaching Routes to other resources. If that is the case,
+                      they MUST clearly document how SectionName is interpreted.
+                      \n When unspecified (empty string), this will reference the
+                      entire resource. For the purpose of status, an attachment
+                      is considered successful if at least one section in the parent
+                      resource accepts it. For example, Gateway listeners can restrict
+                      which Routes can attach to them by Route kind, namespace,
+                      or hostname. If 1 of 2 Gateway listeners accept attachment
+                      from the referencing Route, the Route MUST be considered successfully
+                      attached. If no Gateway listeners accept attachment from this
+                      Route, the Route MUST be considered detached from the Gateway.
+                      \n Support: Core"
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                    - name
+                  type: object
+                maxItems: 32
+                type: array
+              rules:
+                description: Rules are a list of TLS matchers and actions.
+                items:
+                  description: TLSRouteRule is the configuration for a given rule.
+                  properties:
+                    backendRefs:
+                      description: "BackendRefs defines the backend(s) where matching
+                      requests should be sent. If unspecified or invalid (refers
+                      to a non-existent resource or a Service with no endpoints),
+                      the rule performs no forwarding; if no filters are specified
+                      that would result in a response being sent, the underlying
+                      implementation must actively reject request attempts to this
+                      backend, by rejecting the connection or returning a 404 status
+                      code. Request rejections must respect weight; if an invalid
+                      backend is requested to have 80% of requests, then 80% of
+                      requests must be rejected instead. \n Support: Core for Kubernetes
+                      Service Support: Custom for any other resource \n Support
+                      for weight: Extended"
+                      items:
+                        description: "BackendRef defines how a Route should forward
+                        a request to a Kubernetes resource. \n Note that when a
+                        namespace is specified, a ReferencePolicy object is required
+                        in the referent namespace to allow that namespace's owner
+                        to accept the reference. See the ReferencePolicy documentation
+                        for details."
+                        properties:
+                          group:
+                            default: ""
+                            description: Group is the group of the referent. For example,
+                              "networking.k8s.io". When unspecified (empty string),
+                              core API group is inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Service
+                            description: Kind is kind of the referent. For example
+                              "HTTPRoute" or "Service". Defaults to "Service" when
+                              not specified.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: "Namespace is the namespace of the backend.
+                            When unspecified, the local namespace is inferred. \n
+                            Note that when a namespace is specified, a ReferencePolicy
+                            object is required in the referent namespace to allow
+                            that namespace's owner to accept the reference. See
+                            the ReferencePolicy documentation for details. \n Support:
+                            Core"
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port specifies the destination port number
+                              to use for this resource. Port is required when the
+                              referent is a Kubernetes Service. For other resources,
+                              destination port might be derived from the referent
+                              resource or this field.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          weight:
+                            default: 1
+                            description: "Weight specifies the proportion of requests
+                            forwarded to the referenced backend. This is computed
+                            as weight/(sum of all weights in this BackendRefs list).
+                            For non-zero values, there may be some epsilon from
+                            the exact proportion defined here depending on the precision
+                            an implementation supports. Weight is not a percentage
+                            and the sum of weights does not need to equal 100. \n
+                            If only one backend is specified and it has a weight
+                            greater than 0, 100% of the traffic is forwarded to
+                            that backend. If weight is set to 0, no traffic should
+                            be forwarded for this entry. If unspecified, weight
+                            defaults to 1. \n Support for this field varies based
+                            on the context where used."
+                            format: int32
+                            maximum: 1000000
+                            minimum: 0
+                            type: integer
+                        required:
+                          - name
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                  type: object
+                maxItems: 16
+                minItems: 1
+                type: array
+            required:
+              - rules
+            type: object
+          status:
+            description: Status defines the current state of TLSRoute.
+            properties:
+              parents:
+                description: "Parents is a list of parent resources (usually Gateways)
+                that are associated with the route, and the status of the route
+                with respect to each parent. When this route attaches to a parent,
+                the controller that manages the parent must add an entry to this
+                list when the controller first sees the route and should update
+                the entry as appropriate when the route or gateway is modified.
+                \n Note that parent references that cannot be resolved by an implementation
+                of this API will not be added to this list. Implementations of this
+                API can only populate Route status for the Gateways/parent resources
+                they are responsible for. \n A maximum of 32 Gateways will be represented
+                in this list. An empty list means the route has not been attached
+                to any Gateway."
+                items:
+                  description: RouteParentStatus describes the status of a route with
+                    respect to an associated Parent.
+                  properties:
+                    conditions:
+                      description: "Conditions describes the status of the route with
+                      respect to the Gateway. Note that the route's availability
+                      is also subject to the Gateway's own status conditions and
+                      listener status. \n If the Route's ParentRef specifies an
+                      existing Gateway that supports Routes of this kind AND that
+                      Gateway's controller has sufficient access, then that Gateway's
+                      controller MUST set the \"Accepted\" condition on the Route,
+                      to indicate whether the route has been accepted or rejected
+                      by the Gateway, and why. \n A Route MUST be considered \"Accepted\"
+                      if at least one of the Route's rules is implemented by the
+                      Gateway. \n There are a number of cases where the \"Accepted\"
+                      condition may not be set due to lack of controller visibility,
+                      that includes when: \n * The Route refers to a non-existent
+                      parent. * The Route is of a type that the controller does
+                      not support. * The Route is in a namespace the the controller
+                      does not have access to."
+                      items:
+                        description: "Condition contains details for one aspect of
+                        the current state of this API Resource. --- This struct
+                        is intended for direct use as an array at the field path
+                        .status.conditions.  For example, type FooStatus struct{
+                        \    // Represents the observations of a foo's current state.
+                        \    // Known .status.conditions.type are: \"Available\",
+                        \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                        \    // +patchStrategy=merge     // +listType=map     //
+                        +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                        \n     // other fields }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                              - "True"
+                              - "False"
+                              - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - message
+                          - reason
+                          - status
+                          - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: "ControllerName is a domain/path string that indicates
+                      the name of the controller that wrote this status. This corresponds
+                      with the controllerName field on GatewayClass. \n Example:
+                      \"example.net/gateway-controller\". \n The format of this
+                      field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid
+                      Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+                      \n Controllers MUST populate this field when writing status.
+                      Controllers should ensure that entries to status populated
+                      with their ControllerName are cleaned up when they are no
+                      longer necessary."
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                    parentRef:
+                      description: ParentRef corresponds with a ParentRef in the spec
+                        that this RouteParentStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: "Group is the group of the referent. \n Support:
+                          Core"
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: "Kind is kind of the referent. \n Support:
+                          Core (Gateway) Support: Custom (Other Resources)"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: "Name is the name of the referent. \n Support:
+                          Core"
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: "Namespace is the namespace of the referent.
+                          When unspecified (or empty string), this refers to the
+                          local namespace of the Route. \n Support: Core"
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        sectionName:
+                          description: "SectionName is the name of a section within
+                          the target resource. In the following resources, SectionName
+                          is interpreted as the following: \n * Gateway: Listener
+                          Name. When both Port (experimental) and SectionName are
+                          specified, the name and port of the selected listener
+                          must match both specified values. \n Implementations MAY
+                          choose to support attaching Routes to other resources.
+                          If that is the case, they MUST clearly document how SectionName
+                          is interpreted. \n When unspecified (empty string), this
+                          will reference the entire resource. For the purpose of
+                          status, an attachment is considered successful if at least
+                          one section in the parent resource accepts it. For example,
+                          Gateway listeners can restrict which Routes can attach
+                          to them by Route kind, namespace, or hostname. If 1 of
+                          2 Gateway listeners accept attachment from the referencing
+                          Route, the Route MUST be considered successfully attached.
+                          If no Gateway listeners accept attachment from this Route,
+                          the Route MUST be considered detached from the Gateway.
+                          \n Support: Core"
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  required:
+                    - controllerName
+                    - parentRef
+                  type: object
+                maxItems: 32
+                type: array
+            required:
+              - parents
+            type: object
+        required:
+          - spec
+        type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/e2e/apibinding/support.go
+++ b/test/e2e/apibinding/support.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"embed"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//go:embed *.yaml
+var testFiles embed.FS
+
+func groupExists(list *metav1.APIGroupList, group string) bool {
+	for _, g := range list.Groups {
+		if g.Name == group {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceExists(list *metav1.APIResourceList, resource string) bool {
+	for _, r := range list.APIResources {
+		if r.Name == resource {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

This PR enables the binding of APIs whose groups are _protected_, as defined in kubernetes/enhancements#1111.

The proposed solution delegates to the user the responsibility of adding the `api-approved.kubernetes.io` annotation to the `APIResourceSchema` resource, as for standard CRDs, so it makes it explicit, and prevents from accidentally declaring APIs in a protected group. With this PR, the APIBinding controller will simply propagate the annotation to the projected CRDs.

In the API import case, where CRDs are generated following the creation of `APIResourceImport` resources, the `NegociatedAPIResource` controller already adds the _approval_ annotation, assuming the API have already been explicitly declared as approved in the downstream workload cluster.    

TODO:
- [x] Propagate the _approval_ annotation from the `APIResourceSchema` resources to the generated CRDs
- [x] Add admission to reject `APIResouceSchema` resources in protected groups without the _approval_ annotation
- [x] Improve `APIBinding` condition message when the generated CRD is invalid
- [x] Add e2e test

## Related issue(s)

Fixes #1083