### PR TITLE
virtual: fix internalapi APIResourceSchema version

### DIFF
--- a/pkg/virtual/framework/internalapis/fixtures/workloadclusters.yaml
+++ b/pkg/virtual/framework/internalapis/fixtures/workloadclusters.yaml
@@ -9,7 +9,7 @@ spec:
     singular: workloadcluster
   scope: Cluster
   versions:
-  - name: v1
+  - name: v1alpha1
     schema:
       description: WorkloadCluster describes a member cluster capable of running workloads.
       properties:

--- a/pkg/virtual/framework/internalapis/import.go
+++ b/pkg/virtual/framework/internalapis/import.go
@@ -144,7 +144,7 @@ func createAPIResourceSchemas(schemes []*runtime.Scheme, openAPIDefinitionsGette
 				Scope: def.ResourceSope,
 				Versions: []apisv1alpha1.APIResourceVersion{
 					{
-						Name:    "v1",
+						Name:    def.GroupVersion.Version,
 						Served:  true,
 						Storage: true,
 						Schema:  runtime.RawExtension{},


### PR DESCRIPTION
Wasn't a problem because everything in internal APIs is v1.