### PR TITLE
Exit build process if Kubernetes version is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,15 @@ LDFLAGS := \
 all: build
 .PHONY: all
 
+pre-build-checks:
+ifeq ($(and $(KUBE_MAJOR_VERSION),$(KUBE_MINOR_VERSION)),)
+	$(info Kubernetes version not set. Ensure jq is installed.)
+	exit 1
+endif
+.PHONY: pre-build-checks
+
 build: WHAT ?= ./cmd/...
-build: ## Build the project
+build: pre-build-checks ## Build the project
 	go build -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 .PHONY: build
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

Check the the environment variables holding the Kubernetes version numbers are set. In case of the values missing abort the build process since it is likely the case that `jq` is not installed on the machine.

## Related issue(s)

Fixes #1417