### PR TITLE
apibinding/conflictchecker: use APIBinding.status.boundResources, not APIExport

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -197,7 +197,6 @@ func (c *controller) reconcileBinding(ctx context.Context, apiBinding *apisv1alp
 		// Check for conflicts
 		checker := &conflictChecker{
 			listAPIBindings:      c.listAPIBindings,
-			getAPIExport:         c.getAPIExport,
 			getAPIResourceSchema: c.getAPIResourceSchema,
 			getCRD:               c.getCRD,
 			crdIndexer:           c.crdIndexer,

--- a/pkg/reconciler/apis/apibinding/conflict_checker_test.go
+++ b/pkg/reconciler/apis/apibinding/conflict_checker_test.go
@@ -63,24 +63,6 @@ func TestNameConflictCheckerGetBoundCRDs(t *testing.T) {
 		).
 		Build()
 
-	apiExports := map[string]*apisv1alpha1.APIExport{
-		"export0": {
-			Spec: apisv1alpha1.APIExportSpec{
-				LatestResourceSchemas: []string{"export0-schema1"},
-			},
-		},
-		"export1": {
-			Spec: apisv1alpha1.APIExportSpec{
-				LatestResourceSchemas: []string{"export1-schema1", "export1-schema2", "export1-schema3"},
-			},
-		},
-		"export2": {
-			Spec: apisv1alpha1.APIExportSpec{
-				LatestResourceSchemas: []string{"export2-schema1", "export2-schema2", "export2-schema3"},
-			},
-		},
-	}
-
 	apiResourceSchemas := map[string]*apisv1alpha1.APIResourceSchema{
 		"export0-schema1": {ObjectMeta: metav1.ObjectMeta{UID: "e0-s1"}},
 		"export1-schema1": {ObjectMeta: metav1.ObjectMeta{UID: "e1-s1"}},
@@ -98,9 +80,6 @@ func TestNameConflictCheckerGetBoundCRDs(t *testing.T) {
 				existingBinding1,
 				existingBinding2,
 			}, nil
-		},
-		getAPIExport: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIExport, error) {
-			return apiExports[name], nil
 		},
 		getAPIResourceSchema: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
 			return apiResourceSchemas[name], nil


### PR DESCRIPTION
Never require APIExport outside of core bind process. APIBinding status must be sufficient.