### PR TITLE
Implement the Syncer virtual workspace authorizer

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -243,7 +243,7 @@ func enableSyncerForWorkspace(ctx context.Context, config *rest.Config, workload
 			Resources:     []string{"workloadclusters/status"},
 		},
 		{
-			Verbs:     []string{"get", "create", "update", "list", "watch"},
+			Verbs:     []string{"get", "create", "update", "delete", "list", "watch"},
 			APIGroups: []string{apiresourcev1alpha1.SchemeGroupVersion.Group},
 			Resources: []string{"apiresourceimports"},
 		},

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -85,7 +85,7 @@ func (o *Options) NewVirtualWorkspaces(
 	extraInformers = append(extraInformers, inf...)
 	workspaces = append(workspaces, vws...)
 
-	inf, vws, err = o.Syncer.NewVirtualWorkspaces(rootPathPrefix, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
+	inf, vws, err = o.Syncer.NewVirtualWorkspaces(rootPathPrefix, kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/virtual/syncer/options/options.go
+++ b/pkg/virtual/syncer/options/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
@@ -53,12 +54,13 @@ func (o *Syncer) Validate(flagPrefix string) []error {
 
 func (o *Syncer) NewVirtualWorkspaces(
 	rootPathPrefix string,
+	kubeClusterClient kubernetes.ClusterInterface,
 	dynamicClusterClient dynamic.ClusterInterface,
 	kcpClusterClient kcpclient.ClusterInterface,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
 ) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
 	virtualWorkspaces := []framework.VirtualWorkspace{
-		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
+		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
 	}
 	return nil, virtualWorkspaces, nil
 }


### PR DESCRIPTION
## Summary

Implement  the Syncer virtual workspace authorizer by issuing a `SubjectAccessReview` with "sync" verb against the `WorkloadCluster` name resource

## Related issue(s)

Fixes #1172