### PR TITLE
ClusterWorkspace+Types: allow name "org"

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -56,7 +56,6 @@ spec:
                 not:
                   enum:
                   - root
-                  - org
                   - system
                 pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
                 type: string

--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml-patch
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml-patch
@@ -9,7 +9,6 @@
       not:
         enum:
         - root
-        - org
         - system
 - op: add
   path: /spec/versions/name=v1alpha1/schema/openAPIV3Schema/properties/spec/default

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -40,7 +40,6 @@ spec:
                 not:
                   enum:
                   - root
-                  - org
                   - system
                   - any
                 pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml-patch
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml-patch
@@ -9,7 +9,6 @@
       not:
         enum:
         - root
-        - org
         - system
         - any
 - op: add

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -52,14 +52,13 @@ spec:
           metadata:
             properties:
               name:
-                maxLength: 31
+                maxLength: 63
                 minLength: 1
                 not:
                   enum:
                   - root
-                  - org
                   - system
-                pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
+                pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
                 type: string
             type: object
           spec:

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml-patch
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml-patch
@@ -2,16 +2,14 @@
   path: /spec/versions/name=v1beta1/schema/openAPIV3Schema/properties/metadata/properties
   value:
     name:
-      pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+      pattern: "^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$"
       minLength: 1
-      maxLength: 31 # half of max name length
+      maxLength: 63 # a quarter of max name length, so the workspace FQN can be a valid DNS subdomain name
       type: string
       not:
         enum:
         - root
-        - org
         - system
 - op: add
   path: /spec/versions/name=v1beta1/schema/openAPIV3Schema/properties/spec/default
   value: {}
-


### PR DESCRIPTION
This was from the time before we had hierarchy.