### PR TITLE
Fix: Add version for kcp and syncer

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/term"
+	"k8s.io/component-base/version"
 
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
 	"github.com/kcp-dev/kcp/pkg/server"
@@ -156,6 +157,12 @@ func main() {
 	})
 
 	help.FitTerminal(cmd.OutOrStdout())
+
+	if v := version.Get().String(); len(v) == 0 {
+		cmd.Version = "<unknown>"
+	} else {
+		cmd.Version = v
+	}
 
 	os.Exit(cli.Run(cmd))
 }

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
 	synceroptions "github.com/kcp-dev/kcp/cmd/syncer/options"
@@ -62,6 +63,12 @@ func NewSyncerCommand() *cobra.Command {
 	}
 
 	options.AddFlags(syncerCommand.Flags())
+
+	if v := version.Get().String(); len(v) == 0 {
+		syncerCommand.Version = "<unknown>"
+	} else {
+		syncerCommand.Version = v
+	}
 
 	return syncerCommand
 }


### PR DESCRIPTION
This commit adds version to  syncer and kcp
commands.

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

## Related issue(s)

Fixes #1380 