### PR TITLE
e2e/framework: set klog verbosity 2

### DIFF
--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -18,6 +18,7 @@ package framework
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -59,6 +60,13 @@ import (
 	conditionsapi "github.com/kcp-dev/kcp/third_party/conditions/apis/conditions/v1alpha1"
 	"github.com/kcp-dev/kcp/third_party/conditions/util/conditions"
 )
+
+func init() {
+	klog.InitFlags(flag.CommandLine)
+	if err := flag.Lookup("v").Value.Set("2"); err != nil {
+		panic(err)
+	}
+}
 
 // TestServerArgs returns the set of kcp args used to start a test
 // server using the token auth file from the working tree.


### PR DESCRIPTION
During e2e the normal component-base klog initialization is not running.