### PR TITLE
apis/workloads: move scheduling labels here

### DIFF
--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -108,4 +108,11 @@ const (
 	// InternalDownstreamClusterLabel is a label with the upstream cluster name applied on the downstream cluster
 	// instead of state.internal.workloads.kcp.dev/<workload-cluster-name> which is used upstream.
 	InternalDownstreamClusterLabel = "internal.workloads.kcp.dev/cluster"
+
+	// SchedulingDisabledLabel on a namespace disables workload placement and scheduling.
+	SchedulingDisabledLabel = "experimental.workloads.kcp.dev/scheduling-disabled"
+
+	// WorkspaceSchedulableLabel on a workspace enables scheduling for the contents
+	// of the workspace. It is applied by default to workspaces of type `Universal`.
+	WorkspaceSchedulableLabel = "workloads.kcp.dev/schedulable"
 )

--- a/pkg/reconciler/workload/namespace/conditions_test.go
+++ b/pkg/reconciler/workload/namespace/conditions_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
@@ -36,14 +37,14 @@ func TestSetScheduledCondition(t *testing.T) {
 	}{
 		"disabled label present but empty": {
 			labels: map[string]string{
-				SchedulingDisabledLabel:                  "",
+				workloadv1alpha1.SchedulingDisabledLabel: "",
 				DeprecatedScheduledClusterNamespaceLabel: "foo",
 			},
 			reason: NamespaceReasonSchedulingDisabled,
 		},
 		"disabled label present but not empty": {
 			labels: map[string]string{
-				SchedulingDisabledLabel:                  "false",
+				workloadv1alpha1.SchedulingDisabledLabel: "false",
 				DeprecatedScheduledClusterNamespaceLabel: "foo",
 			},
 			reason: NamespaceReasonSchedulingDisabled,

--- a/pkg/reconciler/workload/namespace/namespace_reconcile.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile.go
@@ -41,14 +41,6 @@ import (
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
 
-const (
-	SchedulingDisabledLabel = "experimental.workloads.kcp.dev/scheduling-disabled"
-
-	// WorkspaceSchedulableLabel on a workspace enables scheduling for the contents
-	// of the workspace. It is applied by default to workspaces of type `Universal`.
-	WorkspaceSchedulableLabel = "workloads.kcp.dev/schedulable"
-)
-
 var (
 	scheduleRequirement           labels.Requirement
 	scheduleEmptyLabelRequirement labels.Requirement
@@ -71,13 +63,13 @@ func init() {
 		scheduleEmptyLabelRequirement = *req
 	}
 	// This matches namespaces that should be scheduled automatically by the namespace controller
-	if req, err := labels.NewRequirement(SchedulingDisabledLabel, selection.DoesNotExist, []string{}); err != nil {
+	if req, err := labels.NewRequirement(workloadv1alpha1.SchedulingDisabledLabel, selection.DoesNotExist, []string{}); err != nil {
 		klog.Fatalf("error creating the schedule label requirement: %v", err)
 	} else {
 		scheduleRequirement = *req
 	}
 	// This matches workspaces whose contents should be scheduled.
-	if req, err := labels.NewRequirement(WorkspaceSchedulableLabel, selection.Equals, []string{"true"}); err != nil {
+	if req, err := labels.NewRequirement(workloadv1alpha1.WorkspaceSchedulableLabel, selection.Equals, []string{"true"}); err != nil {
 		klog.Fatalf("error creating the schedule label requirement: %v", err)
 	} else {
 		workspaceSchedulableRequirement = *req

--- a/pkg/reconciler/workload/namespace/namespace_test.go
+++ b/pkg/reconciler/workload/namespace/namespace_test.go
@@ -124,7 +124,7 @@ func TestIsWorkspaceSchedulable(t *testing.T) {
 		t.Run(testCase.testName, func(t *testing.T) {
 			labels := map[string]string{}
 			if testCase.schedulable {
-				labels[WorkspaceSchedulableLabel] = "true"
+				labels[workloadv1alpha1.WorkspaceSchedulableLabel] = "true"
 			}
 			getWorkspace := func(key string) (*tenancyv1alpha1.ClusterWorkspace, error) {
 				return &tenancyv1alpha1.ClusterWorkspace{

--- a/pkg/reconciler/workload/namespace/scheduler_test.go
+++ b/pkg/reconciler/workload/namespace/scheduler_test.go
@@ -116,14 +116,14 @@ func TestAssignCluster(t *testing.T) {
 		"scheduling disabled set to empty -> no change even for unknown cluster name": {
 			labels: map[string]string{
 				DeprecatedScheduledClusterNamespaceLabel: unknownClusterName,
-				SchedulingDisabledLabel:                  "",
+				workloadv1alpha1.SchedulingDisabledLabel: "",
 			},
 			expectedCluster: unknownClusterName,
 		},
 		"scheduling disabled set to any value -> no change even for unknown cluster name": {
 			labels: map[string]string{
 				DeprecatedScheduledClusterNamespaceLabel: unknownClusterName,
-				SchedulingDisabledLabel:                  "foo",
+				workloadv1alpha1.SchedulingDisabledLabel: "foo",
 			},
 			expectedCluster: unknownClusterName,
 		},

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -50,10 +50,10 @@ import (
 
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	workloadcliplugin "github.com/kcp-dev/kcp/pkg/cliplugins/workload/plugin"
-	nscontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/namespace"
 	"github.com/kcp-dev/kcp/pkg/syncer"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
@@ -256,7 +256,7 @@ func NewWorkspaceWithWorkloads(t *testing.T, server RunningServer, orgClusterNam
 
 	labels := map[string]string{}
 	if !schedulable {
-		labels[nscontroller.WorkspaceSchedulableLabel] = "false"
+		labels[workloadv1alpha1.WorkspaceSchedulableLabel] = "false"
 	}
 
 	ws, err := clusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -124,7 +124,7 @@ func TestNamespaceScheduler(t *testing.T) {
 					if err != nil {
 						return err
 					}
-					ns.Labels[nscontroller.SchedulingDisabledLabel] = ""
+					ns.Labels[workloadv1alpha1.SchedulingDisabledLabel] = ""
 					_, err = server.client.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{})
 					return err
 				})


### PR DESCRIPTION
Those labels belong into the API package.