### PR TITLE
e2e/syncer: make the test app sleep, not restart with AlreadyExists

### DIFF
--- a/test/e2e/fixtures/kcp-test-image/icc-test.go
+++ b/test/e2e/fixtures/kcp-test-image/icc-test.go
@@ -64,7 +64,9 @@ func main() {
 		log.Panicln("failed to create configmap", err)
 	}
 
-	log.Printf("configmap %s created\n", configMapName)
+	log.Printf("configmap %s created. Going to sleep.\n", configMapName)
+
+	<-ctx.Done()
 }
 
 func DetectNamespace() (string, error) {


### PR DESCRIPTION
Before this the first run of the container created the configmap, the second and following failed with AlreadyExists and panic'ed, leading to unavailable deployment under bad timing.