### PR TITLE
pkg/server: init audit annotations

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -152,6 +152,17 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 	}
 }
 
+// WithAnnotations initializes the audit annotations in the context. Without intialization, there
+// won't be any annotations.
+func WithAnnotations(handler http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler.ServeHTTP(w, req.WithContext(
+			kaudit.WithAuditAnnotations(req.Context()),
+		))
+	})
+}
+
+// WithClusterAnnotation annotates the cluster name from the context into the audit logs
 func WithClusterAnnotation(handler http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		cluster := request.ClusterFrom(req.Context())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -230,6 +230,9 @@ func (s *Server) Run(ctx context.Context) error {
 		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler, unsafeServiceAccountPreAuth)
 		apiHandler = WithAcceptHeader(apiHandler)
 
+		// initializes Annotations and should therefore be called as early as possible in the handler chain
+		apiHandler = WithAnnotations(apiHandler)
+
 		return apiHandler
 	}
 

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -89,9 +89,8 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	// TODO(david): we need to provide user-facing details if this polling goes on forever. Blocking here is a bad UX.
 	// TODO(david): Also, any regressions in our code will make any e2e test that starts a syncer (at least in-process)
 	// TODO(david): block until it hits the 10 minute overall test timeout.
-	err = wait.PollImmediateInfinite(gvrQueryInterval, func() (bool, error) {
-		klog.Infof("Attempting to retrieve the Syncer virtual workspace URL from WorkloadCluster %s|%s", cfg.KCPClusterName, cfg.WorkloadClusterName)
-
+	klog.Infof("Attempting to retrieve the Syncer virtual workspace URL from WorkloadCluster %s|%s", cfg.KCPClusterName, cfg.WorkloadClusterName)
+	err = wait.PollImmediateInfinite(5*time.Second, func() (bool, error) {
 		workloadCluster, err := kcpClusterClient.Cluster(cfg.KCPClusterName).WorkloadV1alpha1().WorkloadClusters().Get(ctx, cfg.WorkloadClusterName, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

Initializes Audit Annotations with `kaudit.WithAuditAnnotations`.

It is necessary to be done by some early middleware. I verified that with the change we annotate the workspace.

## Related issue(s)
https://github.com/kcp-dev/kcp/issues/862