### PR TITLE
Enable syncer finalizers (k8s & virtual) by default.

### DIFF
--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -81,7 +81,7 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 		}
 	}
 	if len(annotationPatch) > 0 {
-		if err := unstructured.SetNestedField(patch, labelPatch, "metadata", "annotations"); err != nil {
+		if err := unstructured.SetNestedField(patch, annotationPatch, "metadata", "annotations"); err != nil {
 			klog.Errorf("unexpected unstructured error: %v", err)
 			return err // should never happen
 		}

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -100,12 +100,8 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		return err
 	}
 	if !exists {
-		if c.advancedSchedulingEnabled {
-			// deleted downstream => remove finalizer upstream
-			klog.InfoS("Downstream GVR %q object %s|%s/%s does not exist. Removing finalizer upstream", gvr.String(), downstreamClusterName, upstreamNamespace, name)
-			return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamClient, upstreamNamespace, c.workloadClusterName, upstreamLogicalCluster, name)
-		}
-		return nil
+		klog.InfoS("Downstream GVR %q object %s|%s/%s does not exist. Removing finalizer upstream", gvr.String(), downstreamClusterName, upstreamNamespace, name)
+		return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamClient, upstreamNamespace, c.workloadClusterName, upstreamLogicalCluster, name)
 	}
 
 	// update upstream status

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -383,7 +383,9 @@ func TestSyncerProcess(t *testing.T) {
 			workloadClusterName:                 "us-west1",
 
 			expectActionsOnFrom: []clienttesting.Action{},
-			expectActionsOnTo:   []clienttesting.Action{},
+			expectActionsOnTo: []clienttesting.Action{
+				getDeploymentAction("theDeployment", "test"),
+			},
 		},
 		"StatusSyncer with AdvancedScheduling, update status upstream": {
 			upstreamLogicalCluster: "root:org:ws",


### PR DESCRIPTION
## Summary

This PR enables the syncer finalizers, k8s-based and virtual ones by default, and the required per-location deletion timestamps. Those features were before feature-gated: https://github.com/kcp-dev/kcp/pull/942

closes https://github.com/kcp-dev/kcp/issues/1193

