### PR TITLE
hack: Remove conflicting bash flag

### DIFF
--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -18,7 +18,6 @@
 # https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/c26a68b23e9317323d5d37660fe9d29b3d2ff40c/scripts/go_install.sh
 
 set -o errexit
-set -o nounset
 set -o pipefail
 
 if [ -z "${1}" ]; then


### PR DESCRIPTION
With the 'nounset' flag set the program never prints nice errors, but just
exits.
e.g when $1 is not set the program should prints
"must provide module as first parameter" and then exit but instead it
says "hack/go-install.sh: line 24: 1: unbound variable"

Signed-off-by: Roy Golan <rgolan@redhat.com>
