### PR TITLE
Fix Ingress cluster assignment based on namespace placement

### DIFF
--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -40,11 +40,6 @@ import (
 // reconcileResource is responsible for setting the cluster for a resource of
 // any type, to match the cluster where its namespace is assigned.
 func (c *Controller) reconcileResource(ctx context.Context, lclusterName logicalcluster.Name, obj *unstructured.Unstructured, gvr *schema.GroupVersionResource) error {
-	if gvr.Group == "networking.k8s.io" && gvr.Resource == "ingresses" {
-		klog.V(4).Infof("Skipping reconciliation of ingress %s/%s", obj.GetNamespace(), obj.GetName())
-		return nil
-	}
-
 	klog.V(2).Infof("Reconciling GVR %q %s|%s/%s", gvr.String(), lclusterName, obj.GetNamespace(), obj.GetName())
 
 	// If the resource is not namespaced (incl if the resource is itself a


### PR DESCRIPTION
## Summary

Ingresses are currently not assigned to workload clusters based on the Placement API. This PR lifts that exception, so the Placement API also applies to Ingress resources.

This should ideally be back-ported to 0.5.0.

Note that this impacts the in-tree ingress-splitter controller, which is to be re-worked already. 

## Related issue(s)

Fixes #896