### PR TITLE
pkg/etcd,server: add --embedded-etcd-force-new-cluster

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -55,7 +55,7 @@ type ClientInfo struct {
 	TrustedCAFile string
 }
 
-func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBytes int64) (ClientInfo, error) {
+func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBytes int64, forceNewCluster bool) (ClientInfo, error) {
 	klog.Info("Creating embedded etcd server")
 	if walSizeBytes != 0 {
 		wal.SegmentSizeBytes = walSizeBytes
@@ -92,6 +92,7 @@ func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBy
 	cfg.ClientTLSInfo.KeyFile = filepath.Join(cfg.Dir, "secrets", "peer", "key.pem")
 	cfg.ClientTLSInfo.TrustedCAFile = filepath.Join(cfg.Dir, "secrets", "ca", "cert.pem")
 	cfg.ClientTLSInfo.ClientCertAuth = true
+	cfg.ForceNewCluster = forceNewCluster
 
 	if enableUnsafeEtcdDisableFsyncHack, _ := strconv.ParseBool(os.Getenv("UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC")); enableUnsafeEtcdDisableFsyncHack {
 		cfg.UnsafeNoFsync = true

--- a/pkg/server/options/embeddedetcd.go
+++ b/pkg/server/options/embeddedetcd.go
@@ -25,10 +25,11 @@ import (
 type EmbeddedEtcd struct {
 	Enabled bool
 
-	Directory    string
-	PeerPort     string
-	ClientPort   string
-	WalSizeBytes int64
+	Directory       string
+	PeerPort        string
+	ClientPort      string
+	WalSizeBytes    int64
+	ForceNewCluster bool
 }
 
 func NewEmbeddedEtcd() *EmbeddedEtcd {
@@ -44,6 +45,7 @@ func (e *EmbeddedEtcd) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&e.PeerPort, "embedded-etcd-peer-port", e.PeerPort, "Port for embedded etcd peer")
 	fs.StringVar(&e.ClientPort, "embedded-etcd-client-port", e.ClientPort, "Port for embedded etcd client")
 	fs.Int64Var(&e.WalSizeBytes, "embedded-etcd-wal-size-bytes", e.WalSizeBytes, "Size of embedded etcd WAL")
+	fs.BoolVar(&e.ForceNewCluster, "embedded-etcd-force-new-cluster", e.ForceNewCluster, "Starts a new cluster from existing data restored from a different system")
 }
 
 func (e *EmbeddedEtcd) Validate() []error {

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -148,10 +148,11 @@ var (
 		"tls-sni-cert-key",                 // A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. The domain patterns also allow IP addresses, but IPs should only be used if the apiserver has visibility to the IP address requested by a client. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".
 
 		// Embedded etcd flags
-		"embedded-etcd-client-port",    // Port for embedded etcd client
-		"embedded-etcd-directory",      // Directory for embedded etcd
-		"embedded-etcd-peer-port",      // Port for embedded etcd peer
-		"embedded-etcd-wal-size-bytes", // Size of embedded etcd WAL
+		"embedded-etcd-client-port",       // Port for embedded etcd client
+		"embedded-etcd-directory",         // Directory for embedded etcd
+		"embedded-etcd-peer-port",         // Port for embedded etcd peer
+		"embedded-etcd-wal-size-bytes",    // Size of embedded etcd WAL
+		"embedded-etcd-force-new-cluster", // Starts a new cluster from existing data restored from a different system
 
 		// KCP Controllers flags
 		"auto-publish-apis",                      // If true, the APIs imported from physical clusters will be published automatically as CRDs

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -125,7 +125,7 @@ func (s *Server) Run(ctx context.Context) error {
 		es := &etcd.Server{
 			Dir: s.options.EmbeddedEtcd.Directory,
 		}
-		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, s.options.EmbeddedEtcd.WalSizeBytes)
+		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.ForceNewCluster)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adding `--embedded-etcd-force-new-cluster` to be able to start the etcd with an existing etcd database.

This is useful for debugging and local development.

See https://etcd.io/docs/v3.3/op-guide/recovery/#restoring-a-cluster-from-membership-mis-reconfiguration-with-wrong-urls for more details.