### PR TITLE
pkg/virtual: externalize VW name and remove extra informers

### DIFF
--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -116,7 +116,7 @@ func Run(o *options.Options, stopCh <-chan struct{}) error {
 	wildcardKcpInformers := kcpinformer.NewSharedInformerFactory(wildcardKcpClient, 10*time.Minute)
 
 	// create apiserver
-	extraInformerStarts, virtualWorkspaces, err := o.VirtualWorkspaces.NewVirtualWorkspaces(kubeClientConfig, o.RootPathPrefix, wildcardKubeInformers, wildcardApiextensionsInformers, wildcardKcpInformers)
+	virtualWorkspaces, err := o.VirtualWorkspaces.NewVirtualWorkspaces(kubeClientConfig, o.RootPathPrefix, wildcardKubeInformers, wildcardApiextensionsInformers, wildcardKcpInformers)
 	if err != nil {
 		return err
 	}
@@ -133,11 +133,11 @@ func Run(o *options.Options, stopCh <-chan struct{}) error {
 	if err := o.Authorization.ApplyTo(&recommendedConfig.Config, virtualWorkspaces); err != nil {
 		return err
 	}
-	rootAPIServerConfig, err := virtualrootapiserver.NewRootAPIConfig(recommendedConfig, append(extraInformerStarts,
+	rootAPIServerConfig, err := virtualrootapiserver.NewRootAPIConfig(recommendedConfig, []virtualrootapiserver.InformerStart{
 		wildcardKubeInformers.Start,
 		wildcardKcpInformers.Start,
 		wildcardApiextensionsInformers.Start,
-	), virtualWorkspaces...)
+	}, virtualWorkspaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -49,7 +49,7 @@ func (s *Server) installVirtualWorkspaces(
 	preHandlerChainMux mux,
 ) error {
 	// create virtual workspaces
-	extraInformerStarts, virtualWorkspaces, err := s.options.Virtual.VirtualWorkspaces.NewVirtualWorkspaces(
+	virtualWorkspaces, err := s.options.Virtual.VirtualWorkspaces.NewVirtualWorkspaces(
 		config,
 		virtualcommandoptions.DefaultRootPathPrefix,
 		s.kubeSharedInformerFactory,
@@ -59,16 +59,6 @@ func (s *Server) installVirtualWorkspaces(
 	if err != nil {
 		return err
 	}
-
-	s.AddPostStartHook("kcp-start-virtual-workspace-extra-informers", func(ctx genericapiserver.PostStartHookContext) error {
-		for _, start := range extraInformerStarts {
-			start(ctx.StopCh)
-		}
-
-		// TODO(sttts): wait for cache sync
-
-		return nil
-	})
 
 	// create apiserver, with its own delegation chain
 	scheme := runtime.NewScheme()
@@ -92,7 +82,7 @@ func (s *Server) installVirtualWorkspaces(
 		return err
 	}
 
-	rootAPIServerConfig, err := virtualrootapiserver.NewRootAPIConfig(recommendedConfig, extraInformerStarts, virtualWorkspaces...)
+	rootAPIServerConfig, err := virtualrootapiserver.NewRootAPIConfig(recommendedConfig, nil, virtualWorkspaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -59,8 +59,6 @@ func BuildVirtualWorkspace(
 	readyCh := make(chan struct{})
 
 	return &virtualdynamic.DynamicVirtualWorkspace{
-		Name: VirtualWorkspaceName,
-
 		RootPathResolver: func(path string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			completedContext = requestContext
 

--- a/pkg/virtual/apiexport/options/options.go
+++ b/pkg/virtual/apiexport/options/options.go
@@ -29,7 +29,6 @@ import (
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/builder"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 )
 
 type APIExport struct{}
@@ -57,27 +56,23 @@ func (o *APIExport) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
+) (workspaces map[string]framework.VirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "apiexport-virtual-workspace")
 	kcpClusterClient, err := kcpclientset.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	dynamicClusterClient, err := dynamic.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	virtualWorkspaces := []framework.VirtualWorkspace{
-		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
+	virtualWorkspaces := map[string]framework.VirtualWorkspace{
+		builder.VirtualWorkspaceName: builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
 	}
-	return nil, virtualWorkspaces, nil
-}
-
-func (o *APIExport) Name() string {
-	return builder.VirtualWorkspaceName
+	return virtualWorkspaces, nil
 }

--- a/pkg/virtual/framework/authorization/authorizer.go
+++ b/pkg/virtual/framework/authorization/authorizer.go
@@ -26,7 +26,7 @@ import (
 	virtualcontext "github.com/kcp-dev/kcp/pkg/virtual/framework/context"
 )
 
-func NewVirtualWorkspaceAuthorizer(virtualWorkspaces ...framework.VirtualWorkspace) authorizer.Authorizer {
+func NewVirtualWorkspaceAuthorizer(virtualWorkspaces map[string]framework.VirtualWorkspace) authorizer.Authorizer {
 	return &virtualWorkspaceAuthorizer{
 		virtualWorkspaces: virtualWorkspaces,
 	}
@@ -35,7 +35,7 @@ func NewVirtualWorkspaceAuthorizer(virtualWorkspaces ...framework.VirtualWorkspa
 var _ authorizer.Authorizer = (*virtualWorkspaceAuthorizer)(nil)
 
 type virtualWorkspaceAuthorizer struct {
-	virtualWorkspaces []framework.VirtualWorkspace
+	virtualWorkspaces map[string]framework.VirtualWorkspace
 }
 
 func (a *virtualWorkspaceAuthorizer) Authorize(ctx context.Context, attrs authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
@@ -44,10 +44,8 @@ func (a *virtualWorkspaceAuthorizer) Authorize(ctx context.Context, attrs author
 		return authorizer.DecisionNoOpinion, "Path not resolved to a valid virtual workspace", nil
 	}
 
-	for _, virtualWorkspace := range a.virtualWorkspaces {
-		if virtualWorkspace.GetName() == virtualWorkspaceName {
-			return virtualWorkspace.Authorize(ctx, attrs)
-		}
+	if vw, found := a.virtualWorkspaces[virtualWorkspaceName]; found {
+		return vw.Authorize(ctx, attrs)
 	}
 
 	// This should never happen if a virtual workspace name has been set in the context by the

--- a/pkg/virtual/framework/dynamic/example_test.go
+++ b/pkg/virtual/framework/dynamic/example_test.go
@@ -38,9 +38,6 @@ func Example() {
 	readyCh := make(chan struct{})
 
 	var _ = dynamic.DynamicVirtualWorkspace{
-
-		Name: "SomeDynamicVirtualWorkspace",
-
 		RootPathResolver: func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			if someAPIDefinitionSetGetter == nil {
 				// If the APIDefinitionSetGetter is not initialized, don't accept the request

--- a/pkg/virtual/framework/dynamic/register.go
+++ b/pkg/virtual/framework/dynamic/register.go
@@ -24,7 +24,7 @@ import (
 
 // Register builds and returns a DynamicAPIServer which will serve APIs whose serving informations are provided by an APISetRetriever.
 // The APISetRetriever is returned by the virtual workspace BootstrapAPISetManagement function.
-func (vw *DynamicVirtualWorkspace) Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
+func (vw *DynamicVirtualWorkspace) Register(vwName string, rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	apiSetRetriever, err := vw.BootstrapAPISetManagement(rootAPIServerConfig)
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (vw *DynamicVirtualWorkspace) Register(rootAPIServerConfig genericapiserver
 	cfg.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
 	config := cfg.Complete()
 
-	server, err := config.New(vw.Name, delegateAPIServer)
+	server, err := config.New(vwName, delegateAPIServer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virtual/framework/dynamic/types.go
+++ b/pkg/virtual/framework/dynamic/types.go
@@ -31,7 +31,6 @@ var _ framework.VirtualWorkspace = (*DynamicVirtualWorkspace)(nil)
 // DynamicVirtualWorkspace is an implementation of a framework.VirtualWorkspace which can dynamically serve resources,
 // based on API definitions (including an OpenAPI v3 schema), and a Rest storage provider.
 type DynamicVirtualWorkspace struct {
-	Name             string
 	RootPathResolver framework.RootPathResolverFunc
 	Authorizer       authorizer.AuthorizerFunc
 	Ready            framework.ReadyFunc
@@ -40,10 +39,6 @@ type DynamicVirtualWorkspace struct {
 	// Usually it would also set up some logic that will call the apiserver.CreateServingInfoFor() method
 	// to add an apidefinition.APIDefinition in the apidefinition.APIDefinitionSetGetter on some event.
 	BootstrapAPISetManagement func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error)
-}
-
-func (vw *DynamicVirtualWorkspace) GetName() string {
-	return vw.Name
 }
 
 func (vw *DynamicVirtualWorkspace) IsReady() error {

--- a/pkg/virtual/framework/fixedgvs/register.go
+++ b/pkg/virtual/framework/fixedgvs/register.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/fixedgvs/apiserver"
 )
 
-func (vw *FixedGroupVersionsVirtualWorkspace) Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
+func (vw *FixedGroupVersionsVirtualWorkspace) Register(vwName string, rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	var vwGroupManager discovery.GroupManager
 	var firstAPIServer *genericapiserver.GenericAPIServer
 	var openAPISpecs []*spec.Swagger

--- a/pkg/virtual/framework/handler/handler.go
+++ b/pkg/virtual/framework/handler/handler.go
@@ -30,20 +30,19 @@ import (
 type HandlerFactory func(rootAPIServerConfig genericapiserver.CompletedConfig) (http.Handler, error)
 
 type VirtualWorkspace struct {
-	framework.Namer
 	framework.RootPathResolver
 	authorizer.Authorizer
 	framework.ReadyChecker
 	HandlerFactory
 }
 
-func (v *VirtualWorkspace) Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
+func (v *VirtualWorkspace) Register(vwName string, rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error) {
 	handler, err := v.HandlerFactory(rootAPIServerConfig)
 	if err != nil {
 		return nil, err
 	}
 	return genericapiserver.NewEmptyDelegateWithCustomHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if vwName, found := virtualcontext.VirtualWorkspaceNameFrom(r.Context()); found && vwName == v.GetName() {
+		if ctxName, found := virtualcontext.VirtualWorkspaceNameFrom(r.Context()); found && ctxName == vwName {
 			handler.ServeHTTP(rw, r)
 			return
 		}

--- a/pkg/virtual/framework/types.go
+++ b/pkg/virtual/framework/types.go
@@ -63,18 +63,6 @@ type ReadyChecker interface {
 	IsReady() error
 }
 
-type Name string
-
-func (n Name) GetName() string {
-	return string(n)
-}
-
-var _ Namer = Name("")
-
-type Namer interface {
-	GetName() string
-}
-
 // VirtualWorkspace is the definition of a virtual workspace
 // that will be registered and made available, at a given prefix,
 // inside a Root API server as a delegated API Server.
@@ -86,8 +74,7 @@ type Namer interface {
 // in a limited number of group/versions, implemented as Rest storages.
 type VirtualWorkspace interface {
 	authorizer.Authorizer
-	Namer
 	RootPathResolver
 	ReadyChecker
-	Register(rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error)
+	Register(name string, rootAPIServerConfig genericapiserver.CompletedConfig, delegateAPIServer genericapiserver.DelegationTarget) (genericapiserver.DelegationTarget, error)
 }

--- a/pkg/virtual/initializingworkspaces/options/options.go
+++ b/pkg/virtual/initializingworkspaces/options/options.go
@@ -28,7 +28,6 @@ import (
 
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces"
 	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces/builder"
 )
@@ -59,21 +58,17 @@ func (o *InitializingWorkspaces) NewVirtualWorkspaces(
 	config *rest.Config,
 	wildcardApiExtensionsInformers apiextensionsinformers.SharedInformerFactory,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
+) (workspaces map[string]framework.VirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "initializingworkspaces-virtual-workspace")
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	dynamicClusterClient, err := dynamic.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	virtualWorkspaces := builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, o.Name()), dynamicClusterClient, kubeClusterClient, wildcardApiExtensionsInformers, wildcardKcpInformers)
-	return nil, virtualWorkspaces, nil
-}
-
-func (o *InitializingWorkspaces) Name() string {
-	return initializingworkspaces.VirtualWorkspaceName
+	virtualWorkspaces := builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, initializingworkspaces.VirtualWorkspaceName), dynamicClusterClient, kubeClusterClient, wildcardApiExtensionsInformers, wildcardKcpInformers)
+	return virtualWorkspaces, nil
 }

--- a/pkg/virtual/options/authorization.go
+++ b/pkg/virtual/options/authorization.go
@@ -79,7 +79,7 @@ func (s *Authorization) AddFlags(fs *pflag.FlagSet) {
 			"contacting the 'core' kubernetes server.")
 }
 
-func (s *Authorization) ApplyTo(config *genericapiserver.Config, virtualWorkspaces []framework.VirtualWorkspace) error {
+func (s *Authorization) ApplyTo(config *genericapiserver.Config, virtualWorkspaces map[string]framework.VirtualWorkspace) error {
 	var authorizers []authorizer.Authorizer
 
 	// group authorizer
@@ -96,7 +96,7 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, virtualWorkspac
 		authorizers = append(authorizers, a)
 	}
 
-	authorizers = append(authorizers, authorization.NewVirtualWorkspaceAuthorizer(virtualWorkspaces...))
+	authorizers = append(authorizers, authorization.NewVirtualWorkspaceAuthorizer(virtualWorkspaces))
 
 	config.Authorization.Authorizer = union.New(authorizers...)
 	return nil

--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -65,7 +65,6 @@ func BuildVirtualWorkspace(
 	readyCh := make(chan struct{})
 
 	return &virtualworkspacesdynamic.DynamicVirtualWorkspace{
-		Name: SyncerVirtualWorkspaceName,
 		RootPathResolver: func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
 			select {
 			case <-readyCh:

--- a/pkg/virtual/workspaces/options/options.go
+++ b/pkg/virtual/workspaces/options/options.go
@@ -28,7 +28,6 @@ import (
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/builder"
 )
 
@@ -58,23 +57,19 @@ func (o *Workspaces) NewVirtualWorkspaces(
 	config *rest.Config,
 	wildcardKubeInformers informers.SharedInformerFactory,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (extraInformers []rootapiserver.InformerStart, workspaces []framework.VirtualWorkspace, err error) {
+) (workspaces map[string]framework.VirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "workspaces-virtual-workspace")
 	kcpClusterClient, err := kcpclient.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	virtualWorkspaces := []framework.VirtualWorkspace{
-		builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, o.Name()), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient),
+	virtualWorkspaces := map[string]framework.VirtualWorkspace{
+		"workspaces": builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient),
 	}
-	return nil, virtualWorkspaces, nil
-}
-
-func (o *Workspaces) Name() string {
-	return "workspaces"
+	return virtualWorkspaces, nil
 }


### PR DESCRIPTION
- name how a VW is registered externally, don't make it know its name and register it like that. The former is much more idiomatic.
- remove unused extra informer code, an anti-pattern we don't want to encourage. Informers should be instatiated in external plumbing.