### PR TITLE
e2e/apibinding: require.Eventually for discovery

### DIFF
--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -101,7 +101,9 @@ func TestProtectedAPI(t *testing.T) {
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "APIBinding %q in workspace %q did not complete", apiBinding.Name, consumerWorkspace)
 
 	t.Logf("Make sure gateway API resource shows up in workspace %q group version discovery", consumerWorkspace)
-	resources, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1alpha2")
-	require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerWorkspace)
-	require.True(t, resourceExists(resources, "tlsroutes"), "consumer workspace %q discovery is missing tlsroutes resource", consumerWorkspace)
+	require.Eventually(t, func() bool {
+		resources, err := kcpClients.Cluster(consumerWorkspace).Discovery().ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1alpha2")
+		require.NoError(t, err, "error retrieving consumer workspace %q API discovery", consumerWorkspace)
+		return resourceExists(resources, "tlsroutes")
+	}, wait.ForeverTestTimeout, time.Millisecond*100, "consumer workspace %q discovery is missing tlsroutes resource", consumerWorkspace)
 }


### PR DESCRIPTION
```
--- FAIL: TestProtectedAPI (4.78s)
    fixture.go:115: shared kcp server will target configuration "/home/runner/work/kcp/kcp/.kcp/admin.kubeconfig"
    fixture.go:246: Created organization workspace root:e2e-org-pc4kq
    fixture.go:309: Created Universal workspace root:e2e-org-pc4kq:e2e-workspace-zmc6p
    fixture.go:309: Created Universal workspace root:e2e-org-pc4kq:e2e-workspace-dbq[29](https://github.com/kcp-dev/kcp/runs/6782662897?check_suite_focus=true#step:10:30)
    apibinding_protected_test.go:59: Install today cowboys APIResourceSchema into service provider workspace "root:e2e-org-pc4kq:e2e-workspace-zmc6p"
    apibinding_protected_test.go:64: Create an APIExport for it
    apibinding_protected_test.go:76: Create an APIBinding in consumer workspace "root:e2e-org-pc4kq:e2e-workspace-dbq29" that points to the gateway-api export from "root:e2e-org-pc4kq:e2e-workspace-zmc6p"
    apibinding_protected_test.go:94: Make sure APIBinding "gateway-api" in workspace "root:e2e-org-pc4kq:e2e-workspace-dbq29" is completed and up-to-date
    apibinding_protected_test.go:103: Make sure gateway API resource shows up in workspace "root:e2e-org-pc4kq:e2e-workspace-dbq29" group version discovery
    apibinding_protected_test.go:106: 
        	Error Trace:	apibinding_protected_test.go:106
        	Error:      	Should be true
        	Test:       	TestProtectedAPI
        	Messages:   	consumer workspace "root:e2e-org-pc4kq:e2e-workspace-dbq29" discovery is missing tlsroutes resource
```
(https://github.com/kcp-dev/kcp/runs/6782662897?check_suite_focus=true)