### PR TITLE
Add etcd metrics listen URLs option to kcp start

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -55,7 +55,7 @@ type ClientInfo struct {
 	TrustedCAFile string
 }
 
-func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBytes int64, forceNewCluster bool) (ClientInfo, error) {
+func (s *Server) Run(ctx context.Context, peerPort, clientPort string, listenMetricsURLs []url.URL, walSizeBytes int64, forceNewCluster bool) (ClientInfo, error) {
 	klog.Info("Creating embedded etcd server")
 	if walSizeBytes != 0 {
 		wal.SegmentSizeBytes = walSizeBytes
@@ -93,6 +93,10 @@ func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBy
 	cfg.ClientTLSInfo.TrustedCAFile = filepath.Join(cfg.Dir, "secrets", "ca", "cert.pem")
 	cfg.ClientTLSInfo.ClientCertAuth = true
 	cfg.ForceNewCluster = forceNewCluster
+
+	if len(listenMetricsURLs) > 0 {
+		cfg.ListenMetricsUrls = listenMetricsURLs
+	}
 
 	if enableUnsafeEtcdDisableFsyncHack, _ := strconv.ParseBool(os.Getenv("UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC")); enableUnsafeEtcdDisableFsyncHack {
 		cfg.UnsafeNoFsync = true

--- a/pkg/server/options/embeddedetcd.go
+++ b/pkg/server/options/embeddedetcd.go
@@ -18,19 +18,33 @@ package options
 
 import (
 	"fmt"
+	"net/url"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/pflag"
+
+	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
 )
 
 type EmbeddedEtcd struct {
 	Enabled bool
 
-	Directory       string
-	PeerPort        string
-	ClientPort      string
-	WalSizeBytes    int64
-	ForceNewCluster bool
+	Directory            string
+	PeerPort             string
+	ClientPort           string
+	ListenMetricsURLList string
+	WalSizeBytes         int64
+	ForceNewCluster      bool
+}
+
+type CompletedEmbeddedEtcd struct {
+	*completedEmbeddedEtcd
+}
+
+type completedEmbeddedEtcd struct {
+	EmbeddedEtcd
+	ListenMetricsURLs []url.URL
 }
 
 func NewEmbeddedEtcd(rootDir string) *EmbeddedEtcd {
@@ -41,15 +55,20 @@ func NewEmbeddedEtcd(rootDir string) *EmbeddedEtcd {
 	}
 }
 
+func (e *EmbeddedEtcd) Complete() CompletedEmbeddedEtcd {
+	return CompletedEmbeddedEtcd{&completedEmbeddedEtcd{EmbeddedEtcd: *e}}
+}
+
 func (e *EmbeddedEtcd) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&e.Directory, "embedded-etcd-directory", e.Directory, "Directory for embedded etcd")
 	fs.StringVar(&e.PeerPort, "embedded-etcd-peer-port", e.PeerPort, "Port for embedded etcd peer")
 	fs.StringVar(&e.ClientPort, "embedded-etcd-client-port", e.ClientPort, "Port for embedded etcd client")
+	fs.StringVar(&e.ListenMetricsURLList, "embedded-etcd-listen-metrics-urls", e.ClientPort, "Comma-separated list of protocol://host:port where embedded etcd server listens for scrapes")
 	fs.Int64Var(&e.WalSizeBytes, "embedded-etcd-wal-size-bytes", e.WalSizeBytes, "Size of embedded etcd WAL")
 	fs.BoolVar(&e.ForceNewCluster, "embedded-etcd-force-new-cluster", e.ForceNewCluster, "Starts a new cluster from existing data restored from a different system")
 }
 
-func (e *EmbeddedEtcd) Validate() []error {
+func (e *CompletedEmbeddedEtcd) Validate() []error {
 	var errs []error
 
 	if e.Enabled {
@@ -58,6 +77,14 @@ func (e *EmbeddedEtcd) Validate() []error {
 		}
 		if e.ClientPort == "" {
 			errs = append(errs, fmt.Errorf("--embedded-etcd-client-port must be specified"))
+		}
+		if e.ListenMetricsURLList != "" {
+			u, err := etcdtypes.NewURLs(strings.Split(e.ListenMetricsURLList, ","))
+			if err != nil {
+				errs = append(errs, fmt.Errorf("--embedded-etcd-listen-metrics-urls parse failure: %w", err))
+			} else {
+				e.ListenMetricsURLs = []url.URL(u)
+			}
 		}
 	}
 

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -148,11 +148,12 @@ var (
 		"tls-sni-cert-key",                 // A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. The domain patterns also allow IP addresses, but IPs should only be used if the apiserver has visibility to the IP address requested by a client. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".
 
 		// Embedded etcd flags
-		"embedded-etcd-client-port",       // Port for embedded etcd client
-		"embedded-etcd-directory",         // Directory for embedded etcd
-		"embedded-etcd-peer-port",         // Port for embedded etcd peer
-		"embedded-etcd-wal-size-bytes",    // Size of embedded etcd WAL
-		"embedded-etcd-force-new-cluster", // Starts a new cluster from existing data restored from a different system
+		"embedded-etcd-client-port",         // Port for embedded etcd client
+		"embedded-etcd-directory",           // Directory for embedded etcd
+		"embedded-etcd-peer-port",           // Port for embedded etcd peer
+		"embedded-etcd-listen-metrics-urls", // Comma-separated list of protocol://host:port where embedded etcd server listens for scrapes
+		"embedded-etcd-wal-size-bytes",      // Size of embedded etcd WAL
+		"embedded-etcd-force-new-cluster",   // Starts a new cluster from existing data restored from a different system
 
 		// KCP Controllers flags
 		"auto-publish-apis",                      // If true, the APIs imported from physical clusters will be published automatically as CRDs

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -61,7 +61,7 @@ type ExtraOptions struct {
 
 type completedOptions struct {
 	GenericControlPlane options.CompletedServerRunOptions
-	EmbeddedEtcd        EmbeddedEtcd
+	EmbeddedEtcd        CompletedEmbeddedEtcd
 	Controllers         Controllers
 	Authorization       Authorization
 	AdminAuthentication AdminAuthentication
@@ -270,7 +270,7 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 		completedOptions: &completedOptions{
 			// TODO: GenericControlPlane here should be completed. But the k/k repo does not expose the CompleteOptions type, but should.
 			GenericControlPlane: completedGenericControlPlane,
-			EmbeddedEtcd:        o.EmbeddedEtcd,
+			EmbeddedEtcd:        o.EmbeddedEtcd.Complete(),
 			Controllers:         o.Controllers,
 			Authorization:       o.Authorization,
 			AdminAuthentication: o.AdminAuthentication,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -131,7 +131,7 @@ func (s *Server) Run(ctx context.Context) error {
 		es := &etcd.Server{
 			Dir: s.options.EmbeddedEtcd.Directory,
 		}
-		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.ForceNewCluster)
+		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, s.options.EmbeddedEtcd.ListenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.ForceNewCluster)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Mike Spreitzer <mspreitz@us.ibm.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
This PR extends the start options of kcp with one that can specify a list of URLs at which the embedded etcd server will listen for metrics scrapes.  If secured, regular client credentials will be required.

## Related issue(s)

Fixes #1427