### PR TITLE
e2e/watchcache: fix missing identity logic

### DIFF
--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -95,7 +95,7 @@ func Run(ctx context.Context, o *options.Options) error {
 	nonIdentityConfig.Host = u.String()
 
 	// resolve identities for system APIBindings
-	nonIdentityKcpClusterClient, err := kcpclient.NewClusterForConfig(nonIdentityConfig) // can only used for apis.kcp.dev
+	nonIdentityKcpClusterClient, err := kcpclient.NewClusterForConfig(nonIdentityConfig) // can only used for wildcard requests of apis.kcp.dev
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -153,7 +153,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// The identities are not known before we can get them from the APIExports via the loopback client, hence we postpone
 	// this to getOrCreateKcpIdentities() in the kcp-start-informers post-start hook.
 	// The informers here are not  used before the informers are actually started (i.e. no race).
-	nonIdentityKcpClusterClient, err := kcpclient.NewClusterForConfig(genericConfig.LoopbackClientConfig) // can only used for apis.kcp.dev
+	nonIdentityKcpClusterClient, err := kcpclient.NewClusterForConfig(genericConfig.LoopbackClientConfig) // can only used for wildcard requests of apis.kcp.dev
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
~~How could that work before, ever?~~ Probably this still worked because https://github.com/kcp-dev/kcp/pull/1395 hasn't merged.