### PR TITLE
Revert "apibinding/conflictchecker: use APIBinding.status.boundResources, not APIExport"

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -197,6 +197,7 @@ func (c *controller) reconcileBinding(ctx context.Context, apiBinding *apisv1alp
 		// Check for conflicts
 		checker := &conflictChecker{
 			listAPIBindings:      c.listAPIBindings,
+			getAPIExport:         c.getAPIExport,
 			getAPIResourceSchema: c.getAPIResourceSchema,
 			getCRD:               c.getCRD,
 			crdIndexer:           c.crdIndexer,

--- a/pkg/reconciler/apis/apibinding/conflict_checker.go
+++ b/pkg/reconciler/apis/apibinding/conflict_checker.go
@@ -30,6 +30,7 @@ import (
 
 type conflictChecker struct {
 	listAPIBindings      func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error)
+	getAPIExport         func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIExport, error)
 	getAPIResourceSchema func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error)
 	getCRD               func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error)
 
@@ -52,13 +53,33 @@ func (ncc *conflictChecker) getBoundCRDs(apiBindingToExclude *apisv1alpha1.APIBi
 		if apiBinding.Name == apiBindingToExclude.Name {
 			continue
 		}
+
+		apiExportClusterName, err := getAPIExportClusterName(apiBinding)
+		if err != nil {
+			return err
+		}
+
+		apiExport, err := ncc.getAPIExport(apiExportClusterName, apiBinding.Spec.Reference.Workspace.ExportName)
+		if err != nil {
+			return err
+		}
+
 		boundSchemaUIDs := sets.NewString()
 		for _, boundResource := range apiBinding.Status.BoundResources {
 			boundSchemaUIDs.Insert(boundResource.Schema.UID)
 		}
 
-		for _, resource := range apiBinding.Status.BoundResources {
-			crd, err := ncc.getCRD(ShadowWorkspaceName, resource.Schema.UID)
+		for _, schemaName := range apiExport.Spec.LatestResourceSchemas {
+			schema, err := ncc.getAPIResourceSchema(apiExportClusterName, schemaName)
+			if err != nil {
+				return err
+			}
+
+			if !boundSchemaUIDs.Has(string(schema.UID)) {
+				continue
+			}
+
+			crd, err := ncc.getCRD(ShadowWorkspaceName, string(schema.UID))
 			if err != nil {
 				return err
 			}

--- a/pkg/reconciler/apis/apibinding/conflict_checker_test.go
+++ b/pkg/reconciler/apis/apibinding/conflict_checker_test.go
@@ -63,6 +63,24 @@ func TestNameConflictCheckerGetBoundCRDs(t *testing.T) {
 		).
 		Build()
 
+	apiExports := map[string]*apisv1alpha1.APIExport{
+		"export0": {
+			Spec: apisv1alpha1.APIExportSpec{
+				LatestResourceSchemas: []string{"export0-schema1"},
+			},
+		},
+		"export1": {
+			Spec: apisv1alpha1.APIExportSpec{
+				LatestResourceSchemas: []string{"export1-schema1", "export1-schema2", "export1-schema3"},
+			},
+		},
+		"export2": {
+			Spec: apisv1alpha1.APIExportSpec{
+				LatestResourceSchemas: []string{"export2-schema1", "export2-schema2", "export2-schema3"},
+			},
+		},
+	}
+
 	apiResourceSchemas := map[string]*apisv1alpha1.APIResourceSchema{
 		"export0-schema1": {ObjectMeta: metav1.ObjectMeta{UID: "e0-s1"}},
 		"export1-schema1": {ObjectMeta: metav1.ObjectMeta{UID: "e1-s1"}},
@@ -80,6 +98,9 @@ func TestNameConflictCheckerGetBoundCRDs(t *testing.T) {
 				existingBinding1,
 				existingBinding2,
 			}, nil
+		},
+		getAPIExport: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIExport, error) {
+			return apiExports[name], nil
 		},
 		getAPIResourceSchema: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
 			return apiResourceSchemas[name], nil


### PR DESCRIPTION
Reverts kcp-dev/kcp#1382

No idea whether this is the root cause, but seeing lots of failing tests since around that time (today's EU morning) when this merged.