### PR TITLE
virtual: Remove unsupported verbs from virtual API server discovery

### DIFF
--- a/pkg/virtual/apiexport/builder/forwarding.go
+++ b/pkg/virtual/apiexport/builder/forwarding.go
@@ -109,9 +109,10 @@ func NewStorageBuilder(ctx context.Context, clusterClient dynamic.ClusterInterfa
 			registry.ListerFunc
 			registry.UpdaterFunc
 			registry.WatcherFunc
-			registry.CreaterFunc
-			registry.CollectionDeleterFunc
-			registry.GracefulDeleterFunc
+			// TODO: add create, delete and deletecollection verbs support
+			// registry.CreaterFunc
+			// registry.CollectionDeleterFunc
+			// registry.GracefulDeleterFunc
 
 			registry.TableConvertorFunc
 			registry.CategoriesProviderFunc
@@ -121,13 +122,14 @@ func NewStorageBuilder(ctx context.Context, clusterClient dynamic.ClusterInterfa
 			ListFactoryFunc: storage.ListFactoryFunc,
 			DestroyerFunc:   storage.DestroyerFunc,
 
-			GetterFunc:            storage.GetterFunc,
-			ListerFunc:            storage.ListerFunc,
-			UpdaterFunc:           storage.UpdaterFunc,
-			WatcherFunc:           storage.WatcherFunc,
-			CreaterFunc:           storage.CreaterFunc,
-			CollectionDeleterFunc: storage.CollectionDeleterFunc,
-			GracefulDeleterFunc:   storage.GracefulDeleterFunc,
+			GetterFunc:  storage.GetterFunc,
+			ListerFunc:  storage.ListerFunc,
+			UpdaterFunc: storage.UpdaterFunc,
+			WatcherFunc: storage.WatcherFunc,
+			// TODO: add create, delete and deletecollection verbs support
+			// CreaterFunc:           storage.CreaterFunc,
+			// CollectionDeleterFunc: storage.CollectionDeleterFunc,
+			// GracefulDeleterFunc:   storage.GracefulDeleterFunc,
 
 			TableConvertorFunc:      storage.TableConvertorFunc,
 			CategoriesProviderFunc:  storage.CategoriesProviderFunc,


### PR DESCRIPTION
## Summary

This PR removes the `create`, `delete` and `deletecollection` verbs from the discovery results returned by the virtual API server, as these are not supported by the underlying storage implementation, and leads the virtual API server to panic when the corresponding operations are being requested, and the client requests to be closed abruptly without further details.

Support for these operations will be provided in a future PR. In the interim, this PR prevents the virtual API server from panicking, and makes it return "405 Method Not Allowed" to clients, that try to perform these not supported operations. 

## Related issue(s)

Relates to #1253.