### PR TITLE
cmd,pkg: use constant for system:master

### DIFF
--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -80,7 +80,7 @@ func start(proxyFlags, shardFlags []string) error {
 	}
 	_, err = clientCA.MakeClientCertificate(".kcp/kcp-admin.crt", ".kcp/kcp-admin.key", &user.DefaultInfo{
 		Name:   "kcp-admin",
-		Groups: []string{"system:kcp:clusterworkspace:admin", "system:masters"},
+		Groups: []string{"system:kcp:clusterworkspace:admin", user.SystemPrivilegedGroup},
 	}, 365)
 	if err != nil {
 		fmt.Printf("failed to create kcp-admin client cert: %v\n", err)

--- a/pkg/admission/finalizer/finalizer_admission.go
+++ b/pkg/admission/finalizer/finalizer_admission.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 // Validate creation and updates for
@@ -81,7 +82,7 @@ func (f *FinalizerPlugin) Validate(ctx context.Context, a admission.Attributes, 
 			return fmt.Errorf("unexpected type %T", a.GetOldObject())
 		}
 
-		isSystem := sets.NewString(a.GetUserInfo().GetGroups()...).Has("system:masters")
+		isSystem := sets.NewString(a.GetUserInfo().GetGroups()...).Has(user.SystemPrivilegedGroup)
 		isDeleting := !u.GetDeletionTimestamp().IsZero()
 		isRemoving := finalizerExists(old.GetFinalizers(), f.FinalizerName) && !finalizerExists(u.GetFinalizers(), f.FinalizerName)
 		exists := finalizerExists(u.GetFinalizers(), f.FinalizerName)

--- a/pkg/admission/finalizer/finalizer_admission_test.go
+++ b/pkg/admission/finalizer/finalizer_admission_test.go
@@ -155,7 +155,7 @@ func TestValidate(t *testing.T) {
 				newAPIBinding().withDeletionTimestamp(time.Now()).APIBinding,
 				newAPIBinding().withFinalizer(apibindingdeletion.APIBindingFinalizer).APIBinding,
 				&user.DefaultInfo{
-					Groups: []string{"system:masters"},
+					Groups: []string{user.SystemPrivilegedGroup},
 				},
 			),
 		},

--- a/pkg/admission/reservedmetadata/admission_test.go
+++ b/pkg/admission/reservedmetadata/admission_test.go
@@ -253,7 +253,7 @@ func TestAdmission(t *testing.T) {
 				},
 				nil,
 				admission.Create,
-				&user.DefaultInfo{Groups: []string{"system:masters"}},
+				&user.DefaultInfo{Groups: []string{user.SystemPrivilegedGroup}},
 			),
 		},
 		{
@@ -329,7 +329,7 @@ func TestAdmission(t *testing.T) {
 				},
 				admission.Update,
 				&user.DefaultInfo{
-					Groups: []string{"system:masters"},
+					Groups: []string{user.SystemPrivilegedGroup},
 				},
 			),
 		},
@@ -600,7 +600,7 @@ func TestAdmission(t *testing.T) {
 				},
 				admission.Update,
 				&user.DefaultInfo{
-					Groups: []string{"system:masters"},
+					Groups: []string{user.SystemPrivilegedGroup},
 				},
 			),
 		},

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -19,6 +19,7 @@ package options
 import (
 	"github.com/spf13/pflag"
 
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	"k8s.io/apiserver/pkg/authorization/path"
@@ -44,7 +45,7 @@ func NewAuthorization() *Authorization {
 		// This allows the kubelet to always get health and readiness without causing an authorization check.
 		// This field can be cleared by callers if they don't want this behavior.
 		AlwaysAllowPaths:  []string{"/healthz", "/readyz", "/livez"},
-		AlwaysAllowGroups: []string{"system:masters"},
+		AlwaysAllowGroups: []string{user.SystemPrivilegedGroup},
 	}
 }
 

--- a/pkg/virtual/options/authorization.go
+++ b/pkg/virtual/options/authorization.go
@@ -19,6 +19,7 @@ package options
 import (
 	"github.com/spf13/pflag"
 
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
 	"k8s.io/apiserver/pkg/authorization/path"
@@ -43,7 +44,7 @@ func NewAuthorization() *Authorization {
 		// This allows the kubelet to always get health and readiness without causing an authorization check.
 		// This field can be cleared by callers if they don't want this behavior.
 		AlwaysAllowPaths:  []string{"/healthz", "/readyz", "/livez"},
-		AlwaysAllowGroups: []string{"system:masters"},
+		AlwaysAllowGroups: []string{user.SystemPrivilegedGroup},
 	}
 }
 

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/apiserver/pkg/authentication/user"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -211,7 +210,7 @@ func (s *REST) getInternalNameFromPrettyName(user kuser.Info, orgClusterName log
 	return "", kerrors.NewNotFound(tenancyv1beta1.Resource("workspaces"), prettyName)
 }
 
-func withoutGroupsWhenPersonal(user user.Info, usePersonalScope bool) user.Info {
+func withoutGroupsWhenPersonal(user kuser.Info, usePersonalScope bool) kuser.Info {
 	if usePersonalScope {
 		return &kuser.DefaultInfo{
 			Name:   user.GetName(),
@@ -223,7 +222,7 @@ func withoutGroupsWhenPersonal(user user.Info, usePersonalScope bool) user.Info 
 	return user
 }
 
-func (s *REST) deprecatedAuthorizeOrgForUser(ctx context.Context, orgClusterName logicalcluster.Name, user user.Info, verb string) error {
+func (s *REST) deprecatedAuthorizeOrgForUser(ctx context.Context, orgClusterName logicalcluster.Name, user kuser.Info, verb string) error {
 	// Root org access is implicit for every user. For non-root orgs, we need to check for
 	// verb=access permissions against the clusterworkspaces/content of the ClusterWorkspace of
 	// the org in the root.
@@ -258,7 +257,7 @@ func (s *REST) deprecatedAuthorizeOrgForUser(ctx context.Context, orgClusterName
 	return nil
 }
 
-func (s *REST) authorizeForUser(ctx context.Context, orgClusterName logicalcluster.Name, user user.Info, verb string, resourceName string) error {
+func (s *REST) authorizeForUser(ctx context.Context, orgClusterName logicalcluster.Name, user kuser.Info, verb string, resourceName string) error {
 	// Root org access is implicit for every user. For non-root orgs, we need to check for
 	// verb permissions against the clusterworkspaces/workspace sub-resource.
 	if orgClusterName == tenancyv1alpha1.RootCluster || sets.NewString(user.GetGroups()...).Has(kuser.SystemPrivilegedGroup) {


### PR DESCRIPTION
## Summary
This cleans up the code base to refer to the underlying constant of `system:masters`.
Also it cleans up package usage in some places.

/cc @sttts @davidfestal 