### PR TITLE
initializingworkspaces: enforce permissions

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -165,6 +165,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/tenancy/initialization/utils.go
+++ b/pkg/apis/tenancy/initialization/utils.go
@@ -79,7 +79,7 @@ func TypeFrom(initializer tenancyv1alpha1.ClusterWorkspaceInitializer) (logicalc
 	case -1:
 		return logicalcluster.Name{}, "", fmt.Errorf("expected cluster workspace initializer in form workspace:name, not %q", initializer)
 	default:
-		return logicalcluster.New(string(initializer[:separatorIndex])), string(initializer[separatorIndex+1:]), nil
+		return logicalcluster.New(string(initializer[:separatorIndex])), tenancyv1alpha1.ObjectName(tenancyv1alpha1.ClusterWorkspaceTypeName(initializer[separatorIndex+1:])), nil
 	}
 }
 

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -120,6 +120,7 @@ func (r ClusterWorkspaceTypeReference) String() string {
 // +crd
 // +genclient
 // +genclient:nonNamespaced
+// +kubebuilder:subresource:status
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster,categories=kcp
 type ClusterWorkspaceType struct {

--- a/pkg/virtual/initializingworkspaces/options/options.go
+++ b/pkg/virtual/initializingworkspaces/options/options.go
@@ -23,6 +23,7 @@ import (
 
 	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
@@ -54,10 +55,11 @@ func (o *InitializingWorkspaces) Validate(flagPrefix string) []error {
 func (o *InitializingWorkspaces) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	dynamicClusterClient dynamic.ClusterInterface,
+	kubeClusterClient kubernetes.ClusterInterface,
 	wildcardApiExtensionsInformers apiextensionsinformers.SharedInformerFactory,
 ) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
 	virtualWorkspaces := []framework.VirtualWorkspace{
-		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), dynamicClusterClient, wildcardApiExtensionsInformers),
+		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), dynamicClusterClient, kubeClusterClient, wildcardApiExtensionsInformers),
 	}
 	return nil, virtualWorkspaces, nil
 }

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -99,7 +99,7 @@ func (o *Options) NewVirtualWorkspaces(
 	extraInformers = append(extraInformers, inf...)
 	workspaces = append(workspaces, vws...)
 
-	inf, vws, err = o.InitializingWorkspaces.NewVirtualWorkspaces(rootPathPrefix, dynamicClusterClient, wildcardApiExtensionsInformers)
+	inf, vws, err = o.InitializingWorkspaces.NewVirtualWorkspaces(rootPathPrefix, dynamicClusterClient, kubeClusterClient, wildcardApiExtensionsInformers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -203,6 +203,7 @@ func artifact(t *testing.T, server RunningServer, producer func() (runtime.Objec
 		gvkForFilename := fmt.Sprintf("%s_%s", group, gvk.Kind)
 
 		file := path.Join(dir, fmt.Sprintf("%s-%s.yaml", gvkForFilename, accessor.GetName()))
+		file = strings.ReplaceAll(file, ":", "_") // github actions don't like colon because NTFS is unhappy with it in path names
 
 		serializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, json.SerializerOptions{Yaml: true})
 		raw := bytes.Buffer{}

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -172,8 +172,11 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 	for _, workspaceType := range []string{
 		"alpha",
 	} {
-		ws, err := sourceKcpTenancyClient.ClusterWorkspaces().Create(ctx, workspaceForType(clusterWorkspaceTypes[workspaceType], testLabelSelector), metav1.CreateOptions{})
-		require.NoError(t, err)
+		var ws *tenancyv1alpha1.ClusterWorkspace
+		require.Eventually(t, func() bool {
+			ws, err = sourceKcpTenancyClient.ClusterWorkspaces().Create(ctx, workspaceForType(clusterWorkspaceTypes[workspaceType], testLabelSelector), metav1.CreateOptions{})
+			return err == nil
+		}, wait.ForeverTestTimeout, time.Millisecond*100)
 		source.Artifact(t, func() (runtime.Object, error) {
 			return sourceKcpTenancyClient.ClusterWorkspaces().Get(ctx, ws.Name, metav1.GetOptions{})
 		})


### PR DESCRIPTION
initializingworkspaces: enforce permissions
    
The user must be able to verb=initialize on the ClusterWorkspaceType
that the initializer is for.
    
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/hold
/assign @sttts 
Part of #1149 

Why doesn't this cause the test to fail ... ?