### PR TITLE
adds crdNoOverlappingGVRAdmission admission 

### DIFF
--- a/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission.go
+++ b/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdnooverlappinggvr
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/cache"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
+)
+
+const (
+	PluginName  = "apis.kcp.dev/CRDNoOverlappingGVR"
+	byWorkspace = PluginName + "-byWorkspace"
+)
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return &crdNoOverlappingGVRAdmission{
+				Handler: admission.NewHandler(admission.Create),
+			}, nil
+		})
+}
+
+type crdNoOverlappingGVRAdmission struct {
+	*admission.Handler
+
+	apiBindingIndexer          cache.Indexer
+	apiBindingIndexerInitError error
+}
+
+// Ensure that the required admission interfaces are implemented.
+var _ = admission.ValidationInterface(&crdNoOverlappingGVRAdmission{})
+var _ = admission.InitializationValidator(&crdNoOverlappingGVRAdmission{})
+
+func (p *crdNoOverlappingGVRAdmission) SetKcpInformers(informers kcpinformers.SharedInformerFactory) {
+	if err := informers.Apis().V1alpha1().APIBindings().Informer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace}); err != nil {
+		p.apiBindingIndexerInitError = err
+		return
+	}
+
+	// just in case the plugin gets init multiple times in case of an error
+	p.apiBindingIndexerInitError = nil
+	p.SetReadyFunc(informers.Apis().V1alpha1().APIBindings().Informer().HasSynced)
+	p.apiBindingIndexer = informers.Apis().V1alpha1().APIBindings().Informer().GetIndexer()
+}
+
+func (p *crdNoOverlappingGVRAdmission) ValidateInitialization() error {
+	if p.apiBindingIndexerInitError != nil {
+		return fmt.Errorf(PluginName+" plugin failed to initialize %q APIBindings indexer, err = %v", byWorkspace, p.apiBindingIndexerInitError)
+	}
+	if p.apiBindingIndexer == nil {
+		return fmt.Errorf(PluginName + " plugin needs an APIBindings indexer")
+	}
+	return nil
+}
+
+// Validate checks if the given CRD's Group and Resource don't overlap with bound CRDs
+func (p *crdNoOverlappingGVRAdmission) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	if a.GetResource().GroupResource() != apiextensions.Resource("customresourcedefinitions") {
+		return nil
+	}
+	if a.GetKind().GroupKind() != apiextensions.Kind("CustomResourceDefinition") {
+		return nil
+	}
+	clusterName, err := request.ClusterNameFrom(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve cluster from context: %w", err)
+	}
+	// ignore CRDs targeting system and non-root workspaces
+	if clusterName == apibinding.ShadowWorkspaceName || clusterName == logicalcluster.New("system:admin") {
+		return nil
+	}
+
+	crd, ok := a.GetObject().(*apiextensions.CustomResourceDefinition)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", a.GetObject())
+	}
+	apiBindingsForCurrentClusterName, err := p.listAPIBindingsFor(clusterName)
+	if err != nil {
+		return err
+	}
+	for _, apiBindingForCurrentClusterName := range apiBindingsForCurrentClusterName {
+		for _, boundResource := range apiBindingForCurrentClusterName.Status.BoundResources {
+			if boundResource.Group == crd.Spec.Group && boundResource.Resource == crd.Spec.Names.Plural {
+				return admission.NewForbidden(a, fmt.Errorf("cannot create %q CustomResourceDefinition with %q group and %q resource because it overlaps with a bound CustomResourceDefinition for %q APIBinding in %q logical cluster",
+					crd.Name, crd.Spec.Group, crd.Spec.Names.Plural, apiBindingForCurrentClusterName.Name, clusterName))
+			}
+		}
+	}
+	return nil
+}
+
+func (p *crdNoOverlappingGVRAdmission) listAPIBindingsFor(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
+	items, err := p.apiBindingIndexer.ByIndex(byWorkspace, clusterName.String())
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*apisv1alpha1.APIBinding, 0, len(items))
+	for _, item := range items {
+		ret = append(ret, item.(*apisv1alpha1.APIBinding))
+	}
+	return ret, nil
+}
+
+func indexByWorkspace(obj interface{}) ([]string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
+	}
+
+	lcluster := logicalcluster.From(metaObj)
+	return []string{lcluster.String()}, nil
+}

--- a/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission_test.go
+++ b/pkg/admission/crdnooverlappinggvr/crdnooverlappinggvr_admission_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdnooverlappinggvr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/cache"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func TestValidate(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		attr           admission.Attributes
+		clusterName    string
+		initialObjects []runtime.Object
+		wantErr        bool
+	}{
+		{
+			name: "creating a conflicting CRD is forbidden",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{createBinding("foo1", "root:acme", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
+			wantErr:        true,
+		},
+
+		{
+			name: "creating a conflicting CRD is allowed in the system:bound-crds workspaces",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "system:bound-crds",
+			initialObjects: []runtime.Object{createBinding("foo1", "root:acme", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "foo"}})},
+		},
+
+		{
+			name: "creating a non-conflicting CRD is allowed",
+			attr: createAttr(&apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "acme.dev",
+					Names: apiextensions.CustomResourceDefinitionNames{Plural: "foo"},
+				},
+			}),
+			clusterName:    "root:acme",
+			initialObjects: []runtime.Object{createBinding("foo1", "root:acme", []apisv1alpha1.BoundAPIResource{{Group: "acme.dev", Resource: "bar"}})},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := indexer.AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace}); err != nil {
+				t.Fatal(err)
+			}
+			for _, obj := range scenario.initialObjects {
+				if err := indexer.Add(obj); err != nil {
+					t.Error(err)
+				}
+			}
+
+			a := &crdNoOverlappingGVRAdmission{Handler: admission.NewHandler(admission.Create, admission.Update), apiBindingIndexer: indexer}
+			ctx := request.WithCluster(context.Background(), request.Cluster{Name: logicalcluster.New(scenario.clusterName)})
+			if err := a.Validate(ctx, scenario.attr, nil); (err != nil) != scenario.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, scenario.wantErr)
+			}
+		})
+	}
+}
+
+func createAttr(obj *apiextensions.CustomResourceDefinition) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		nil,
+		apiextensionsv1.Kind("CustomResourceDefinition").WithVersion("v1"),
+		"",
+		"test",
+		apiextensionsv1.Resource("customresourcedefinitions").WithVersion("v1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func createBinding(name string, clusterName string, boundResources []apisv1alpha1.BoundAPIResource) *apisv1alpha1.APIBinding {
+	return &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: name, ClusterName: clusterName},
+		Status:     apisv1alpha1.APIBindingStatus{BoundResources: boundResources},
+	}
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspaceshard"
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspacetype"
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspacetypeexists"
+	"github.com/kcp-dev/kcp/pkg/admission/crdnooverlappinggvr"
 	kcpmutatingwebhook "github.com/kcp-dev/kcp/pkg/admission/mutatingwebhook"
 	workspacenamespacelifecycle "github.com/kcp-dev/kcp/pkg/admission/namespacelifecycle"
 	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdannotations"
@@ -65,6 +66,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	kcpmutatingwebhook.PluginName,
 	reservedcrdannotations.PluginName,
 	reservedcrdgroups.PluginName,
+	crdnooverlappinggvr.PluginName,
 )
 
 func beforeWebhooks(recommended []string, plugins ...string) []string {
@@ -93,6 +95,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	kcpmutatingwebhook.Register(plugins)
 	reservedcrdannotations.Register(plugins)
 	reservedcrdgroups.Register(plugins)
+	crdnooverlappinggvr.Register(plugins)
 }
 
 var defaultOnPluginsInKcp = sets.NewString(


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
introduces an admission plugin for ensuring CRD's Group and Resource fields for logical clusters are unique and don't overlap with bound CRDs.

TODO:
- change the binding controller to check for conflicting GRVs (separate PR)
## Related issue(s)

xref: https://github.com/kcp-dev/kcp/issues/748