### PR TITLE
hack: check for missing parameters correctly

### DIFF
--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -21,22 +21,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ -z "${1}" ]; then
+if [[ -z "${1:-}" ]]; then
   echo "must provide module as first parameter"
   exit 1
 fi
 
-if [ -z "${2}" ]; then
+if [[ -z "${2:-}" ]]; then
   echo "must provide binary name as second parameter"
   exit 1
 fi
 
-if [ -z "${3}" ]; then
+if [[ -z "${3:-}" ]]; then
   echo "must provide version as third parameter"
   exit 1
 fi
 
-if [ -z "${GOBIN}" ]; then
+if [[ -z "${GOBIN:-}" ]]; then
   echo "GOBIN is not set. Must set GOBIN to install the bin in a specified directory."
   exit 1
 fi

--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -18,6 +18,7 @@
 # https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/c26a68b23e9317323d5d37660fe9d29b3d2ff40c/scripts/go_install.sh
 
 set -o errexit
+set -o nounset
 set -o pipefail
 
 if [ -z "${1}" ]; then


### PR DESCRIPTION
`nounset` is an extremely valuable flag for ensuring that a shell script
does what is expected. When checking for missing parameters, simply use
the default substitution syntax so that the flag is not tripped.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

```
$ head -n 21 hack/go-install.sh | tail -n 1
set -o nounset
$ hack/go-install.sh 
must provide module as first parameter
$ hack/go-install.sh  1
must provide binary name as second parameter
$ hack/go-install.sh  1 2
must provide version as third parameter
$ hack/go-install.sh  1 2 3
GOBIN is not set. Must set GOBIN to install the bin in a specified directory.
```

/assign @ncdc 