### PR TITLE
Add break when cluster found

### DIFF
--- a/pkg/reconciler/scheduling/placement/placement_reconcile.go
+++ b/pkg/reconciler/scheduling/placement/placement_reconcile.go
@@ -151,6 +151,8 @@ func (r *placementReconciler) reconcile(ctx context.Context, ns *corev1.Namespac
 		}
 		chosenLocationName = l.Name
 		chosenClusters = ready
+		// We can stop searching as we found ready clusters
+		break
 	}
 	if chosenLocationName == "" {
 		// TODO(sttts): come up with some both quicker rescheduling initially, but also some backoff when scheduling fails again


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dvernier@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

Add a break when matching clusters found for location

## Related issue(s)

Fixes # no issue created