### PR TITLE
Syncer: Deployment Mutator use the full secret name instead of a hardcoded one 

### DIFF
--- a/pkg/syncer/spec/mutators/deployment.go
+++ b/pkg/syncer/spec/mutators/deployment.go
@@ -79,6 +79,10 @@ func (dm *DeploymentMutator) Mutate(obj *unstructured.Unstructured) error {
 	for _, secret := range secretList {
 		// Find the SA token that matches the service account name.
 		if val, ok := secret.GetAnnotations()[corev1.ServiceAccountNameKey]; ok && val == desiredServiceAccountName {
+			if desiredServiceAccountName == "default" {
+				desiredSecretName = "kcp-" + secret.GetName()
+				break
+			}
 			desiredSecretName = secret.GetName()
 			break
 		}

--- a/pkg/syncer/spec/mutators/deployment_test.go
+++ b/pkg/syncer/spec/mutators/deployment_test.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/kcp-dev/logicalcluster"
 	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -43,7 +44,7 @@ var kcpApiAccessVolume = corev1.Volume{
 				{
 					Secret: &corev1.SecretProjection{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "kcp-default-token",
+							Name: "default-token-1234",
 						},
 						Items: []corev1.KeyToPath{
 							{
@@ -81,20 +82,43 @@ var kcpApiAccessVolumeMount = corev1.VolumeMount{
 	ReadOnly:  true,
 }
 
-func TestMutate(t *testing.T) {
+func TestDeploymentMutate(t *testing.T) {
 	for _, c := range []struct {
 		desc                                   string
+		upstreamSecrets                        []*corev1.Secret
 		originalDeployment, expectedDeployment *appsv1.Deployment
 		config                                 *rest.Config
 	}{{
 		desc: "Deployment without Envs or volumes is mutated.",
+		upstreamSecrets: []*corev1.Secret{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default-token-1234",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
+					Annotations: map[string]string{
+						"kubernetes.io/service-account.name": "default",
+					},
+				},
+				Data: map[string][]byte{
+					"token":     []byte("token"),
+					"namespace": []byte("namespace"),
+				},
+			},
+		},
 		originalDeployment: &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
 				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-deployment",
+				Name:        "test-deployment",
+				Namespace:   "namespace",
+				ClusterName: "root:default:testing",
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: new(int32),
@@ -116,7 +140,9 @@ func TestMutate(t *testing.T) {
 				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-deployment",
+				Name:        "test-deployment",
+				Namespace:   "namespace",
+				ClusterName: "root:default:testing",
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: new(int32),
@@ -158,13 +184,35 @@ func TestMutate(t *testing.T) {
 		},
 	}, {
 		desc: "Deployment with one env var gets mutated but the already existing env var remains the same",
+		upstreamSecrets: []*corev1.Secret{
+			{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "default-token-1234",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
+					Annotations: map[string]string{
+						"kubernetes.io/service-account.name": "default",
+					},
+				},
+				Data: map[string][]byte{
+					"token":     []byte("token"),
+					"namespace": []byte("namespace"),
+				},
+			},
+		},
 		originalDeployment: &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Deployment",
 				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-deployment",
+				Name:        "test-deployment",
+				Namespace:   "namespace",
+				ClusterName: "root:default:testing",
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: new(int32),
@@ -192,7 +240,9 @@ func TestMutate(t *testing.T) {
 				APIVersion: "apps/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-deployment",
+				Name:        "test-deployment",
+				Namespace:   "namespace",
+				ClusterName: "root:default:testing",
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: new(int32),
@@ -238,13 +288,35 @@ func TestMutate(t *testing.T) {
 		},
 	},
 		{desc: "Deployment with an env var named KUBERNETES_SERVICE_PORT gets mutated and it is overridden and not duplicated",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "default-token-1234",
+						Namespace:   "namespace",
+						ClusterName: "root:default:testing",
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
 			originalDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Deployment",
 					APIVersion: "apps/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-deployment",
+					Name:        "test-deployment",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32),
@@ -272,7 +344,9 @@ func TestMutate(t *testing.T) {
 					APIVersion: "apps/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-deployment",
+					Name:        "test-deployment",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32),
@@ -313,13 +387,35 @@ func TestMutate(t *testing.T) {
 				Host: "https://4.5.6.7:12345",
 			}},
 		{desc: "Deployment with an existing VolumeMount named kcp-api-access gets mutated and it is overridden and not duplicated",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "default-token-1234",
+						Namespace:   "namespace",
+						ClusterName: "root:default:testing",
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
 			originalDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Deployment",
 					APIVersion: "apps/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-deployment",
+					Name:        "test-deployment",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32),
@@ -354,7 +450,9 @@ func TestMutate(t *testing.T) {
 					APIVersion: "apps/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-deployment",
+					Name:        "test-deployment",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32),
@@ -394,15 +492,36 @@ func TestMutate(t *testing.T) {
 			config: &rest.Config{
 				Host: "https://4.5.6.7:12345",
 			}},
-
 		{desc: "Deployment with an existing Volume named kcp-api-access gets mutated and it is overridden and not duplicated",
+			upstreamSecrets: []*corev1.Secret{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Secret",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "default-token-1234",
+						Namespace:   "namespace",
+						ClusterName: "root:default:testing",
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": "default",
+						},
+					},
+					Data: map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					},
+				},
+			},
 			originalDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Deployment",
 					APIVersion: "apps/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-deployment",
+					Name:        "test-deployment",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32),
@@ -447,7 +566,9 @@ func TestMutate(t *testing.T) {
 					APIVersion: "apps/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-deployment",
+					Name:        "test-deployment",
+					Namespace:   "namespace",
+					ClusterName: "root:default:testing",
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: new(int32),
@@ -492,7 +613,17 @@ func TestMutate(t *testing.T) {
 			t.Run(c.desc, func(t *testing.T) {
 				upstreamURL, err := url.Parse(c.config.Host)
 				require.NoError(t, err)
-				dm := NewDeploymentMutator(upstreamURL)
+
+				dm := NewDeploymentMutator(upstreamURL, func(upstreamLogicalCluster logicalcluster.Name, namespace string) ([]*unstructured.Unstructured, error) {
+					unstructuredObjects := make([]*unstructured.Unstructured, 0, len(c.upstreamSecrets))
+					for _, obj := range c.upstreamSecrets {
+						unstObj, err := toUnstructured(obj)
+						require.NoError(t, err)
+						unstructuredObjects = append(unstructuredObjects, unstObj)
+					}
+					return unstructuredObjects, nil
+				})
+
 				unstrOriginalDeployment, err := toUnstructured(c.originalDeployment)
 				require.NoError(t, err, "toRuntimeObject() = %v", err)
 

--- a/pkg/syncer/spec/mutators/deployment_test.go
+++ b/pkg/syncer/spec/mutators/deployment_test.go
@@ -44,7 +44,7 @@ var kcpApiAccessVolume = corev1.Volume{
 				{
 					Secret: &corev1.SecretProjection{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "default-token-1234",
+							Name: "kcp-default-token-1234",
 						},
 						Items: []corev1.KeyToPath{
 							{

--- a/pkg/syncer/spec/mutators/secrets.go
+++ b/pkg/syncer/spec/mutators/secrets.go
@@ -19,7 +19,6 @@ package mutators
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -39,27 +38,20 @@ func NewSecretMutator() *SecretMutator {
 }
 
 // Mutate applies the mutator changes to the object.
-func (sm *SecretMutator) Mutate(downstreamObj *unstructured.Unstructured) error {
-	var secret corev1.Secret
-	err := runtime.DefaultUnstructuredConverter.FromUnstructured(
-		downstreamObj.UnstructuredContent(),
-		&secret)
-	if err != nil {
-		return err
+func (sm *SecretMutator) Mutate(obj *unstructured.Unstructured) error {
+	// We need transform the serviceaccount tokens into an Opaque secret, in order to avoid the pcluster to rewrite them,
+	// and we remove the annotations that point to the kcp serviceaccount name/uid.
+	if _, ok := obj.GetAnnotations()[corev1.ServiceAccountNameKey]; ok {
+		obj.Object["type"] = string(corev1.SecretTypeOpaque)
+		annotations := obj.GetAnnotations()
+		delete(annotations, corev1.ServiceAccountNameKey)
+		delete(annotations, corev1.ServiceAccountUIDKey)
+		if len(annotations) == 0 {
+			obj.SetAnnotations(nil)
+		} else {
+			obj.SetAnnotations(annotations)
+		}
 	}
-
-	// We need to transform the default kcp token into an Opaque secret, in order to avoid the pcluster to rewrite it.
-	if secret.Name == "kcp-default-token" {
-		secret.Type = corev1.SecretTypeOpaque
-	}
-
-	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&secret)
-	if err != nil {
-		return err
-	}
-
-	// Set the changes back into the obj.
-	downstreamObj.SetUnstructuredContent(unstructured)
 
 	return nil
 }

--- a/pkg/syncer/spec/mutators/secrets_test.go
+++ b/pkg/syncer/spec/mutators/secrets_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutators
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecretsMutate(t *testing.T) {
+	for _, c := range []struct {
+		desc                           string
+		originalSecret, expectedSecret *corev1.Secret
+	}{{
+		desc: "A secret that is not a ServiceAccount token, should not be mutated",
+		originalSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-super-secret-stuff",
+				Annotations: map[string]string{
+					"testing": "testing",
+				},
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		},
+		expectedSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-super-secret-stuff",
+				Annotations: map[string]string{
+					"testing": "testing",
+				},
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+		},
+	}, {
+		desc: "A ServiceAccount secret, should be mutated",
+		originalSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-token-f8f8f8",
+				Annotations: map[string]string{
+					"kubernetes.io/service-account.name": "default",
+					"kubernetes.io/service-account.uid":  "asdasdasdasdasdsadsadas",
+				},
+			},
+			Type: corev1.SecretTypeServiceAccountToken,
+			Data: map[string][]byte{
+				"token":     []byte("token"),
+				"namespace": []byte("namespace"),
+			},
+		},
+		expectedSecret: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default-token-f8f8f8",
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"token":     []byte("token"),
+				"namespace": []byte("namespace"),
+			},
+		},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			sm := SecretMutator{}
+			unstrOriginalSecret, err := toUnstructured(c.originalSecret)
+			require.NoError(t, err)
+			unstrExpectedSecret, err := toUnstructured(c.expectedSecret)
+			require.NoError(t, err)
+			// The Secret mutator doesn't use the logical cluster.
+			err = sm.Mutate(unstrOriginalSecret)
+			require.NoError(t, err)
+			if !apiequality.Semantic.DeepEqual(unstrOriginalSecret, unstrExpectedSecret) {
+				t.Errorf("secret mutated incorrectly, got: %v expected: %v", unstrOriginalSecret.Object, unstrExpectedSecret.Object)
+			}
+		})
+	}
+}

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -235,8 +235,19 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	}
 
 	upstreamObjLogicalCluster := logicalcluster.From(upstreamObj)
-
 	downstreamObj := upstreamObj.DeepCopy()
+
+	// Run name transformations on the downstreamObj.
+	transformedName := getTransformedName(downstreamObj)
+
+	// Run any transformations on the object before we apply it to the downstream cluster.
+	if mutator, ok := c.mutators[gvr]; ok {
+		if err := mutator(downstreamObj); err != nil {
+			return err
+		}
+	}
+
+	downstreamObj.SetName(transformedName)
 	downstreamObj.SetUID("")
 	downstreamObj.SetResourceVersion("")
 	downstreamObj.SetNamespace(downstreamNamespace)
@@ -257,16 +268,6 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	delete(labels, workloadv1alpha1.InternalClusterResourceStateLabelPrefix+c.workloadClusterName)
 	labels[workloadv1alpha1.InternalDownstreamClusterLabel] = c.workloadClusterName
 	downstreamObj.SetLabels(labels)
-
-	// Run name transformations on the downstreamObj.
-	transformName(downstreamObj)
-
-	// Run any transformations on the object before we apply it to the downstream cluster.
-	if mutator, ok := c.mutators[gvr]; ok {
-		if err := mutator(downstreamObj); err != nil {
-			return err
-		}
-	}
 
 	if c.advancedSchedulingEnabled {
 		specDiffPatch := upstreamObj.GetAnnotations()[workloadv1alpha1.ClusterSpecDiffAnnotationPrefix+c.workloadClusterName]
@@ -343,18 +344,13 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	return nil
 }
 
-// transformName changes the object name into the desired one downstream.
-func transformName(syncedObject *unstructured.Unstructured) {
+// getTransformedName returns the desired object name.
+func getTransformedName(syncedObject *unstructured.Unstructured) string {
 	configMapGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
-	secretGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 
 	if syncedObject.GroupVersionKind() == configMapGVR && syncedObject.GetName() == "kube-root-ca.crt" {
-		syncedObject.SetName("kcp-root-ca.crt")
+		return "kcp-root-ca.crt"
 	}
-	// TODO(jmprusi): We are rewriting the name of the object into a non random one so we can reference it from the deployment transformer
-	//                but this means that means than more than one default-token-XXXX object will overwrite the same "kcp-default-token"
-	//				  object. This must be fixed.
-	if syncedObject.GroupVersionKind() == secretGVR && strings.Contains(syncedObject.GetName(), "default-token-") {
-		syncedObject.SetName("kcp-default-token")
-	}
+
+	return syncedObject.GetName()
 }

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -1099,7 +1099,7 @@ func setPodSpecServiceAccount(fields ...string) unstructuredChange {
 		{"name":"kcp-api-access","projected":{
 			"defaultMode":420,
 			"sources":[
-				{"secret":{"items":[{"key":"token","path":"token"},{"key":"namespace","path":"namespace"}],"name": "default-token-abc"}},
+				{"secret":{"items":[{"key":"token","path":"token"},{"key":"namespace","path":"namespace"}],"name": "kcp-default-token-abc"}},
 				{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kcp-root-ca.crt"}}
 			]
 		}}

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -463,7 +463,7 @@ func TestSyncerProcess(t *testing.T) {
 	tests := map[string]struct {
 		fromNamespace *corev1.Namespace
 		gvr           schema.GroupVersionResource
-		fromResource  runtime.Object
+		fromResources []runtime.Object
 		toResources   []runtime.Object
 
 		resourceToProcessName               string
@@ -484,9 +484,18 @@ func TestSyncerProcess(t *testing.T) {
 				"state.internal.workloads.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
-			fromResource: deployment("theDeployment", "test", "root:org:ws", map[string]string{
-				"state.internal.workloads.kcp.dev/us-west1": "Sync",
-			}, nil, nil),
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.internal.workloads.kcp.dev/us-west1": "Sync",
+				}, nil, nil),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
@@ -527,8 +536,17 @@ func TestSyncerProcess(t *testing.T) {
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
 				"state.internal.workloads.kcp.dev/us-west1": "Sync",
 			}, nil),
-			gvr:                                 schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
-			fromResource:                        deployment("theDeployment", "test", "root:org:ws", nil, nil, nil),
+			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", nil, nil, nil),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
@@ -547,9 +565,18 @@ func TestSyncerProcess(t *testing.T) {
 				"state.internal.workloads.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
-			fromResource: deployment("theDeployment", "test", "root:org:ws", map[string]string{
-				"state.internal.workloads.kcp.dev/us-west1": "Sync",
-			}, nil, nil),
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.internal.workloads.kcp.dev/us-west1": "Sync",
+				}, nil, nil),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
@@ -599,9 +626,18 @@ func TestSyncerProcess(t *testing.T) {
 				"state.internal.workloads.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
-			fromResource: deployment("theDeployment", "test", "root:org:ws", map[string]string{
-				"state.internal.workloads.kcp.dev/us-west1": "Sync",
-			}, map[string]string{"experimental.spec-diff.workloads.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, nil),
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws", map[string]string{
+					"state.internal.workloads.kcp.dev/us-west1": "Sync",
+				}, map[string]string{"experimental.spec-diff.workloads.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, nil),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
@@ -676,10 +712,19 @@ func TestSyncerProcess(t *testing.T) {
 					"internal.workloads.kcp.dev/cluster": "us-west1",
 				}, nil, []string{"workloads.kcp.dev/syncer-us-west1"}),
 			},
-			fromResource: deployment("theDeployment", "test", "root:org:ws",
-				map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
-				map[string]string{"deletion.internal.workloads.kcp.dev/us-west1": time.Now().Format(time.RFC3339)},
-				[]string{"workloads.kcp.dev/syncer-us-west1"}),
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"deletion.internal.workloads.kcp.dev/us-west1": time.Now().Format(time.RFC3339)},
+					[]string{"workloads.kcp.dev/syncer-us-west1"}),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
@@ -720,16 +765,24 @@ func TestSyncerProcess(t *testing.T) {
 						"kcp.dev/namespace-locator": `{"logical-cluster":"root:org:ws","namespace":"test"}`,
 					}),
 			},
-			fromResource: deployment("theDeployment", "test", "root:org:ws",
-				map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
-				map[string]string{"another.valid.annotation/this": "value",
-					"deletion.internal.workloads.kcp.dev/us-west1": time.Now().Format(time.RFC3339)},
-				[]string{"workloads.kcp.dev/syncer-us-west1"}),
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"another.valid.annotation/this": "value",
+						"deletion.internal.workloads.kcp.dev/us-west1": time.Now().Format(time.RFC3339)},
+					[]string{"workloads.kcp.dev/syncer-us-west1"}),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
 			advancedSchedulingEnabled:           true,
-
 			expectActionsOnFrom: []clienttesting.Action{
 				getDeploymentAction("theDeployment", "test"),
 				updateDeploymentAction("test",
@@ -782,13 +835,22 @@ func TestSyncerProcess(t *testing.T) {
 					"internal.workloads.kcp.dev/cluster": "us-west1",
 				}, nil, []string{"workloads.kcp.dev/syncer-us-west1"}),
 			},
-			fromResource: deployment("theDeployment", "test", "root:org:ws",
-				map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
-				map[string]string{
-					"deletion.internal.workloads.kcp.dev/us-west1": time.Now().Format(time.RFC3339),
-					"finalizers.workloads.kcp.dev/us-west1":        "another-controller-finalizer",
-				},
-				[]string{"workloads.kcp.dev/syncer-us-west1"}),
+			fromResources: []runtime.Object{
+				secret("default-token-abc", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{"kubernetes.io/service-account.name": "default"},
+					map[string][]byte{
+						"token":     []byte("token"),
+						"namespace": []byte("namespace"),
+					}),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{"state.internal.workloads.kcp.dev/us-west1": "Sync"},
+					map[string]string{
+						"deletion.internal.workloads.kcp.dev/us-west1": time.Now().Format(time.RFC3339),
+						"finalizers.workloads.kcp.dev/us-west1":        "another-controller-finalizer",
+					},
+					[]string{"workloads.kcp.dev/syncer-us-west1"}),
+			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			workloadClusterName:                 "us-west1",
@@ -850,8 +912,8 @@ func TestSyncerProcess(t *testing.T) {
 			kcpLogicalCluster := logicalcluster.New(tc.upstreamLogicalCluster)
 			var allFromResources []runtime.Object
 			allFromResources = append(allFromResources, tc.fromNamespace)
-			if tc.fromResource != nil {
-				allFromResources = append(allFromResources, tc.fromResource)
+			if tc.fromResources != nil {
+				allFromResources = append(allFromResources, tc.fromResources...)
 			}
 
 			fromClient := dynamicfake.NewSimpleDynamicClient(scheme, allFromResources...)
@@ -874,6 +936,7 @@ func TestSyncerProcess(t *testing.T) {
 
 			gvrs := []schema.GroupVersionResource{
 				{Group: "", Version: "v1", Resource: "namespaces"},
+				{Group: "", Version: "v1", Resource: "secrets"},
 				tc.gvr,
 			}
 			upstreamURL, err := url.Parse("https://kcp.dev:6443")
@@ -962,6 +1025,21 @@ func deployment(name, namespace, clusterName string, labels, annotations map[str
 	}
 }
 
+func secret(name, namespace, clusterName string, labels, annotations map[string]string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			ClusterName: clusterName,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Data:       data,
+		StringData: nil,
+		Type:       corev1.SecretTypeServiceAccountToken,
+	}
+}
+
 type deploymentChange func(*appsv1.Deployment)
 
 func changeDeployment(in *appsv1.Deployment, changes ...deploymentChange) *appsv1.Deployment {
@@ -1021,7 +1099,7 @@ func setPodSpecServiceAccount(fields ...string) unstructuredChange {
 		{"name":"kcp-api-access","projected":{
 			"defaultMode":420,
 			"sources":[
-				{"secret":{"items":[{"key":"token","path":"token"},{"key":"namespace","path":"namespace"}],"name":"kcp-default-token"}},
+				{"secret":{"items":[{"key":"token","path":"token"},{"key":"namespace","path":"namespace"}],"name": "default-token-abc"}},
 				{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kcp-root-ca.crt"}}
 			]
 		}}

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -87,23 +87,7 @@ func TestSyncerLifecycle(t *testing.T) {
 	downstreamNamespaceName, err := shared.PhysicalClusterNamespaceName(nsLocator)
 	require.NoError(t, err)
 
-	// TODO(marun) The name mapping should be defined for reuse outside of the transformName method in pkg/syncer
-	secretName := "kcp-default-token"
 	configMapName := "kcp-root-ca.crt"
-
-	t.Logf("Waiting for downstream service account secret %s/%s to be created...", downstreamNamespaceName, secretName)
-	require.Eventually(t, func() bool {
-		_, err = downstreamKubeClient.CoreV1().Secrets(downstreamNamespaceName).Get(ctx, secretName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return false
-		}
-		if err != nil {
-			t.Errorf("saw an error waiting for downstream service account secret %s/%s to be created: %v", downstreamNamespaceName, secretName, err)
-			return false
-		}
-		return true
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "downstream service account secret %s/%s was not created", downstreamNamespaceName, secretName)
-
 	t.Logf("Waiting for downstream configmap %s/%s to be created...", downstreamNamespaceName, configMapName)
 	require.Eventually(t, func() bool {
 		_, err = downstreamKubeClient.CoreV1().ConfigMaps(downstreamNamespaceName).Get(ctx, configMapName, metav1.GetOptions{})


### PR DESCRIPTION
The Deployment Mutator will look for a ServiceAccount token, and use its full name for syncing downstream, instead of hardcoding one secret name (kcp-default-token).

* only the default token is prefixed with: "kcp-", to avoid possible conflicts with the downstream default tokens.
* the token secret type is set to `Opaque`, instead of ServiceAccount type
* the token annotations for a `ServiceAccount` are removed

closes https://github.com/kcp-dev/kcp/issues/1062

related to: https://github.com/kcp-dev/kcp/issues/1058 https://github.com/kcp-dev/kcp/issues/280
