### PR TITLE
pkg/admission: add reserved metadata admission plugin

### DIFF
--- a/config/crds/scheduling.kcp.dev_placements.yaml
+++ b/config/crds/scheduling.kcp.dev_placements.yaml
@@ -26,7 +26,7 @@ spec:
           When a location is selected by the placement, the placement turns to Unbound
           state. In Pending or Unbound state, the selection rule can be updated to
           select another location. When the a namespace is annotated by another controller
-          or user with the key of \"scheudling.kcp.dev/placement\", the namespace
+          or user with the key of \"scheduling.kcp.dev/placement\", the namespace
           will pick one placement, and this placement is transfered to Bound state.
           Any update to spec of the placement is ignored in Bound state and reflected
           in the conditions. The placement will turn back to Unbound state when no

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -50,6 +50,7 @@ import (
 	workspacenamespacelifecycle "github.com/kcp-dev/kcp/pkg/admission/namespacelifecycle"
 	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdannotations"
 	"github.com/kcp-dev/kcp/pkg/admission/reservedcrdgroups"
+	"github.com/kcp-dev/kcp/pkg/admission/reservedmetadata"
 	kcpvalidatingwebhook "github.com/kcp-dev/kcp/pkg/admission/validatingwebhook"
 )
 
@@ -67,6 +68,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	reservedcrdannotations.PluginName,
 	reservedcrdgroups.PluginName,
 	crdnooverlappinggvr.PluginName,
+	reservedmetadata.PluginName,
 )
 
 func beforeWebhooks(recommended []string, plugins ...string) []string {
@@ -96,6 +98,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	reservedcrdannotations.Register(plugins)
 	reservedcrdgroups.Register(plugins)
 	crdnooverlappinggvr.Register(plugins)
+	reservedmetadata.Register(plugins)
 }
 
 var defaultOnPluginsInKcp = sets.NewString(

--- a/pkg/admission/reservedmetadata/admission.go
+++ b/pkg/admission/reservedmetadata/admission.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedmetadata
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/utils/strings/slices"
+)
+
+const (
+	PluginName = "apis.kcp.dev/ReservedMetadata"
+)
+
+var (
+	annotationAllowList = []string{}
+
+	labelAllowList = []string{
+		"experimental.workload.kcp.dev/scheduling-disabled",
+	}
+)
+
+// Register registers the reserved metadata plugin for creation and updates.
+// Deletion and connect operations are not relevant as not object changes are expected here.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return &reservedMetadata{
+				Handler:             admission.NewHandler(admission.Create, admission.Update),
+				annotationAllowList: annotationAllowList,
+				labelAllowList:      labelAllowList,
+			}, nil
+		})
+}
+
+// reservedMetadata is a validating admission plugin protecting against mutating reserved kcp metadata.
+type reservedMetadata struct {
+	*admission.Handler
+
+	annotationAllowList []string
+	labelAllowList      []string
+}
+
+var _ = admission.ValidationInterface(&reservedMetadata{})
+
+// Validate asserts the underlying object for changes in labels and annotations.
+// If the user is member of the "system:masters" group, all mutations are allowed.
+func (o *reservedMetadata) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	newMeta, err := meta.Accessor(a.GetObject())
+	// nolint: nilerr
+	if err != nil {
+		// The object we are dealing with doesn't have object metadata defined
+		// hence it doesn't have annotations to be checked.
+		return nil
+	}
+
+	oldMeta, err := meta.Accessor(a.GetOldObject())
+	if err != nil {
+		oldMeta = &metav1.ObjectMeta{}
+	}
+
+	if slices.Contains(a.GetUserInfo().GetGroups(), user.SystemPrivilegedGroup) {
+		return nil
+	}
+
+	if err := assertViolation(newMeta.GetAnnotations(), oldMeta.GetAnnotations(), annotationAllowList); err != nil {
+		return admission.NewForbidden(a, fmt.Errorf("modification of reserved annotation: %w", err))
+	}
+
+	if err := assertViolation(newMeta.GetLabels(), oldMeta.GetLabels(), labelAllowList); err != nil {
+		return admission.NewForbidden(a, fmt.Errorf("modification of reserved label: %w", err))
+	}
+
+	return nil
+}
+
+// diff computes the difference between values of left and right.
+// It returns all keys from left and right, where:
+//
+// - left has a key not present in right
+// - right has a key not present in left
+// - the values differ between left and right for the same key
+func diff(left, right map[string]string) []string {
+	var (
+		result      = make([]string, 0, len(left)+len(right))
+		onlyOnRight = make(map[string]string, len(right))
+	)
+
+	for k, v := range right {
+		onlyOnRight[k] = v
+	}
+
+	for kLeft, vLeft := range left {
+		vRight, inRight := right[kLeft]
+
+		if inRight {
+			if vLeft != vRight {
+				result = append(result, kLeft)
+			}
+			delete(onlyOnRight, kLeft)
+		} else {
+			result = append(result, kLeft)
+		}
+	}
+
+	for k := range onlyOnRight {
+		result = append(result, k)
+	}
+
+	return result
+}
+
+func assertViolation(new, old map[string]string, allowList []string) error {
+	for _, key := range diff(new, old) {
+		for i := range allowList {
+			if strings.HasSuffix(allowList[i], "*") && strings.HasPrefix(key, allowList[i][:len(allowList[i])-1]) {
+				return nil
+			} else if allowList[i] == key {
+				return nil
+			}
+		}
+
+		if strings.HasSuffix(key, "kcp.dev") {
+			return fmt.Errorf("%q", key)
+		}
+	}
+
+	return nil
+}

--- a/pkg/admission/reservedmetadata/admission_test.go
+++ b/pkg/admission/reservedmetadata/admission_test.go
@@ -1,0 +1,577 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reservedmetadata
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+func newAttr(obj, oldObject runtime.Object, op admission.Operation, user user.Info) admission.Attributes {
+	return admission.NewAttributesRecord(
+		obj,
+		oldObject,
+		schema.GroupVersionKind{},
+		"",
+		"test",
+		schema.GroupVersionResource{},
+		"",
+		op,
+		&metav1.CreateOptions{},
+		false,
+		user,
+	)
+}
+
+func TestAdmission(t *testing.T) {
+	for _, tc := range []struct {
+		testName string
+		attr     admission.Attributes
+		wantErr  string
+	}{
+		{
+			testName: "empty object",
+			attr:     newAttr(nil, nil, admission.Create, &user.DefaultInfo{}),
+		},
+		{
+			testName: "empty old object",
+			attr:     newAttr(&v1.Pod{}, nil, admission.Create, &user.DefaultInfo{}),
+		},
+		{
+			testName: "unchanged empty labels/annotations",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "unchanged labels/annotations",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "changed label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "added kcp.dev label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved label: \"some.kcp.dev\"",
+		},
+		{
+			testName: "deleted kcp.dev label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":          "bar",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved label: \"some.kcp.dev\"",
+		},
+		{
+			testName: "created kcp.dev label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "new",
+							"some.kcp.dev": "new",
+						},
+					},
+				},
+				nil,
+				admission.Create,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved label: \"some.kcp.dev\"",
+		},
+		{
+			testName: "created kcp.dev label as system:masters",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "new",
+							"some.kcp.dev": "new",
+						},
+					},
+				},
+				nil,
+				admission.Create,
+				&user.DefaultInfo{Groups: []string{"system:masters"}},
+			),
+		},
+		{
+			testName: "changed kcp.dev label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":          "bar",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved label: \"some.kcp.dev\"",
+		},
+		{
+			testName: "changed label preserving kcp.dev labels",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":          "bar",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "added kcp.dev label as system:masters",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{
+					Groups: []string{"system:masters"},
+				},
+			),
+		},
+		{
+			testName: "added allow-listed label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":                 "changed",
+							"foo.kcp.dev/allowed": "added",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "deleted allow-listed label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":                 "bar",
+							"foo.kcp.dev/allowed": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "changed allow-listed label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":                 "changed",
+							"foo.kcp.dev/allowed": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":                 "bar",
+							"foo.kcp.dev/allowed": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "added allow-listed wildcard label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":                 "changed",
+							"foo.kcp.dev/allowed": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "deleted allow-listed wildcard label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":                 "bar",
+							"foo.kcp.dev/allowed": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "changed allow-listed wildcard label",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":                 "changed",
+							"foo.kcp.dev/allowed": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo":                 "bar",
+							"foo.kcp.dev/allowed": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "changed annotations",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							"foo": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Annotations: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+		},
+		{
+			testName: "added kcp.dev annotation",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Annotations: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved annotation: \"some.kcp.dev\"",
+		},
+		{
+			testName: "deleted kcp.dev annotation",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							"foo": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Annotations: map[string]string{
+							"foo":          "bar",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved annotation: \"some.kcp.dev\"",
+		},
+		{
+			testName: "changed kcp.dev annotation",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Annotations: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "changed",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Annotations: map[string]string{
+							"foo":          "bar",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{},
+			),
+			wantErr: "forbidden: modification of reserved annotation: \"some.kcp.dev\"",
+		},
+		{
+			testName: "added kcp.dev annotation as system:masters",
+			attr: newAttr(
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+						Labels: map[string]string{
+							"foo":          "changed",
+							"some.kcp.dev": "bar",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+				admission.Update,
+				&user.DefaultInfo{
+					Groups: []string{"system:masters"},
+				},
+			),
+		},
+	} {
+		t.Run(tc.testName, func(t *testing.T) {
+			plugin := &reservedMetadata{
+				Handler:             admission.NewHandler(admission.Create, admission.Update),
+				annotationAllowList: []string{"foo.kcp.dev/allowed"},
+				labelAllowList:      []string{"foo.kcp.dev/allowed"},
+			}
+			var ctx context.Context
+
+			gotErr := ""
+			err := plugin.Validate(ctx, tc.attr, nil)
+			if err != nil {
+				gotErr = err.Error()
+			}
+
+			if gotErr != tc.wantErr {
+				t.Errorf("want error %q, got %q", tc.wantErr, gotErr)
+			}
+		})
+	}
+}

--- a/pkg/apis/scheduling/v1alpha1/types_placement.go
+++ b/pkg/apis/scheduling/v1alpha1/types_placement.go
@@ -26,7 +26,7 @@ import (
 //
 // placement is in Pending state initially. When a location is selected by the placement, the placement
 // turns to Unbound state. In Pending or Unbound state, the selection rule can be updated to select another location.
-// When the a namespace is annotated by another controller or user with the key of "scheudling.kcp.dev/placement",
+// When the a namespace is annotated by another controller or user with the key of "scheduling.kcp.dev/placement",
 // the namespace will pick one placement, and this placement is transfered to Bound state. Any update to spec of the placement
 // is ignored in Bound state and reflected in the conditions. The placement will turn back to Unbound state when no namespace
 // uses this placement any more.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2199,7 +2199,7 @@ func schema_pkg_apis_scheduling_v1alpha1_Placement(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "placement defines a selection rule to choose ONE location for MULTIPLE namespaces in a workspace.\n\nplacement is in Pending state initially. When a location is selected by the placement, the placement turns to Unbound state. In Pending or Unbound state, the selection rule can be updated to select another location. When the a namespace is annotated by another controller or user with the key of \"scheudling.kcp.dev/placement\", the namespace will pick one placement, and this placement is transfered to Bound state. Any update to spec of the placement is ignored in Bound state and reflected in the conditions. The placement will turn back to Unbound state when no namespace uses this placement any more.",
+				Description: "placement defines a selection rule to choose ONE location for MULTIPLE namespaces in a workspace.\n\nplacement is in Pending state initially. When a location is selected by the placement, the placement turns to Unbound state. In Pending or Unbound state, the selection rule can be updated to select another location. When the a namespace is annotated by another controller or user with the key of \"scheduling.kcp.dev/placement\", the namespace will pick one placement, and this placement is transfered to Bound state. Any update to spec of the placement is ignored in Bound state and reflected in the conditions. The placement will turn back to Unbound state when no namespace uses this placement any more.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {


### PR DESCRIPTION
## Summary
This adds a new plugin locking down reserved system labels and annotations.

## Related issue(s)

Fixes #1138

Accompanying document about kcp labels/annotations: https://docs.google.com/spreadsheets/d/1DfcEqKG3koLOveddpLwebvULK2imOGJnpe0nwWZmhAY/edit#gid=0

**Question:** We marked a lot of labels/annotations as internal. I suggest I create a separate PR with the naming changes.

/cc @sttts @ncdc 