### PR TITLE
Fix image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
-# Ignore server only used for e2e testing
+# Ignore servers only used for e2e testing
 cmd/test-server
+cmd/sharded-test-server
+
 bin/


### PR DESCRIPTION
## Summary
Fix image build by adding cmd/sharded-test-server to .dockerignore, as
we don't want to include it in the kcp image.

## Related issue(s)

Fixes #1406 