### PR TITLE
*: shorten initializer names

### DIFF
--- a/config/organization/clusterworkspacetype-team.yaml
+++ b/config/organization/clusterworkspacetype-team.yaml
@@ -4,4 +4,4 @@ metadata:
   name: team
 spec:
   initializers:
-  - initializers.tenancy.kcp.dev/team
+  - tenancy.kcp.dev/team

--- a/config/organization/clusterworkspacetype-universal.yaml
+++ b/config/organization/clusterworkspacetype-universal.yaml
@@ -4,6 +4,6 @@ metadata:
   name: universal
 spec:
   initializers:
-  - initializers.tenancy.kcp.dev/universal
+  - tenancy.kcp.dev/universal
   additionalWorkspaceLabels:
     workloads.kcp.dev/schedulable: "true"

--- a/config/root/clusterworkspacetype-organization.yaml
+++ b/config/root/clusterworkspacetype-organization.yaml
@@ -4,4 +4,4 @@ metadata:
   name: organization
 spec:
   initializers:
-  - initializers.tenancy.kcp.dev/organization
+  - tenancy.kcp.dev/organization

--- a/config/team/clusterworkspacetype-universal.yaml
+++ b/config/team/clusterworkspacetype-universal.yaml
@@ -4,6 +4,6 @@ metadata:
   name: universal
 spec:
   initializers:
-  - initializers.tenancy.kcp.dev/universal
+  - tenancy.kcp.dev/universal
   additionalWorkspaceLabels:
     workloads.kcp.dev/schedulable: "true"

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	typeInitializerKeyDomain = "initializers.tenancy.kcp.dev"
+	typeInitializerKeyDomain = "tenancy.kcp.dev"
 )
 
 func (c *controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) error {


### PR DESCRIPTION
We know these are names for initializers. We do not need to state as
much in their domain.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @sttts 