### PR TITLE
accept ClusterWorkspaceTypeName starting with lower-case

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -141,7 +141,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[A-Z][a-zA-Z0-9]+$
+                    pattern: ^[a-zA-Z][a-zA-Z0-9]+$
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -62,7 +62,7 @@ spec:
                   type to be nested."
                 items:
                   description: ClusterWorkspaceTypeName is a name of a ClusterWorkspaceType
-                  pattern: ^[A-Z][a-zA-Z0-9]+$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9]+$
                   type: string
                 type: array
               allowedParentWorkspaceTypes:
@@ -73,7 +73,7 @@ spec:
                   this one."
                 items:
                   description: ClusterWorkspaceTypeName is a name of a ClusterWorkspaceType
-                  pattern: ^[A-Z][a-zA-Z0-9]+$
+                  pattern: ^[a-zA-Z][a-zA-Z0-9]+$
                   type: string
                 minItems: 1
                 type: array
@@ -82,7 +82,7 @@ spec:
                   that will be used by default if another, nested ClusterWorkspace
                   is created in a workspace of this type. When this field is unset,
                   the user must specify a type when creating nested workspaces.
-                pattern: ^[A-Z][a-zA-Z0-9]+$
+                pattern: ^[a-zA-Z][a-zA-Z0-9]+$
                 type: string
               initializer:
                 description: "initializer determines if this ClusterWorkspaceType

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -78,7 +78,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[A-Z][a-zA-Z0-9]+$
+                    pattern: ^[a-zA-Z][a-zA-Z0-9]+$
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -132,7 +132,7 @@ type ClusterWorkspaceTypeReference struct {
 
 // ClusterWorkspaceTypeName is a name of a ClusterWorkspaceType
 //
-// +kubebuilder:validation:Pattern=`^[A-Z][a-zA-Z0-9]+$`
+// +kubebuilder:validation:Pattern=`^[a-zA-Z][a-zA-Z0-9]+$`
 type ClusterWorkspaceTypeName string
 
 func (r ClusterWorkspaceTypeReference) String() string {

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -130,7 +130,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 	t.Log("Create workspace types that add initializers")
 	// ClusterWorkspaceTypes and the initializer names will have to be globally unique, so we add some suffix here
 	// to ensure that parallel test runs do not impact our ability to verify this behavior. ClusterWorkspaceType names
-	// are pretty locked down, using this regex: '^[A-Z][a-zA-Z0-9]+$' - so we just add some simple lowercase suffix.
+	// are pretty locked down, using this regex: '^[a-zA-Z][a-zA-Z0-9]+$' - so we just add some simple lowercase suffix.
 	const characters = "abcdefghijklmnopqrstuvwxyz"
 	suffix := func() string {
 		b := make([]byte, 10)


### PR DESCRIPTION
## Summary
To be able to use custom CWTs (not only the build-in ones) the format of the `ClusterWorkspaceTypeName` should accept names that start with lower-case letters.
I modified the regex pattern to accept both types of letters lower-case and upper-case (to support also the existing build-in CWTs).

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/1398