### PR TITLE
virtualworkspaces: allow access to remove iniitalizers

### DIFF
--- a/cmd/kcp-front-proxy/filters.go
+++ b/cmd/kcp-front-proxy/filters.go
@@ -18,33 +18,16 @@ package main
 
 import (
 	"net/http"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/klog/v2"
 )
-
-// newRequestInfoFactory creates a new RequestInfoFactory for filters to use
-func newRequestInfoFactory() *apirequest.RequestInfoFactory {
-	apiPrefixes := sets.NewString(strings.Trim(genericapiserver.APIGroupPrefix, "/"))
-	legacyAPIPrefixes := sets.String{}
-	apiPrefixes.Insert(strings.Trim(genericapiserver.DefaultLegacyAPIPrefix, "/"))
-	legacyAPIPrefixes.Insert(strings.Trim(genericapiserver.DefaultLegacyAPIPrefix, "/"))
-
-	return &apirequest.RequestInfoFactory{
-		APIPrefixes:          apiPrefixes,
-		GrouplessAPIPrefixes: legacyAPIPrefixes,
-	}
-}
 
 // withOptionalClientCert creates a handler that verifies a request's client
 // cert if one is presented but passes through to the next handler if one is

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -39,6 +39,7 @@ import (
 
 	frontproxyoptions "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/options"
 	"github.com/kcp-dev/kcp/pkg/proxy"
+	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
 )
 
 func main() {
@@ -99,7 +100,7 @@ routed based on paths.`,
 			failedHandler := newUnauthorizedHandler()
 			handler = withOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
 
-			requestInfoFactory := newRequestInfoFactory()
+			requestInfoFactory := requestinfo.NewFactory()
 			handler = genericapifilters.WithRequestInfo(handler, requestInfoFactory)
 			handler = genericfilters.WithPanicRecovery(handler, requestInfoFactory)
 

--- a/pkg/apis/apis/v1alpha1/crd_to_apiresourceschema.go
+++ b/pkg/apis/apis/v1alpha1/crd_to_apiresourceschema.go
@@ -43,7 +43,7 @@ func CRDToAPIResourceSchema(crd *apiextensionsv1.CustomResourceDefinition, prefi
 
 	apiResourceSchema := &APIResourceSchema{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: prefix + "." + crd.Name,
+			Name: name,
 		},
 		Spec: APIResourceSchemaSpec{
 			Group: crd.Spec.Group,

--- a/pkg/metadata/dynamic.go
+++ b/pkg/metadata/dynamic.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/kcp-dev/logicalcluster"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+
+	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
 )
 
 // NewDynamicMetadataClusterClientForConfig returns a dynamic cluster client that only
@@ -58,11 +58,6 @@ type metadataTransport struct {
 	http.RoundTripper
 }
 
-var requestInfoFactory = request.RequestInfoFactory{
-	APIPrefixes:          sets.NewString("api", "apis"),
-	GrouplessAPIPrefixes: sets.NewString("api"),
-}
-
 func (t *metadataTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	partialType, err := partialType(req)
 	if err != nil {
@@ -86,7 +81,7 @@ func partialType(req *http.Request) (string, error) {
 		baseReq.URL = &baseURL
 	}
 
-	info, err := requestInfoFactory.NewRequestInfo(&baseReq)
+	info, err := requestinfo.NewFactory().NewRequestInfo(&baseReq)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/server/requestinfo/util.go
+++ b/pkg/server/requestinfo/util.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestinfo
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server"
+)
+
+// NewFactory creates a new RequestInfoFactory for filters to use
+func NewFactory() *request.RequestInfoFactory {
+	return &request.RequestInfoFactory{
+		APIPrefixes: sets.NewString(
+			strings.Trim(server.APIGroupPrefix, "/"),
+			strings.Trim(server.DefaultLegacyAPIPrefix, "/"),
+		),
+		GrouplessAPIPrefixes: sets.NewString(
+			strings.Trim(server.DefaultLegacyAPIPrefix, "/"),
+		),
+	}
+}

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -79,6 +79,7 @@ func TestServerArgs() []string {
 func TestServerArgsWithTokenAuthFile(tokenAuthFile string) []string {
 	return []string{
 		"--discovery-poll-interval=5s",
+		"-v=4",
 		"--token-auth-file", tokenAuthFile,
 	}
 }

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -388,7 +388,7 @@ func (c *kcpServer) defaultConfig() (*rest.Config, error) {
 func (c *kcpServer) DefaultConfig(t *testing.T) *rest.Config {
 	cfg, err := c.defaultConfig()
 	require.NoError(t, err)
-	return cfg
+	return rest.AddUserAgent(rest.CopyConfig(cfg), t.Name())
 }
 
 // RawConfig exposes a copy of the client config for this server.


### PR DESCRIPTION
A consumer of the initializingworkspaces virtual workspace can today see
the list of workspaces they need to iniitalize, and now they can also
update those workspaces to remove their own initializer, but no other,
once they are done.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Depends on #1329 
Part of #1149 
/assign @sttts 

This is not fully functional yet but overall approach is reviewable.
