### PR TITLE
capitalize ClusterWorkspaceType names provided in CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.0
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/multierr v1.7.0
+	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/square/go-jose.v2 v2.2.2

--- a/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kcp-dev/logicalcluster"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -229,6 +230,53 @@ func TestCreate(t *testing.T) {
 			} else if got != nil && !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("unexpected config, diff (expected, got): %s", cmp.Diff(tt.expected, got))
 			}
+		})
+	}
+}
+
+func TestStructureWorkspaceType(t *testing.T) {
+	tests := []struct {
+		workspaceTypeName, currentClusterName string
+		expected                              tenancyv1alpha1.ClusterWorkspaceTypeReference
+	}{
+		{
+			workspaceTypeName:  "Foo",
+			currentClusterName: "root",
+			expected: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+				Name: "Foo",
+				Path: "root",
+			},
+		},
+		{
+			workspaceTypeName:  "foo",
+			currentClusterName: "root",
+			expected: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+				Name: "Foo",
+				Path: "root",
+			},
+		},
+		{
+			workspaceTypeName:  "root:bar:Foo",
+			currentClusterName: "root",
+			expected: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+				Name: "Foo",
+				Path: "root:bar",
+			},
+		},
+		{
+			workspaceTypeName:  "root:bar:foo",
+			currentClusterName: "root",
+			expected: tenancyv1alpha1.ClusterWorkspaceTypeReference{
+				Name: "Foo",
+				Path: "root:bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("when workspace type name is %s and the current cluster name %s", tt.workspaceTypeName, tt.currentClusterName), func(t *testing.T) {
+			clusterWorkspaceTypeReference := structureWorkspaceType(tt.workspaceTypeName, tt.currentClusterName)
+
+			assert.Equal(t, tt.expected, clusterWorkspaceTypeReference)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
When dumb people like me forget that the name of the CWT has to start with a capital, then the logic capitalizes it.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/1398