### PR TITLE
Add kcp start options for embedded etcd server Prometheus scrape URLs

### DIFF
--- a/pkg/etcd/etcd.go
+++ b/pkg/etcd/etcd.go
@@ -55,7 +55,7 @@ type ClientInfo struct {
 	TrustedCAFile string
 }
 
-func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBytes int64, forceNewCluster bool) (ClientInfo, error) {
+func (s *Server) Run(ctx context.Context, peerPort, clientPort string, listenMetricsURLs []url.URL, walSizeBytes int64, forceNewCluster bool) (ClientInfo, error) {
 	klog.Info("Creating embedded etcd server")
 	if walSizeBytes != 0 {
 		wal.SegmentSizeBytes = walSizeBytes
@@ -93,6 +93,10 @@ func (s *Server) Run(ctx context.Context, peerPort, clientPort string, walSizeBy
 	cfg.ClientTLSInfo.TrustedCAFile = filepath.Join(cfg.Dir, "secrets", "ca", "cert.pem")
 	cfg.ClientTLSInfo.ClientCertAuth = true
 	cfg.ForceNewCluster = forceNewCluster
+
+	if len(listenMetricsURLs) > 0 {
+		cfg.ListenMetricsUrls = listenMetricsURLs
+	}
 
 	if enableUnsafeEtcdDisableFsyncHack, _ := strconv.ParseBool(os.Getenv("UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC")); enableUnsafeEtcdDisableFsyncHack {
 		cfg.UnsafeNoFsync = true

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -148,11 +148,12 @@ var (
 		"tls-sni-cert-key",                 // A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. The domain patterns also allow IP addresses, but IPs should only be used if the apiserver has visibility to the IP address requested by a client. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com".
 
 		// Embedded etcd flags
-		"embedded-etcd-client-port",       // Port for embedded etcd client
-		"embedded-etcd-directory",         // Directory for embedded etcd
-		"embedded-etcd-peer-port",         // Port for embedded etcd peer
-		"embedded-etcd-wal-size-bytes",    // Size of embedded etcd WAL
-		"embedded-etcd-force-new-cluster", // Starts a new cluster from existing data restored from a different system
+		"embedded-etcd-client-port",         // Port for embedded etcd client
+		"embedded-etcd-directory",           // Directory for embedded etcd
+		"embedded-etcd-peer-port",           // Port for embedded etcd peer
+		"embedded-etcd-listen-metrics-urls", // The list of protocol://host:port where embedded etcd server listens for Prometheus scrapes
+		"embedded-etcd-wal-size-bytes",      // Size of embedded etcd WAL
+		"embedded-etcd-force-new-cluster",   // Starts a new cluster from existing data restored from a different system
 
 		// KCP Controllers flags
 		"auto-publish-apis",                      // If true, the APIs imported from physical clusters will be published automatically as CRDs

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"net/url"
 	"time"
 
 	"github.com/kcp-dev/logicalcluster"
+	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
@@ -131,7 +133,15 @@ func (s *Server) Run(ctx context.Context) error {
 		es := &etcd.Server{
 			Dir: s.options.EmbeddedEtcd.Directory,
 		}
-		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.ForceNewCluster)
+		var listenMetricsURLs []url.URL
+		if len(s.options.EmbeddedEtcd.ListenMetricsURLs) > 0 {
+			var err error
+			listenMetricsURLs, err = etcdtypes.NewURLs(s.options.EmbeddedEtcd.ListenMetricsURLs)
+			if err != nil {
+				return err
+			}
+		}
+		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, listenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.ForceNewCluster)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
This PR extends the start options of kcp with one that can specify a list of URLs at which the embedded etcd server will listen for metrics scrapes. If secured, regular client credentials will be required.

This is a hopefully better alternative to #1431 .

I did not take on the task of introducing a Config struct in this PR, expecting it should go in a separate PR.

## Related issue(s)

Fixes #1427 