### PR TITLE
Replace `--use` with `--enter`

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -48,7 +48,7 @@ var (
 	%[1]s workspace -
 
 	# create a workspace and immediately enter it
-	%[1]s workspace create my-workspace --use
+	%[1]s workspace create my-workspace --enter
 
 	# create a context with the current workspace, e.g. root:default:my-workspace
 	%[1]s workspace create-context


### PR DESCRIPTION
Signed-off-by: Mike Spreitzer <mspreitz@us.ibm.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
This PR updates the outdated command line flag cited in #1189 .

## Related issue(s)

Fixes #1189