### PR TITLE
e2e-shared-server: stop running 2x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,7 +176,7 @@ jobs:
           kind get kubeconfig > /tmp/kind-kubeconfig
           ARTIFACT_DIR=/tmp/e2e \
           PATH="${PATH}:$(pwd)/bin/" \
-          TEST_ARGS="./test/e2e... -args --use-default-kcp-server --syncer-image=$(cat /tmp/syncer-image) --kcp-test-image=$(cat /tmp/kcp-test-image) --pcluster-kubeconfig=/tmp/kind-kubeconfig" \
+          TEST_ARGS="-args --use-default-kcp-server --syncer-image=$(cat /tmp/syncer-image) --kcp-test-image=$(cat /tmp/kcp-test-image) --pcluster-kubeconfig=/tmp/kind-kubeconfig" \
           COUNT=2 \
           E2E_PARALLELISM=2 \
           make test-e2e


### PR DESCRIPTION
## Summary
I _think_ we're running `test/e2e...` twice in e2e-shared-server, once from the defaulting of `WHAT` in Makefile for `test-e2e` and a second time in ci.yaml where we have `test/e2e...` in `TEST_ARGS`. Let's see if this reduces test time...

## Related issue(s)

Fixes #