### PR TITLE
Do not stomp other APIExports in a workspace with NegotatedAPIResources

### DIFF
--- a/pkg/reconciler/workload/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/workload/apiexport/apiexport_reconcile.go
@@ -62,6 +62,10 @@ type schemaReconciler struct {
 func (r *schemaReconciler) reconcile(ctx context.Context, export *apisv1alpha1.APIExport) (reconcileStatus, error) {
 	clusterName := logicalcluster.From(export)
 
+	if export.Name != TemporaryComputeServiceExportName {
+		return reconcileStatusStop, nil
+	}
+
 	resources, err := r.listNegotiatedAPIResources(clusterName)
 	if err != nil {
 		return reconcileStatusStop, err


### PR DESCRIPTION
Only `"kubernetes"` is our current, temporary name. This will change with location workspaces.