### PR TITLE
test-servers: enable audit logs

### DIFF
--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -41,7 +41,7 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 		return nil, fmt.Errorf("failed to write server cert: %w", err)
 	}
 
-	klog.Infof("Creating extra serving certs in .kcp with hostnames %v to be used by e2e webhooks", n, hostnames)
+	klog.Infof("Creating extra serving certs in .kcp with hostnames %v to be used by e2e webhooks", hostnames)
 	cert, err = servingCA.MakeServerCert(hostnames, 365)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server cert: %w", err)

--- a/cmd/test-server/kcp/audit-policy.yaml
+++ b/cmd/test-server/kcp/audit-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+- RequestReceived
+omitManagedFields: true
+rules:
+- level: None
+  nonResourceURLs:
+  - "/api*"
+  - "/version"
+
+- level: Metadata
+  resources:
+  - group: ""
+    resources: ["secrets", "configmaps"]
+  - group: "authorization.k8s.io"
+    resources: ["subjectaccessreviews"]
+
+- level: Metadata
+  verbs: ["list", "watch"]
+
+- level: Metadata
+  verbs: ["get", "delete"]
+  omitStages:
+  - ResponseStarted
+
+- level: RequestResponse
+  verbs: ["create", "update", "patch"]
+  omitStages:
+  - ResponseStarted

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -78,7 +79,9 @@ func start(shardFlags []string) error {
 	defer cancelFn()
 
 	logFilePath := flag.Lookup("log-file-path").Value.String()
-	errCh, err := shard.Start(ctx, "kcp", ".kcp", logFilePath, shardFlags)
+	errCh, err := shard.Start(ctx, "kcp", ".kcp", logFilePath,
+		append(shardFlags, "--audit-log-path", filepath.Join(filepath.Dir(logFilePath), "audit.log")),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -124,7 +124,7 @@ func (s *Server) installKubeNamespaceController(ctx context.Context, config *res
 		metadata,
 		discoverResourcesFn,
 		s.kubeSharedInformerFactory.Core().V1().Namespaces(),
-		time.Duration(30)*time.Second,
+		time.Duration(5)*time.Minute,
 		corev1.FinalizerKubernetes,
 	)
 


### PR DESCRIPTION
Enables us to 
- trace the whole life-cycle of every object. I.e. which state at which time, changed by which actor. Everything.
- identify hotlooping or just which component produces most load.