### PR TITLE
e2e: prepare for system:masters root shard kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,9 @@ test-e2e-sharded: build-all
 	trap 'kill -TERM $$PID' TERM INT EXIT; \
 	while [ ! -f .kcp/admin.kubeconfig ]; do sleep 1; done; \
 	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) \
-		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
+		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" \
+		--root-kubeconfig=.kcp-0/admin.kubeconfig --root-shard-admin-context="shard-admin" \
+		 $(TEST_ARGS)
 
 .PHONY: test
 ifdef USE_GOTESTSUM

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -23,11 +23,12 @@ import (
 )
 
 type testConfig struct {
-	syncerImage         string
-	kcpTestImage        string
-	pclusterKubeconfig  string
-	kcpKubeconfig       string
-	useDefaultKCPServer bool
+	syncerImage                   string
+	kcpTestImage                  string
+	pclusterKubeconfig            string
+	kcpKubeconfig, rootKubeconfig string
+	rootShardAdminContext         string
+	useDefaultKCPServer           bool
 }
 
 var TestConfig *testConfig
@@ -57,6 +58,18 @@ func (c *testConfig) KCPKubeconfig() string {
 	}
 }
 
+func (c *testConfig) RootKubeconfig() string {
+	if c.useDefaultKCPServer && len(c.rootKubeconfig) > 0 {
+		panic(errors.New("Only one of --use-default-kcp-server and --root-kubeconfig should be set."))
+	}
+
+	return c.rootKubeconfig
+}
+
+func (c *testConfig) RootShardAdminContext() string {
+	return c.rootShardAdminContext
+}
+
 func init() {
 	TestConfig = &testConfig{}
 	registerFlags(TestConfig)
@@ -65,6 +78,8 @@ func init() {
 
 func registerFlags(c *testConfig) {
 	flag.StringVar(&c.kcpKubeconfig, "kcp-kubeconfig", "", "Path to the kubeconfig for a kcp server.")
+	flag.StringVar(&c.rootKubeconfig, "root-kubeconfig", "", "Path to the kubeconfig for a root kcp shard. If not set, the kcp-kubeconfig is used.")
+	flag.StringVar(&c.rootShardAdminContext, "root-shard-admin-context", "base", "The context in the root-kubeconfig for a system:masters shard admin.")
 	flag.StringVar(&c.pclusterKubeconfig, "pcluster-kubeconfig", "", "Path to the kubeconfig for a kubernetes cluster to sync to. Requires --syncer-image.")
 	flag.StringVar(&c.syncerImage, "syncer-image", "", "The syncer image to use with the pcluster. Requires --pcluster-kubeconfig")
 	flag.StringVar(&c.kcpTestImage, "kcp-test-image", "", "The test image to use with the pcluster. Requires --pcluster-kubeconfig")

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -396,7 +396,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := sf.UpstreamServer.RawConfig()
 	require.NoError(t, err)
-	_, kubeconfigPath := WriteLogicalClusterConfig(t, upstreamRawConfig, sf.WorkspaceClusterName)
+	_, kubeconfigPath := WriteLogicalClusterConfig(t, upstreamRawConfig, "system:admin", sf.WorkspaceClusterName)
 
 	useDeployedSyncer := len(TestConfig.PClusterKubeconfig()) > 0
 
@@ -647,8 +647,8 @@ func (sf *StartedSyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx cont
 // WriteLogicalClusterConfig creates a logical cluster config for the given config and
 // cluster name and writes it to the test's artifact path. Useful for configuring the
 // workspace plugin with --kubeconfig.
-func WriteLogicalClusterConfig(t *testing.T, rawConfig clientcmdapi.Config, clusterName logicalcluster.Name) (clientcmd.ClientConfig, string) {
-	logicalRawConfig := LogicalClusterRawConfig(rawConfig, clusterName)
+func WriteLogicalClusterConfig(t *testing.T, rawConfig clientcmdapi.Config, contextName string, clusterName logicalcluster.Name) (clientcmd.ClientConfig, string) {
+	logicalRawConfig := LogicalClusterRawConfig(rawConfig, contextName, clusterName)
 	artifactDir, err := CreateTempDirForTest(t, "artifacts")
 	require.NoError(t, err)
 	pathSafeClusterName := strings.ReplaceAll(clusterName.String(), ":", "_")

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -261,9 +261,7 @@ type ArtifactFunc func(*testing.T, func() (runtime.Object, error))
 type WorkloadClusterOption func(cluster *workloadv1alpha1.WorkloadCluster)
 
 // LogicalClusterRawConfig returns the raw cluster config of the given config.
-func LogicalClusterRawConfig(rawConfig clientcmdapi.Config, logicalClusterName logicalcluster.Name) clientcmdapi.Config {
-	contextName := "system:admin"
-
+func LogicalClusterRawConfig(rawConfig clientcmdapi.Config, contextName string, logicalClusterName logicalcluster.Name) clientcmdapi.Config {
 	var configCluster = *rawConfig.Clusters[contextName] // shallow copy
 	configCluster.Server += logicalClusterName.Path()
 


### PR DESCRIPTION
The fake downstream logical clusters need direct shard access with a system:masters user. This PR adds `--root-kubeconfig` and `--root-shard-admin-context` to the test binary.