### PR TITLE
e2e/virtual/initializers: fix flake in TestInitializingWorkspacesVirtualWorkspaceDiscovery

### DIFF
--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -226,7 +226,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 		sort.Slice(actual.Items, func(i, j int) bool {
 			return actual.Items[i].UID < actual.Items[j].UID
 		})
-		require.Empty(t, cmp.Diff(expected, actual.Items), "cluster workspace list for initializer %s incorrect", initializer)
+		require.Empty(t, cmp.Diff(pruneVolatileFields(expected), pruneVolatileFields(actual.Items)), "cluster workspace list for initializer %s incorrect", initializer)
 	}
 
 	t.Log("Start WATCH streams to confirm behavior on changes")
@@ -315,6 +315,15 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 			break
 		}
 	}
+}
+
+func pruneVolatileFields(items []tenancyv1alpha1.ClusterWorkspace) []tenancyv1alpha1.ClusterWorkspace {
+	for i := range items {
+		items[i].ResourceVersion = ""
+		items[i].ManagedFields = nil
+		items[i].Finalizers = nil
+	}
+	return items
 }
 
 func workspaceForType(workspaceType string, testLabelSelector map[string]string) *tenancyv1alpha1.ClusterWorkspace {


### PR DESCRIPTION
Prune fields that get touched by other actors.
```
--- FAIL: TestInitializingWorkspacesVirtualWorkspaceAccess (0.65s)
    fixture.go:115: shared kcp server will target configuration "/home/runner/work/kcp/kcp/.kcp/admin.kubeconfig"
    fixture.go:246: Created organization workspace root:e2e-org-k8skn
    fixture.go:309: Created Universal workspace root:e2e-org-k8skn:e2e-workspace-2qpv2
    virtualworkspace_test.go:117: Create workspace types that add initializers
    virtualworkspace_test.go:162: Create workspaces that using the new types, which will get stuck in initializing
    virtualworkspace_test.go:167: 
        	Error Trace:	virtualworkspace_test.go:167
        	Error:      	Received unexpected error:
        	            	clusterworkspaces.tenancy.kcp.dev "e2e-workspace-" is forbidden: spec.type "Alphaeannsuvqzy" does not exist
        	Test:       	TestInitializingWorkspacesVirtualWorkspaceAccess
--- FAIL: TestInitializingWorkspacesVirtualWorkspaceAccess (1.05s)
    fixture.go:115: shared kcp server will target configuration "/home/runner/work/kcp/kcp/.kcp/admin.kubeconfig"
    fixture.go:246: Created organization workspace root:e2e-org-cpgp8
    fixture.go:309: Created Universal workspace root:e2e-org-cpgp8:e2e-workspace-l8njq
    virtualworkspace_test.go:117: Create workspace types that add initializers
    virtualworkspace_test.go:162: Create workspaces that using the new types, which will get stuck in initializing
    virtualworkspace_test.go:170: Wait for workspaces to get stuck in initializing
    virtualworkspace_test.go:186: Create clients through the virtual workspace
    virtualworkspace_test.go:207: Ensure that LIST calls through the virtual workspace show the correct values
    virtualworkspace_test.go:229: 
        	Error Trace:	virtualworkspace_test.go:229
        	Error:      	Should be empty, but was   []v1alpha1.ClusterWorkspace{
        	            	  	{
        	            	  		TypeMeta: {Kind: "ClusterWorkspace", APIVersion: "tenancy.kcp.dev/v1alpha1"},
        	            	  		ObjectMeta: v1.ObjectMeta{
        	            	  			... // 3 identical fields
        	            	  			SelfLink:          "",
        	            	  			UID:               "a023ee2d-d355-4002-b2b8-49cc02bca233",
        	            	- 			ResourceVersion:   "8809",
        	            	+ 			ResourceVersion:   "8818",
        	            	  			Generation:        1,
        	            	  			CreationTimestamp: {Time: s"2022-06-07 18:21:35 +0000 UTC"},
        	            	  			... // 3 identical fields
        	            	  			Annotations:     nil,
        	            	  			OwnerReferences: nil,
        	            	- 			Finalizers:      nil,
        	            	+ 			Finalizers:      []string{"tenancy.kcp.dev/workspace-finalizer"},
        	            	  			ClusterName:     "root:e2e-org-cpgp8",
        	            	  			ManagedFields: []v1.ManagedFieldsEntry{
        	            	  				{Manager: "Go-http-client", Operation: "Update", APIVersion: "tenancy.kcp.dev/v1alpha1", Time: s"2022-06-07 18:21:35 +0000 UTC", ...},
        	            	  				{
        	            	  					... // 3 identical fields
        	            	  					Time:       s"2022-06-07 18:21:35 +0000 UTC",
        	            	  					FieldsType: "FieldsV1",
        	            	  					FieldsV1: &v1.FieldsV1{
        	            	  						Raw: bytes.Join({
        	            	  							`{"f:metadata":{`,
        	            	+ 							`"f:finalizers":{".":{},"v:\"tenancy.kcp.dev/workspace-finalizer\`,
        	            	+ 							`"":{}},`,
        	            	  							`"f:labels":{"f:initializer.internal.kcp.dev-beta-gvaqyygapp":{},`,
        	            	  							`"f:internal.kcp.dev/phase":{}}}}`,
        	            	  						}, ""),
        	            	  					},
        	            	  					Subresource: "",
        	            	  				},
        	            	  				{Manager: "kcp", Operation: "Update", APIVersion: "tenancy.kcp.dev/v1alpha1", Time: s"2022-06-07 18:21:35 +0000 UTC", ...},
        	            	  			},
        	            	  		},
        	            	  		Spec:   {Type: "Betaixokgnsbwt"},
        	            	  		Status: {Phase: "Initializing", Conditions: {{Type: "WorkspaceScheduled", Status: "True", LastTransitionTime: {Time: s"2022-06-07 18:21:35 +0000 UTC"}}, {Type: "WorkspaceShardValid", Status: "True", LastTransitionTime: {Time: s"2022-06-07 18:21:35 +0000 UTC"}}}, BaseURL: "https://10.1.1.123:6443/clusters/root:e2e-org-cpgp8:e2e-workspac"..., Location: {Current: "root"}, ...},
        	            	  	},
        	            	  	{
        	            	  		TypeMeta: {Kind: "ClusterWorkspace", APIVersion: "tenancy.kcp.dev/v1alpha1"},
        	            	  		ObjectMeta: v1.ObjectMeta{
        	            	  			... // 3 identical fields
        	            	  			SelfLink:          "",
        	            	  			UID:               "cb194ff4-a453-4c74-b57e-2[50](https://github.com/kcp-dev/kcp/runs/6779921627?check_suite_focus=true#step:10:51)2d6b68db0",
        	            	- 			ResourceVersion:   "8811",
        	            	+ 			ResourceVersion:   "8820",
        	            	  			Generation:        1,
        	            	  			CreationTimestamp: {Time: s"2022-06-07 18:21:35 +0000 UTC"},
        	            	  			... // 3 identical fields
        	            	  			Annotations:     nil,
        	            	  			OwnerReferences: nil,
        	            	- 			Finalizers:      nil,
        	            	+ 			Finalizers:      []string{"tenancy.kcp.dev/workspace-finalizer"},
        	            	  			ClusterName:     "root:e2e-org-cpgp8",
        	            	  			ManagedFields: []v1.ManagedFieldsEntry{
        	            	  				{Manager: "Go-http-client", Operation: "Update", APIVersion: "tenancy.kcp.dev/v1alpha1", Time: s"2022-06-07 18:21:35 +0000 UTC", ...},
        	            	  				{
        	            	  					... // 3 identical fields
        	            	  					Time:       s"2022-06-07 18:21:35 +0000 UTC",
        	            	  					FieldsType: "FieldsV1",
        	            	  					FieldsV1: &v1.FieldsV1{
        	            	  						Raw: bytes.Join({
        	            	  							`{"f:metadata":{`,
        	            	+ 							`"f:finalizers":{".":{},"v:\"tenancy.kcp.dev/workspace-finalizer\`,
        	            	+ 							`"":{}},`,
        	            	  							`"f:labels":{"f:initializer.internal.kcp.dev-alpha-tbphtrvnjb":{}`,
        	            	  							`,"f:initializer.internal.kcp.dev-beta-gvaqyygapp":{},"f:internal`,
        	            	  							`.kcp.dev/phase":{}}}}`,
        	            	  						}, ""),
        	            	  					},
        	            	  					Subresource: "",
        	            	  				},
        	            	  				{Manager: "kcp", Operation: "Update", APIVersion: "tenancy.kcp.dev/v1alpha1", Time: s"2022-06-07 18:21:35 +0000 UTC", ...},
        	            	  			},
        	            	  		},
        	            	  		Spec:   {Type: "Gammarrdslptssm"},
        	            	  		Status: {Phase: "Initializing", Conditions: {{Type: "WorkspaceScheduled", Status: "True", LastTransitionTime: {Time: s"2022-06-07 18:21:35 +0000 UTC"}}, {Type: "WorkspaceShardValid", Status: "True", LastTransitionTime: {Time: s"2022-06-07 18:21:35 +0000 UTC"}}}, BaseURL: "https://10.1.1.123:6443/clusters/root:e2e-org-cpgp8:e2e-workspac"..., Location: {Current: "root"}, ...},
        	            	  	},
        	            	  }
        	Test:       	TestInitializingWorkspacesVirtualWorkspaceAccess
        	Messages:   	cluster workspace list for initializer beta incorrect
FAIL
```
https://github.com/kcp-dev/kcp/runs/6779921627?check_suite_focus=true