### PR TITLE
APIBinding reconciler checks for overlapping CRDs in a logical cluster

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -155,6 +155,12 @@ func NewController(
 		},
 	})
 
+	if err := crdInformer.Informer().AddIndexers(cache.Indexers{
+		indexByWorkspace: indexByWorkspaceFunc,
+	}); err != nil {
+		return nil, err
+	}
+
 	apiResourceSchemaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.enqueueAPIResourceSchema(obj) },
 		UpdateFunc: func(_, obj interface{}) { c.enqueueAPIResourceSchema(obj) },

--- a/pkg/reconciler/apis/apibinding/apibinding_indexes.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_indexes.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clusters"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
@@ -85,4 +86,16 @@ func indexAPIBindingsByIdentityGroupResourceFunc(obj interface{}) ([]string, err
 
 func IdentityGroupResourceKeyFunc(identity, group, resource string) string {
 	return fmt.Sprintf("%s/%s/%s", identity, group, resource)
+}
+
+const indexByWorkspace = "apiBindingsByWorkspace"
+
+func indexByWorkspaceFunc(obj interface{}) ([]string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
+	}
+
+	lcluster := logicalcluster.From(metaObj)
+	return []string{lcluster.String()}, nil
 }

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -194,15 +194,16 @@ func (c *controller) reconcileBinding(ctx context.Context, apiBinding *apisv1alp
 			return nil
 		}
 
-		// Check for naming conflicts
-		nameConflictChecker := &nameConflictChecker{
+		// Check for conflicts
+		checker := &conflictChecker{
 			listAPIBindings:      c.listAPIBindings,
 			getAPIExport:         c.getAPIExport,
 			getAPIResourceSchema: c.getAPIResourceSchema,
 			getCRD:               c.getCRD,
+			crdIndexer:           c.crdIndexer,
 		}
 
-		if err := nameConflictChecker.checkForConflicts(crd, apiBinding); err != nil {
+		if err := checker.checkForConflicts(crd, apiBinding); err != nil {
 			conditions.MarkFalse(
 				apiBinding,
 				apisv1alpha1.BindingUpToDate,

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/pointer"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
@@ -507,6 +508,11 @@ func TestReconcileBinding(t *testing.T) {
 					return crd, tc.createCRDError
 				},
 				deletedCRDTracker: &lockedStringSet{},
+				crdIndexer:        cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{}),
+			}
+
+			if err := c.crdIndexer.AddIndexers(cache.Indexers{indexByWorkspace: indexByWorkspaceFunc}); err != nil {
+				t.Fatal(err)
 			}
 
 			err := c.reconcile(context.Background(), tc.apiBinding)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
changes the APIBinding controller to check for CRDs with overlapping GVRs in a logical cluster. Initially, we wanted to implement it as an admission plugging. Since it might involve network calls we decided to move it to the controller.
## Related issue(s)

Fixes #748