### PR TITLE
ci: Wrap commit ID in quotes

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Update sha and commit
         run: |-
-          sed -i -e 's/tag: [0-9a-f]\{7\}/tag: ${{ needs.build.outputs.sha_short }}/' manifest/unstable-values.yaml
+          sed -i -e 's/tag: "[0-9a-f]\{7\}"/tag: "${{ needs.build.outputs.sha_short }}"/' manifest/unstable-values.yaml
           git config user.email "klape+kcp-bot@redhat.com"
           git config user.name "KCP Bot"
           git add manifest/unstable-values.yaml


### PR DESCRIPTION
When updating gitops repo with new commit hash, it needs to be wrapped
in quotes so that it doesn't get incorrectly interpolated into something
else.

Example: 69353e8 gets interpolated like scientific notation

Signed-off-by: Kyle Lape <klape@redhat.com>