### PR TITLE
server: only make default paths absolute, not user-provided ones

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -19,6 +19,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -60,9 +61,19 @@ func main() {
 
 	cols, _, _ := term.TerminalSize(cmd.OutOrStdout())
 
-	serverOptions := options.NewOptions()
+	// manually extract root directory from flags first as it influence all other flags
+	rootDir := ".kcp"
+	for i, f := range os.Args {
+		if f == "--root-directory" {
+			if i < len(os.Args)-1 {
+				rootDir = os.Args[i+1]
+			} // else let normal flag processing fail
+		} else if strings.HasPrefix(f, "--root-directory=") {
+			rootDir = strings.TrimPrefix(f, "--root-directory=")
+		}
+	}
 
-	// Default to -v=2
+	serverOptions := options.NewOptions(rootDir)
 	serverOptions.GenericControlPlane.Logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	startCmd := &cobra.Command{

--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/spf13/pflag"
@@ -43,10 +44,10 @@ type AdminAuthentication struct {
 	TokenHashFilePath string
 }
 
-func NewAdminAuthentication() *AdminAuthentication {
+func NewAdminAuthentication(rootDir string) *AdminAuthentication {
 	return &AdminAuthentication{
-		KubeConfigPath:    "admin.kubeconfig",
-		TokenHashFilePath: ".admin-token-store",
+		KubeConfigPath:    filepath.Join(rootDir, "admin.kubeconfig"),
+		TokenHashFilePath: filepath.Join(rootDir, ".admin-token-store"),
 	}
 }
 

--- a/pkg/server/options/embeddedetcd.go
+++ b/pkg/server/options/embeddedetcd.go
@@ -18,6 +18,7 @@ package options
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
 )
@@ -32,9 +33,9 @@ type EmbeddedEtcd struct {
 	ForceNewCluster bool
 }
 
-func NewEmbeddedEtcd() *EmbeddedEtcd {
+func NewEmbeddedEtcd(rootDir string) *EmbeddedEtcd {
 	return &EmbeddedEtcd{
-		Directory:  "etcd-server",
+		Directory:  filepath.Join(rootDir, "etcd-server"),
 		PeerPort:   "2380",
 		ClientPort: "2379",
 	}

--- a/pkg/server/options/flags_test.go
+++ b/pkg/server/options/flags_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestNamedFlagSetOrder(t *testing.T) {
-	fss := NewOptions().Flags()
+	fss := NewOptions(".kcp").Flags()
 	var names []string
 	for name, fs := range fss.FlagSets {
 		if !fs.HasFlags() {
@@ -41,7 +41,7 @@ func TestNamedFlagSetOrder(t *testing.T) {
 }
 
 func TestAllowedFlagList(t *testing.T) {
-	o := NewOptions()
+	o := NewOptions(".kcp")
 	fss := o.rawFlags()
 
 	missing := map[string][]*pflag.Flag{}
@@ -68,7 +68,7 @@ func TestAllowedFlagList(t *testing.T) {
 }
 
 func TestAllowedFlagListCleanup(t *testing.T) {
-	o := NewOptions()
+	o := NewOptions(".kcp")
 	fss := o.rawFlags()
 
 	allFlags := map[string]*pflag.Flag{}

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -127,7 +127,7 @@ func newKcpServer(t *testing.T, cfg kcpConfig, artifactDir, dataDir string) (*kc
 			"--embedded-etcd-client-port=" + etcdClientPort,
 			"--embedded-etcd-peer-port=" + etcdPeerPort,
 			"--embedded-etcd-wal-size-bytes=" + strconv.Itoa(5*1000), // 5KB
-			"--kubeconfig-path=admin.kubeconfig",
+			"--kubeconfig-path=" + filepath.Join(dataDir, "admin.kubeconfig"),
 		},
 			cfg.Args...),
 		dataDir:     dataDir,
@@ -236,7 +236,7 @@ func (c *kcpServer) Run(opts ...RunOption) error {
 
 	// run kcp start in-process for easier debugging
 	if runOpts.runInProcess {
-		serverOptions := options.NewOptions()
+		serverOptions := options.NewOptions(".kcp")
 		all := pflag.NewFlagSet("kcp", pflag.ContinueOnError)
 		for _, fs := range serverOptions.Flags().FlagSets {
 			all.AddFlagSet(fs)


### PR DESCRIPTION
This old code didn't make sense. If I pass foo.key as flag, I don't want it to mean `.kcp/foo.key`. The reason why things should be abolute (best effort only btw.) is that logs make more sense, i.e. that you see when a wrong path is chosen.