### PR TITLE
makefile: update things to be consistent & simple

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,15 +67,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: kcp
       - uses: actions/setup-go@v3
         with:
           go-version: v1.17
       - name: Check dependencies
         run: |
-          cd kcp
-          hack/validate-k8s.sh
+          make verify-k8s-deps
 
   lint:
     name: lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,19 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: kcp
       - uses: actions/setup-go@v3
         with:
           go-version: v1.17
       - name: Check imports
         run: |
-          cd kcp
-          make imports
-          if  ! git diff --exit-code; then
-            echo "imports are out of date, run make imports"
-            exit 1
-          fi
+          make verify-imports
 
   deps:
     name: deps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,8 +96,6 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: v1.17
-      - name: Download modules
-        run: go mod download
       - name: Check codegen
         run: make verify-codegen
 

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ test:
 verify-k8s-deps:
 	hack/validate-k8s.sh
 
+.PHONY: verify-imports
+verify-imports:
+	hack/verify-imports.sh
+
 .PHONY: demos
 demos: build ## Runs all the default demos (kubecon and apiNegotiation).
 	cd contrib/demo && ./runDemoScripts.sh

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ $(YAML_PATCH):
 	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) github.com/pivotal-cf/yaml-patch/cmd/yaml-patch $(YAML_PATCH_BIN) $(YAML_PATCH_VER)
 
 codegen: $(CONTROLLER_GEN) $(YAML_PATCH) ## Run the codegenerators
+	go mod download
 	./hack/update-codegen.sh
 	$(MAKE) imports
 .PHONY: codegen

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ test: WHAT ?= ./...
 test:
 	go test -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic $(TEST_ARGS) $$(go list "$(WHAT)" | grep -v ./test/e2e/)
 
+.PHONY: verify-k8s-deps
+verify-k8s-deps:
+	hack/validate-k8s.sh
+
 .PHONY: demos
 demos: build ## Runs all the default demos (kubecon and apiNegotiation).
 	cd contrib/demo && ./runDemoScripts.sh

--- a/hack/verify-imports.sh
+++ b/hack/verify-imports.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script ensures that the generated client code checked into git is up-to-date
+# with the generator. If it is not, re-generate the configuration to update it.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+make -C "$( dirname "${BASH_SOURCE[0]}")/../" imports
+if ! git diff --quiet --exit-code ; then
+	cat << EOF
+ERROR: This check enforces that import statements are ordered correctly.
+ERROR: The import statements are out of order. Run the following command
+ERROR: to regenerate the statements:
+ERROR: $ make imports
+ERROR: The following differences were found:
+EOF
+	git diff
+	exit 1
+fi


### PR DESCRIPTION
We should not require more than a simple `make` target to run any test.