### PR TITLE
remove getting cluster name from object meta 

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -82,7 +82,7 @@ func NewController(
 			var ret []*apisv1alpha1.APIBinding
 
 			for i := range list {
-				if list[i].ClusterName != clusterName.String() {
+				if logicalcluster.From(list[i]) != clusterName {
 					continue
 				}
 

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -977,6 +977,7 @@ func (b *bindingBuilder) Build() *apisv1alpha1.APIBinding {
 }
 
 func (b *bindingBuilder) WithClusterName(clusterName string) *bindingBuilder {
+	//TODO (shawn-hurley): We may need to change how we set this
 	b.ClusterName = clusterName
 	return b
 }

--- a/pkg/reconciler/apis/apiresource/negotiation.go
+++ b/pkg/reconciler/apis/apiresource/negotiation.go
@@ -681,7 +681,8 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 				OwnerReferences: []metav1.OwnerReference{
 					NegotiatedAPIResourceAsOwnerReference(negotiatedApiResource),
 				},
-				ClusterName: negotiatedApiResource.ClusterName,
+				//TODO: (shawn-hurley) We need to figure out how to set this
+				ClusterName: logicalcluster.From(negotiatedApiResource).String(),
 			},
 			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 				Scope: negotiatedApiResource.Spec.Scope,

--- a/pkg/reconciler/workload/basecontroller/controller.go
+++ b/pkg/reconciler/workload/basecontroller/controller.go
@@ -167,8 +167,9 @@ func (c *ClusterReconciler) enqueueAPIResourceImportRelatedCluster(obj interface
 	if apiResourceImport != nil {
 		c.enqueue(&metav1.PartialObjectMetadata{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        apiResourceImport.Spec.Location,
-				ClusterName: apiResourceImport.ClusterName,
+				Name: apiResourceImport.Spec.Location,
+				// TODO: (shawn-hurley)
+				ClusterName: logicalcluster.From(apiResourceImport).String(),
 			},
 		})
 	}

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -392,7 +392,7 @@ func (s *REST) getClusterWorkspace(ctx context.Context, name string, options *me
 	}
 	var existingClusterWorkspace *tenancyv1alpha1.ClusterWorkspace
 	for _, ws := range obj.Items {
-		if ws.Name == workspace.Name && ws.ClusterName == workspace.ClusterName {
+		if ws.Name == workspace.Name && logicalcluster.From(&ws).String() == logicalcluster.From(workspace).String() {
 			existingClusterWorkspace = workspace
 			break
 		}


### PR DESCRIPTION
## Summary
Removing getting logicalcluster from objects metadata, and instead use logicalcluster.From.

Handeling Setting the value, will be completed in a followup PR.
## Related issue(s)

Partial fix for #1008 