### PR TITLE
virtual: ignore requests without clusters/ suffix

### DIFF
--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -87,22 +87,21 @@ func BuildVirtualWorkspace(rootPathPrefix string, dynamicClusterClient dynamic.C
 			//  /services/syncer/root:org:ws/<workload-cluster-name>/clusters/*/api/v1/configmaps
 			//                  ┌───────────────────────────────────┘
 			// We are now here: ┘
-			// Now, we parse out the logical cluster but change the semantic. If a client does not provide the
-			// logical cluster for their request, we will assume a wildcard request. We need to add this to the
-			// context so that our delegate client-go requests can re-encode it.
-			cluster := genericapirequest.Cluster{Name: logicalcluster.Wildcard, Wildcard: true}
-			if strings.HasPrefix(realPath, "/clusters/") {
-				withoutClustersPrefix := strings.TrimPrefix(realPath, "/clusters/")
-				parts = strings.SplitN(withoutClustersPrefix, "/", 2)
-				lclusterName := parts[0]
-				realPath = "/"
-				if len(parts) > 1 {
-					realPath += parts[1]
-				}
-				cluster = genericapirequest.Cluster{Name: logicalcluster.New(lclusterName)}
-				if lclusterName == "*" {
-					cluster.Wildcard = true
-				}
+			// Now, we parse out the logical cluster.
+			if !strings.HasPrefix(realPath, "/clusters/") {
+				return // don't accept
+			}
+
+			withoutClustersPrefix := strings.TrimPrefix(realPath, "/clusters/")
+			parts = strings.SplitN(withoutClustersPrefix, "/", 2)
+			clusterName := parts[0]
+			realPath = "/"
+			if len(parts) > 1 {
+				realPath += parts[1]
+			}
+			cluster := genericapirequest.Cluster{Name: logicalcluster.New(clusterName)}
+			if clusterName == "*" {
+				cluster.Wildcard = true
 			}
 
 			completedContext = genericapirequest.WithCluster(requestContext, cluster)

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -151,11 +151,11 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		{
 			name: "isolated API domains per syncer",
 			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name) {
-				kubelikeVWDiscoverClient, err := clientgodiscovery.NewDiscoveryClientForConfig(kubelikeSyncerVWConfig)
+				kubelikeVWDiscoverClusterClient, err := clientgodiscovery.NewDiscoveryClientForConfig(kubelikeSyncerVWConfig)
 				require.NoError(t, err)
 
 				t.Logf("Check discovery in kubelike virtual workspace")
-				_, kubelikeAPIResourceLists, err := kubelikeVWDiscoverClient.ServerGroupsAndResources()
+				_, kubelikeAPIResourceLists, err := kubelikeVWDiscoverClusterClient.WithCluster(logicalcluster.Wildcard).ServerGroupsAndResources()
 				require.NoError(t, err)
 				require.Empty(t, cmp.Diff([]*metav1.APIResourceList{
 					deploymentsAPIResourceList(kubelikeClusterName.String()),
@@ -207,9 +207,9 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				}, sortAPIResourceList(kubelikeAPIResourceLists)))
 
 				t.Logf("Check discovery in wildwest virtual workspace")
-				wildwestVWDiscoverClient, err := clientgodiscovery.NewDiscoveryClientForConfig(wildwestSyncerVWConfig)
+				wildwestVWDiscoverClusterClient, err := clientgodiscovery.NewDiscoveryClientForConfig(wildwestSyncerVWConfig)
 				require.NoError(t, err)
-				_, wildwestAPIResourceLists, err := wildwestVWDiscoverClient.ServerGroupsAndResources()
+				_, wildwestAPIResourceLists, err := wildwestVWDiscoverClusterClient.WithCluster(logicalcluster.Wildcard).ServerGroupsAndResources()
 				require.NoError(t, err)
 				require.Empty(t, cmp.Diff([]*metav1.APIResourceList{
 					deploymentsAPIResourceList(wildwestClusterName.String()),


### PR DESCRIPTION
Pass through the handler chain, which eventually ends as 403 or 404 depending on authz.