### PR TITLE
Makefile: wait for test server admin.kubeconfig before starting tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ test-e2e-shared: build-all
 	TEST_IMAGE=$$(KO_DOCKER_REPO=kind.local ko build --platform=linux/$(ARCH) ./test/e2e/fixtures/kcp-test-image) && test -n "$${TEST_IMAGE}"; \
 	NO_GORUN=1 ./bin/test-server --log-file-path="$(LOG_DIR)/kcp.log" $(TEST_SERVER_ARGS) 2>&1 & PID=$$!; echo "PID $$PID"; \
 	trap 'kill -TERM $$PID' TERM INT EXIT; \
+	while [ ! -f .kcp/admin.kubeconfig ]; do sleep 1; done; \
 	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) \
 		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
 
@@ -208,6 +209,7 @@ test-e2e-sharded: build-all
 	TEST_IMAGE=$$(KO_DOCKER_REPO=kind.local ko build --platform=linux/$(ARCH) ./test/e2e/fixtures/kcp-test-image) && test -n "$${TEST_IMAGE}"; \
 	NO_GORUN=1 ./bin/sharded-test-server --v=2 $(TEST_SERVER_ARGS) 2>&1 & PID=$$!; echo "PID $$PID"; \
 	trap 'kill -TERM $$PID' TERM INT EXIT; \
+	while [ ! -f .kcp/admin.kubeconfig ]; do sleep 1; done; \
 	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) \
 		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
 


### PR DESCRIPTION
Our tests expect the admin.kubeconfig and will fail if it does not exist.