### PR TITLE
makefile: update path to include output binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
         with:
           go-version: v1.17
       - run: make build
-      - run: PATH="${PATH}:$(pwd)/bin/" make test
+      - run: make test
 
   e2e:
     name: e2e
@@ -109,7 +109,7 @@ jobs:
         with:
           go-version: v1.17
       - run: make build
-      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" E2E_PARALLELISM=2 make test-e2e
+      - run: ARTIFACT_DIR=/tmp/e2e E2E_PARALLELISM=2 make test-e2e
       - uses: cytopia/upload-artifact-retry-action@v0.1.2
         if: ${{ always() }}
         with:
@@ -125,7 +125,7 @@ jobs:
         with:
           go-version: v1.17
       - run: make build
-      - run: ARTIFACT_DIR=/tmp/e2e PATH="${PATH}:$(pwd)/bin/" COUNT=5 E2E_PARALLELISM=2 make test-e2e
+      - run: ARTIFACT_DIR=/tmp/e2e COUNT=5 E2E_PARALLELISM=2 make test-e2e
       - uses: cytopia/upload-artifact-retry-action@v0.1.2
         if: ${{ always() }}
         with:
@@ -163,7 +163,6 @@ jobs:
       - run: |-
           kind get kubeconfig > /tmp/kind-kubeconfig
           ARTIFACT_DIR=/tmp/e2e \
-          PATH="${PATH}:$(pwd)/bin/" \
           TEST_ARGS="-args --use-default-kcp-server --syncer-image=$(cat /tmp/syncer-image) --kcp-test-image=$(cat /tmp/kcp-test-image) --pcluster-kubeconfig=/tmp/kind-kubeconfig" \
           COUNT=2 \
           E2E_PARALLELISM=2 \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ SHELL := /usr/bin/env bash
 GO_INSTALL = ./hack/go-install.sh
 
 TOOLS_DIR=hack/tools
-GOBIN_DIR := $(abspath $(TOOLS_DIR))
+TOOLS_GOBIN_DIR := $(abspath $(TOOLS_DIR))
+GOBIN_DIR=$(abspath ./bin )
+PATH := $(GOBIN_DIR):$(TOOLS_GOBIN_DIR):$(PATH)
 TMPDIR := $(shell mktemp -d)
 
 CONTROLLER_GEN_VER := v0.7.0
@@ -38,7 +40,7 @@ export OPENSHIFT_GOIMPORTS # so hack scripts can use it
 
 GOLANGCI_LINT_VER := v1.44.2
 GOLANGCI_LINT_BIN := golangci-lint
-GOLANGCI_LINT := $(GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
+GOLANGCI_LINT := $(TOOLS_GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
 GOTESTSUM_VER := v1.8.1
 GOTESTSUM_BIN := gotestsum
@@ -82,7 +84,7 @@ install:
 .PHONY: install
 
 $(GOLANGCI_LINT):
-	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
 lint: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run --timeout=10m ./...
@@ -97,13 +99,13 @@ tools: $(GOLANGCI_LINT) $(CONTROLLER_GEN) $(YAML_PATCH) $(GOTESTSUM) $(OPENSHIFT
 .PHONY: tools
 
 $(CONTROLLER_GEN):
-	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-tools/cmd/controller-gen $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-tools/cmd/controller-gen $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)
 
 $(YAML_PATCH):
-	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) github.com/pivotal-cf/yaml-patch/cmd/yaml-patch $(YAML_PATCH_BIN) $(YAML_PATCH_VER)
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/pivotal-cf/yaml-patch/cmd/yaml-patch $(YAML_PATCH_BIN) $(YAML_PATCH_VER)
 
 $(GOTESTSUM):
-	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) gotest.tools/gotestsum $(GOTESTSUM_BIN) $(GOTESTSUM_VER)
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) gotest.tools/gotestsum $(GOTESTSUM_BIN) $(GOTESTSUM_VER)
 
 codegen: $(CONTROLLER_GEN) $(YAML_PATCH) ## Run the codegenerators
 	go mod download
@@ -129,7 +131,7 @@ verify-codegen:
 	fi
 
 $(OPENSHIFT_GOIMPORTS):
-	GOBIN=$(GOBIN_DIR) $(GO_INSTALL) github.com/openshift-eng/openshift-goimports $(OPENSHIFT_GOIMPORTS_BIN) $(OPENSHIFT_GOIMPORTS_VER)
+	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/openshift-eng/openshift-goimports $(OPENSHIFT_GOIMPORTS_BIN) $(OPENSHIFT_GOIMPORTS_VER)
 
 .PHONY: imports
 imports: $(OPENSHIFT_GOIMPORTS)


### PR DESCRIPTION
There's no real reason to expect every single user to manage their path
individually when calling `make`, and it furthermore never makes sense
to use an out-of-date binary that we create, so our output should be a
prefix to the path.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
