### PR TITLE
virtual workspaces: skips registartion of default health checks

### DIFF
--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/dynamic"
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -82,6 +83,12 @@ func (s *Server) installVirtualWorkspaces(
 	codecs := serializer.NewCodecFactory(scheme)
 
 	recommendedConfig := genericapiserver.NewRecommendedConfig(codecs)
+	// the recommended config attaches healthz.PingHealthz, healthz.LogHealthz
+	// which already have been added to the server so just skip them here
+	// otherwise we will panic with duplicate path registration of "/readyz/ping"
+	recommendedConfig.HealthzChecks = []healthz.HealthChecker{}
+	recommendedConfig.ReadyzChecks = []healthz.HealthChecker{}
+	recommendedConfig.LivezChecks = []healthz.HealthChecker{}
 	recommendedConfig.Authentication = auth
 
 	authorizationOptions := virtualoptions.NewAuthorization()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
the recommended config used by the virtual workspaces server attaches `healthz.PingHealthz`, `healthz.LogHealthz`
these checks have already been added to the previous server 
so we need to skip them otherwise we will panic with:

```
E0615 10:08:47.692463   34375 pathrecorder.go:109] duplicate path registration of "/readyz/ping": original registration from goroutine 1 [running]:
runtime/debug.Stack()
	/Users/lszaszki/.gimme/versions/go1.17.darwin.amd64/src/runtime/debug/stack.go:24 +0x65
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).trackCallers(0xc001761570, {0xc001f59090, 0xc})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:107 +0x35
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).Handle(0xc001761570, {0xc001f59090, 0xc002f6f238}, {0x4149380, 0xc0032873c0})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:175 +0xc5
k8s.io/apiserver/pkg/server/healthz.InstallPathHandlerWithHealthyFunc({0x41454a0, 0xc001761570}, {0x3bffc8d, 0x7}, 0xc0025878c0, {0xc0026f7400, 0x2b, 0x4b5})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:189 +0x58c
k8s.io/apiserver/pkg/server/healthz.InstallReadyzHandlerWithHealthyFunc(...)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:146
k8s.io/apiserver/pkg/server.(*GenericAPIServer).installReadyz(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz.go:106 +0x11a
k8s.io/apiserver/pkg/server.(*GenericAPIServer).PrepareRun(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/genericapiserver.go:400 +0x24a
github.com/kcp-dev/kcp/pkg/server.(*Server).Run(0xc0000e8c60, {0x419db90, 0xc001134100})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/pkg/server/server.go:505 +0x2187
main.main.func2(0xc000926c80, {0x3bfc3b0, 0x0, 0x0})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:105 +0xcc
github.com/spf13/cobra.(*Command).execute(0xc000926c80, {0x5d6aea8, 0x0, 0x0})
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc000926780)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:148 +0x58c


new registration from goroutine 1 [running]:
runtime/debug.Stack()
	/Users/lszaszki/.gimme/versions/go1.17.darwin.amd64/src/runtime/debug/stack.go:24 +0x65
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).trackCallers(0xc001761570, {0xc001f590c0, 0xc})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:107 +0x35
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).Handle(0xc001761570, {0xc001f590c0, 0xc002f6f238}, {0x4149380, 0xc003287f60})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:175 +0xc5
k8s.io/apiserver/pkg/server/healthz.InstallPathHandlerWithHealthyFunc({0x41454a0, 0xc001761570}, {0x3bffc8d, 0x7}, 0xc0025878c0, {0xc0026f7400, 0x2b, 0x4b5})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:189 +0x58c
k8s.io/apiserver/pkg/server/healthz.InstallReadyzHandlerWithHealthyFunc(...)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:146
k8s.io/apiserver/pkg/server.(*GenericAPIServer).installReadyz(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz.go:106 +0x11a
k8s.io/apiserver/pkg/server.(*GenericAPIServer).PrepareRun(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/genericapiserver.go:400 +0x24a
github.com/kcp-dev/kcp/pkg/server.(*Server).Run(0xc0000e8c60, {0x419db90, 0xc001134100})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/pkg/server/server.go:505 +0x2187
main.main.func2(0xc000926c80, {0x3bfc3b0, 0x0, 0x0})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:105 +0xcc
github.com/spf13/cobra.(*Command).execute(0xc000926c80, {0x5d6aea8, 0x0, 0x0})
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc000926780)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:148 +0x58c
E0615 10:08:47.692998   34375 pathrecorder.go:109] duplicate path registration of "/readyz/log": original registration from goroutine 1 [running]:
runtime/debug.Stack()
	/Users/lszaszki/.gimme/versions/go1.17.darwin.amd64/src/runtime/debug/stack.go:24 +0x65
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).trackCallers(0xc001761570, {0xc001f590a0, 0xb})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:107 +0x35
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).Handle(0xc001761570, {0xc001f590a0, 0xc002f6f238}, {0x4149380, 0xc003287440})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:175 +0xc5
k8s.io/apiserver/pkg/server/healthz.InstallPathHandlerWithHealthyFunc({0x41454a0, 0xc001761570}, {0x3bffc8d, 0x7}, 0xc0025878c0, {0xc0026f7400, 0x2b, 0x4b5})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:189 +0x58c
k8s.io/apiserver/pkg/server/healthz.InstallReadyzHandlerWithHealthyFunc(...)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:146
k8s.io/apiserver/pkg/server.(*GenericAPIServer).installReadyz(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz.go:106 +0x11a
k8s.io/apiserver/pkg/server.(*GenericAPIServer).PrepareRun(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/genericapiserver.go:400 +0x24a
github.com/kcp-dev/kcp/pkg/server.(*Server).Run(0xc0000e8c60, {0x419db90, 0xc001134100})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/pkg/server/server.go:505 +0x2187
main.main.func2(0xc000926c80, {0x3bfc3b0, 0x0, 0x0})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:105 +0xcc
github.com/spf13/cobra.(*Command).execute(0xc000926c80, {0x5d6aea8, 0x0, 0x0})
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc000926780)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:148 +0x58c


new registration from goroutine 1 [running]:
runtime/debug.Stack()
	/Users/lszaszki/.gimme/versions/go1.17.darwin.amd64/src/runtime/debug/stack.go:24 +0x65
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).trackCallers(0xc001761570, {0xc001f590e0, 0xb})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:107 +0x35
k8s.io/apiserver/pkg/server/mux.(*PathRecorderMux).Handle(0xc001761570, {0xc001f590e0, 0xc002f6f238}, {0x4149380, 0xc0032ea040})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/mux/pathrecorder.go:175 +0xc5
k8s.io/apiserver/pkg/server/healthz.InstallPathHandlerWithHealthyFunc({0x41454a0, 0xc001761570}, {0x3bffc8d, 0x7}, 0xc0025878c0, {0xc0026f7400, 0x2b, 0x4b5})
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:189 +0x58c
k8s.io/apiserver/pkg/server/healthz.InstallReadyzHandlerWithHealthyFunc(...)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz/healthz.go:146
k8s.io/apiserver/pkg/server.(*GenericAPIServer).installReadyz(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/healthz.go:106 +0x11a
k8s.io/apiserver/pkg/server.(*GenericAPIServer).PrepareRun(0xc00027f8c0)
	/Users/lszaszki/go/pkg/mod/github.com/p0lyn0mial/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20220614143607-6d7f770e8387/pkg/server/genericapiserver.go:400 +0x24a
github.com/kcp-dev/kcp/pkg/server.(*Server).Run(0xc0000e8c60, {0x419db90, 0xc001134100})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/pkg/server/server.go:505 +0x2187
main.main.func2(0xc000926c80, {0x3bfc3b0, 0x0, 0x0})
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:105 +0xcc
github.com/spf13/cobra.(*Command).execute(0xc000926c80, {0x5d6aea8, 0x0, 0x0})
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc000926780)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/lszaszki/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	/Users/lszaszki/go/src/github.com/kcp-dev/kcp/cmd/kcp/kcp.go:148 +0x58c
	```
## Related issue(s)

Fixes #