### PR TITLE
Add kcp start option --embedded-etcd-quota-backend-bytes

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -55,7 +55,7 @@ type ClientInfo struct {
 	TrustedCAFile string
 }
 
-func (s *Server) Run(ctx context.Context, peerPort, clientPort string, listenMetricsURLs []url.URL, walSizeBytes int64, forceNewCluster bool) (ClientInfo, error) {
+func (s *Server) Run(ctx context.Context, peerPort, clientPort string, listenMetricsURLs []url.URL, walSizeBytes, quotaBackendBytes int64, forceNewCluster bool) (ClientInfo, error) {
 	klog.Info("Creating embedded etcd server")
 	if walSizeBytes != 0 {
 		wal.SegmentSizeBytes = walSizeBytes
@@ -100,6 +100,10 @@ func (s *Server) Run(ctx context.Context, peerPort, clientPort string, listenMet
 
 	if enableUnsafeEtcdDisableFsyncHack, _ := strconv.ParseBool(os.Getenv("UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC")); enableUnsafeEtcdDisableFsyncHack {
 		cfg.UnsafeNoFsync = true
+	}
+
+	if quotaBackendBytes > 0 {
+		cfg.QuotaBackendBytes = quotaBackendBytes
 	}
 
 	e, err := embed.StartEtcd(cfg)

--- a/pkg/server/options/embeddedetcd.go
+++ b/pkg/server/options/embeddedetcd.go
@@ -32,6 +32,7 @@ type EmbeddedEtcd struct {
 	ClientPort        string
 	ListenMetricsURLs []string
 	WalSizeBytes      int64
+	QuotaBackendBytes int64
 	ForceNewCluster   bool
 }
 
@@ -49,6 +50,7 @@ func (e *EmbeddedEtcd) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&e.ClientPort, "embedded-etcd-client-port", e.ClientPort, "Port for embedded etcd client")
 	fs.StringSliceVar(&e.ListenMetricsURLs, "embedded-etcd-listen-metrics-urls", e.ListenMetricsURLs, "The list of protocol://host:port where embedded etcd server listens for Prometheus scrapes")
 	fs.Int64Var(&e.WalSizeBytes, "embedded-etcd-wal-size-bytes", e.WalSizeBytes, "Size of embedded etcd WAL")
+	fs.Int64Var(&e.QuotaBackendBytes, "embedded-etcd-quota-backend-bytes", e.WalSizeBytes, "Alarm threshold for embedded etcd backend bytes")
 	fs.BoolVar(&e.ForceNewCluster, "embedded-etcd-force-new-cluster", e.ForceNewCluster, "Starts a new cluster from existing data restored from a different system")
 }
 

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -153,6 +153,7 @@ var (
 		"embedded-etcd-peer-port",           // Port for embedded etcd peer
 		"embedded-etcd-listen-metrics-urls", // The list of protocol://host:port where embedded etcd server listens for Prometheus scrapes
 		"embedded-etcd-wal-size-bytes",      // Size of embedded etcd WAL
+		"embedded-etcd-quota-backend-bytes", // Alarm threshold for embedded etcd backend bytes
 		"embedded-etcd-force-new-cluster",   // Starts a new cluster from existing data restored from a different system
 
 		// KCP Controllers flags

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -141,7 +141,7 @@ func (s *Server) Run(ctx context.Context) error {
 				return err
 			}
 		}
-		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, listenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.ForceNewCluster)
+		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, listenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.QuotaBackendBytes, s.options.EmbeddedEtcd.ForceNewCluster)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Mike Spreitzer <mspreitz@us.ibm.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
Add `kcp start` option to configure the embedded etcd server's `--quota-backend-bytes`.

## Related issue(s)

Fixes #1426