### PR TITLE
Changes to the downstream namespace generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/googleapis/gnostic v0.5.5
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster v1.1.0
+	github.com/martinlindhe/base36 v1.1.1 // indirect
 	github.com/muesli/reflow v0.1.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -504,6 +504,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/martinlindhe/base36 v1.1.1 h1:1F1MZ5MGghBXDZ2KJ3QfxmiydlWOGB8HCEtkap5NkVg=
+github.com/martinlindhe/base36 v1.1.1/go.mod h1:vMS8PaZ5e/jV9LwFKlm0YLnXl/hpOihiBxKkIoc3g08=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/pkg/syncer/shared/namespace.go
+++ b/pkg/syncer/shared/namespace.go
@@ -20,8 +20,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kcp-dev/logicalcluster"
+	"github.com/martinlindhe/base36"
 )
 
 const (
@@ -54,6 +56,11 @@ func PhysicalClusterNamespaceName(l NamespaceLocator) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	hash := sha256.Sum224(b)
-	return fmt.Sprintf("kcp%x", hash), nil
+	// hash the marshalled locator.
+	hash := sha256.Sum224(b[:])
+	// convert the hash to base36 (alphanumeric) to decrease collision probabilities
+	base36hash := strings.ToLower(base36.EncodeBytes(hash[:]))
+	// use 12 chars of the base36hash, should be enough to avoid collisions and
+	// keep the namespaces short enough.
+	return fmt.Sprintf("kcp-%s", base36hash[:12]), nil
 }

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -512,7 +512,7 @@ func TestSyncerProcess(t *testing.T) {
 				createNamespaceAction(
 					"",
 					changeUnstructured(
-						toUnstructured(t, namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+						toUnstructured(t, namespace("kcp-iq68ijd8g8nl", "",
 							map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							},
@@ -524,11 +524,11 @@ func TestSyncerProcess(t *testing.T) {
 				),
 				patchDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 					types.ApplyPatchType,
 					toJson(t,
 						changeUnstructured(
-							toUnstructured(t, deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+							toUnstructured(t, deployment("theDeployment", "kcp-iq68ijd8g8nl", "", map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							}, nil, nil)),
 							setNestedField(map[string]interface{}{}, "status"),
@@ -565,7 +565,7 @@ func TestSyncerProcess(t *testing.T) {
 				createNamespaceAction(
 					"",
 					changeUnstructured(
-						toUnstructured(t, namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+						toUnstructured(t, namespace("kcp-iq68ijd8g8nl", "",
 							map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							},
@@ -577,11 +577,11 @@ func TestSyncerProcess(t *testing.T) {
 				),
 				patchDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 					types.ApplyPatchType,
 					toJson(t,
 						changeUnstructured(
-							toUnstructured(t, deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+							toUnstructured(t, deployment("theDeployment", "kcp-iq68ijd8g8nl", "", map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							}, nil, nil)),
 							setNestedField(map[string]interface{}{}, "status"),
@@ -615,7 +615,7 @@ func TestSyncerProcess(t *testing.T) {
 			expectActionsOnTo: []clienttesting.Action{
 				deleteDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 				),
 			},
 		},
@@ -626,13 +626,13 @@ func TestSyncerProcess(t *testing.T) {
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
-				namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+				namespace("kcp-iq68ijd8g8nl", "", map[string]string{
 					"internal.workload.kcp.dev/cluster": "us-west1",
 				},
 					map[string]string{
 						"kcp.dev/namespace-locator": `{"logical-cluster":"root:org:ws","namespace":"test"}`,
 					}),
-				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "root:org:ws", map[string]string{
+				deployment("theDeployment", "kcp-iq68ijd8g8nl", "root:org:ws", map[string]string{
 					"internal.workload.kcp.dev/cluster": "us-west1",
 				}, nil, []string{"workload.kcp.dev/syncer-us-west1"}),
 			},
@@ -658,7 +658,7 @@ func TestSyncerProcess(t *testing.T) {
 				createNamespaceAction(
 					"",
 					changeUnstructured(
-						toUnstructured(t, namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+						toUnstructured(t, namespace("kcp-iq68ijd8g8nl", "",
 							map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							},
@@ -670,7 +670,7 @@ func TestSyncerProcess(t *testing.T) {
 				),
 				deleteDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 				),
 			},
 		},
@@ -681,7 +681,7 @@ func TestSyncerProcess(t *testing.T) {
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
-				namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+				namespace("kcp-iq68ijd8g8nl", "", map[string]string{
 					"internal.workload.kcp.dev/cluster": "us-west1",
 				},
 					map[string]string{
@@ -724,7 +724,7 @@ func TestSyncerProcess(t *testing.T) {
 				createNamespaceAction(
 					"",
 					changeUnstructured(
-						toUnstructured(t, namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+						toUnstructured(t, namespace("kcp-iq68ijd8g8nl", "",
 							map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							},
@@ -736,7 +736,7 @@ func TestSyncerProcess(t *testing.T) {
 				),
 				deleteDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 				),
 			},
 		},
@@ -747,13 +747,13 @@ func TestSyncerProcess(t *testing.T) {
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
-				namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+				namespace("kcp-iq68ijd8g8nl", "", map[string]string{
 					"internal.workload.kcp.dev/cluster": "us-west1",
 				},
 					map[string]string{
 						"kcp.dev/namespace-locator": `{"logical-cluster":"root:org:ws","namespace":"test"}`,
 					}),
-				deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+				deployment("theDeployment", "kcp-iq68ijd8g8nl", "", map[string]string{
 					"internal.workload.kcp.dev/cluster": "us-west1",
 				}, nil, nil),
 			},
@@ -782,7 +782,7 @@ func TestSyncerProcess(t *testing.T) {
 				createNamespaceAction(
 					"",
 					changeUnstructured(
-						toUnstructured(t, namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+						toUnstructured(t, namespace("kcp-iq68ijd8g8nl", "",
 							map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							},
@@ -794,11 +794,11 @@ func TestSyncerProcess(t *testing.T) {
 				),
 				patchDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 					types.ApplyPatchType,
 					toJson(t,
 						changeUnstructured(
-							toUnstructured(t, deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+							toUnstructured(t, deployment("theDeployment", "kcp-iq68ijd8g8nl", "", map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							}, map[string]string{
 								"deletion.internal.workload.kcp.dev/us-west1": time.Now().Format(time.RFC3339),
@@ -858,7 +858,7 @@ func TestSyncerProcess(t *testing.T) {
 				createNamespaceAction(
 					"",
 					changeUnstructured(
-						toUnstructured(t, namespace("kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "",
+						toUnstructured(t, namespace("kcp-iq68ijd8g8nl", "",
 							map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							},
@@ -870,11 +870,11 @@ func TestSyncerProcess(t *testing.T) {
 				),
 				patchDeploymentAction(
 					"theDeployment",
-					"kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973",
+					"kcp-iq68ijd8g8nl",
 					types.ApplyPatchType,
 					toJson(t,
 						changeUnstructured(
-							toUnstructured(t, deployment("theDeployment", "kcp0124d7647eb6a00b1fcb6f2252201601634989dd79deb7375c373973", "", map[string]string{
+							toUnstructured(t, deployment("theDeployment", "kcp-iq68ijd8g8nl", "", map[string]string{
 								"internal.workload.kcp.dev/cluster": "us-west1",
 							}, map[string]string{"experimental.spec-diff.workload.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, nil)),
 							setNestedField(map[string]interface{}{


### PR DESCRIPTION
This PR changes the pattern used to generate the downstream namespace. It generates a shorter string while maintaining a big enough random part to avoid conflicts.

related: https://github.com/kcp-dev/kcp/issues/1280