### PR TITLE
e2e: switch NewWorkspaceFixture to options

### DIFF
--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -111,8 +111,4 @@ const (
 
 	// SchedulingDisabledLabel on a namespace with value "true" disables workload placement and scheduling.
 	SchedulingDisabledLabel = "experimental.workload.kcp.dev/scheduling-disabled"
-
-	// WorkspaceSchedulableLabel on a workspace enables scheduling for the contents
-	// of the workspace. It is applied by default to workspaces of type `Universal`.
-	WorkspaceSchedulableLabel = "workload.kcp.dev/schedulable"
 )

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -52,10 +52,10 @@ func TestAPIBindingAuthorizer(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	rbacServiceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	serviceProvider2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumer1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumer2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	rbacServiceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	serviceProvider2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumer1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumer2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -51,8 +51,8 @@ func TestAPIBindingDeletion(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -45,8 +45,8 @@ func TestProtectedAPI(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	providerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	providerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -59,11 +59,11 @@ func TestAPIBinding(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	serviceProvider1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	serviceProvider2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumer1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumer2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumer3Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	serviceProvider1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	serviceProvider2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumer1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumer2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumer3Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -56,8 +56,8 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	targetWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	targetWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 
@@ -196,8 +196,8 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	targetWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	targetWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/authorizer/rootcacertconfigmap_test.go
+++ b/test/e2e/authorizer/rootcacertconfigmap_test.go
@@ -42,7 +42,7 @@ func TestRootCACertConfigmap(t *testing.T) {
 
 	server := framework.SharedKcpServer(t)
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)

--- a/test/e2e/authorizer/serviceaccounts_test.go
+++ b/test/e2e/authorizer/serviceaccounts_test.go
@@ -45,7 +45,7 @@ func TestServiceAccounts(t *testing.T) {
 
 	server := framework.SharedKcpServer(t)
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
@@ -163,7 +163,7 @@ func TestServiceAccounts(t *testing.T) {
 
 			t.Run("Access another workspace in the same org", func(t *testing.T) {
 				t.Log("Create namespace with the same name ")
-				otherClusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+				otherClusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 				_, err := kubeClusterClient.Cluster(otherClusterName).CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: namespace.Name,
@@ -179,7 +179,7 @@ func TestServiceAccounts(t *testing.T) {
 			t.Run("Access an equally named workspace in another org", func(t *testing.T) {
 				t.Log("Create namespace with the same name")
 				otherOrgClusterName := framework.NewOrganizationFixture(t, server)
-				otherClusterName := framework.NewWorkspaceFixture(t, server, otherOrgClusterName, "Universal")
+				otherClusterName := framework.NewWorkspaceFixture(t, server, otherOrgClusterName)
 				_, err := kubeClusterClient.Cluster(otherClusterName).CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: namespace.Name,

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -127,27 +127,27 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	org := framework.NewOrganizationFixture(t, server)
 
 	// These 2 workspaces will have the same sheriffs CRD schema as normal CRDs
-	wsNormalCRD1a := framework.NewWorkspaceFixture(t, server, org, "Universal")
-	wsNormalCRD1b := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsNormalCRD1a := framework.NewWorkspaceFixture(t, server, org)
+	wsNormalCRD1b := framework.NewWorkspaceFixture(t, server, org)
 
 	// This workspace will have a different sherrifs CRD schema as a normal CRD - will conflict with 1a/1b.
-	wsNormalCRD2 := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsNormalCRD2 := framework.NewWorkspaceFixture(t, server, org)
 
 	// These 2 workspaces will export a sheriffs API with the same schema
-	wsExport1a := framework.NewWorkspaceFixture(t, server, org, "Universal")
-	wsExport1b := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsExport1a := framework.NewWorkspaceFixture(t, server, org)
+	wsExport1b := framework.NewWorkspaceFixture(t, server, org)
 
 	// This workspace will export a sheriffs API with a different schema
-	wsExport2 := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsExport2 := framework.NewWorkspaceFixture(t, server, org)
 
 	// This workspace will consume from wsExport1a
-	wsConsume1a := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsConsume1a := framework.NewWorkspaceFixture(t, server, org)
 
 	// This workspace will consume from wsExport1b
-	wsConsume1b := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsConsume1b := framework.NewWorkspaceFixture(t, server, org)
 
 	// This workspace will consume from wsExport2
-	wsConsume2 := framework.NewWorkspaceFixture(t, server, org, "Universal")
+	wsConsume2 := framework.NewWorkspaceFixture(t, server, org)
 
 	// Make sure the informers aren't throttled because dynamic informers do lots of discovery which slows down tests
 	cfg := server.DefaultConfig(t)
@@ -263,7 +263,7 @@ func TestBuiltInCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	require.NoError(t, err, "error creating kube cluster client")
 
 	for i := 0; i < 3; i++ {
-		ws := framework.NewWorkspaceFixture(t, server, org, "Universal")
+		ws := framework.NewWorkspaceFixture(t, server, org)
 
 		configMapName := fmt.Sprintf("test-cm-%d", i)
 		configMap := &corev1.ConfigMap{

--- a/test/e2e/conformance/webhook_test.go
+++ b/test/e2e/conformance/webhook_test.go
@@ -84,8 +84,8 @@ func TestMutatingWebhookInWorkspace(t *testing.T) {
 
 	organization := framework.NewOrganizationFixture(t, server)
 	logicalClusters := []logicalcluster.Name{
-		framework.NewWorkspaceFixture(t, server, organization, "Universal"),
-		framework.NewWorkspaceFixture(t, server, organization, "Universal"),
+		framework.NewWorkspaceFixture(t, server, organization),
+		framework.NewWorkspaceFixture(t, server, organization),
 	}
 
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
@@ -203,8 +203,8 @@ func TestValidatingWebhookInWorkspace(t *testing.T) {
 
 	organization := framework.NewOrganizationFixture(t, server)
 	logicalClusters := []logicalcluster.Name{
-		framework.NewWorkspaceFixture(t, server, organization, "Universal"),
-		framework.NewWorkspaceFixture(t, server, organization, "Universal"),
+		framework.NewWorkspaceFixture(t, server, organization),
+		framework.NewWorkspaceFixture(t, server, organization),
 	}
 
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -44,7 +44,7 @@ func TestCustomResourceCreation(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -541,7 +541,7 @@ func newPersistentKCPServer(name, kubeconfigPath string) (RunningServer, error) 
 // NewFakeWorkloadServer creates a workspace in the provided server and org
 // and creates a server fixture for the logical cluster that results.
 func NewFakeWorkloadServer(t *testing.T, server RunningServer, org logicalcluster.Name) RunningServer {
-	logicalClusterName := NewWorkspaceWithWorkloads(t, server, org, "Universal", false)
+	logicalClusterName := NewWorkspaceFixture(t, server, org)
 	rawConfig, err := server.RawConfig()
 	require.NoError(t, err, "failed to read config for server")
 	logicalConfig, kubeconfigPath := WriteLogicalClusterConfig(t, rawConfig, logicalClusterName)

--- a/test/e2e/reconciler/apiexport/apiexport_controller_test.go
+++ b/test/e2e/reconciler/apiexport/apiexport_controller_test.go
@@ -43,7 +43,7 @@ func TestRequeueWhenIdentitySecretAdded(t *testing.T) {
 	t.Cleanup(cancel)
 
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	workspaceClusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	workspaceClusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	t.Logf("Running test in cluster %s", workspaceClusterName)
 
 	cfg := server.DefaultConfig(t)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -154,7 +154,7 @@ func TestClusterController(t *testing.T) {
 			t.Cleanup(cancelFunc)
 
 			t.Log("Creating a workspace")
-			wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
+			wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
 			// clients
 			sourceConfig := source.DefaultConfig(t)

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -146,7 +146,7 @@ func TestIngressController(t *testing.T) {
 			ctx, cancelFunc := context.WithCancel(context.Background())
 			t.Cleanup(cancelFunc)
 
-			clusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
+			clusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
 			// clients
 			sourceConfig := source.DefaultConfig(t)

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -268,7 +268,7 @@ func TestNamespaceScheduler(t *testing.T) {
 			kubeClient, err := kubernetes.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")
 
-			clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+			clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 			client := kubeClient.Cluster(clusterName)
 

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -53,9 +53,9 @@ func TestScheduling(t *testing.T) {
 	source := framework.SharedKcpServer(t)
 
 	orgClusterName := framework.NewOrganizationFixture(t, source)
-	negotiationClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
-	userClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
-	secondUserClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName, "Universal")
+	negotiationClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
+	userClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
+	secondUserClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.DefaultConfig(t))
 	require.NoError(t, err)

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -54,7 +54,7 @@ func TestSyncerLifecycle(t *testing.T) {
 	orgClusterName := framework.NewOrganizationFixture(t, upstreamServer)
 
 	t.Log("Creating a workspace")
-	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName, "Universal")
+	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName)
 
 	// The Start method of the fixture will initiate syncer start and then wait for
 	// its workload cluster to go ready. This implicitly validates the syncer
@@ -361,7 +361,7 @@ func TestSyncWorkload(t *testing.T) {
 	orgClusterName := framework.NewOrganizationFixture(t, upstreamServer)
 
 	t.Log("Creating a workspace")
-	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName, "Universal")
+	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName)
 
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()
@@ -393,7 +393,7 @@ func TestCordonUncordonDrain(t *testing.T) {
 	upstreamCfg := upstreamServer.DefaultConfig(t)
 
 	t.Log("Creating a workspace")
-	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName, "Universal")
+	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName)
 
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -55,8 +55,8 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 
 	// Need to Create a Producer w/ APIExport
 	orgClusterName := framework.NewOrganizationFixture(t, server)
-	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
-	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
+	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.DefaultConfig(t)
 

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -100,7 +100,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 	t.Parallel()
 
 	source := framework.SharedKcpServer(t)
-	clusterName := framework.NewWorkspaceFixture(t, source, tenancyv1alpha1.RootCluster, "Universal")
+	clusterName := framework.NewWorkspaceFixture(t, source, tenancyv1alpha1.RootCluster)
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
@@ -115,7 +115,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, clusterName, []string{"user-1"}, nil, []string{"access"})
 
 	// Create a Workspace that will not be Initializing and should not be shown in the virtual workspace
-	framework.NewWorkspaceFixture(t, source, clusterName, "Universal")
+	framework.NewWorkspaceFixture(t, source, clusterName)
 
 	sourceKcpTenancyClient := sourceKcpClusterClient.Cluster(clusterName).TenancyV1alpha1()
 

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -430,7 +430,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				kcpClusterClient, err := kcpclient.NewClusterForConfig(server.DefaultConfig(t))
 				require.NoError(t, err)
 
-				otherWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+				otherWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 				t.Logf("Create a binding in the other workspace")
 				binding := &apisv1alpha1.APIBinding{
@@ -565,7 +565,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			ctx, cancelFunc := context.WithCancel(context.Background())
 			t.Cleanup(cancelFunc)
 
-			kubelikeWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+			kubelikeWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 			t.Logf("Deploying syncer into workspace %s", kubelikeWorkspace)
 			_ = framework.SyncerFixture{
@@ -611,7 +611,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 			t.Log("Setting up an unrelated workspace with cowboys...")
 
-			unrelatedWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+			unrelatedWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 			unrelatedWorkspaceWorkspaceClient := wildwestClusterClient.Cluster(unrelatedWorkspace)
 
 			sourceCrdClient, err := apiextensionsclientset.NewClusterForConfig(server.DefaultConfig(t))
@@ -640,7 +640,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			wildwestWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName, "Universal")
+			wildwestWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 			wildwestWorkloadClusterName := fmt.Sprintf("wildwest-%d", +rand.Intn(1000000))
 
 			t.Logf("Deploying syncer into workspace %s", wildwestWorkspace)

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -252,7 +252,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 				vwUser2Client := server.virtualUserKcpClients[1]
 
 				createOrgMemberRoleForGroup(t, ctx, server.kubeClusterClient, server.orgClusterName, "team-1", "team-2")
-				parentCluster := framework.NewWorkspaceFixture(t, server, server.orgClusterName, "Universal")
+				parentCluster := framework.NewWorkspaceFixture(t, server, server.orgClusterName)
 				createOrgMemberRoleForGroup(t, ctx, server.kubeClusterClient, parentCluster, "team-1", "team-2")
 
 				t.Logf("Create custom ClusterWorkspaceType 'Custom'")

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -83,7 +83,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 		{
 			name: "create a workspace with an explicit non-existing type",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				universal := framework.NewWorkspaceFixture(t, server, tenancyv1alpha1.RootCluster, "Universal")
+				universal := framework.NewWorkspaceFixture(t, server, tenancyv1alpha1.RootCluster)
 				t.Logf("Create a workspace with explicit non-existing type")
 				workspace, err := server.kcpClusterClient.Cluster(universal).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "myapp"},
@@ -139,7 +139,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 		{
 			name: "create a workspace with a type that has an initializer",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				universal := framework.NewWorkspaceFixture(t, server, tenancyv1alpha1.RootCluster, "Universal")
+				universal := framework.NewWorkspaceFixture(t, server, tenancyv1alpha1.RootCluster)
 				t.Logf("Create type Foo with an initializer")
 				cwt, err := server.kcpClusterClient.Cluster(universal).TenancyV1alpha1().ClusterWorkspaceTypes().Create(ctx, &tenancyv1alpha1.ClusterWorkspaceType{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
@@ -203,8 +203,8 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 			name: "create a workspace with deeper nesting",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
 				org := framework.NewOrganizationFixture(t, server)
-				team := framework.NewWorkspaceFixture(t, server, org, "Team")
-				universal := framework.NewWorkspaceFixture(t, server, team, "Universal")
+				team := framework.NewWorkspaceFixture(t, server, org, framework.WithType(tenancyv1alpha1.RootCluster, "Team"))
+				universal := framework.NewWorkspaceFixture(t, server, team)
 
 				require.Len(t, strings.Split(universal.String(), ":"), 4, "expecting root:org:team:universal, i.e. 4 levels")
 				require.True(t, strings.HasPrefix(universal.String(), team.String()), "expecting universal to be a child of team")


### PR DESCRIPTION
Pre-req for more customization of ClusterWorkspaces in tests (for scheduling), and removal of redundant `"Universal"` everywhere.