### PR TITLE
Don't sync ServiceAccounts by default

### DIFF
--- a/pkg/syncer/spec/mutators/deployment.go
+++ b/pkg/syncer/spec/mutators/deployment.go
@@ -64,10 +64,6 @@ func (dm *DeploymentMutator) Mutate(downstreamObj *unstructured.Unstructured) er
 	// Alias for the template.spec to improve readability.
 	templateSpec := &deployment.Spec.Template.Spec
 
-	if templateSpec.ServiceAccountName == "" || templateSpec.ServiceAccountName == "default" {
-		templateSpec.ServiceAccountName = "kcp-default"
-	}
-
 	// Setting AutomountServiceAccountToken to false allow us to control the ServiceAccount
 	// VolumeMount and Volume definitions.
 	templateSpec.AutomountServiceAccountToken = utilspointer.BoolPtr(false)

--- a/pkg/syncer/spec/mutators/deployment_test.go
+++ b/pkg/syncer/spec/mutators/deployment_test.go
@@ -123,7 +123,6 @@ func TestMutate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						AutomountServiceAccountToken: utilspointer.BoolPtr(false),
-						ServiceAccountName:           "kcp-default",
 						Containers: []corev1.Container{
 							{
 								Name:  "test-container",
@@ -200,7 +199,6 @@ func TestMutate(t *testing.T) {
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						AutomountServiceAccountToken: utilspointer.BoolPtr(false),
-						ServiceAccountName:           "kcp-default",
 						Containers: []corev1.Container{
 							{
 								Name:  "test-container",
@@ -281,7 +279,6 @@ func TestMutate(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: utilspointer.BoolPtr(false),
-							ServiceAccountName:           "kcp-default",
 							Containers: []corev1.Container{
 								{
 									Name:  "test-container",
@@ -364,7 +361,6 @@ func TestMutate(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: utilspointer.BoolPtr(false),
-							ServiceAccountName:           "kcp-default",
 							Containers: []corev1.Container{
 								{
 									Name:  "test-container",
@@ -458,7 +454,6 @@ func TestMutate(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: utilspointer.BoolPtr(false),
-							ServiceAccountName:           "kcp-default",
 							Containers: []corev1.Container{
 								{
 									Name:  "test-container",

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -346,14 +346,10 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 // transformName changes the object name into the desired one downstream.
 func transformName(syncedObject *unstructured.Unstructured) {
 	configMapGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
-	serviceAccountGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 	secretGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 
 	if syncedObject.GroupVersionKind() == configMapGVR && syncedObject.GetName() == "kube-root-ca.crt" {
 		syncedObject.SetName("kcp-root-ca.crt")
-	}
-	if syncedObject.GroupVersionKind() == serviceAccountGVR && syncedObject.GetName() == "default" {
-		syncedObject.SetName("kcp-default")
 	}
 	// TODO(jmprusi): We are rewriting the name of the object into a non random one so we can reference it from the deployment transformer
 	//                but this means that means than more than one default-token-XXXX object will overwrite the same "kcp-default-token"

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -1017,7 +1017,6 @@ func setPodSpecServiceAccount(fields ...string) unstructuredChange {
 	err := json.Unmarshal([]byte(`{
 	"automountServiceAccountToken":false,
 	"containers":null,
-	"serviceAccountName":"kcp-default",
 	"volumes":[
 		{"name":"kcp-api-access","projected":{
 			"defaultMode":420,

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -187,12 +187,8 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 // TransformName changes the object name into the desired one upstream.
 func transformName(syncedObject *unstructured.Unstructured) {
 	configMapGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
-	serviceAccountGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 
 	if syncedObject.GroupVersionKind() == configMapGVR && syncedObject.GetName() == "kcp-root-ca.crt" {
 		syncedObject.SetName("kube-root-ca.crt")
-	}
-	if syncedObject.GroupVersionKind() == serviceAccountGVR && syncedObject.GetName() == "kcp-default" {
-		syncedObject.SetName("default")
 	}
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -267,9 +267,9 @@ func getAllGVRs(discoveryClient discovery.DiscoveryInterface, resourcesToSync ..
 			return nil, err
 		}
 	}
-	// TODO(jmprusi): Added ServiceAccounts, Configmaps and Secrets to the default syncing, but we should figure out
+	// TODO(jmprusi): Added Configmaps and Secrets to the default syncing, but we should figure out
 	//                a way to avoid doing that: https://github.com/kcp-dev/kcp/issues/727
-	gvrstrs := sets.NewString("serviceaccounts.v1.", "configmaps.v1.", "secrets.v1.") // A syncer should always watch serviceaccounts, secrets and configmaps.
+	gvrstrs := sets.NewString("configmaps.v1.", "secrets.v1.") // A syncer should always watch secrets and configmaps.
 	for _, r := range rs {
 		// v1 -> v1.
 		// apps/v1 -> v1.apps

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -88,23 +88,8 @@ func TestSyncerLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	// TODO(marun) The name mapping should be defined for reuse outside of the transformName method in pkg/syncer
-	serviceAccountName := "kcp-default"
 	secretName := "kcp-default-token"
 	configMapName := "kcp-root-ca.crt"
-
-	t.Logf("Waiting for downstream service account %s/%s to be created...", downstreamNamespaceName, serviceAccountName)
-	require.Eventually(t, func() bool {
-		// TODO(marun) The name mapping should be defined for reuse outside of the transformName method in pkg/syncer
-		_, err = downstreamKubeClient.CoreV1().ServiceAccounts(downstreamNamespaceName).Get(ctx, serviceAccountName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return false
-		}
-		if err != nil {
-			t.Errorf("saw an error waiting for downstream service account %s/%s to be created: %v", downstreamNamespaceName, serviceAccountName, err)
-			return false
-		}
-		return true
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream service account %s/%s was not created", downstreamNamespaceName, serviceAccountName)
 
 	t.Logf("Waiting for downstream service account secret %s/%s to be created...", downstreamNamespaceName, secretName)
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
We are syncing the default serviceaccount from KCP to downstream, but it is not actually used downstream.

* Syncer: Stop syncing the serviceaccount by default.
* Syncer: Don't rename serviceaccount resources.
* Mutators: Deployment, don't add the serviceaccount to the downstream deployment podTemplate spec.
