### PR TITLE
Use authorization.WorkspaceAcccessNotPermittedReason

### DIFF
--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -18,7 +18,6 @@ package authorization
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/kcp-dev/logicalcluster"
@@ -69,10 +68,9 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, err
 	}
 
-	workspaceAccessNotPermittedReason := fmt.Sprintf("%q workspace access not permitted", cluster.Name)
 	if !cluster.Name.HasPrefix(tenancyv1alpha1.RootCluster) {
 		// nobody other than system:masters (excluded from authz) has access to workspaces not based in root
-		return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
+		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, nil
 	}
 
 	subjectClusters := map[logicalcluster.Name]bool{}
@@ -91,21 +89,21 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 		if isAuthenticated && (isUser || isServiceAccountFromRootCluster) {
 			return a.delegate.Authorize(ctx, attr)
 		}
-		return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
+		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, nil
 	}
 
 	// get org in the root
 	requestTopLevelOrgName, ok := topLevelOrg(cluster.Name)
 	if !ok {
-		return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
+		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, nil
 	}
 
 	// check the org workspace exists in the root workspace
 	if _, err := a.clusterWorkspaceLister.Get(clusters.ToClusterAwareKey(tenancyv1alpha1.RootCluster, requestTopLevelOrgName)); err != nil {
 		if errors.IsNotFound(err) {
-			return authorizer.DecisionDeny, workspaceAccessNotPermittedReason, nil
+			return authorizer.DecisionDeny, WorkspaceAcccessNotPermittedReason, nil
 		}
-		return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, err
+		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, err
 	}
 
 	switch {
@@ -121,7 +119,7 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 			}
 		}
 
-		return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
+		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, nil
 
 	case isUser:
 		var (
@@ -159,7 +157,7 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 		}
 	}
 
-	return authorizer.DecisionNoOpinion, workspaceAccessNotPermittedReason, nil
+	return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, nil
 }
 
 func topLevelOrg(clusterName logicalcluster.Name) (string, bool) {

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -47,6 +47,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/apis/tenancy/projection"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	tenancyclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/typed/tenancy/v1alpha1"
@@ -234,7 +235,7 @@ func (s *REST) authorizeOrgForUser(ctx context.Context, orgClusterName logicalcl
 	authz, err := s.delegatedAuthz(parent, s.kubeClusterClient)
 	if err != nil {
 		klog.Errorf("failed to get delegated authorizer for logical cluster %s", user.GetName(), parent)
-		return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), orgName, fmt.Errorf("%q workspace access not permitted", parent))
+		return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), orgName, fmt.Errorf(authorization.WorkspaceAcccessNotPermittedReason))
 	}
 	typeUseAttr := authorizer.AttributesRecord{
 		User:            user,
@@ -248,10 +249,10 @@ func (s *REST) authorizeOrgForUser(ctx context.Context, orgClusterName logicalcl
 	}
 	if decision, reason, err := authz.Authorize(ctx, typeUseAttr); err != nil {
 		klog.Errorf("failed to authorize user %q to %q clusterworkspaces/content name %q in %s", user.GetName(), verb, orgName, parent)
-		return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), orgName, fmt.Errorf("%q workspace access not permitted", parent))
+		return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), orgName, fmt.Errorf(authorization.WorkspaceAcccessNotPermittedReason))
 	} else if decision != authorizer.DecisionAllow {
 		klog.Errorf("user %q lacks (%s) clusterworkspaces/content %q permission for %q in %s: %s", user.GetName(), decisions[decision], verb, orgName, parent, reason)
-		return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), orgName, fmt.Errorf("%q workspace access not permitted", parent))
+		return kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), orgName, fmt.Errorf(authorization.WorkspaceAcccessNotPermittedReason))
 	}
 
 	return nil

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -461,7 +461,7 @@ func TestListPersonalWorkspacesInWrongOrg(t *testing.T) {
 		apply: func(t *testing.T, storage *REST, ctx context.Context, kubeClient *fake.Clientset, kcpClient *tenancyv1fake.Clientset, listerCheckedUsers func() []kuser.Info, testData TestData) {
 			response, err := storage.List(ctx, nil)
 
-			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"orgName\" is forbidden: \"root\" workspace access not permitted")
+			assert.EqualError(t, err, "workspaces.tenancy.kcp.dev \"orgName\" is forbidden: workspace access not permitted")
 			assert.Nil(t, response, "response should be nil")
 		},
 	}
@@ -965,7 +965,7 @@ func TestCreatePersonalWorkspaceForbiddenToNonOrgMember(t *testing.T) {
 				},
 			}
 			response, err := storage.Create(ctx, &newWorkspace, nil, &metav1.CreateOptions{})
-			require.EqualError(t, err, "workspaces.tenancy.kcp.dev \"orgName\" is forbidden: \"root\" workspace access not permitted")
+			require.EqualError(t, err, "workspaces.tenancy.kcp.dev \"orgName\" is forbidden: workspace access not permitted")
 			require.Nil(t, response)
 			checkedUsers := listerCheckedUsers()
 			require.Len(t, checkedUsers, 0, "The workspaceLister shouldn't have checked any user")


### PR DESCRIPTION
We got some more places where a custom string was used.