### PR TITLE
makefile: manage boilerplate verification locally

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,17 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          path: kcp
-      - uses: actions/checkout@v3
-        with:
-          repository: kubernetes/repo-infra
-          ref: master
-          path: repo-infra
-          fetch-depth: 1
       - run: |
-          cd kcp
-          ./../repo-infra/hack/verify_boilerplate.py --boilerplate-dir=hack/boilerplate
+          make verify-boilerplate
 
   imports:
     name: imports

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,15 @@ $(OPENSHIFT_GOIMPORTS):
 imports: $(OPENSHIFT_GOIMPORTS)
 	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev/kcp
 
+$(TOOLS_DIR)/verify_boilerplate.py:
+	mkdir -p $(TOOLS_DIR)
+	curl --fail --retry 3 -L -o $(TOOLS_DIR)/verify_boilerplate.py https://raw.githubusercontent.com/kubernetes/repo-infra/master/hack/verify_boilerplate.py
+	chmod +x $(TOOLS_DIR)/verify_boilerplate.py
+
+.PHONY: verify-boilerplate
+verify-boilerplate: $(TOOLS_DIR)/verify_boilerplate.py
+	$(TOOLS_DIR)/verify_boilerplate.py --boilerplate-dir=hack/boilerplate
+
 ifdef ARTIFACT_DIR
 GOTESTSUM_ARGS += --junitfile=$(ARTIFACT_DIR)/junit.xml
 endif


### PR DESCRIPTION
Similarly to how we use `go install` to get tools we need for other
tasks, we can just download this script ourselves, as we need nothing
else from the repo-infra repository.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @sttts @ncdc 