### PR TITLE
Fix partial meta request determination logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster v1.0.0
 	github.com/muesli/reflow v0.1.0
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1

--- a/pkg/server/apiextensions_test.go
+++ b/pkg/server/apiextensions_test.go
@@ -131,3 +131,25 @@ func TestDecorateCRDWithBinding(t *testing.T) {
 		})
 	}
 }
+
+func Test_isPartialMetadataHeader(t *testing.T) {
+	tests := map[string]struct {
+		accept string
+		want   bool
+	}{
+		"empty header": {
+			accept: "",
+			want:   false,
+		},
+		"metadata informer factory": {
+			accept: "application/vnd.kubernetes.protobuf;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json",
+			want:   true,
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := isPartialMetadataHeader(test.accept)
+			require.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The accept header can have multiple clauses, but we were only supporting
one. The Kubernetes metadataSharedInformerFactory generates requests
with the accept header having multiple clauses, and our previous logic
didn't handle them correctly, leading to thinking the request was not
for partial metadata, when in fact it was supposed to be.

## Related issue(s)

Discovered while working on #1061