### PR TITLE
Fix kcp image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY pkg/apis/go.mod pkg/apis/go.mod
+COPY pkg/apis/go.sum pkg/apis/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 USER 0


### PR DESCRIPTION
## Summary
Now that pkg/apis is a separate go module, and the root go.mod points to
it using a relative replace directive, we have to make sure we copy
pkg/apis/go.{mod,sum} into the build container before invoking 'go mod
download'

## Related issue(s)

Follow up to #1175 