### PR TITLE
Workspaces VW: Fix obsolete permission management...

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -283,11 +283,14 @@ func (kc *KubeConfig) currentWorkspace(ctx context.Context, host string, workspa
 
 	parentClusterName, workspaceName := clusterName.Split()
 	workspacePrettyName := workspaceName
-	if !parentClusterName.Empty() && clusterName.HasPrefix(tenancyv1alpha1.RootCluster) {
-		// we are in a workspace below root, but not root itself
-		ws, err := getWorkspaceFromInternalName(ctx, workspaceName, kc.clusterClient.Cluster(parentClusterName))
-		if err == nil {
-			workspacePrettyName = ws.Name
+	if !parentClusterName.Empty() {
+		if grandParentClusterName, _ := parentClusterName.Split(); grandParentClusterName == tenancyv1alpha1.RootCluster {
+			// We are in a child workspace of a top-level organization workspace.
+			// That's the typical case where personal workspace have been created.
+			ws, err := getWorkspaceFromInternalName(ctx, workspaceName, kc.personalClient.Cluster(parentClusterName))
+			if err == nil {
+				workspacePrettyName = ws.Name
+			}
 		}
 	}
 

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -261,7 +261,7 @@ func (s *REST) authorizeOrgForUser(ctx context.Context, orgClusterName logicalcl
 func (s *REST) authorizeForUser(ctx context.Context, orgClusterName logicalcluster.Name, user user.Info, verb string, resourceName string) error {
 	// Root org access is implicit for every user. For non-root orgs, we need to check for
 	// verb permissions against the clusterworkspaces/workspace sub-resource.
-	if orgClusterName == tenancyv1alpha1.RootCluster || sets.NewString(user.GetGroups()...).Has("system:masters") {
+	if orgClusterName == tenancyv1alpha1.RootCluster || sets.NewString(user.GetGroups()...).Has(kuser.SystemPrivilegedGroup) {
 		return nil
 	}
 

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -277,7 +277,14 @@ func (s *REST) authorizeForUser(ctx context.Context, orgClusterName logicalclust
 			if err := s.deprecatedAuthorizeOrgForUser(ctx, orgClusterName, user, "access"); err != nil {
 				return err
 			}
+			// Let's fall through here:
+			// if access to the current org workspace is granted (old permission model),
+			// we still need to check the `delete` permission for the workspace we want to delete
+		default:
+			klog.Errorf("Verb %q not supported in the case of a workspace living in a top-level organization", verb)
+			return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), resourceName, fmt.Errorf("%q workspace %q in workspace %q is not allowed", verb, resourceName, orgClusterName))
 		}
+
 	}
 
 	// check for <verb> permission on the ClusterWorkspace workspace subresource for the <resourceName>

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1558,7 +1558,7 @@ func TestDeletePersonalWorkspaceForbiddenToUser(t *testing.T) {
 		},
 		apply: func(t *testing.T, storage *REST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
 			response, deletedNow, err := storage.Delete(ctx, "foo", nil, &metav1.DeleteOptions{})
-			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"foo\" is forbidden: deletion in workspace \"root:orgName\" is not allowed")
+			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"foo\" is forbidden: \"delete\" workspace \"foo\" in workspace \"root:orgName\" is not allowed")
 			assert.Nil(t, response)
 			assert.False(t, deletedNow)
 			crbList, err := kubeClient.Tracker().List(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"), "")
@@ -1651,7 +1651,7 @@ func TestDeletePersonalWorkspaceForbiddenToOrgAdmin(t *testing.T) {
 		},
 		apply: func(t *testing.T, storage *REST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
 			response, deletedNow, err := storage.Delete(ctx, "foo", nil, &metav1.DeleteOptions{})
-			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"foo\" is forbidden: deletion in workspace \"root:orgName\" is not allowed")
+			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"foo\" is forbidden: \"delete\" workspace \"foo\" in workspace \"root:orgName\" is not allowed")
 			assert.Nil(t, response)
 			assert.False(t, deletedNow)
 			crbList, err := kubeClient.Tracker().List(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"), "")
@@ -1741,7 +1741,7 @@ func TestDeleteWorkspaceForbiddenToUser(t *testing.T) {
 		},
 		apply: func(t *testing.T, storage *REST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
 			response, deletedNow, err := storage.Delete(ctx, "foo", nil, &metav1.DeleteOptions{})
-			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"foo\" is forbidden: deletion in workspace \"root:orgName\" is not allowed")
+			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"foo\" is forbidden: \"delete\" workspace \"foo\" in workspace \"root:orgName\" is not allowed")
 			assert.Nil(t, response)
 			assert.False(t, deletedNow)
 			crbList, err := kubeClient.Tracker().List(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), rbacv1.SchemeGroupVersion.WithKind("ClusterRoleBinding"), "")


### PR DESCRIPTION
## Summary

Fix obsolete permission management in the `workspaces` virtual workspace.

#### Current situation

The `workspaces` virtual workspace is still based on the old approach where user workspaces used to be created in top-level organization workspaces.
It checks permissions against the `clusterworkspaces/content` resource named with the name of the current workspace (typically an organization) in the parent workspace of the current organization workspace.

- for  `get`, `list` and `watch`, it checks the `access` verb
- for `create`, it checks the `member` verb

Additionally to delete a workspace it also checks the `delete` verb on the `clusterworkspaces/workspace` resource of the current organization workspace.

This is both incompatible with:
- the new approach that non-admin user workspaces should not be created in top-level orgs in the future 
- the Home workspaces that can be created on-the-fly (as well as their home bucket parent workspaces) when first accessed. 

#### Implemented changes

In the case of workspaces that are children of a top-level organization, we keep the same mechanism as before, to keep compatibility for a while for user workspaces already created in top-level organizations) 

In all other cases, SARs in the `workspaces` virtual workspace are now always **checked against the `clusterworkspaces/workspace` resource in the current workspace** (not the parent anymore).

- for `get`, `list`, `watch` requests, it checks the `get` verb
- for `create` requests, it checks the `create` verb
- for `delete` requests, it checks the `get` verb, as well as the `delete` verb on resource name of the child workspace which is being deleted.

Due to the KCP authorizer architecture, these SAR will also check the `access` verb on the `clusterworkspaces/content` resource in the parent workspaces (through the `workspaceContentAuthorizer`) as well as basic membership of the top-level org through the `topLevelOrgAccessAuthorizer`. So we don't loose any security checks previously done. 

## Related issue(s)

Prerequisite PR for the [Home workspace EPIC](#1069)