### PR TITLE
Workspaces: Keep already-set owner annotations

### DIFF
--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -501,6 +501,39 @@ func TestAdmit(t *testing.T) {
 			},
 		},
 		{
+			name: "error when trying to keep user information on create when system:masters",
+			types: []*tenancyv1alpha1.ClusterWorkspaceType{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						ClusterName: "root:org",
+					},
+				},
+			},
+			a: createAttrWithUser(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"tenancy.kcp.dev/owner": `{"username":12,"uid":["invalid"]}`,
+					},
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+						Name: "Foo",
+						Path: "root:org",
+					},
+				},
+			}, &user.DefaultInfo{
+				Name:   "someone",
+				UID:    "id",
+				Groups: []string{"a", "b", "system:masters"},
+				Extra: map[string][]string{
+					"one": {"1", "01"},
+				},
+			}),
+			wantErr: true,
+		},
+		{
 			name: "override user information on create when not system:masters",
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				{

--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -454,6 +454,98 @@ func TestAdmit(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "keep user information on create when system:masters",
+			types: []*tenancyv1alpha1.ClusterWorkspaceType{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						ClusterName: "root:org",
+					},
+				},
+			},
+			a: createAttrWithUser(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+					},
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+						Name: "Foo",
+						Path: "root:org",
+					},
+				},
+			}, &user.DefaultInfo{
+				Name:   "someone",
+				UID:    "id",
+				Groups: []string{"a", "b", "system:masters"},
+				Extra: map[string][]string{
+					"one": {"1", "01"},
+				},
+			}),
+			expectedObj: &tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+					},
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+						Name: "Foo",
+						Path: "root:org",
+					},
+				},
+			},
+		},
+		{
+			name: "override user information on create when not system:masters",
+			types: []*tenancyv1alpha1.ClusterWorkspaceType{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						ClusterName: "root:org",
+					},
+				},
+			},
+			a: createAttrWithUser(&tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+					},
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+						Name: "Foo",
+						Path: "root:org",
+					},
+				},
+			}, &user.DefaultInfo{
+				Name:   "someone",
+				UID:    "id",
+				Groups: []string{"a", "b"},
+				Extra: map[string][]string{
+					"one": {"1", "01"},
+				},
+			}),
+			expectedObj: &tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"tenancy.kcp.dev/owner": `{"username":"someone","uid":"id","groups":["a","b"],"extra":{"one":["1","01"]}}`,
+					},
+				},
+				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
+					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+						Name: "Foo",
+						Path: "root:org",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1176,6 +1176,9 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 				tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: clusterWorkspace.Name,
+						Annotations: map[string]string{
+							"tenancy.kcp.dev/owner": `{"username":"test-user","uid":"test-uid","groups":["test-group"]}`,
+						},
 					},
 				},
 			))


### PR DESCRIPTION
## Summary

This PR allows keeping an already-set `owner` annotation on workspace creation, when it has been set by a `system:masters` user.

## Related issue(s)

This is related to required cleanup of obsolete parts in the `workspaces` virtual workspace to prepare for the Home workspace implementation.   