### PR TITLE
brings back the watch cache

### DIFF
--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -115,8 +115,8 @@ func NewOptions(rootDir string) *Options {
 	o.GenericControlPlane.Admission.DisablePlugins = kcpadmission.DefaultOffAdmissionPlugins().List()
 	o.GenericControlPlane.Admission.RecommendedPluginOrder = kcpadmission.AllOrderedPlugins
 
-	// turn off the watch cache temporarily until we resolve the issue with DDSIF (not syncing after restart)
-	o.GenericControlPlane.Etcd.EnableWatchCache = false
+	// turn on the watch cache
+	o.GenericControlPlane.Etcd.EnableWatchCache = true
 
 	return o
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
In addition, it provides coverage of `DynamicDiscoverySharedInformerFactory` to prove it works when the cache is on

## Related issue(s)

Fixes #