### PR TITLE
Makefile: fix build-all target for GNU make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ build: ## Build the project
 .PHONY: build
 
 .PHONY: build-all
-build-all: WHAT := ./cmd/...
-build-all: build
+build-all:
+	@$(MAKE) build WHAT=./cmd/...
 
 install: WHAT ?= ./cmd/...
 install:


### PR DESCRIPTION
In contrast to BSD make, https://www.gnu.org/software/make/manual/make.html#Target_002dspecific seems to be broken.