### PR TITLE
reconciler/clusterworkspace: split into independent reconcilers

### DIFF
--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_controller.go
@@ -20,41 +20,32 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"path"
-	"strings"
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/google/go-cmp/cmp"
 	"github.com/kcp-dev/logicalcluster"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clusters"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/kcp/pkg/apis/tenancy/initialization"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	conditionsv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	tenancyinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	tenancylister "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 )
 
 const (
-	currentShardIndex  = "shard"
-	unschedulableIndex = "unschedulable"
-	controllerName     = "workspace"
+	controllerName = "workspace"
 )
 
 func NewController(
@@ -78,28 +69,16 @@ func NewController(
 		UpdateFunc: func(_, obj interface{}) { c.enqueue(obj) },
 	})
 	if err := c.workspaceIndexer.AddIndexers(map[string]cache.IndexFunc{
-		currentShardIndex: func(obj interface{}) ([]string, error) {
-			if workspace, ok := obj.(*tenancyv1alpha1.ClusterWorkspace); ok {
-				return []string{workspace.Status.Location.Current}, nil
-			}
-			return []string{}, nil
-		},
-		unschedulableIndex: func(obj interface{}) ([]string, error) {
-			if workspace, ok := obj.(*tenancyv1alpha1.ClusterWorkspace); ok {
-				if conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceScheduled) && conditions.GetReason(workspace, tenancyv1alpha1.WorkspaceScheduled) == tenancyv1alpha1.WorkspaceReasonUnschedulable {
-					return []string{"true"}, nil
-				}
-			}
-			return []string{}, nil
-		},
+		byCurrentShard: indexByCurrentShard,
+		unschedulable:  indexUnschedulable,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to add indexer for ClusterWorkspace: %w", err)
 	}
 
 	rootWorkspaceShardInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.enqueueUpsertedShard(obj, "add") },
-		UpdateFunc: func(obj, _ interface{}) { c.enqueueUpsertedShard(obj, "update") },
-		DeleteFunc: func(obj interface{}) { c.enqueueDeletedShard(obj) },
+		AddFunc:    func(obj interface{}) { c.enqueueShard(obj) },
+		UpdateFunc: func(obj, _ interface{}) { c.enqueueShard(obj) },
+		DeleteFunc: func(obj interface{}) { c.enqueueShard(obj) },
 	})
 
 	return c, nil
@@ -128,45 +107,33 @@ func (c *Controller) enqueue(obj interface{}) {
 	c.queue.Add(key)
 }
 
-func (c *Controller) enqueueUpsertedShard(obj interface{}, verb string) {
-	shard, ok := obj.(*tenancyv1alpha1.ClusterWorkspaceShard)
-	if !ok {
-		runtime.HandleError(fmt.Errorf("got %T when handling added ClusterWorkspaceShard", obj))
-		return
-	}
-	klog.Infof("Handling %sed shard %q", verb, shard.Name)
-	workspaces, err := c.workspaceIndexer.ByIndex(unschedulableIndex, "true")
+func (c *Controller) enqueueShard(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	for _, workspace := range workspaces {
-		key, err := cache.MetaNamespaceKeyFunc(workspace)
-		if err != nil {
-			runtime.HandleError(err)
-			return
-		}
-		klog.Infof("Queuing unschedulable workspace %q", key)
-		c.queue.Add(key)
-	}
-}
+	_, name := clusters.SplitClusterAwareKey(key)
 
-func (c *Controller) enqueueDeletedShard(obj interface{}) {
-	shard, ok := obj.(*tenancyv1alpha1.ClusterWorkspaceShard)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			klog.V(2).Infof("Couldn't get object from tombstone %#v", obj)
+	shard, err := c.rootWorkspaceShardLister.Get(key)
+	if err == nil {
+		workspaces, err := c.workspaceIndexer.ByIndex(unschedulable, "true")
+		if err != nil {
+			runtime.HandleError(err)
 			return
 		}
-		shard, ok = tombstone.Obj.(*tenancyv1alpha1.ClusterWorkspaceShard)
-		if !ok {
-			klog.V(2).Infof("Tombstone contained object that is not a ClusterWorkspaceShard: %#v", obj)
-			return
+		for _, workspace := range workspaces {
+			key, err := cache.MetaNamespaceKeyFunc(workspace)
+			if err != nil {
+				runtime.HandleError(err)
+				return
+			}
+			klog.Infof("Queuing unschedulable workspace %q because of shard %s update", key, shard)
+			c.queue.Add(key)
 		}
 	}
-	klog.Infof("handling removed shard %q", shard.Name)
-	workspaces, err := c.workspaceIndexer.ByIndex(currentShardIndex, shard.Name)
+
+	workspaces, err := c.workspaceIndexer.ByIndex(byCurrentShard, name)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -177,7 +144,7 @@ func (c *Controller) enqueueDeletedShard(obj interface{}) {
 			runtime.HandleError(err)
 			return
 		}
-		klog.Infof("queuing orphaned workspace %q", key)
+		klog.Infof("Queueing workspace %q on shard %q", key, name)
 		c.queue.Add(key)
 	}
 }
@@ -224,245 +191,95 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (c *Controller) process(ctx context.Context, key string) error {
-	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		klog.Errorf("invalid key: %q: %v", key, err)
+func (c *Controller) patchIfNeeded(ctx context.Context, old, obj *tenancyv1alpha1.ClusterWorkspace) error {
+	specOrObjectMetaChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec) || !equality.Semantic.DeepEqual(old.ObjectMeta, obj.ObjectMeta)
+	statusChanged := !equality.Semantic.DeepEqual(old.Status, obj.Status)
+
+	if !specOrObjectMetaChanged && !statusChanged {
 		return nil
 	}
-	clusterName, name := clusters.SplitClusterAwareKey(clusterAwareName)
 
-	obj, err := c.workspaceLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
+	forPatch := func(apiExport *tenancyv1alpha1.ClusterWorkspace) tenancyv1alpha1.ClusterWorkspace {
+		var ret tenancyv1alpha1.ClusterWorkspace
+		if specOrObjectMetaChanged {
+			ret.ObjectMeta = apiExport.ObjectMeta
+			ret.Spec = apiExport.Spec
+		} else {
+			ret.Status = apiExport.Status
+		}
+		return ret
+	}
+
+	clusterName := logicalcluster.From(old)
+	name := old.Name
+
+	oldForPatch := forPatch(old)
+	// to ensure they appear in the patch as preconditions
+	oldForPatch.UID = ""
+	oldForPatch.ResourceVersion = ""
+
+	oldData, err := json.Marshal(oldForPatch)
+	if err != nil {
+		return fmt.Errorf("failed to Marshal old data for ClusterWorkspace %s|%s: %w", clusterName, name, err)
+	}
+
+	newForPatch := forPatch(obj)
+	// to ensure they appear in the patch as preconditions
+	newForPatch.UID = old.UID
+	newForPatch.ResourceVersion = old.ResourceVersion
+
+	newData, err := json.Marshal(newForPatch)
+	if err != nil {
+		return fmt.Errorf("failed to Marshal new data for ClusterWorkspace %s|%s: %w", clusterName, name, err)
+	}
+
+	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+	if err != nil {
+		return fmt.Errorf("failed to create patch for ClusterWorkspace %s|%s: %w", clusterName, name, err)
+	}
+
+	var subresources []string
+	if statusChanged {
+		subresources = []string{"status"}
+	}
+
+	_, err = c.kcpClient.Cluster(clusterName).TenancyV1alpha1().ClusterWorkspaces().Patch(ctx, obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...)
+	if err != nil {
+		return fmt.Errorf("failed to patch ClusterWorkspace %s|%s: %w", clusterName, name, err)
+	}
+
+	if specOrObjectMetaChanged && statusChanged {
+		klog.Errorf("Programmer error: spec and status changed in same reconcile iteration:\n%s", cmp.Diff(old, obj))
+		c.enqueue(obj) // enqueue again to take care of the spec change, assuming the patch did nothing
+	}
+
+	return nil
+}
+
+func (c *Controller) process(ctx context.Context, key string) error {
+	obj, err := c.workspaceLister.Get(key)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil // object deleted before we handled it
 		}
 		return err
 	}
-	previous := obj.DeepCopy()
+
+	old := obj
 	obj = obj.DeepCopy()
 
-	reconcileMetadata(obj)
-
-	// If the object being reconciled changed as a result, update it.
-	if !equality.Semantic.DeepEqual(previous.ObjectMeta, obj.ObjectMeta) {
-		// to ensure they appear in the patch as preconditions
-		previous.ObjectMeta.UID = ""
-		previous.ObjectMeta.ResourceVersion = ""
-		oldData, err := json.Marshal(tenancyv1alpha1.ClusterWorkspace{
-			ObjectMeta: previous.ObjectMeta,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to Marshal old data for workspace %s|%s: %w", clusterName, name, err)
-		}
-
-		newData, err := json.Marshal(tenancyv1alpha1.ClusterWorkspace{
-			ObjectMeta: obj.ObjectMeta,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to Marshal new data for workspace %s|%s: %w", clusterName, name, err)
-		}
-
-		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
-		if err != nil {
-			return fmt.Errorf("failed to create patch for workspace %s|%s: %w", clusterName, name, err)
-		}
-		_, uerr := c.kcpClient.Cluster(clusterName).TenancyV1alpha1().ClusterWorkspaces().Patch(ctx, obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		return uerr
-	}
-
+	var errs []error
 	if err := c.reconcile(ctx, obj); err != nil {
-		return err
+		errs = append(errs, err)
 	}
+
+	// Regardless of whether reconcile returned an error or not, always try to patch status if needed. Return the
+	// reconciliation error at the end.
 
 	// If the object being reconciled changed as a result, update it.
-	if !equality.Semantic.DeepEqual(previous.Status, obj.Status) {
-		oldData, err := json.Marshal(tenancyv1alpha1.ClusterWorkspace{
-			Status: previous.Status,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to Marshal old data for workspace %s|%s: %w", clusterName, name, err)
-		}
-
-		newData, err := json.Marshal(tenancyv1alpha1.ClusterWorkspace{
-			ObjectMeta: metav1.ObjectMeta{
-				UID:             previous.UID,
-				ResourceVersion: previous.ResourceVersion,
-			}, // to ensure they appear in the patch as preconditions
-			Status: obj.Status,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to Marshal new data for workspace %s|%s: %w", clusterName, name, err)
-		}
-
-		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
-		if err != nil {
-			return fmt.Errorf("failed to create patch for workspace %s|%s: %w", clusterName, name, err)
-		}
-		_, uerr := c.kcpClient.Cluster(clusterName).TenancyV1alpha1().ClusterWorkspaces().Patch(ctx, obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
-		return uerr
+	if err := c.patchIfNeeded(ctx, old, obj); err != nil {
+		errs = append(errs, err)
 	}
 
-	return nil
-}
-
-func reconcileMetadata(workspace *tenancyv1alpha1.ClusterWorkspace) {
-	if workspace.Labels == nil {
-		workspace.Labels = map[string]string{}
-	}
-	workspace.Labels[tenancyv1alpha1.ClusterWorkspacePhaseLabel] = string(workspace.Status.Phase)
-
-	initializerKeys := sets.NewString()
-	for _, initializer := range workspace.Status.Initializers {
-		key, value := initialization.InitializerToLabel(initializer)
-		initializerKeys.Insert(key)
-		workspace.Labels[key] = value
-	}
-
-	for key := range workspace.Labels {
-		if strings.HasPrefix(key, tenancyv1alpha1.ClusterWorkspaceInitializerLabelPrefix) {
-			if !initializerKeys.Has(key) {
-				delete(workspace.Labels, key)
-			}
-		}
-	}
-}
-
-func (c *Controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) error {
-	workspaceClusterName := logicalcluster.From(workspace)
-	switch workspace.Status.Phase {
-	case tenancyv1alpha1.ClusterWorkspacePhaseScheduling:
-		// possibly de-schedule while still in scheduling phase
-		if current := workspace.Status.Location.Current; current != "" {
-			// make sure current shard still exists
-			if shard, err := c.rootWorkspaceShardLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, current)); errors.IsNotFound(err) {
-				klog.Infof("De-scheduling workspace %s|%s from nonexistent shard %q", tenancyv1alpha1.RootCluster, workspace.Name, current)
-				workspace.Status.Location.Current = ""
-				workspace.Status.BaseURL = ""
-			} else if err != nil {
-				return err
-			} else if valid, _, _ := isValidShard(shard); !valid {
-				klog.Infof("De-scheduling workspace %s|%s from invalid shard %q", tenancyv1alpha1.RootCluster, workspace.Name, current)
-				workspace.Status.Location.Current = ""
-				workspace.Status.BaseURL = ""
-			}
-		}
-
-		if workspace.Status.Location.Current == "" {
-			// find a shard for this workspace, randomly
-			shards, err := c.rootWorkspaceShardLister.List(labels.Everything())
-			if err != nil {
-				return err
-			}
-
-			validShards := make([]*tenancyv1alpha1.ClusterWorkspaceShard, 0, len(shards))
-			invalidShards := map[string]struct {
-				reason, message string
-			}{}
-			for _, shard := range shards {
-				if valid, reason, message := isValidShard(shard); valid {
-					validShards = append(validShards, shard)
-				} else {
-					invalidShards[shard.Name] = struct {
-						reason, message string
-					}{
-						reason:  reason,
-						message: message,
-					}
-				}
-			}
-
-			if len(validShards) > 0 {
-				targetShard := validShards[rand.Intn(len(validShards))]
-
-				u, err := url.Parse(targetShard.Spec.ExternalURL)
-				if err != nil {
-					// shouldn't happen since we just checked in isValidShard
-					conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonReasonUnknown, conditionsv1alpha1.ConditionSeverityError, "Invalid connection information on target ClusterWorkspaceShard: %v.", err)
-					return err // requeue
-				}
-				u.Path = path.Join(u.Path, workspaceClusterName.Join(workspace.Name).Path())
-
-				workspace.Status.BaseURL = u.String()
-				workspace.Status.Location.Current = targetShard.Name
-
-				conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
-				klog.Infof("Scheduled workspace %s|%s to %s|%s", workspaceClusterName, workspace.Name, logicalcluster.From(targetShard), targetShard.Name)
-			} else {
-				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "No available shards to schedule the workspace.")
-				failures := make([]string, 0, len(invalidShards))
-				for name, x := range invalidShards {
-					failures = append(failures, fmt.Sprintf("  %s: reason %q, message %q", name, x.reason, x.message))
-				}
-				klog.Infof("No valid shards found for workspace %s|%s, skipped:\n%s", workspaceClusterName, workspace.Name, strings.Join(failures, "\n"))
-			}
-		}
-
-	case tenancyv1alpha1.ClusterWorkspacePhaseInitializing, tenancyv1alpha1.ClusterWorkspacePhaseReady:
-		// movement can only happen after scheduling
-		if workspace.Status.Location.Target == "" {
-			break
-		}
-
-		current, target := workspace.Status.Location.Current, workspace.Status.Location.Target
-		if current == target {
-			workspace.Status.Location.Target = ""
-			break
-		}
-
-		_, err := c.rootWorkspaceShardLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, target))
-		if errors.IsNotFound(err) {
-			klog.Infof("Cannot move to nonexistent shard %q", tenancyv1alpha1.RootCluster, workspace.Name, target)
-		} else if err != nil {
-			return err
-		}
-
-		klog.Infof("Moving workspace %q to %q", workspace.Name, workspace.Status.Location.Target)
-		workspace.Status.Location.Current = workspace.Status.Location.Target
-		workspace.Status.Location.Target = ""
-	}
-
-	// check scheduled shard. This has no influence on the workspace baseURL or shard assignment. This might be a trigger for
-	// a movement controller in the future (or a human intervention) to move workspaces off a shard.
-	if workspace.Status.Location.Current != "" {
-		if shard, err := c.rootWorkspaceShardLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, workspace.Status.Location.Current)); errors.IsNotFound(err) {
-			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceShardValid, tenancyv1alpha1.WorkspaceShardValidReasonShardNotFound, conditionsv1alpha1.ConditionSeverityError, fmt.Sprintf("ClusterWorkspaceShard %q got deleted.", workspace.Status.Location.Current))
-		} else if err != nil {
-			return err
-		} else if valid, reason, message := isValidShard(shard); !valid {
-			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceShardValid, reason, conditionsv1alpha1.ConditionSeverityError, message)
-		} else {
-			conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceShardValid)
-		}
-	}
-
-	switch workspace.Status.Phase {
-	case "":
-		workspace.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseScheduling
-	case tenancyv1alpha1.ClusterWorkspacePhaseScheduling:
-		// TODO(sttts): in the future this step is done by a workspace shard itself. I.e. moving to initializing is a step
-		//              of acceptance of the workspace on that shard.
-		if workspace.Status.Location.Current != "" && workspace.Status.BaseURL != "" {
-			// do final quorum read to avoid race when the workspace shard is being deleted
-			_, err := c.kcpClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Get(ctx, workspace.Status.Location.Current, metav1.GetOptions{})
-			if err != nil {
-				// reschedule
-				workspace.Status.Location.Current = ""
-				workspace.Status.BaseURL = ""
-				return nil // nolint:nilerr
-			}
-
-			workspace.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseInitializing
-		}
-	case tenancyv1alpha1.ClusterWorkspacePhaseInitializing:
-		if len(workspace.Status.Initializers) == 0 {
-			workspace.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseReady
-		}
-	}
-
-	return nil
-}
-
-func isValidShard(shard *tenancyv1alpha1.ClusterWorkspaceShard) (valid bool, reason, message string) {
-	return true, "", ""
+	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_indexes.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_indexes.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+)
+
+const (
+	byCurrentShard = "byCurrentShard"
+	unschedulable  = "unschedulable"
+)
+
+func indexByCurrentShard(obj interface{}) ([]string, error) {
+	ws := obj.(*tenancyv1alpha1.ClusterWorkspace)
+	return []string{ws.Status.Location.Current}, nil
+}
+
+func indexUnschedulable(obj interface{}) ([]string, error) {
+	workspace := obj.(*tenancyv1alpha1.ClusterWorkspace)
+	if conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceScheduled) && conditions.GetReason(workspace, tenancyv1alpha1.WorkspaceScheduled) == tenancyv1alpha1.WorkspaceReasonUnschedulable {
+		return []string{"true"}, nil
+	}
+	return []string{}, nil
+}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	"context"
+
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/clusters"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+type reconcileStatus int
+
+const (
+	reconcileStatusStop reconcileStatus = iota
+	reconcileStatusContinue
+)
+
+type reconciler interface {
+	reconcile(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) (reconcileStatus, error)
+}
+
+func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1alpha1.ClusterWorkspace) error {
+	reconcilers := []reconciler{
+		&metaDataReconciler{},
+		&schedulingReconciler{
+			getShard: func(name string) (*tenancyv1alpha1.ClusterWorkspaceShard, error) {
+				return c.rootWorkspaceShardLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, name))
+			},
+			listShards: c.rootWorkspaceShardLister.List,
+		},
+		&phaseReconciler{
+			getShardWithQuorum: c.kcpClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Get,
+		},
+	}
+
+	var errs []error
+
+	for _, r := range reconcilers {
+		var err error
+		var status reconcileStatus
+		status, err = r.reconcile(ctx, ws)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if status == reconcileStatusStop {
+			break
+		}
+	}
+
+	return utilserrors.NewAggregate(errs)
+}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/initialization"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+type metaDataReconciler struct {
+}
+
+func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) (reconcileStatus, error) {
+	if workspace.Labels == nil {
+		workspace.Labels = map[string]string{}
+	}
+	workspace.Labels[tenancyv1alpha1.ClusterWorkspacePhaseLabel] = string(workspace.Status.Phase)
+
+	initializerKeys := sets.NewString()
+	for _, initializer := range workspace.Status.Initializers {
+		key, value := initialization.InitializerToLabel(initializer)
+		initializerKeys.Insert(key)
+		workspace.Labels[key] = value
+	}
+
+	for key := range workspace.Labels {
+		if strings.HasPrefix(key, tenancyv1alpha1.ClusterWorkspaceInitializerLabelPrefix) {
+			if !initializerKeys.Has(key) {
+				delete(workspace.Labels, key)
+			}
+		}
+	}
+
+	return reconcileStatusContinue, nil
+}
+
+func initializerLabelFor(initializer tenancyv1alpha1.ClusterWorkspaceInitializer) string {
+	return string(tenancyv1alpha1.ClusterWorkspaceInitializerLabelPrefix + initializer)
+}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
@@ -30,9 +30,10 @@ import (
 
 func TestReconcileMetadata(t *testing.T) {
 	for _, testCase := range []struct {
-		name     string
-		input    *tenancyv1alpha1.ClusterWorkspace
-		expected metav1.ObjectMeta
+		name       string
+		input      *tenancyv1alpha1.ClusterWorkspace
+		expected   metav1.ObjectMeta
+		wantStatus reconcileStatus
 	}{
 		{
 			name: "adds entirely missing labels",
@@ -52,6 +53,7 @@ func TestReconcileMetadata(t *testing.T) {
 					"initializer.internal.kcp.dev/ccf53a4988ae8515ee77131ef507cabaf1": "ccf53a4988ae8515ee77131ef507cabaf18822766c2a4cff33b24eb8",
 				},
 			},
+			wantStatus: reconcileStatusStopAndRequeue,
 		},
 		{
 			name: "adds partially missing labels",
@@ -78,6 +80,7 @@ func TestReconcileMetadata(t *testing.T) {
 					"initializer.internal.kcp.dev/ccf53a4988ae8515ee77131ef507cabaf1": "ccf53a4988ae8515ee77131ef507cabaf18822766c2a4cff33b24eb8",
 				},
 			},
+			wantStatus: reconcileStatusStopAndRequeue,
 		},
 		{
 			name: "removes previously-needed labels removed on mutation that removes initializer",
@@ -102,6 +105,35 @@ func TestReconcileMetadata(t *testing.T) {
 					"initializer.internal.kcp.dev/2eadcbf778956517ec99fd1c1c32a9b13c": "2eadcbf778956517ec99fd1c1c32a9b13cbae759770fc37c341c7fe8",
 				},
 			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
+		{
+			name: "does nothing when labels match",
+			input: &tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"internal.kcp.dev/phase": "Ready",
+						"initializer.internal.kcp.dev/2eadcbf778956517ec99fd1c1c32a9b13c": "2eadcbf778956517ec99fd1c1c32a9b13cbae759770fc37c341c7fe8",
+						"initializer.internal.kcp.dev/aceeb26461953562d30366db65b200f642": "aceeb26461953562d30366db65b200f64241f9e5fe888892d52eea5c",
+						"initializer.internal.kcp.dev/ccf53a4988ae8515ee77131ef507cabaf1": "ccf53a4988ae8515ee77131ef507cabaf18822766c2a4cff33b24eb8",
+					},
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase: tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{
+						"pluto", "venus", "apollo",
+					},
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"internal.kcp.dev/phase": "Ready",
+					"initializer.internal.kcp.dev/2eadcbf778956517ec99fd1c1c32a9b13c": "2eadcbf778956517ec99fd1c1c32a9b13cbae759770fc37c341c7fe8",
+					"initializer.internal.kcp.dev/aceeb26461953562d30366db65b200f642": "aceeb26461953562d30366db65b200f64241f9e5fe888892d52eea5c",
+					"initializer.internal.kcp.dev/ccf53a4988ae8515ee77131ef507cabaf1": "ccf53a4988ae8515ee77131ef507cabaf18822766c2a4cff33b24eb8",
+				},
+			},
+			wantStatus: reconcileStatusContinue,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -109,7 +141,7 @@ func TestReconcileMetadata(t *testing.T) {
 			status, err := reconciler.reconcile(context.Background(), testCase.input)
 
 			require.NoError(t, err)
-			require.Equal(t, reconcileStatusContinue, status)
+			require.Equal(t, testCase.wantStatus, status)
 
 			if diff := cmp.Diff(testCase.input.ObjectMeta, testCase.expected); diff != "" {
 				t.Errorf("invalid output after reconciling metadata: %v", diff)

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package clusterworkspace
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -103,7 +105,12 @@ func TestReconcileMetadata(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			reconcileMetadata(testCase.input)
+			reconciler := metaDataReconciler{}
+			status, err := reconciler.reconcile(context.Background(), testCase.input)
+
+			require.NoError(t, err)
+			require.Equal(t, reconcileStatusContinue, status)
+
 			if diff := cmp.Diff(testCase.input.ObjectMeta, testCase.expected); diff != "" {
 				t.Errorf("invalid output after reconciling metadata: %v", diff)
 			}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_phase.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+type phaseReconciler struct {
+	getShardWithQuorum func(ctx context.Context, name string, options metav1.GetOptions) (*tenancyv1alpha1.ClusterWorkspaceShard, error)
+}
+
+func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) (reconcileStatus, error) {
+	switch workspace.Status.Phase {
+	case "":
+		workspace.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseScheduling
+	case tenancyv1alpha1.ClusterWorkspacePhaseScheduling:
+		// TODO(sttts): in the future this step is done by a workspace shard itself. I.e. moving to initializing is a step
+		//              of acceptance of the workspace on that shard.
+		if workspace.Status.Location.Current != "" && workspace.Status.BaseURL != "" {
+			// do final quorum read to avoid race when the workspace shard is being deleted
+			_, err := r.getShardWithQuorum(ctx, workspace.Status.Location.Current, metav1.GetOptions{})
+			if err != nil {
+				// reschedule
+				workspace.Status.Location.Current = ""
+				workspace.Status.BaseURL = ""
+				return reconcileStatusContinue, nil // nolint:nilerr
+			}
+
+			workspace.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseInitializing
+		}
+	case tenancyv1alpha1.ClusterWorkspacePhaseInitializing:
+		if len(workspace.Status.Initializers) == 0 {
+			workspace.Status.Phase = tenancyv1alpha1.ClusterWorkspacePhaseReady
+		}
+	}
+
+	return reconcileStatusContinue, nil
+}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_scheduling.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterworkspace
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/klog/v2"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+)
+
+type schedulingReconciler struct {
+	getShard   func(name string) (*tenancyv1alpha1.ClusterWorkspaceShard, error)
+	listShards func(selector labels.Selector) ([]*tenancyv1alpha1.ClusterWorkspaceShard, error)
+}
+
+func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancyv1alpha1.ClusterWorkspace) (reconcileStatus, error) {
+	workspaceClusterName := logicalcluster.From(workspace)
+	switch workspace.Status.Phase {
+	case tenancyv1alpha1.ClusterWorkspacePhaseScheduling:
+		// possibly de-schedule while still in scheduling phase
+		if current := workspace.Status.Location.Current; current != "" {
+			// make sure current shard still exists
+			if shard, err := r.getShard(current); errors.IsNotFound(err) {
+				klog.Infof("De-scheduling workspace %s|%s from nonexistent shard %q", tenancyv1alpha1.RootCluster, workspace.Name, current)
+				workspace.Status.Location.Current = ""
+				workspace.Status.BaseURL = ""
+			} else if err != nil {
+				return reconcileStatusStop, err
+			} else if valid, _, _ := isValidShard(shard); !valid {
+				klog.Infof("De-scheduling workspace %s|%s from invalid shard %q", tenancyv1alpha1.RootCluster, workspace.Name, current)
+				workspace.Status.Location.Current = ""
+				workspace.Status.BaseURL = ""
+			}
+		}
+
+		if workspace.Status.Location.Current == "" {
+			selector := labels.Everything()
+
+			// find a shard for this workspace, randomly
+			var err error
+			shards, err := r.listShards(selector)
+			if err != nil {
+				return reconcileStatusStop, err
+			}
+
+			validShards := make([]*tenancyv1alpha1.ClusterWorkspaceShard, 0, len(shards))
+			invalidShards := map[string]struct {
+				reason, message string
+			}{}
+			for _, shard := range shards {
+				if valid, reason, message := isValidShard(shard); valid {
+					validShards = append(validShards, shard)
+				} else {
+					invalidShards[shard.Name] = struct {
+						reason, message string
+					}{
+						reason:  reason,
+						message: message,
+					}
+				}
+			}
+
+			if len(validShards) > 0 {
+				targetShard := validShards[rand.Intn(len(validShards))]
+
+				u, err := url.Parse(targetShard.Spec.ExternalURL)
+				if err != nil {
+					// shouldn't happen since we just checked in isValidShard
+					conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonReasonUnknown, conditionsv1alpha1.ConditionSeverityError, "Invalid connection information on target ClusterWorkspaceShard: %v.", err)
+					return reconcileStatusStop, err // requeue
+				}
+				u.Path = path.Join(u.Path, workspaceClusterName.Join(workspace.Name).Path())
+
+				workspace.Status.BaseURL = u.String()
+				workspace.Status.Location.Current = targetShard.Name
+
+				conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
+				klog.Infof("Scheduled workspace %s|%s to %s|%s", workspaceClusterName, workspace.Name, logicalcluster.From(targetShard), targetShard.Name)
+			} else {
+				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "No available shards to schedule the workspace.")
+				failures := make([]string, 0, len(invalidShards))
+				for name, x := range invalidShards {
+					failures = append(failures, fmt.Sprintf("  %s: reason %q, message %q", name, x.reason, x.message))
+				}
+				klog.Infof("No valid shards found for workspace %s|%s, skipped:\n%s", workspaceClusterName, workspace.Name, strings.Join(failures, "\n"))
+			}
+		}
+	case tenancyv1alpha1.ClusterWorkspacePhaseInitializing, tenancyv1alpha1.ClusterWorkspacePhaseReady:
+		// movement can only happen after scheduling
+		if workspace.Status.Location.Target == "" {
+			break
+		}
+
+		current, target := workspace.Status.Location.Current, workspace.Status.Location.Target
+		if current == target {
+			workspace.Status.Location.Target = ""
+			break
+		}
+
+		_, err := r.getShard(target)
+		if errors.IsNotFound(err) {
+			klog.Infof("Cannot move to nonexistent shard %q", tenancyv1alpha1.RootCluster, workspace.Name, target)
+		} else if err != nil {
+			return reconcileStatusStop, err
+		}
+
+		klog.Infof("Moving workspace %q to %q", workspace.Name, workspace.Status.Location.Target)
+		workspace.Status.Location.Current = workspace.Status.Location.Target
+		workspace.Status.Location.Target = ""
+	}
+
+	// check scheduled shard. This has no influence on the workspace baseURL or shard assignment. This might be a trigger for
+	// a movement controller in the future (or a human intervention) to move workspaces off a shard.
+	if workspace.Status.Location.Current != "" {
+		if shard, err := r.getShard(workspace.Status.Location.Current); errors.IsNotFound(err) {
+			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceShardValid, tenancyv1alpha1.WorkspaceShardValidReasonShardNotFound, conditionsv1alpha1.ConditionSeverityError, "ClusterWorkspaceShard %q got deleted.", workspace.Status.Location.Current)
+		} else if err != nil {
+			return reconcileStatusStop, err
+		} else if valid, reason, message := isValidShard(shard); !valid {
+			conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceShardValid, reason, conditionsv1alpha1.ConditionSeverityError, message)
+		} else {
+			conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceShardValid)
+		}
+	}
+
+	return reconcileStatusContinue, nil
+}
+
+func isValidShard(shard *tenancyv1alpha1.ClusterWorkspaceShard) (valid bool, reason, message string) {
+	return true, "", ""
+}


### PR DESCRIPTION
For easier testing and less monolithic code. This is pre-req for more advanced logic around ClusterWorkspace scheduling.