### PR TITLE
virtual: clean up post-start errors and var names

### DIFF
--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
@@ -160,7 +161,8 @@ func BuildVirtualWorkspace(
 					"apiexports":         wildcardKcpInformers.Apis().V1alpha1().APIExports().Informer(),
 				} {
 					if !cache.WaitForNamedCacheSync(name, hookContext.StopCh, informer.HasSynced) {
-						return errors.New("informer not synced")
+						klog.Errorf("informer not synced")
+						return nil
 					}
 				}
 

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -19,7 +19,6 @@ package builder
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -125,7 +124,8 @@ func BuildVirtualWorkspace(
 					"customresourcedefinitions": wildcardApiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Informer(),
 				} {
 					if !cache.WaitForNamedCacheSync(name, hookContext.StopCh, informer.HasSynced) {
-						return errors.New("informer not synced")
+						klog.Errorf("informer not synced")
+						return nil
 					}
 				}
 
@@ -186,7 +186,8 @@ func BuildVirtualWorkspace(
 					"customresourcedefinitions": wildcardApiExtensionsInformers.Apiextensions().V1().CustomResourceDefinitions().Informer(),
 				} {
 					if !cache.WaitForNamedCacheSync(name, hookContext.StopCh, informer.HasSynced) {
-						return errors.New("informer not synced")
+						klog.Errorf("informer not synced")
+						return nil
 					}
 				}
 
@@ -243,7 +244,8 @@ func BuildVirtualWorkspace(
 					"clusterworkspaces": wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces().Informer(),
 				} {
 					if !cache.WaitForNamedCacheSync(name, hookContext.StopCh, informer.HasSynced) {
-						return errors.New("informer not synced")
+						klog.Errorf("informer not synced")
+						return nil
 					}
 				}
 

--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clusters"
+	"k8s.io/klog/v2"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
@@ -184,7 +185,8 @@ func BuildVirtualWorkspace(
 					"apiexports":         wildcardKcpInformers.Apis().V1alpha1().APIExports().Informer(),
 				} {
 					if !cache.WaitForNamedCacheSync(name, hookContext.StopCh, informer.HasSynced) {
-						return errors.New("informer not synced")
+						klog.Errorf("informer not synced")
+						return nil
 					}
 				}
 

--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -134,7 +134,8 @@ func BuildVirtualWorkspace(rootPathPrefix string, wildcardsClusterWorkspaces wor
 							wildcardsRbacInformers.Roles().Informer(),
 						} {
 							if !cache.WaitForNamedCacheSync("workspaceauthorizationcache", context.StopCh, informer.HasSynced) {
-								return errors.New("informer not synced")
+								klog.Errorf("informer not synced")
+								return nil
 							}
 						}
 						rootWorkspaceAuthorizationCache.Run(1*time.Second, context.StopCh)


### PR DESCRIPTION
Post-start-hooks should never return an error. They should just block. An error leads to stack trace output. Why? Legacy reasons 🤷

With this the terminal is not filled with stack traces on ctrl-c on startup.