### PR TITLE
virtual: add initializingworkspaces endpoint

### DIFF
--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -56,6 +56,7 @@ func (s *Server) installVirtualWorkspaces(
 		dynamicClusterClient,
 		kcpClusterClient,
 		s.kubeSharedInformerFactory,
+		s.apiextensionsSharedInformerFactory,
 		s.kcpSharedInformerFactory,
 	)
 	if err != nil {

--- a/pkg/virtual/framework/forwardingregistry/wrappers.go
+++ b/pkg/virtual/framework/forwardingregistry/wrappers.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forwardingregistry
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func WithLabelSelector(labelSelector map[string]string) StorageWrapper {
+	return func(resource schema.GroupResource, storage *StoreFuncs) *StoreFuncs {
+		requirements, selectable := labels.SelectorFromSet(labels.Set(labelSelector)).Requirements()
+		if !selectable {
+			// we can't return an error here since this ends up inside of the k8s apiserver code where
+			// no errors are expected, so the best we can do is panic - this is likely ok since there's
+			// no real way that the syncer virtual workspace would ever create an unselectable selector
+			panic(fmt.Sprintf("creating a new store with an unselectable set: %v", labelSelector))
+		}
+
+		delegateLister := storage.ListerFunc
+		storage.ListerFunc = func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+			selector := options.LabelSelector
+			if selector == nil {
+				selector = labels.Everything()
+			}
+			options.LabelSelector = selector.Add(requirements...)
+			return delegateLister.List(ctx, options)
+		}
+
+		delegateGetter := storage.GetterFunc
+		storage.GetterFunc = func(ctx context.Context, name string, options *v1.GetOptions) (runtime.Object, error) {
+			obj, err := delegateGetter.Get(ctx, name, options)
+			if err != nil {
+				return obj, err
+			}
+
+			metaObj, ok := obj.(v1.Object)
+			if !ok {
+				return nil, fmt.Errorf("expected a metav1.Object, got %T", obj)
+			}
+			if !labels.Everything().Add(requirements...).Matches(labels.Set(metaObj.GetLabels())) {
+				return nil, errors.NewNotFound(resource, name)
+			}
+
+			return obj, err
+		}
+
+		delegateWatcher := storage.WatcherFunc
+		storage.WatcherFunc = func(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
+			selector := options.LabelSelector
+			if selector == nil {
+				selector = labels.Everything()
+			}
+			options.LabelSelector = selector.Add(requirements...)
+			return delegateWatcher.Watch(ctx, options)
+		}
+
+		return storage
+	}
+}

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	crdinfomer "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
+
+	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdgroups"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	virtualworkspacesdynamic "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	if err := tenancyv1alpha1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+}
+
+func BuildVirtualWorkspace(
+	rootPathPrefix string,
+	dynamicClusterClient dynamic.ClusterInterface,
+	wildcardApiExtensionsInformers apiextensionsinformers.SharedInformerFactory,
+) framework.VirtualWorkspace {
+	if !strings.HasSuffix(rootPathPrefix, "/") {
+		rootPathPrefix += "/"
+	}
+
+	readyCh := make(chan struct{})
+
+	return &virtualworkspacesdynamic.DynamicVirtualWorkspace{
+		Name: initializingworkspaces.VirtualWorkspaceName,
+		RootPathResolver: func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+
+			completedContext = requestContext
+			if !strings.HasPrefix(urlPath, rootPathPrefix) {
+				return
+			}
+			withoutRootPathPrefix := strings.TrimPrefix(urlPath, rootPathPrefix)
+
+			// Incoming requests to this virtual workspace will look like:
+			//  /services/initializingworkspaces/<initializer>/clusters/*/apis/workload.kcp.dev/v1alpha1/workloadclusters
+			//                                  └───────────┐
+			// Where the withoutRootPathPrefix starts here: ┘
+			parts := strings.SplitN(withoutRootPathPrefix, "/", 2)
+			if len(parts) < 2 {
+				return
+			}
+
+			initializerName := parts[0]
+			if initializerName == "" {
+				return
+			}
+
+			realPath := "/" + parts[1]
+
+			//  /services/initializingworkspaces/<initializer>/clusters/*/apis/workload.kcp.dev/v1alpha1/workloadclusters
+			//                  ┌─────────────────────────────┘
+			// We are now here: ┘
+			// Now, we parse out the logical cluster and validate that only wildcard requests are allowed.
+			if !strings.HasPrefix(realPath, "/clusters/") {
+				return // don't accept
+			}
+
+			withoutClustersPrefix := strings.TrimPrefix(realPath, "/clusters/")
+			parts = strings.SplitN(withoutClustersPrefix, "/", 2)
+			clusterName := parts[0]
+			realPath = "/"
+			if len(parts) > 1 {
+				realPath += parts[1]
+			}
+
+			if clusterName != "*" {
+				return false, "", nil
+				// TODO: how do we signal that this is an error?
+			}
+
+			completedContext = genericapirequest.WithCluster(requestContext, genericapirequest.Cluster{Name: logicalcluster.Wildcard, Wildcard: true})
+			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, dynamiccontext.APIDomainKey(initializerName))
+			prefixToStrip = strings.TrimSuffix(urlPath, realPath)
+			accepted = true
+			return
+		},
+		Ready: func() error {
+			select {
+			case <-readyCh:
+				return nil
+			default:
+				return errors.New("initializingworkspaces virtual workspace controllers are not started")
+			}
+		},
+		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
+			retriever := &apiSetRetriever{
+				config:               mainConfig,
+				dynamicClusterClient: dynamicClusterClient,
+				crdInformer:          wildcardApiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions(),
+			}
+
+			if err := mainConfig.AddPostStartHook(initializingworkspaces.VirtualWorkspaceName, func(hookContext genericapiserver.PostStartHookContext) error {
+				defer close(readyCh)
+
+				for name, informer := range map[string]cache.SharedIndexInformer{
+					"customresourcedefinitions": wildcardApiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Informer(),
+				} {
+					if !cache.WaitForNamedCacheSync(name, hookContext.StopCh, informer.HasSynced) {
+						return errors.New("informer not synced")
+					}
+				}
+
+				return nil
+			}); err != nil {
+				return nil, err
+			}
+
+			return retriever, nil
+		},
+	}
+}
+
+type apiSetRetriever struct {
+	config               genericapiserver.CompletedConfig
+	dynamicClusterClient dynamic.ClusterInterface
+	crdInformer          crdinfomer.CustomResourceDefinitionInformer
+}
+
+func (a *apiSetRetriever) GetAPIDefinitionSet(ctx context.Context, key dynamiccontext.APIDomainKey) (apis apidefinition.APIDefinitionSet, apisExist bool, err error) {
+	initializerName := string(key)
+
+	crd, err := a.crdInformer.Lister().Get(
+		clusters.ToClusterAwareKey(
+			logicalcluster.New(reservedcrdgroups.SystemCRDLogicalClusterName),
+			"clusterworkspaces.tenancy.kcp.dev",
+		),
+	)
+	if err != nil {
+		return nil, false, err
+	}
+
+	apiResourceSchema := &apisv1alpha1.APIResourceSchema{
+		Spec: apisv1alpha1.APIResourceSchemaSpec{
+			Group: crd.Spec.Group,
+			Names: crd.Spec.Names,
+			Scope: crd.Spec.Scope,
+		},
+	}
+
+	for i := range crd.Spec.Versions {
+		crdVersion := crd.Spec.Versions[i]
+
+		apiResourceVersion := apisv1alpha1.APIResourceVersion{
+			Name:                     crdVersion.Name,
+			Served:                   crdVersion.Served,
+			Storage:                  crdVersion.Storage,
+			Deprecated:               crdVersion.Deprecated,
+			DeprecationWarning:       crdVersion.DeprecationWarning,
+			AdditionalPrinterColumns: crdVersion.AdditionalPrinterColumns,
+		}
+
+		if crdVersion.Schema != nil && crdVersion.Schema.OpenAPIV3Schema != nil {
+			schemaBytes, err := json.Marshal(crdVersion.Schema.OpenAPIV3Schema)
+			if err != nil {
+				return nil, false, fmt.Errorf("error converting version %q schema: %w", crdVersion.Name, err)
+			}
+			apiResourceVersion.Schema.Raw = schemaBytes
+		}
+
+		// we never expose subresources for this virtual workspace
+
+		apiResourceSchema.Spec.Versions = append(apiResourceSchema.Spec.Versions, apiResourceVersion)
+	}
+
+	apis = make(apidefinition.APIDefinitionSet, len(apiResourceSchema.Spec.Versions))
+	for _, version := range apiResourceSchema.Spec.Versions {
+		gvr := schema.GroupVersionResource{
+			Group:    apiResourceSchema.Spec.Group,
+			Version:  version.Name,
+			Resource: apiResourceSchema.Spec.Names.Plural,
+		}
+		apiDefinition, err := apiserver.CreateServingInfoFor(
+			a.config,
+			apiResourceSchema,
+			version.Name,
+			provideForwardingRestStorage(ctx, a.dynamicClusterClient, initializerName),
+		)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to create serving info: %w", err)
+		}
+		apis[gvr] = apiDefinition
+	}
+
+	return apis, len(apis) > 0, nil
+}
+
+var _ apidefinition.APIDefinitionSetGetter = &apiSetRetriever{}

--- a/pkg/virtual/initializingworkspaces/doc.go
+++ b/pkg/virtual/initializingworkspaces/doc.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package initializingworkspaces and its sub-packages provide the Initializing Workspace Virtual Workspace.
+//
+// It allows for one basic functions:
+// - cross-cluster LIST + WATCH of Workspaces which:
+//   - are in the Initializing phase
+//   - request initialization by a specific controller
+//
+// That is, a request for
+// GET /services/initializingworkspaces/<initializer>/clusters/*/apis/tenancy.kcp.io/v1alpha1/clusterworkspaces
+// will return a list of ClusterWorkspace objects which are Initializing and for which spec.initializers contains the
+// <initializer-name>.
+// WATCH semantics are similar to (and implemented by) label selectors - a ClusterWorkspace that stops
+// matching the requirements to be served (not being in Initializing phase, not requesting initialization by
+// the controller) will be removed from the stream with a synthetic Deleted event.
+package initializingworkspaces
+
+const VirtualWorkspaceName string = "initializingworkspaces"

--- a/pkg/virtual/initializingworkspaces/options/options.go
+++ b/pkg/virtual/initializingworkspaces/options/options.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"path"
+
+	"github.com/spf13/pflag"
+
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
+	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces"
+	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces/builder"
+)
+
+type InitializingWorkspaces struct{}
+
+func New() *InitializingWorkspaces {
+	return &InitializingWorkspaces{}
+}
+
+func (o *InitializingWorkspaces) AddFlags(flags *pflag.FlagSet, prefix string) {
+	if o == nil {
+		return
+	}
+}
+
+func (o *InitializingWorkspaces) Validate(flagPrefix string) []error {
+	if o == nil {
+		return nil
+	}
+	errs := []error{}
+
+	return errs
+}
+
+func (o *InitializingWorkspaces) NewVirtualWorkspaces(
+	rootPathPrefix string,
+	dynamicClusterClient dynamic.ClusterInterface,
+	wildcardApiExtensionsInformers apiextensionsinformers.SharedInformerFactory,
+) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
+	virtualWorkspaces := []framework.VirtualWorkspace{
+		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), dynamicClusterClient, wildcardApiExtensionsInformers),
+	}
+	return nil, virtualWorkspaces, nil
+}
+
+func (o *InitializingWorkspaces) Name() string {
+	return initializingworkspaces.VirtualWorkspaceName
+}

--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/forwardingregistry"
 	syncercontext "github.com/kcp-dev/kcp/pkg/virtual/syncer/context"
 	"github.com/kcp-dev/kcp/pkg/virtual/syncer/controllers/apireconciler"
 )
@@ -133,7 +134,7 @@ func BuildVirtualWorkspace(
 				wildcardKcpInformers.Apis().V1alpha1().APIExports(),
 				func(workloadClusterName string, apiResourceSchema *apisv1alpha1.APIResourceSchema, version string, apiExportIdentityHash string) (apidefinition.APIDefinition, error) {
 					ctx, cancelFn := context.WithCancel(context.Background())
-					storageWrapper := WithLabelSelector(map[string]string{
+					storageWrapper := forwardingregistry.WithLabelSelector(map[string]string{
 						workloadv1alpha1.InternalClusterResourceStateLabelPrefix + workloadClusterName: string(workloadv1alpha1.ResourceStateSync),
 					})
 					storageBuilder := NewStorageBuilder(ctx, dynamicClusterClient, apiExportIdentityHash, storageWrapper)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -236,7 +236,7 @@ func NewOrganizationFixture(t *testing.T, server RunningServer) (orgClusterName 
 		ws, err := clusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, org.Name, metav1.GetOptions{})
 		require.Falsef(t, apierrors.IsNotFound(err), "workspace %s was deleted", org.Name)
 		if err != nil {
-			klog.Errorf("failed to get workspace %s: %v", org.Name, err)
+			t.Logf("failed to get workspace %s: %v", org.Name, err)
 			return false
 		}
 		return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
@@ -299,7 +299,7 @@ func NewWorkspaceWithWorkloads(t *testing.T, server RunningServer, orgClusterNam
 		ws, err := clusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, ws.Name, metav1.GetOptions{})
 		require.Falsef(t, apierrors.IsNotFound(err), "workspace %s was deleted", ws.Name)
 		if err != nil {
-			klog.Errorf("failed to get workspace %s: %v", ws.Name, err)
+			t.Logf("failed to get workspace %s: %v", ws.Name, err)
 			return false
 		}
 		return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -1,0 +1,363 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializingworkspaces
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/endpoints/discovery"
+	clientgodiscovery "k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/clientcmd"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	tenancyv1alpha1client "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestInitializingWorkspacesVirtualWorkspaceDiscovery(t *testing.T) {
+	t.Parallel()
+
+	source := framework.SharedKcpServer(t)
+
+	rawConfig, err := source.RawConfig()
+	require.NoError(t, err)
+
+	adminCluster := rawConfig.Clusters["system:admin"]
+	adminContext := rawConfig.Contexts["system:admin"]
+	virtualWorkspaceRawConfig := rawConfig.DeepCopy()
+
+	virtualWorkspaceRawConfig.Clusters["virtual"] = adminCluster.DeepCopy()
+	virtualWorkspaceRawConfig.Clusters["virtual"].Server = adminCluster.Server + "/services/initializingworkspaces/whatever"
+	virtualWorkspaceRawConfig.Contexts["virtual"] = adminContext.DeepCopy()
+	virtualWorkspaceRawConfig.Contexts["virtual"].Cluster = "virtual"
+
+	virtualWorkspaceConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "virtual", nil, nil).ClientConfig()
+	require.NoError(t, err)
+
+	virtualWorkspaceDiscoveryClient, err := clientgodiscovery.NewDiscoveryClientForConfig(virtualWorkspaceConfig)
+	require.NoError(t, err)
+	_, apiResourceLists, err := virtualWorkspaceDiscoveryClient.WithCluster(logicalcluster.Wildcard).ServerGroupsAndResources()
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*metav1.APIResourceList{{
+		GroupVersion: "v1", // TODO: we should figure out why discovery shows this empty group
+	}, {
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "APIResourceList",
+			APIVersion: "v1",
+		},
+		GroupVersion: "tenancy.kcp.dev/v1alpha1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:               "ClusterWorkspace",
+				Name:               "clusterworkspaces",
+				SingularName:       "clusterworkspace",
+				Categories:         []string{"kcp"},
+				Verbs:              metav1.Verbs{"list", "watch"},
+				StorageVersionHash: discovery.StorageVersionHash("", "tenancy.kcp.dev", "v1alpha1", "ClusterWorkspace"),
+			},
+		},
+	}}, apiResourceLists))
+}
+
+func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
+	t.Parallel()
+
+	source := framework.SharedKcpServer(t)
+	orgClusterName := framework.NewOrganizationFixture(t, source)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	sourceConfig := source.DefaultConfig(t)
+	rawConfig, err := source.RawConfig()
+	require.NoError(t, err)
+
+	sourceKcpClusterClient, err := kcpclient.NewClusterForConfig(sourceConfig)
+	require.NoError(t, err)
+
+	// Create a Workspace that will not be Initializing and should not be shown in the virtual workspace
+	framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
+
+	sourceKcpTenancyClient := sourceKcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1()
+
+	testLabelSelector := map[string]string{
+		"internal.kcp.dev/e2e-test": t.Name(),
+	}
+
+	t.Log("Create workspace types that add initializers")
+	// ClusterWorkspaceTypes and the initializer names will have to be globally unique, so we add some suffix here
+	// to ensure that parallel test runs do not impact our ability to verify this behavior. ClusterWorkspaceType names
+	// are pretty locked down, using this regex: '^[A-Z][a-zA-Z0-9]+$' - so we just add some simple lowercase suffix.
+	const characters = "abcdefghijklmnopqrstuvwxyz"
+	suffix := func() string {
+		b := make([]byte, 10)
+		for i := range b {
+			b[i] = characters[rand.Intn(len(characters))]
+		}
+		return string(b)
+	}
+	clusterWorkspaceTypeNames := map[string]string{}
+	for _, name := range []string{
+		"alpha", "beta", "gamma",
+	} {
+		clusterWorkspaceTypeNames[name] = name + suffix()
+	}
+	clusterWorkspaceInitializerNames := map[string]tenancyv1alpha1.ClusterWorkspaceInitializer{}
+	for _, name := range []string{
+		"alpha", "beta",
+	} {
+		clusterWorkspaceInitializerNames[name] = tenancyv1alpha1.ClusterWorkspaceInitializer(name + "-" + suffix())
+	}
+
+	for name, initializers := range map[string][]string{
+		"alpha": {"alpha"},
+		"beta":  {"beta"},
+		"gamma": {"alpha", "beta"},
+	} {
+		var initializerNames []tenancyv1alpha1.ClusterWorkspaceInitializer
+		for _, initializerName := range initializers {
+			initializerNames = append(initializerNames, clusterWorkspaceInitializerNames[initializerName])
+		}
+		_, err = sourceKcpTenancyClient.ClusterWorkspaceTypes().Create(ctx, &tenancyv1alpha1.ClusterWorkspaceType{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterWorkspaceTypeNames[name],
+			},
+			Spec: tenancyv1alpha1.ClusterWorkspaceTypeSpec{
+				Initializers: initializerNames,
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Log("Create workspaces that using the new types, which will get stuck in initializing")
+	for _, workspaceType := range []string{
+		"alpha", "beta", "gamma",
+	} {
+		_, err := sourceKcpTenancyClient.ClusterWorkspaces().Create(ctx, workspaceForType(clusterWorkspaceTypeNames[workspaceType], testLabelSelector), metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	t.Log("Wait for workspaces to get stuck in initializing")
+	require.Eventually(t, func() bool {
+		workspaces, err := sourceKcpTenancyClient.ClusterWorkspaces().List(ctx, metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(testLabelSelector).String(),
+		})
+		if err != nil {
+			t.Logf("error listing workspaces: %v", err)
+			return false
+		}
+		if len(workspaces.Items) != 3 {
+			t.Logf("got %d workspaces, expected 3", len(workspaces.Items))
+			return false
+		}
+		return workspacesStuckInInitializing(t, workspaces.Items...)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	t.Log("Create clients through the virtual workspace")
+	adminCluster := rawConfig.Clusters["system:admin"]
+	adminContext := rawConfig.Contexts["system:admin"]
+	virtualWorkspaceRawConfig := rawConfig.DeepCopy()
+
+	clients := map[string]tenancyv1alpha1client.ClusterWorkspaceInterface{}
+	for _, initializer := range []string{
+		"alpha", "beta",
+	} {
+		initializerName := clusterWorkspaceInitializerNames[initializer]
+		virtualWorkspaceRawConfig.Clusters[initializer] = adminCluster.DeepCopy()
+		virtualWorkspaceRawConfig.Clusters[initializer].Server = adminCluster.Server + "/services/initializingworkspaces/" + string(initializerName)
+		virtualWorkspaceRawConfig.Contexts[initializer] = adminContext.DeepCopy()
+		virtualWorkspaceRawConfig.Contexts[initializer].Cluster = initializer
+		virtualWorkspaceConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, initializer, nil, nil).ClientConfig()
+		require.NoError(t, err)
+		virtualKcpClusterClient, err := kcpclient.NewClusterForConfig(virtualWorkspaceConfig)
+		require.NoError(t, err)
+		clients[initializer] = virtualKcpClusterClient.Cluster(logicalcluster.Wildcard).TenancyV1alpha1().ClusterWorkspaces()
+	}
+
+	t.Log("Ensure that LIST calls through the virtual workspace show the correct values")
+	workspaces, err := sourceKcpTenancyClient.ClusterWorkspaces().List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(testLabelSelector).String(),
+	})
+	require.NoError(t, err)
+	workspacesByType := map[string]tenancyv1alpha1.ClusterWorkspace{}
+	for i := range workspaces.Items {
+		workspacesByType[strings.ToLower(workspaces.Items[i].Spec.Type)] = workspaces.Items[i]
+	}
+
+	for initializer, expected := range map[string][]tenancyv1alpha1.ClusterWorkspace{
+		"alpha": {workspacesByType[clusterWorkspaceTypeNames["alpha"]], workspacesByType[clusterWorkspaceTypeNames["gamma"]]},
+		"beta":  {workspacesByType[clusterWorkspaceTypeNames["beta"]], workspacesByType[clusterWorkspaceTypeNames["gamma"]]},
+	} {
+		sort.Slice(expected, func(i, j int) bool {
+			return expected[i].UID < expected[j].UID
+		})
+		actual, err := clients[initializer].List(ctx, metav1.ListOptions{}) // no list options, all filtering is implicit
+		require.NoError(t, err)
+		sort.Slice(actual.Items, func(i, j int) bool {
+			return actual.Items[i].UID < actual.Items[j].UID
+		})
+		require.Empty(t, cmp.Diff(expected, actual.Items), "cluster workspace list for initializer %s incorrect", initializer)
+	}
+
+	t.Log("Start WATCH streams to confirm behavior on changes")
+	watchers := map[string]watch.Interface{}
+	for _, initializer := range []string{
+		"alpha", "beta",
+	} {
+		watcher, err := clients[initializer].Watch(ctx, metav1.ListOptions{
+			ResourceVersion: workspaces.ResourceVersion,
+		})
+		require.NoError(t, err)
+		watchers[initializer] = watcher
+	}
+
+	t.Log("Adding a new workspace that both watchers should see")
+	ws, err := sourceKcpTenancyClient.ClusterWorkspaces().Create(ctx, workspaceForType(clusterWorkspaceTypeNames["gamma"], testLabelSelector), metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		workspace, err := sourceKcpTenancyClient.ClusterWorkspaces().Get(ctx, ws.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("error listing workspaces: %v", err)
+			return false
+		}
+		return workspacesStuckInInitializing(t, *workspace)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	ws, err = sourceKcpTenancyClient.ClusterWorkspaces().Get(ctx, ws.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	for initializer, watcher := range watchers {
+		for {
+			select {
+			case evt := <-watcher.ResultChan():
+				// there might be other actors doing who-knows-what on the workspaces, so we need to specifically
+				// look for the first event *relating to the new workspace* that we get
+				if evt.Object.(metav1.Object).GetUID() != ws.UID {
+					continue
+				}
+				require.Equal(t, evt.Type, watch.Added)
+				require.Equal(t, evt.Object.(metav1.Object).GetUID(), ws.UID, "got incorrect object in watch stream for initializer %s", initializer)
+			case <-time.Tick(wait.ForeverTestTimeout):
+				t.Fatalf("never saw a watche event for the %s initializer", initializer)
+			}
+			break
+		}
+	}
+
+	t.Log("Transitioning the new workspace out of initializing")
+	previous := ws.DeepCopy()
+	oldData, err := json.Marshal(tenancyv1alpha1.ClusterWorkspace{
+		Status: previous.Status,
+	})
+	require.NoError(t, err)
+
+	obj := ws.DeepCopy()
+	obj.Status.Initializers = []tenancyv1alpha1.ClusterWorkspaceInitializer{}
+	obj.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseReady
+	newData, err := json.Marshal(tenancyv1alpha1.ClusterWorkspace{
+		Status: obj.Status,
+	})
+	require.NoError(t, err)
+
+	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+	require.NoError(t, err)
+	ws, err = sourceKcpTenancyClient.ClusterWorkspaces().Patch(ctx, obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	require.NoError(t, err)
+
+	for initializer, watcher := range watchers {
+		for {
+			select {
+			case evt := <-watcher.ResultChan():
+				if evt.Type == watch.Modified {
+					ws = evt.Object.(*tenancyv1alpha1.ClusterWorkspace)
+					continue // we will see some modification events from the above patch and the resulting controller reactions
+				}
+				// there might be other actors doing who-knows-what on the workspaces, so we need to specifically
+				// look for the first event *relating to the new workspace* that we get
+				if evt.Object.(metav1.Object).GetUID() != ws.UID {
+					continue
+				}
+				require.Equal(t, evt.Type, watch.Deleted)
+				require.Equal(t, evt.Object.(metav1.Object).GetUID(), ws.UID, "got incorrect object in watch stream for initializer %s", initializer)
+			case <-time.Tick(wait.ForeverTestTimeout):
+				t.Fatalf("never saw a watch event for the %s initializer", initializer)
+			}
+			break
+		}
+	}
+}
+
+func workspaceForType(workspaceType string, testLabelSelector map[string]string) *tenancyv1alpha1.ClusterWorkspace {
+	return &tenancyv1alpha1.ClusterWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-workspace-",
+			Labels:       testLabelSelector,
+		},
+		Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+			Type: strings.ToUpper(string(workspaceType[0])) + workspaceType[1:],
+		},
+	}
+}
+
+func workspacesStuckInInitializing(t *testing.T, workspaces ...tenancyv1alpha1.ClusterWorkspace) bool {
+	for _, workspace := range workspaces {
+		if workspace.Status.Phase != tenancyv1alpha1.ClusterWorkspacePhaseInitializing {
+			t.Logf("workspace %s is in %s, not %s", workspace.Name, workspace.Status.Phase, tenancyv1alpha1.ClusterWorkspacePhaseInitializing)
+			return false
+		}
+		if len(workspace.Status.Initializers) == 0 {
+			t.Logf("workspace %s has no initializers", workspace.Name)
+			return false
+		}
+		if !workspaceLabelsUpToDate(t, workspace) {
+			return false
+		}
+	}
+	return true
+}
+
+// this is really an implementation detail of the virtual workspace, but since we have a couple of moving pieces
+// we do ultimately need to wait for labels to propagate before checking anything else, or the VW will not work
+func workspaceLabelsUpToDate(t *testing.T, workspace tenancyv1alpha1.ClusterWorkspace) bool {
+	if workspace.ObjectMeta.Labels[tenancyv1alpha1.ClusterWorkspacePhaseLabel] != string(tenancyv1alpha1.ClusterWorkspacePhaseInitializing) {
+		t.Logf("workspace %s phase label is not updated yet", workspace.Name)
+		return false
+	}
+	for _, initializer := range workspace.Status.Initializers {
+		if _, exists := workspace.ObjectMeta.Labels[string(tenancyv1alpha1.ClusterWorkspaceInitializerLabelPrefix+initializer)]; !exists {
+			t.Logf("workspace %s initializer labels are not updated yet", workspace.Name)
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
virtual: add initializingworkspaces endpoint

This endpoint shows a client the ClusterWorkspaces which are

a) initializing
b) waiting for the client's initalizer to be removed

This endpoint is accessed under

/services/initilizingworkspaces/<initializer>

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

based off of #https://github.com/kcp-dev/kcp/pull/1140
/assign @sttts @ncdc 

Follow-ups:
- [ ] add authz
- [ ] allow access to workspace contents