### PR TITLE
virtual: Avoid error logs for `/readz` requests

### DIFF
--- a/pkg/virtual/framework/context/keys.go
+++ b/pkg/virtual/framework/context/keys.go
@@ -18,7 +18,6 @@ package context
 
 import (
 	"context"
-	"errors"
 )
 
 type virtualWorkspaceNameKeyType string
@@ -33,10 +32,7 @@ func WithVirtualWorkspaceName(ctx context.Context, virtualWorkspaceName string) 
 }
 
 // VirtualWorkspaceNameFrom retrieves the VirtualWorkspace name from the context, if any.
-func VirtualWorkspaceNameFrom(ctx context.Context) (string, error) {
+func VirtualWorkspaceNameFrom(ctx context.Context) (string, bool) {
 	wcn, hasVirtualWorkspaceName := ctx.Value(virtualWorkspaceNameKey).(string)
-	if !hasVirtualWorkspaceName {
-		return "", errors.New("context must contain a valid non-empty virtual workspace name")
-	}
-	return wcn, nil
+	return wcn, hasVirtualWorkspaceName
 }


### PR DESCRIPTION
## Summary

Cleanup followup on PR https://github.com/kcp-dev/kcp/pull/1180

We should not consider non-virtual-workspace requests (like `/readz` requests) as errors and dump errors in logs 