### PR TITLE
Add virtual workspace readiness checks to the KCP server in the embedded case

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -477,7 +477,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, kubeClusterClient, dynamicClusterClient, kcpClusterClient, genericConfig.Authentication, genericConfig.ExternalAddress, preHandlerChainMux); err != nil {
+		if err := s.installVirtualWorkspaces(ctx, server, kubeClusterClient, dynamicClusterClient, kcpClusterClient, genericConfig.Authentication, genericConfig.ExternalAddress, preHandlerChainMux); err != nil {
 			return err
 		}
 	} else if err := s.installVirtualWorkspacesRedirect(ctx, preHandlerChainMux); err != nil {

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -43,6 +43,7 @@ type mux interface {
 
 func (s *Server) installVirtualWorkspaces(
 	ctx context.Context,
+	server *genericapiserver.GenericAPIServer,
 	kubeClusterClient kubernetesclient.ClusterInterface,
 	dynamicClusterClient dynamic.ClusterInterface,
 	kcpClusterClient kcpclient.ClusterInterface,
@@ -100,6 +101,10 @@ func (s *Server) installVirtualWorkspaces(
 
 	rootAPIServer, err := completedRootAPIServerConfig.New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
+		return err
+	}
+
+	if err := server.AddReadyzChecks(completedRootAPIServerConfig.GenericConfig.ReadyzChecks...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Add virtual workspace readiness checks to the KCP server when the virtual workspaces are started inside
the KCP server process.

- Also rework virtual workspace readiness checks to add each virtual workspace check individually in the virtual workspace root API Server, instead of having only a readiness summary that fails on the first failing check.

## Related issue(s)

Fixes #1223