### PR TITLE
adding authorizer for the api export virtual workspace

### DIFF
--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
@@ -123,11 +122,6 @@ func BuildVirtualWorkspace(
 			return
 		},
 
-		Authorizer: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			klog.Error("the authorizer for the 'initializingworkspaces' virtual workspace is not implemented !")
-			return authorizer.DecisionAllow, "", nil
-		},
-
 		Ready: func() error {
 			select {
 			case <-readyCh:
@@ -199,12 +193,14 @@ func getAuthorizer(client kubernetes.ClusterInterface) authorizer.AuthorizerFunc
 		}
 
 		SARAttributes := authorizer.AttributesRecord{
-			User:       attr.GetUser(),
-			Verb:       "content",
-			Name:       apiExportName,
-			APIGroup:   apisv1alpha1.SchemeGroupVersion.Group,
-			APIVersion: apisv1alpha1.SchemeGroupVersion.Version,
-			Resource:   "apiexport",
+			APIGroup:        apisv1alpha1.SchemeGroupVersion.Group,
+			APIVersion:      apisv1alpha1.SchemeGroupVersion.Version,
+			User:            attr.GetUser(),
+			Verb:            attr.GetVerb(),
+			Name:            apiExportName,
+			Resource:        "apiexports",
+			ResourceRequest: true,
+			Subresource:     "content",
 		}
 
 		return authz.Authorize(ctx, SARAttributes)

--- a/pkg/virtual/apiexport/options/options.go
+++ b/pkg/virtual/apiexport/options/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
@@ -53,12 +54,13 @@ func (o *APIExport) Validate(flagPrefix string) []error {
 
 func (o *APIExport) NewVirtualWorkspaces(
 	rootPathPrefix string,
+	kubeClusterClient kubernetes.ClusterInterface,
 	dynamicClusterClient dynamic.ClusterInterface,
 	kcpClusterClient kcpclientset.ClusterInterface,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
 ) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
 	virtualWorkspaces := []framework.VirtualWorkspace{
-		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
+		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
 	}
 	return nil, virtualWorkspaces, nil
 }

--- a/pkg/virtual/framework/types.go
+++ b/pkg/virtual/framework/types.go
@@ -49,4 +49,5 @@ type VirtualWorkspace interface {
 	ResolveRootPath(urlPath string, context context.Context) (accepted bool, prefixToStrip string, completedContext context.Context)
 	IsReady() error
 	Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error)
+	Authorize(context.Context, authorizer.Attributes) (authorizer.Decision, string, error)
 }

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -92,7 +92,7 @@ func (o *Options) NewVirtualWorkspaces(
 	extraInformers = append(extraInformers, inf...)
 	workspaces = append(workspaces, vws...)
 
-	inf, vws, err = o.APIExport.NewVirtualWorkspaces(rootPathPrefix, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
+	inf, vws, err = o.APIExport.NewVirtualWorkspaces(rootPathPrefix, kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -162,7 +162,7 @@ func TestAPIBindingAuthorizer(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			t.Logf("Make sure that the status of cowboy can be updated in workspace %q", consumer)
-			_, err = cowboyClient.UpdateStatus(ctx, &cowboys.Items[0], metav1.UpdateOptions{})
+			_, err = cowboyClient.Update(ctx, &cowboys.Items[0], metav1.UpdateOptions{})
 			require.NoError(t, err, "expected error updating status of cowboys")
 		}
 	}

--- a/test/e2e/virtual/apiexport/apiresourceschema_cowboys.yaml
+++ b/test/e2e/virtual/apiexport/apiresourceschema_cowboys.yaml
@@ -1,0 +1,46 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: today.cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      description: Cowboy is part of the wild west
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CowboySpec holds the desired state of the Cowboy.
+          properties:
+            intent:
+              type: string
+          type: object
+        status:
+          description: CowboyStatus communicates the observed state of the Cowboy.
+          properties:
+            result:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/virtual/apiexport/support.go
+++ b/test/e2e/virtual/apiexport/support.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"embed"
+	"path"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	virtualoptions "github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned"
+)
+
+//go:embed *.yaml
+var testFiles embed.FS
+
+func groupExists(list *metav1.APIGroupList, group string) bool {
+	for _, g := range list.Groups {
+		if g.Name == group {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceExists(list *metav1.APIResourceList, resource string) bool {
+	for _, r := range list.APIResources {
+		if r.Name == resource {
+			return true
+		}
+	}
+	return false
+}
+
+type virtualClusterClient struct {
+	config *rest.Config
+}
+
+func (c *virtualClusterClient) Cluster(cluster logicalcluster.Name, exportName string) (*wildwestclientset.Cluster, error) {
+	config := rest.CopyConfig(c.config)
+	//	/services/apiexport/root:org:ws/<apiexport-name>/clusters/*/api/v1/configmaps
+	config.Host += path.Join(virtualoptions.DefaultRootPathPrefix, "apiexport", cluster.String(), exportName)
+	return wildwestclientset.NewClusterForConfig(config)
+}
+
+func userConfig(username string, cfg *rest.Config) *rest.Config {
+	cfgCopy := rest.CopyConfig(cfg)
+	cfgCopy.BearerToken = username + "-token"
+	return cfgCopy
+}

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster"
+	"github.com/stretchr/testify/require"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
+
+	"github.com/kcp-dev/kcp/config/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest"
+	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
+	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestAPIExportVirtualWorkspace(t *testing.T) {
+	t.Parallel()
+
+	server := framework.SharedKcpServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Need to Create a Producer w/ APIExport
+	orgClusterName := framework.NewOrganizationFixture(t, server)
+	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+
+	cfg := server.DefaultConfig(t)
+
+	kcpClients, err := clientset.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	dynamicClients, err := dynamic.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct dynamic cluster client for server")
+
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct kube cluster client for server")
+
+	wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(cfg)
+	require.NoError(t, err, "failed to construct wildwest cluster client for server")
+
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1", "user-2"}, nil, []string{"member"})
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, serviceProviderWorkspace, []string{"user-1", "user-2"}, nil, []string{"member", "access"})
+
+	setUpServiceProvider(ctx, dynamicClients, kcpClients, kubeClusterClient, serviceProviderWorkspace, t)
+
+	bindConsumerToProvider(ctx, consumerWorkspace, serviceProviderWorkspace, t, kcpClients)
+
+	createCowboyInConsumer(ctx, t, consumerWorkspace, wildwestClusterClient)
+
+	t.Logf("test that the admin user can use the virtual workspace to get cowboys")
+	vc := virtualClusterClient{cfg}
+	wildwestVCClient, err := vc.Cluster(serviceProviderWorkspace, "today-cowboys")
+	require.NoError(t, err)
+	cowboysProjected, err := wildwestVCClient.Cluster(logicalcluster.Wildcard).WildwestV1alpha1().Cowboys("").List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(cowboysProjected.Items))
+
+	// Attempt to use VW using user-1 should expect an error
+	t.Logf("Make sure that user-1 is denied")
+	user1VC := virtualClusterClient{config: userConfig("user-1", cfg)}
+	wwUser1VC, err := user1VC.Cluster(serviceProviderWorkspace, "today-cowboys")
+	require.NoError(t, err)
+	_, err = wwUser1VC.Cluster(logicalcluster.Wildcard).WildwestV1alpha1().Cowboys("").List(ctx, metav1.ListOptions{})
+	require.True(t, apierrors.IsForbidden(err))
+
+	// Create clusterRoleBindings for content access.
+	t.Logf("create the cluster role and bindings to give access to the virtual worksapce for user-1")
+	cr, crb := createClusterRoleAndBindings("user-1-vw", "user-1", "User", []string{"list", "get"})
+	_, err = kubeClusterClient.Cluster(serviceProviderWorkspace).RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = kubeClusterClient.Cluster(serviceProviderWorkspace).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Get cowboys from the virtual workspace with user-1.
+	t.Logf("Get Cowboys with user-1")
+	require.Eventually(t, func() bool {
+		cbs, err := wwUser1VC.Cluster(logicalcluster.Wildcard).WildwestV1alpha1().Cowboys("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		require.Equal(t, 1, len(cbs.Items))
+
+		// Attempt to update it should fail
+		cb := cbs.Items[0]
+		cb.Status.Result = "updated"
+		_, err = wwUser1VC.Cluster(logicalcluster.From(&cb)).WildwestV1alpha1().Cowboys(cb.Namespace).UpdateStatus(ctx, &cb, metav1.UpdateOptions{})
+		require.Error(t, err)
+		require.True(t, apierrors.IsForbidden(err))
+
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "expected user-1 to list cowboys from virtual workspace")
+
+	// Test that users are able to update status of cowboys status
+	t.Logf("create the cluster role and bindings to give access to the virtual worksapce for user-2")
+	cr, crb = createClusterRoleAndBindings("user-2-vw", "user-2", "User", []string{"update", "list"})
+	_, err = kubeClusterClient.Cluster(serviceProviderWorkspace).RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = kubeClusterClient.Cluster(serviceProviderWorkspace).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	user2VC := virtualClusterClient{config: userConfig("user-2", cfg)}
+	wwUser2VC, err := user2VC.Cluster(serviceProviderWorkspace, "today-cowboys")
+	require.NoError(t, err)
+	t.Logf("Get Cowboy and update status with user-2")
+	require.Eventually(t, func() bool {
+		cbs, err := wwUser2VC.Cluster(logicalcluster.Wildcard).WildwestV1alpha1().Cowboys("").List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		if len(cbs.Items) != 1 {
+			return false
+		}
+
+		cb := cbs.Items[0]
+		cb.Status.Result = "updated"
+		_, err = wwUser2VC.Cluster(logicalcluster.From(&cb)).WildwestV1alpha1().Cowboys(cb.Namespace).UpdateStatus(ctx, &cb, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		return true
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "expected user-2 to list cowboys from virtual workspace")
+
+}
+
+func setUpServiceProvider(ctx context.Context, dynamicClients *dynamic.Cluster, kcpClients *clientset.Cluster, kubeClusterClient *kubernetes.Cluster, serviceProviderWorkspace logicalcluster.Name, t *testing.T) {
+	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(serviceProviderWorkspace).Discovery()))
+	err := helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	require.NoError(t, err)
+
+	t.Logf("Create an APIExport for it")
+	cowboysAPIExport := &apisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "today-cowboys",
+		},
+		Spec: apisv1alpha1.APIExportSpec{
+			LatestResourceSchemas: []string{"today.cowboys.wildwest.dev"},
+		},
+	}
+	_, err = kcpClients.Cluster(serviceProviderWorkspace).ApisV1alpha1().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func bindConsumerToProvider(ctx context.Context, consumerWorkspace, providerWorkspace logicalcluster.Name, t *testing.T, kcpClients *clientset.Cluster) {
+	t.Logf("Create an APIBinding in consumer workspace %q that points to the today-cowboys export from %q", consumerWorkspace, providerWorkspace)
+	apiBinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys",
+		},
+		Spec: apisv1alpha1.APIBindingSpec{
+			Reference: apisv1alpha1.ExportReference{
+				Workspace: &apisv1alpha1.WorkspaceExportReference{
+					Path:       providerWorkspace.String(),
+					ExportName: "today-cowboys",
+				},
+			},
+		},
+	}
+
+	_, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Logf("Make sure %q API group shows up in consumer workspace %q group discovery", wildwest.GroupName, consumerWorkspace)
+	err = wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(c context.Context) (done bool, err error) {
+		groups, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerGroups()
+		if err != nil {
+			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", consumerWorkspace, err)
+		}
+		return groupExists(groups, wildwest.GroupName), nil
+	})
+	require.NoError(t, err)
+	t.Logf("Make sure cowboys API resource shows up in consumer workspace %q group version discovery", consumerWorkspace)
+	resources, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerResourcesForGroupVersion(wildwestv1alpha1.SchemeGroupVersion.String())
+	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerWorkspace)
+	require.True(t, resourceExists(resources, "cowboys"), "consumer workspace %q discovery is missing cowboys resource", consumerWorkspace)
+}
+
+func createCowboyInConsumer(ctx context.Context, t *testing.T, consumer1Workspace logicalcluster.Name, wildwestClusterClient *wildwestclientset.Cluster) {
+	t.Logf("Make sure we can perform CRUD operations against consumer workspace %q for the bound API", consumer1Workspace)
+
+	t.Logf("Make sure list shows nothing to start")
+	cowboyClient := wildwestClusterClient.Cluster(consumer1Workspace).WildwestV1alpha1().Cowboys("default")
+	var cowboys *wildwestv1alpha1.CowboyList
+	// Adding a poll here to wait for the user's to get access via RBAC informer updates.
+
+	require.Eventually(t, func() bool {
+		var err error
+		cowboys, err = cowboyClient.List(ctx, metav1.ListOptions{})
+		return err == nil
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected to be able to list ")
+	require.Zero(t, len(cowboys.Items), "expected 0 cowboys inside consumer workspace %q", consumer1Workspace)
+
+	t.Logf("Create a cowboy CR in consumer workspace %q", consumer1Workspace)
+	cowboyName := fmt.Sprintf("cowboy-%s", consumer1Workspace.Base())
+	cowboy := &wildwestv1alpha1.Cowboy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cowboyName,
+			Namespace: "default",
+		},
+	}
+	_, err := cowboyClient.Create(ctx, cowboy, metav1.CreateOptions{})
+	require.NoError(t, err, "error creating cowboy in consumer workspace %q", consumer1Workspace)
+}
+
+func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs []string) (*rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding) {
+	clusterRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     verbs,
+				APIGroups: []string{apisv1alpha1.SchemeGroupVersion.Group},
+				Resources: []string{"apiexports/content"},
+			},
+		},
+	}
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: subjectKind,
+				Name: subjectName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     name,
+		},
+	}
+	return clusterRole, clusterRoleBinding
+}


### PR DESCRIPTION
## Summary
Adding the authorizer for apiexport that will check that the requesting user has access to the apiexport context subresource for the specific API export. the verb being used will be forwarded along to be checked.

example: watch cowboys

request path: `/services/apiexport/root:org:ws/cowboys-export/clusters/*/api/v1/cowboys`

SAR check would ask if I can `list` on the specific `cowboys-export` `/content` subresource.

## Related issue(s)
Follow on for: https://github.com/kcp-dev/kcp/pull/1176
Fixes #1151 