### PR TITLE
Added prerequisites on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ However, `kcp` is not an acronym.
 
 ## How do I get started?
 
+First of all, be sure to have [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [Go](https://golang.org/doc/install) (1.17+) installed.
+
 After cloning the repository, you can start kcp on your machine using this command:
 
 ```


### PR DESCRIPTION
This trivial PR fixes #1282 about mentioning prerequisites (kubectl but mainly minimum Go version) on the README when users go through the guide and try to start kcp before reading the CONTRIBUTING guide.