### PR TITLE
server/apiextensions: stop serving non-wildcard identity requests

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -120,8 +120,7 @@ func NewController(
 	})
 
 	if err := apiBindingInformer.Informer().AddIndexers(cache.Indexers{
-		indexAPIBindingsByWorkspaceExport:       indexAPIBindingsByWorkspaceExportFunc,
-		IndexAPIBindingsByIdentityGroupResource: indexAPIBindingsByIdentityGroupResourceFunc,
+		indexAPIBindingsByWorkspaceExport: indexAPIBindingsByWorkspaceExportFunc,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/apis/apibinding/apibinding_indexes.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_indexes.go
@@ -67,27 +67,6 @@ func indexAPIExportsByAPIResourceSchemasFunc(obj interface{}) ([]string, error) 
 	return ret, nil
 }
 
-const IndexAPIBindingsByIdentityGroupResource = "apiBindingsByIdentityGroupResource"
-
-func indexAPIBindingsByIdentityGroupResourceFunc(obj interface{}) ([]string, error) {
-	apiBinding, ok := obj.(*apisv1alpha1.APIBinding)
-	if !ok {
-		return []string{}, fmt.Errorf("obj is supposed to be an APIBinding, but is %T", obj)
-	}
-
-	var ret []string
-
-	for _, r := range apiBinding.Status.BoundResources {
-		ret = append(ret, IdentityGroupResourceKeyFunc(r.Schema.IdentityHash, r.Group, r.Resource))
-	}
-
-	return ret, nil
-}
-
-func IdentityGroupResourceKeyFunc(identity, group, resource string) string {
-	return fmt.Sprintf("%s/%s/%s", identity, group, resource)
-}
-
 const indexByWorkspace = "apiBindingsByWorkspace"
 
 func indexByWorkspaceFunc(obj interface{}) ([]string, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -276,10 +276,11 @@ func (s *Server) Run(ctx context.Context) error {
 		return fmt.Errorf("configure api extensions: %w", err)
 	}
 
-	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                            // nolint: errcheck
-	s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                 // nolint: errcheck
-	s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byGroupResourceName: indexByGroupResourceName}) // nolint: errcheck
-	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                            // nolint: errcheck
+	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                               // nolint: errcheck
+	s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                    // nolint: errcheck
+	s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byGroupResourceName: indexCRDByGroupResourceName}) // nolint: errcheck
+	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                               // nolint: errcheck
+	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byIdentityGroupResource: indexAPIBindingByIdentityGroupResource})             // nolint: errcheck
 
 	apiBindingAwareCRDLister := &apiBindingAwareCRDLister{
 		kcpClusterClient:  kcpClusterClient,


### PR DESCRIPTION
Per workspace no identity is necessary as GVR is unique. This mode of access was never expected to work.