### PR TITLE
CLI: Support home workspace through `~`

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -181,6 +181,13 @@ func (kc *KubeConfig) UseWorkspace(ctx context.Context, name string) error {
 		u.Path = path.Join(u.Path, parentClusterName.Path())
 		newServerHost = u.String()
 
+	case "~":
+		homeWorkspace, err := kc.clusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1beta1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		newServerHost = homeWorkspace.Status.URL
+
 	case "":
 		return kc.CurrentWorkspace(ctx, false)
 


### PR DESCRIPTION
## Summary

Introduce a way to go to the user Home workspace doing:
```
kubectl workspace '~'
```
This PR depends on PR #1373 which implements the feature on the KCP server side.

## Related issue(s)

Part of the [User Home Workspaces EPIC](#1069)