### PR TITLE
reconciler/workloads/apiexport: fix missing byWorkspace index for exports

### DIFF
--- a/pkg/reconciler/workload/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/workload/apiexport/apiexport_controller.go
@@ -78,6 +78,12 @@ func NewController(
 		return nil, err
 	}
 
+	if err := apiExportInformer.Informer().AddIndexers(cache.Indexers{
+		byWorkspace: indexByWorksapce,
+	}); err != nil {
+		return nil, err
+	}
+
 	apiExportInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj) },
 		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj) },


### PR DESCRIPTION
The index is used (in `enqueueNegotiatedAPIResource`), but not created. Hence, we lose triggers for APIExport updates.