### PR TITLE
pkg/server: add audit annotation init

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -152,6 +152,18 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 	}
 }
 
+// WithAuditAnnotation initializes audit annotations in the context. Without
+// initialization kaudit.AddAuditAnnotation isn't preserved.
+func WithAuditAnnotation(handler http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		handler.ServeHTTP(w, req.WithContext(
+			kaudit.WithAuditAnnotations(req.Context()),
+		))
+	})
+}
+
+// WithClusterAnnotation adds the cluster name into the annotation of an audit
+// event. Needs initialized annotations.
 func WithClusterAnnotation(handler http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		cluster := request.ClusterFrom(req.Context())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -226,6 +226,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		apiHandler = WithWorkspaceProjection(apiHandler)
 		apiHandler = WithClusterAnnotation(apiHandler)
+		apiHandler = WithAuditAnnotation(apiHandler) // Must run before any audit annotation is made
 		apiHandler = WithClusterScope(apiHandler)
 		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler, unsafeServiceAccountPreAuth)
 		apiHandler = WithAcceptHeader(apiHandler)


### PR DESCRIPTION
Signed-off-by: Krzysztof Ostrowski <kostrows@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

Initializes Audit Annotations with `kaudit.WithAuditAnnotations`.

It is necessary to be done by some early middleware. I verified that with the change we annotate the workspace.

## Hint

Previous PR lost reference and couldn't be changed anymore.

## Related issue(s)
https://github.com/kcp-dev/kcp/pull/1113
https://github.com/kcp-dev/kcp/issues/862