### PR TITLE
config/universal: mark default ns create-only

### DIFF
--- a/config/root/namespace-default.yaml
+++ b/config/root/namespace-default.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: default
+  annotations:
+    "bootstrap.kcp.dev/create-only": "true"

--- a/config/universal/default-namespace.yaml
+++ b/config/universal/default-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: default
+  annotations:
+    "bootstrap.kcp.dev/create-only": "true"


### PR DESCRIPTION
This might have caused scheduling annotations and labels to be reset during e2e 🤦‍♂️ 

So innocent:
<img width="1096" alt="Untitled" src="https://user-images.githubusercontent.com/730123/177184550-a822a056-270f-4028-ad14-37f65699d0e2.png">
