### PR TITLE
test/e2e: make tests shard aware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 
 build: WHAT ?= ./cmd/...
 build: pre-build-checks ## Build the project
-	go build -ldflags="$(LDFLAGS)" -o bin $(WHAT)
+	go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 .PHONY: build
 
 .PHONY: build-all

--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ test-e2e-sharded: build-all
 	trap 'kill -TERM $$PID' TERM INT EXIT; \
 	while [ ! -f .kcp/admin.kubeconfig ]; do sleep 1; done; \
 	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) \
-		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
+		-args --use-default-kcp-server --root-shard-kubeconfig=$(PWD)/.kcp-0/admin.kubeconfig --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
 
 .PHONY: test
 ifdef USE_GOTESTSUM

--- a/cmd/kcp-front-proxy/options/authentication.go
+++ b/cmd/kcp-front-proxy/options/authentication.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/request/x509"
+	"k8s.io/apiserver/pkg/authentication/user"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 
@@ -41,7 +42,9 @@ type Authentication struct {
 
 // NewAuthentication creates a default Authentication
 func NewAuthentication() *Authentication {
-	return &Authentication{}
+	return &Authentication{
+		DropGroups: []string{user.SystemPrivilegedGroup},
+	}
 }
 
 // ApplyTo sets up the x509 Authenticator if the client-ca-file option was passed

--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -204,7 +204,7 @@ func kcpAdminKubeConfig(ctx context.Context, hostIP string) error {
 
 	var kubeConfig clientcmdapi.Config
 	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-		"admin": {
+		"kcp-admin": {
 			ClientKey:         ".kcp/kcp-admin.key",
 			ClientCertificate: ".kcp/kcp-admin.crt",
 		},
@@ -214,21 +214,16 @@ func kcpAdminKubeConfig(ctx context.Context, hostIP string) error {
 			Server:               baseHost + "/clusters/root",
 			CertificateAuthority: ".kcp/serving-ca.crt",
 		},
-		"root:default": {
-			Server:               baseHost + "/clusters/root:default",
-			CertificateAuthority: ".kcp/serving-ca.crt",
-		},
-		"system:admin": {
+		"base": {
 			Server:               baseHost,
 			CertificateAuthority: ".kcp/serving-ca.crt",
 		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
-		"root":         {Cluster: "root", AuthInfo: "admin"},
-		"default":      {Cluster: "root:default", AuthInfo: "admin"},
-		"system:admin": {Cluster: "system:admin", AuthInfo: "admin"},
+		"root": {Cluster: "root", AuthInfo: "kcp-admin"},
+		"base": {Cluster: "base", AuthInfo: "kcp-admin"},
 	}
-	kubeConfig.CurrentContext = "default"
+	kubeConfig.CurrentContext = "base"
 
 	if err := clientcmdapi.FlattenConfig(&kubeConfig); err != nil {
 		return err

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -29,6 +29,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
 	"github.com/kcp-dev/kcp/cmd/sharded-test-server/third_party/library-go/crypto"
+	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 )
 
 func main() {
@@ -80,7 +81,7 @@ func start(proxyFlags, shardFlags []string, numberOfShards int) error {
 	}
 	_, err = clientCA.MakeClientCertificate(".kcp/kcp-admin.crt", ".kcp/kcp-admin.key", &user.DefaultInfo{
 		Name:   "kcp-admin",
-		Groups: []string{"system:kcp:clusterworkspace:admin"},
+		Groups: []string{bootstrap.SystemKcpClusterWorkspaceAdminGroup, bootstrap.SystemKcpAdminGroup},
 	}, 365)
 	if err != nil {
 		fmt.Printf("failed to create kcp-admin client cert: %v\n", err)

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -80,7 +80,7 @@ func start(proxyFlags, shardFlags []string, numberOfShards int) error {
 	}
 	_, err = clientCA.MakeClientCertificate(".kcp/kcp-admin.crt", ".kcp/kcp-admin.key", &user.DefaultInfo{
 		Name:   "kcp-admin",
-		Groups: []string{"system:kcp:clusterworkspace:admin", user.SystemPrivilegedGroup},
+		Groups: []string{"system:kcp:clusterworkspace:admin"},
 	}, 365)
 	if err != nil {
 		fmt.Printf("failed to create kcp-admin client cert: %v\n", err)

--- a/config/root/clusterrole-kcp-admin-maximal-permission-policy.yaml
+++ b/config/root/clusterrole-kcp-admin-maximal-permission-policy.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:kcp:apiexport:kcp-admin:maximal-permission-policy
+rules:
+  - apiGroups: ["tenancy.kcp.dev"]
+    verbs: ["*"]
+    resources: ["*"]

--- a/config/root/clusterrolebinding-kcp-admin-maximal-permission-policy.yaml
+++ b/config/root/clusterrolebinding-kcp-admin-maximal-permission-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kcp:authenticated:apiexport:kcp-admin:maximal-permission-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kcp:apiexport:kcp-admin:maximal-permission-policy
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: apis.kcp.dev:binding:system:kcp:admin

--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -24,13 +24,18 @@ import (
 
 const (
 	SystemKcpClusterWorkspaceAccessGroup = "system:kcp:clusterworkspace:access"
-	SystemKcpClusterWorkspaceAdminGroup  = "system:kcp:clusterworkspace:admin"
+	// An admin group per cluster workspace.
+	// Members of this group have all permissions in the referenced cluster workspace (capped by maximal permission policy).
+	SystemKcpClusterWorkspaceAdminGroup = "system:kcp:clusterworkspace:admin"
+	// A global admin group.
+	// Members of this group have all permissions across all cluster workspaces.
+	SystemKcpAdminGroup = "system:kcp:admin"
 )
 
 // ClusterRoleBindings return default rolebindings to the default roles
 func clusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	return []rbacv1.ClusterRoleBinding{
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups(SystemKcpClusterWorkspaceAdminGroup).BindingOrDie(), "system:kcp:clusterworkspace:admin"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups(SystemKcpClusterWorkspaceAdminGroup, SystemKcpAdminGroup).BindingOrDie(), "system:kcp:clusterworkspace:admin"),
 	}
 }
 

--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -112,9 +112,13 @@ func (s *AdminAuthentication) ApplyTo(config *genericapiserver.Config) (volatile
 	}
 
 	kcpAdminUser := &user.DefaultInfo{
-		Name:   kcpAdminUserName,
-		UID:    uuid.New().String(),
-		Groups: []string{bootstrap.SystemKcpClusterWorkspaceAdminGroup, bootstrap.SystemKcpClusterWorkspaceAccessGroup},
+		Name: kcpAdminUserName,
+		UID:  uuid.New().String(),
+		Groups: []string{
+			bootstrap.SystemKcpAdminGroup,
+			bootstrap.SystemKcpClusterWorkspaceAdminGroup,
+			bootstrap.SystemKcpClusterWorkspaceAccessGroup,
+		},
 	}
 
 	newAuthenticator := group.NewAuthenticatedGroupAdder(bearertoken.New(authenticator.WrapAudienceAgnosticToken(config.Authentication.APIAudiences, authenticator.TokenFunc(func(ctx context.Context, requestToken string) (*authenticator.Response, bool, error) {

--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -35,19 +35,30 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
+)
+
+const (
+	// A shard admin being member of the privileged system:masters group.
+	// This will bypass most kcp authorization checks.
+	shardAdminUserName = "shard-admin"
+	// A kcp admin being member of system:kcp:clusterworkspace:admin and system:kcp:clusterworkspace:access.
+	// This user will be subject of kcp authorization checks.
+	kcpAdminUserName = "kcp-admin"
 )
 
 type AdminAuthentication struct {
 	KubeConfigPath string
 
 	// TODO: move into Secret in-cluster, maybe by using an "in-cluster" string as value
-	TokenHashFilePath string
+	ShardAdminTokenHashFilePath string
 }
 
 func NewAdminAuthentication(rootDir string) *AdminAuthentication {
 	return &AdminAuthentication{
-		KubeConfigPath:    filepath.Join(rootDir, "admin.kubeconfig"),
-		TokenHashFilePath: filepath.Join(rootDir, ".admin-token-store"),
+		KubeConfigPath:              filepath.Join(rootDir, "admin.kubeconfig"),
+		ShardAdminTokenHashFilePath: filepath.Join(rootDir, ".admin-token-store"),
 	}
 }
 
@@ -58,7 +69,7 @@ func (s *AdminAuthentication) Validate() []error {
 
 	errs := []error{}
 
-	if s.TokenHashFilePath == "" && s.KubeConfigPath != "" {
+	if s.ShardAdminTokenHashFilePath == "" && s.KubeConfigPath != "" {
 		errs = append(errs, fmt.Errorf("--admin-kubeconfig requires --admin-token-hash-file-path"))
 	}
 
@@ -72,93 +83,111 @@ func (s *AdminAuthentication) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.KubeConfigPath, "kubeconfig-path", s.KubeConfigPath,
 		"Path to which the administrative kubeconfig should be written at startup. If this is relative, it is relative to --root-directory.")
-	fs.StringVar(&s.TokenHashFilePath, "authentication-admin-token-path", s.TokenHashFilePath,
+	fs.StringVar(&s.ShardAdminTokenHashFilePath, "authentication-admin-token-path", s.ShardAdminTokenHashFilePath,
 		"Path to which the administrative token hash should be written at startup. If this is relative, it is relative to --root-directory.")
 }
 
-func (s *AdminAuthentication) ApplyTo(config *genericapiserver.Config) (newTokenOrEmpty string, tokenHash []byte, err error) {
+// ApplyTo returns a new volatile kcp admin token.
+// It also returns a new shard admin token and its hash if the configured shard admin hash file is not present.
+// If the shard admin hash file is present only the shard admin hash is returned and the returned shard admin token is empty.
+func (s *AdminAuthentication) ApplyTo(config *genericapiserver.Config) (volatileKcpAdminToken, shardAdminToken string, shardAdminTokenHash []byte, err error) {
 	// try to load existing token to reuse
-	tokenHash, err = ioutil.ReadFile(s.TokenHashFilePath)
+	shardAdminTokenHash, err = ioutil.ReadFile(s.ShardAdminTokenHashFilePath)
 	if os.IsNotExist(err) {
-		newTokenOrEmpty = uuid.New().String()
-		sum := sha256.Sum256([]byte(newTokenOrEmpty))
-		tokenHash = sum[:]
-		if err := ioutil.WriteFile(s.TokenHashFilePath, tokenHash, 0600); err != nil {
-			return "", nil, err
+		shardAdminToken = uuid.New().String()
+		sum := sha256.Sum256([]byte(shardAdminToken))
+		shardAdminTokenHash = sum[:]
+		if err := ioutil.WriteFile(s.ShardAdminTokenHashFilePath, shardAdminTokenHash, 0600); err != nil {
+			return "", "", nil, err
 		}
 	}
 
-	var uid = uuid.New().String()
-	adminUser := &user.DefaultInfo{
-		Name:   user.APIServerUser,
-		UID:    uid,
+	volatileKcpAdminToken = uuid.New().String()
+
+	shardAdminUser := &user.DefaultInfo{
+		Name:   shardAdminUserName,
+		UID:    uuid.New().String(),
 		Groups: []string{user.SystemPrivilegedGroup},
+	}
+
+	kcpAdminUser := &user.DefaultInfo{
+		Name:   kcpAdminUserName,
+		UID:    uuid.New().String(),
+		Groups: []string{bootstrap.SystemKcpClusterWorkspaceAdminGroup, bootstrap.SystemKcpClusterWorkspaceAccessGroup},
 	}
 
 	newAuthenticator := bearertoken.New(authenticator.WrapAudienceAgnosticToken(config.Authentication.APIAudiences, authenticator.TokenFunc(func(ctx context.Context, requestToken string) (*authenticator.Response, bool, error) {
 		requestTokenHash := sha256.Sum256([]byte(requestToken))
-		if !bytes.Equal(requestTokenHash[:], tokenHash) {
-			return nil, false, nil
+		if bytes.Equal(requestTokenHash[:], shardAdminTokenHash) {
+			return &authenticator.Response{User: shardAdminUser}, true, nil
 		}
-		return &authenticator.Response{User: adminUser}, true, nil
+
+		if requestToken == volatileKcpAdminToken {
+			return &authenticator.Response{User: kcpAdminUser}, true, nil
+		}
+
+		return nil, false, nil
 	})))
 
 	config.Authentication.Authenticator = authenticatorunion.New(newAuthenticator, config.Authentication.Authenticator)
 
-	return newTokenOrEmpty, tokenHash, nil
+	return volatileKcpAdminToken, shardAdminToken, shardAdminTokenHash, nil
 }
 
-func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, newToken string, tokenHash []byte) error {
+func (s *AdminAuthentication) WriteKubeConfig(config *genericapiserver.Config, kcpAdminToken, shardAdminToken string, shardAdminTokenHash []byte) error {
 	externalCACert, _ := config.SecureServing.Cert.CurrentCertKeyContent()
 	externalKubeConfigHost := fmt.Sprintf("https://%s", config.ExternalAddress)
 
-	externalAdminUserName := "admin"
-	if newToken == "" {
+	if shardAdminToken == "" { // shard admin token has been generated previously, we have to read it from kubeconfig
 		// The same token will be used: retrieve it, but only if its hash matches the stored token hash.
 		existingExternalKubeConfig, err := clientcmd.LoadFromFile(s.KubeConfigPath)
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
 		if existingExternalKubeConfig != nil {
-			if externalAdminUser := existingExternalKubeConfig.AuthInfos[externalAdminUserName]; externalAdminUser != nil {
-				kubeConfigTokenHash := sha256.Sum256([]byte(externalAdminUser.Token))
-				if !bytes.Equal(kubeConfigTokenHash[:], tokenHash) {
-					return fmt.Errorf("admin token in file %s is not valid anymore. Remove file %s and restart KCP", s.KubeConfigPath, s.TokenHashFilePath)
+			if shardAdminAuth := existingExternalKubeConfig.AuthInfos[shardAdminUserName]; shardAdminAuth != nil {
+				kubeConfigTokenHash := sha256.Sum256([]byte(shardAdminAuth.Token))
+				if !bytes.Equal(kubeConfigTokenHash[:], shardAdminTokenHash) {
+					return fmt.Errorf("admin token in file %q is not valid anymore. Remove file %q and restart KCP", s.KubeConfigPath, s.ShardAdminTokenHashFilePath)
 				}
-				newToken = externalAdminUser.Token
+
+				shardAdminToken = shardAdminAuth.Token
 			}
 		}
 	}
-	if newToken == "" {
-		return fmt.Errorf("cannot create the 'admin.kubeconfig` file with an empty token for the %s user", externalAdminUserName)
+
+	// give up: either there is no new generated shard admin token or the kubeconfig file is malicious.
+	if shardAdminToken == "" {
+		return fmt.Errorf("cannot create the 'admin.kubeconfig` file with an empty token for the %s user", shardAdminUserName)
 	}
-	externalKubeConfig := createKubeConfig("admin", newToken, externalKubeConfigHost, "", externalCACert)
+
+	externalKubeConfig := createKubeConfig(kcpAdminToken, shardAdminToken, externalKubeConfigHost, "", externalCACert)
 	return clientcmd.WriteToFile(*externalKubeConfig, s.KubeConfigPath)
 }
 
-func createKubeConfig(adminUserName, adminBearerToken, baseHost, tlsServerName string, caData []byte) *clientcmdapi.Config {
+func createKubeConfig(kcpAdminToken, shardAdminToken, baseHost, tlsServerName string, caData []byte) *clientcmdapi.Config {
 	var kubeConfig clientcmdapi.Config
 	//Create Client and Shared
 	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-		adminUserName: {Token: adminBearerToken},
+		kcpAdminUserName:   {Token: kcpAdminToken},
+		shardAdminUserName: {Token: shardAdminToken},
 	}
 	kubeConfig.Clusters = map[string]*clientcmdapi.Cluster{
-		// root is the virtual cluster containing the organizations
 		"root": {
 			Server:                   baseHost + "/clusters/root",
 			CertificateAuthorityData: caData,
 			TLSServerName:            tlsServerName,
 		},
-		// system:admin is the virtual cluster running by default
-		"system:admin": {
+		"base": {
 			Server:                   baseHost,
 			CertificateAuthorityData: caData,
 			TLSServerName:            tlsServerName,
 		},
 	}
 	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
-		"root":         {Cluster: "root", AuthInfo: adminUserName},
-		"system:admin": {Cluster: "system:admin", AuthInfo: adminUserName},
+		"root":         {Cluster: "root", AuthInfo: kcpAdminUserName},
+		"base":         {Cluster: "base", AuthInfo: kcpAdminUserName},
+		"system:admin": {Cluster: "base", AuthInfo: shardAdminUserName},
 	}
 	kubeConfig.CurrentContext = "root"
 	return &kubeConfig

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -220,8 +220,8 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 			return nil, err
 		}
 	}
-	if !filepath.IsAbs(o.AdminAuthentication.TokenHashFilePath) {
-		o.AdminAuthentication.TokenHashFilePath, err = filepath.Abs(o.AdminAuthentication.TokenHashFilePath)
+	if !filepath.IsAbs(o.AdminAuthentication.ShardAdminTokenHashFilePath) {
+		o.AdminAuthentication.ShardAdminTokenHashFilePath, err = filepath.Abs(o.AdminAuthentication.ShardAdminTokenHashFilePath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -72,7 +72,7 @@ const resyncPeriod = 10 * time.Hour
 // as a library rather than as a single binary. Using its constructor function, you can easily
 // setup a new api-server and start it:
 //
-//   srv := server.NewServer(server.DefaultConfig())
+//   srv := server.NewServer(server.BaseConfig())
 //   srv.Run(ctx)
 //
 // You may optionally provide PostStartHookFunc and PreShutdownHookFunc hooks before starting

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -219,7 +219,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if err := s.options.Authorization.ApplyTo(genericConfig, s.kubeSharedInformerFactory, s.kcpSharedInformerFactory); err != nil {
 		return err
 	}
-	newTokenOrEmpty, tokenHash, err := s.options.AdminAuthentication.ApplyTo(genericConfig)
+	kcpAdminToken, shardAdminToken, shardAdminTokenHash, err := s.options.AdminAuthentication.ApplyTo(genericConfig)
 	if err != nil {
 		return err
 	}
@@ -601,7 +601,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 
-	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, newTokenOrEmpty, tokenHash); err != nil {
+	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, kcpAdminToken, shardAdminToken, shardAdminTokenHash); err != nil {
 		return err
 	}
 

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -61,8 +61,7 @@ func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
 	kcpClusterClient, err := clientset.NewClusterForConfig(server.BaseConfig(t))
 	require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 
-	rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", server.RootShardConfig(t))
-	rootKcpClusterClient, err := clientset.NewClusterForConfig(rootCfg)
+	rootKcpClusterClient, err := clientset.NewClusterForConfig(server.RootShardConfig(t))
 	require.NoError(t, err)
 
 	t.Logf("Creating workspace")

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -55,13 +55,13 @@ func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	kubeClusterClient, err := kubernetes.NewForConfig(server.DefaultConfig(t))
+	kubeClusterClient, err := kubernetes.NewForConfig(server.BaseConfig(t))
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
-	kcpClusterClient, err := clientset.NewClusterForConfig(server.DefaultConfig(t))
+	kcpClusterClient, err := clientset.NewClusterForConfig(server.BaseConfig(t))
 	require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 
-	rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", server.DefaultConfig(t))
+	rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", server.RootShardConfig(t))
 	rootKcpClusterClient, err := clientset.NewClusterForConfig(rootCfg)
 	require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
 				t.Parallel()
 
 				t.Logf("Creating a ClusterWorkspaceType as user-1")
-				userKcpClusterClient, err := clientset.NewClusterForConfig(framework.UserConfig("user-1", server.DefaultConfig(t)))
+				userKcpClusterClient, err := clientset.NewClusterForConfig(framework.UserConfig("user-1", server.BaseConfig(t)))
 				require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 				framework.Eventually(t, func() (bool, string) { // authz makes this eventually succeed
 					_, err = userKcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaceTypes().Create(ctx, &tenancyv1alpha1.ClusterWorkspaceType{
@@ -115,7 +115,7 @@ func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
 				t.Parallel()
 
 				t.Logf("Creating a APIExport as user-1")
-				userKcpClusterClient, err := clientset.NewClusterForConfig(framework.UserConfig("user-1", server.DefaultConfig(t)))
+				userKcpClusterClient, err := clientset.NewClusterForConfig(framework.UserConfig("user-1", server.BaseConfig(t)))
 				require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 				framework.Eventually(t, func() (bool, string) { // authz makes this eventually succeed
 					_, err := userKcpClusterClient.Cluster(orgClusterName).ApisV1alpha1().APIExports().Create(ctx, &apisv1alpha1.APIExport{
@@ -158,7 +158,7 @@ func TestAPIBindingAuthorizer(t *testing.T) {
 	consumer1Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	consumer2Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -54,7 +54,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/apibinding/apibinding_permissionclaims_test.go
+++ b/test/e2e/apibinding/apibinding_permissionclaims_test.go
@@ -55,7 +55,7 @@ func TestAPIBindingPermissionClaims(t *testing.T) {
 	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -48,7 +48,7 @@ func TestProtectedAPI(t *testing.T) {
 	providerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -239,11 +239,7 @@ func TestAPIBinding(t *testing.T) {
 
 	verifyWildcardList := func(consumerWorkspace logicalcluster.Name, expectedItems int) {
 		t.Logf("Get consumer %s workspace shard and create a shard client that is able to do wildcard requests", consumerWorkspace)
-		parent, _ := consumerWorkspace.Parent()
-		consumerWS, err := kcpClients.Cluster(parent).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, consumerWorkspace.Base(), metav1.GetOptions{})
-		require.NoError(t, err)
-		shardCfg := framework.ShardConfig(t, kcpClients, consumerWS.Status.Location.Current, rootShardCfg)
-		shardDynamicClients, err := dynamic.NewClusterForConfig(shardCfg)
+		shardDynamicClients, err := dynamic.NewClusterForConfig(rootShardCfg)
 		require.NoError(t, err)
 
 		t.Logf("Get APIBinding for workspace %s", consumerWorkspace.String())

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -62,7 +62,7 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	targetWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")
@@ -202,7 +202,7 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	targetWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -127,10 +127,9 @@ func TestAuthorizer(t *testing.T) {
 		},
 		"cluster admins can use wildcard clusters, non-cluster admin cannot": func(t *testing.T) {
 			// create client talking directly to root shard to test wildcard requests
-			rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", rootShardCfg)
-			rootKubeClusterClient, err := kubernetes.NewClusterForConfig(rootCfg)
+			rootKubeClusterClient, err := kubernetes.NewClusterForConfig(rootShardCfg)
 			require.NoError(t, err)
-			user1RootKubeClusterClient, err := kubernetes.NewClusterForConfig(framework.UserConfig("user-1", rootCfg))
+			user1RootKubeClusterClient, err := kubernetes.NewClusterForConfig(framework.UserConfig("user-1", rootShardCfg))
 			require.NoError(t, err)
 
 			_, err = rootKubeClusterClient.Cluster(logicalcluster.Wildcard).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
@@ -140,10 +139,7 @@ func TestAuthorizer(t *testing.T) {
 		},
 		"with system:admin permissions, workspace2 non-admin user-3 can list Namespaces with a bootstrap ClusterRole": func(t *testing.T) {
 			// get workspace2 shard and create a client to tweak the local bootstrap policy
-			org1Workspace, err := kcpClusterClient.Cluster(org1).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, "workspace2", metav1.GetOptions{})
-			require.NoError(t, err)
-			shardCfg := framework.ShardConfig(t, kcpClusterClient, org1Workspace.Status.Location.Current, rootShardCfg)
-			shardKubeClusterClient, err := kubernetes.NewClusterForConfig(shardCfg)
+			shardKubeClusterClient, err := kubernetes.NewClusterForConfig(rootShardCfg)
 			require.NoError(t, err)
 
 			_, err = user3KubeClusterClient.Cluster(org1.Join("workspace2")).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -54,7 +54,8 @@ func TestAuthorizer(t *testing.T) {
 	t.Cleanup(cancelFunc)
 
 	server := framework.SharedKcpServer(t)
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
+	rootShardCfg := server.RootShardConfig(t)
 
 	kubeClusterClient, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err)
@@ -126,7 +127,7 @@ func TestAuthorizer(t *testing.T) {
 		},
 		"cluster admins can use wildcard clusters, non-cluster admin cannot": func(t *testing.T) {
 			// create client talking directly to root shard to test wildcard requests
-			rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", cfg)
+			rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", rootShardCfg)
 			rootKubeClusterClient, err := kubernetes.NewClusterForConfig(rootCfg)
 			require.NoError(t, err)
 			user1RootKubeClusterClient, err := kubernetes.NewClusterForConfig(framework.UserConfig("user-1", rootCfg))
@@ -141,7 +142,7 @@ func TestAuthorizer(t *testing.T) {
 			// get workspace2 shard and create a client to tweak the local bootstrap policy
 			org1Workspace, err := kcpClusterClient.Cluster(org1).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, "workspace2", metav1.GetOptions{})
 			require.NoError(t, err)
-			shardCfg := framework.ShardConfig(t, kcpClusterClient, org1Workspace.Status.Location.Current, cfg)
+			shardCfg := framework.ShardConfig(t, kcpClusterClient, org1Workspace.Status.Location.Current, rootShardCfg)
 			shardKubeClusterClient, err := kubernetes.NewClusterForConfig(shardCfg)
 			require.NoError(t, err)
 

--- a/test/e2e/authorizer/rootcacertconfigmap_test.go
+++ b/test/e2e/authorizer/rootcacertconfigmap_test.go
@@ -44,7 +44,7 @@ func TestRootCACertConfigmap(t *testing.T) {
 	orgClusterName := framework.NewOrganizationFixture(t, server)
 	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
 	require.NoError(t, err)
 

--- a/test/e2e/authorizer/serviceaccounts_test.go
+++ b/test/e2e/authorizer/serviceaccounts_test.go
@@ -47,7 +47,7 @@ func TestServiceAccounts(t *testing.T) {
 	orgClusterName := framework.NewOrganizationFixture(t, server)
 	clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
 	require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestServiceAccounts(t *testing.T) {
 	}
 	for _, ttc := range testCases {
 		t.Run(ttc.name, func(t *testing.T) {
-			saRestConfig := framework.ConfigWithToken(ttc.token(t), server.DefaultConfig(t))
+			saRestConfig := framework.ConfigWithToken(ttc.token(t), server.BaseConfig(t))
 			saKubeClusterClient, err := kubernetes.NewClusterForConfig(saRestConfig)
 			require.NoError(t, err)
 			saKubeClient, err := kubernetes.NewForConfig(saRestConfig)

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -93,11 +93,10 @@ func TestCrossLogicalClusterList(t *testing.T) {
 	}
 
 	t.Logf("Listing ClusterWorkspace CRs across logical clusters with identity")
-	rootCfg := framework.ShardConfig(t, kcpClients, "root", rootShardCfg)
 	tenancyExport, err := kcpClients.Cluster(tenancyapi.RootCluster).ApisV1alpha1().APIExports().Get(ctx, "tenancy.kcp.dev", metav1.GetOptions{})
 	require.NoError(t, err, "error getting tenancy API export")
 	require.NotEmptyf(t, tenancyExport.Status.IdentityHash, "tenancy API export has no identity hash")
-	dynamicClusterClient, err := dynamic.NewClusterForConfig(rootCfg)
+	dynamicClusterClient, err := dynamic.NewClusterForConfig(rootShardCfg)
 	require.NoError(t, err, "failed to construct kcp client for server")
 	client := dynamicClusterClient.Cluster(logicalcluster.Wildcard).Resource(tenancyv1alpha1.SchemeGroupVersion.WithResource(fmt.Sprintf("clusterworkspaces:%s", tenancyExport.Status.IdentityHash)))
 	workspaces, err := client.List(ctx, metav1.ListOptions{})
@@ -188,8 +187,7 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	bootstrapCRD(t, wsNormalCRD1b, crdClusterClient.Cluster(wsNormalCRD1b).ApiextensionsV1().CustomResourceDefinitions(), sheriffCRD1)
 
 	t.Logf("Create a root shard client that is able to do wildcard requests")
-	rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", rootShardConfig)
-	rootShardDynamicClients, err := dynamic.NewClusterForConfig(rootCfg)
+	rootShardDynamicClients, err := dynamic.NewClusterForConfig(rootShardConfig)
 	require.NoError(t, err)
 
 	t.Logf("Trying to wildcard list without identity. It should fail.")
@@ -215,13 +213,13 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	apifixtures.CreateSheriff(ctx, t, dynamicClusterClient, wsConsume2, group, wsConsume2.String())
 
 	t.Logf("Trying to wildcard list with PartialObjectMetadata content-type and it should work")
-	rootShardMetadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootCfg)
+	rootShardMetadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootShardConfig)
 	require.NoError(t, err, "failed to construct dynamic client for server")
 	_, err = rootShardMetadataClusterClient.Cluster(logicalcluster.Wildcard).Resource(sheriffsGVR).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "expected wildcard list to work with metadata client even though schemas are different")
 
 	t.Log("Start dynamic metadata informers")
-	identityRootCfg, resolve := bootstrap.NewConfigWithWildcardIdentities(rootCfg, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
+	identityRootCfg, resolve := bootstrap.NewConfigWithWildcardIdentities(rootShardConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
 	require.Eventually(t, func() bool {
 		return resolve(ctx) == nil
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
@@ -275,11 +273,6 @@ func TestBuiltInCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	cfg := server.BaseConfig(t)
 	rootShardCfg := server.RootShardConfig(t)
 
-	kcpClusterClient, err := kcpclientset.NewClusterForConfig(cfg)
-	require.NoError(t, err, "failed to construct kcp client for server")
-
-	rootCfg := framework.ShardConfig(t, kcpClusterClient, "root", rootShardCfg)
-
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
 	require.NoError(t, err, "error creating kube cluster client")
 
@@ -301,7 +294,7 @@ func TestBuiltInCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	configMapGVR := corev1.Resource("configmaps").WithVersion("v1")
 
 	t.Logf("Trying to wildcard list with PartialObjectMetadata content-type and it should work")
-	metadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootCfg)
+	metadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootShardCfg)
 	require.NoError(t, err, "failed to construct dynamic client for server")
 	list, err := metadataClusterClient.Cluster(logicalcluster.Wildcard).Resource(configMapGVR).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "expected wildcard list to work")

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -277,7 +277,7 @@ func TestBuiltInCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	require.NoError(t, err, "error creating kube cluster client")
 
 	for i := 0; i < 3; i++ {
-		ws := framework.NewWorkspaceFixture(t, server, org)
+		ws := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
 
 		configMapName := fmt.Sprintf("test-cm-%d", i)
 		configMap := &corev1.ConfigMap{

--- a/test/e2e/conformance/webhook_test.go
+++ b/test/e2e/conformance/webhook_test.go
@@ -52,7 +52,7 @@ func TestMutatingWebhookInWorkspace(t *testing.T) {
 	t.Cleanup(cancelFunc)
 
 	// using known path to cert and key
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	scheme := runtime.NewScheme()
 	err := admissionregistrationv1.AddToScheme(scheme)
@@ -171,7 +171,7 @@ func TestValidatingWebhookInWorkspace(t *testing.T) {
 	t.Cleanup(cancelFunc)
 
 	// using known path to cert and key
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	scheme := runtime.NewScheme()
 	err := admissionregistrationv1.AddToScheme(scheme)

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -46,7 +46,7 @@ func TestCustomResourceCreation(t *testing.T) {
 	orgClusterName := framework.NewOrganizationFixture(t, server)
 	sourceWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -23,11 +23,11 @@ import (
 )
 
 type testConfig struct {
-	syncerImage         string
-	kcpTestImage        string
-	pclusterKubeconfig  string
-	kcpKubeconfig       string
-	useDefaultKCPServer bool
+	syncerImage                        string
+	kcpTestImage                       string
+	pclusterKubeconfig                 string
+	kcpKubeconfig, rootShardKubeconfig string
+	useDefaultKCPServer                bool
 }
 
 var TestConfig *testConfig
@@ -57,6 +57,13 @@ func (c *testConfig) KCPKubeconfig() string {
 	}
 }
 
+func (c *testConfig) RootShardKubeconfig() string {
+	if c.rootShardKubeconfig == "" {
+		return c.KCPKubeconfig()
+	}
+	return c.rootShardKubeconfig
+}
+
 func init() {
 	TestConfig = &testConfig{}
 	registerFlags(TestConfig)
@@ -65,6 +72,7 @@ func init() {
 
 func registerFlags(c *testConfig) {
 	flag.StringVar(&c.kcpKubeconfig, "kcp-kubeconfig", "", "Path to the kubeconfig for a kcp server.")
+	flag.StringVar(&c.rootShardKubeconfig, "root-shard-kubeconfig", "", "Path to the kubeconfig for a kcp shard server. If unset, kcp-kubeconfig is used.")
 	flag.StringVar(&c.pclusterKubeconfig, "pcluster-kubeconfig", "", "Path to the kubeconfig for a kubernetes cluster to sync to. Requires --syncer-image.")
 	flag.StringVar(&c.syncerImage, "syncer-image", "", "The syncer image to use with the pcluster. Requires --pcluster-kubeconfig")
 	flag.StringVar(&c.kcpTestImage, "kcp-test-image", "", "The test image to use with the pcluster. Requires --pcluster-kubeconfig")

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -117,7 +117,7 @@ func SharedKcpServer(t *testing.T) RunningServer {
 		// Use a persistent server
 
 		t.Logf("shared kcp server will target configuration %q", kubeconfig)
-		server, err := newPersistentKCPServer(serverName, kubeconfig)
+		server, err := newPersistentKCPServer(serverName, kubeconfig, TestConfig.RootShardKubeconfig())
 		require.NoError(t, err, "failed to create persistent server fixture")
 		return server
 	}

--- a/test/e2e/reconciler/apiexport/apiexport_controller_test.go
+++ b/test/e2e/reconciler/apiexport/apiexport_controller_test.go
@@ -46,7 +46,7 @@ func TestRequeueWhenIdentitySecretAdded(t *testing.T) {
 	workspaceClusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	t.Logf("Running test in cluster %s", workspaceClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "error creating kcp cluster client")

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -167,7 +167,7 @@ func TestClusterController(t *testing.T) {
 			wsClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
 			// clients
-			sourceConfig := source.DefaultConfig(t)
+			sourceConfig := source.BaseConfig(t)
 			sourceKubeClusterClient, err := kubernetesclient.NewClusterForConfig(sourceConfig)
 			require.NoError(t, err)
 			sourceWildwestClusterClient, err := wildwestclientset.NewClusterForConfig(sourceConfig)

--- a/test/e2e/reconciler/clusterworkspace/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspace/controller_test.go
@@ -191,7 +191,7 @@ func TestWorkspaceController(t *testing.T) {
 				server = framework.PrivateKcpServer(t)
 			}
 
-			cfg := server.DefaultConfig(t)
+			cfg := server.BaseConfig(t)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -151,7 +151,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				t.Logf("Finally check if all resources has been removed")
 
 				// Note: we have to access the shard direction to access a logical cluster without workspace
-				rootCfg := framework.ShardConfig(t, server.kcpClusterClient, "root", server.RunningServer.DefaultConfig(t))
+				rootCfg := framework.ShardConfig(t, server.kcpClusterClient, "root", server.RunningServer.RootShardConfig(t))
 				rootShardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(rootCfg)
 
 				nslist, err := rootShardKubeClusterClient.Cluster(workspaceCluster).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
@@ -201,12 +201,12 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				// get clients for the right shards. We have to access the shards directly to see object (Namespace and ClusterWorkspace) deletion
 				// without being stopped at the (front-proxy) gate because the parent workspace is already gone.
-				rootShardConfig := framework.ShardConfig(t, server.kcpClusterClient, "root", server.RunningServer.DefaultConfig(t))
+				rootShardConfig := framework.ShardConfig(t, server.kcpClusterClient, "root", server.RunningServer.BaseConfig(t))
 				rootShardKcpClusterClient, err := clientset.NewClusterForConfig(rootShardConfig)
 				require.NoError(t, err, "failed to create kube client for root shard")
 				rootShardKcpClient := rootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster)
-				orgShardKcpClient, orgShardKubeClient := shardClients(t, server.kcpClusterClient, server.DefaultConfig(t), server.orgClusterName)
-				_, wsShardKubeClient := shardClients(t, server.kcpClusterClient, server.DefaultConfig(t), workspaceClusterName)
+				orgShardKcpClient, orgShardKubeClient := shardClients(t, server.kcpClusterClient, server.BaseConfig(t), server.orgClusterName)
+				_, wsShardKubeClient := shardClients(t, server.kcpClusterClient, server.BaseConfig(t), workspaceClusterName)
 
 				t.Logf("Delete org workspace")
 				err = server.kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaces().Delete(ctx, orgWorkspaceName, metav1.DeleteOptions{})
@@ -263,7 +263,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 			server := sharedServer
 
-			cfg := server.DefaultConfig(t)
+			cfg := server.BaseConfig(t)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -151,8 +151,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				t.Logf("Finally check if all resources has been removed")
 
 				// Note: we have to access the shard direction to access a logical cluster without workspace
-				rootCfg := framework.ShardConfig(t, server.kcpClusterClient, "root", server.RunningServer.RootShardConfig(t))
-				rootShardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(rootCfg)
+				rootShardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(server.RunningServer.RootShardConfig(t))
 
 				nslist, err := rootShardKubeClusterClient.Cluster(workspaceCluster).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 				require.NoError(t, err, "failed to list namespaces in workspace %s", workspace.Name)

--- a/test/e2e/reconciler/clusterworkspaceshard/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspaceshard/controller_test.go
@@ -65,7 +65,7 @@ func TestWorkspaceShardController(t *testing.T) {
 				server = framework.PrivateKcpServer(t)
 			}
 
-			cfg := server.DefaultConfig(t)
+			cfg := server.BaseConfig(t)
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -152,7 +152,7 @@ func TestIngressController(t *testing.T) {
 			clusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
 			// clients
-			sourceConfig := source.DefaultConfig(t)
+			sourceConfig := source.BaseConfig(t)
 			sourceKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(sourceConfig)
 			require.NoError(t, err)
 			sourceKubeClient := sourceKubeClusterClient.Cluster(clusterName)
@@ -332,16 +332,16 @@ func TestIngressController(t *testing.T) {
 
 			ingressConfig := clientcmdapi.Config{
 				Clusters: map[string]*clientcmdapi.Cluster{
-					"ingress-workspace": adminConfig.Clusters["system:admin"],
+					"ingress-workspace": adminConfig.Clusters["base"],
 				},
 				Contexts: map[string]*clientcmdapi.Context{
 					"ingress-workspace": {
 						Cluster:  "ingress-workspace",
-						AuthInfo: "admin",
+						AuthInfo: "kcp-admin",
 					},
 				},
 				AuthInfos: map[string]*clientcmdapi.AuthInfo{
-					"admin": adminConfig.AuthInfos["admin"],
+					"kcp-admin": adminConfig.AuthInfos["kcp-admin"],
 				},
 				CurrentContext: "ingress-workspace",
 			}

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -143,13 +143,13 @@ func TestNamespaceScheduler(t *testing.T) {
 		{
 			name: "GVRs are removed, and then quickly re-added to a new workspace",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				crdClusterClient, err := apiextensionsclient.NewClusterForConfig(server.DefaultConfig(t))
+				crdClusterClient, err := apiextensionsclient.NewClusterForConfig(server.BaseConfig(t))
 				require.NoError(t, err, "failed to construct apiextensions client for server")
 
-				dynamicClusterClient, err := dynamic.NewClusterForConfig(server.DefaultConfig(t))
+				dynamicClusterClient, err := dynamic.NewClusterForConfig(server.BaseConfig(t))
 				require.NoError(t, err, "failed to construct dynamic client for server")
 
-				kubeClusterClient, err := kubernetes.NewClusterForConfig(server.DefaultConfig(t))
+				kubeClusterClient, err := kubernetes.NewClusterForConfig(server.BaseConfig(t))
 				require.NoError(t, err, "failed to construct kubernetes client for server")
 
 				t.Log("Create a ready SyncTarget, and keep it artificially ready") // we don't want the syncer to do anything with CRDs, hence we fake the syncer
@@ -241,7 +241,7 @@ func TestNamespaceScheduler(t *testing.T) {
 			ctx, cancelFunc := context.WithCancel(context.Background())
 			t.Cleanup(cancelFunc)
 
-			cfg := server.DefaultConfig(t)
+			cfg := server.BaseConfig(t)
 
 			kubeClient, err := kubernetes.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -57,9 +57,9 @@ func TestScheduling(t *testing.T) {
 	userClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 	secondUserClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
-	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.DefaultConfig(t))
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err)
-	kcpClusterClient, err := kcpclient.NewClusterForConfig(source.DefaultConfig(t))
+	kcpClusterClient, err := kcpclient.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err)
 
 	t.Logf("Check that there is no services resource in the user workspace")

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -57,9 +57,9 @@ func TestMultiPlacement(t *testing.T) {
 	locationClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 	userClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
-	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.DefaultConfig(t))
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err)
-	kcpClusterClient, err := kcpclient.NewClusterForConfig(source.DefaultConfig(t))
+	kcpClusterClient, err := kcpclient.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err)
 
 	t.Logf("Check that there is no services resource in the user workspace")

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -56,9 +56,9 @@ func TestPlacementUpdate(t *testing.T) {
 	locationClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 	userClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
-	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.DefaultConfig(t))
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err)
-	kcpClusterClient, err := kcpclient.NewClusterForConfig(source.DefaultConfig(t))
+	kcpClusterClient, err := kcpclient.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err)
 
 	t.Logf("Check that there is no services resource in the user workspace")

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -72,7 +72,7 @@ func TestSyncerLifecycle(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
-	upstreamConfig := upstreamServer.DefaultConfig(t)
+	upstreamConfig := upstreamServer.BaseConfig(t)
 	upstreamKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(upstreamConfig)
 	require.NoError(t, err)
 	upstreamKubeClient := upstreamKubeClusterClient.Cluster(wsClusterName)
@@ -449,7 +449,7 @@ func TestSyncWorkload(t *testing.T) {
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()
 	require.NoError(t, err)
-	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, wsClusterName)
+	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, wsClusterName, "base")
 
 	subCommand := []string{
 		"workload",
@@ -474,7 +474,7 @@ func TestCordonUncordonDrain(t *testing.T) {
 	t.Log("Creating an organization")
 	orgClusterName := framework.NewOrganizationFixture(t, upstreamServer)
 
-	upstreamCfg := upstreamServer.DefaultConfig(t)
+	upstreamCfg := upstreamServer.BaseConfig(t)
 
 	t.Log("Creating a workspace")
 	wsClusterName := framework.NewWorkspaceFixture(t, upstreamServer, orgClusterName)
@@ -482,7 +482,7 @@ func TestCordonUncordonDrain(t *testing.T) {
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()
 	require.NoError(t, err)
-	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, wsClusterName)
+	_, kubeconfigPath := framework.WriteLogicalClusterConfig(t, upstreamRawConfig, wsClusterName, "base")
 
 	clients, err := clientset.NewClusterForConfig(upstreamCfg)
 	require.NoError(t, err, "failed to construct client for server")

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -63,7 +63,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	serviceProviderWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")
@@ -237,7 +237,7 @@ func TestAPIExportPermissionClaims(t *testing.T) {
 	consumerWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 	consumerWorkspace2 := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-	cfg := server.DefaultConfig(t)
+	cfg := server.BaseConfig(t)
 
 	kcpClients, err := clientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -675,11 +675,11 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			virtualWorkspaceRawConfig := rawConfig.DeepCopy()
 			virtualWorkspaceRawConfig.Clusters["kubelike"] = rawConfig.Clusters["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Clusters["kubelike"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + kubelikeWorkspace.String() + "/kubelike"
-			virtualWorkspaceRawConfig.Contexts["kubelike"] = rawConfig.Contexts["system:admin"].DeepCopy()
+			virtualWorkspaceRawConfig.Contexts["kubelike"] = rawConfig.Contexts["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["kubelike"].Cluster = "kubelike"
 			virtualWorkspaceRawConfig.Clusters["wildwest"] = rawConfig.Clusters["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Clusters["wildwest"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + wildwestWorkspace.String() + "/" + wildwestSyncTargetName
-			virtualWorkspaceRawConfig.Contexts["wildwest"] = rawConfig.Contexts["system:admin"].DeepCopy()
+			virtualWorkspaceRawConfig.Contexts["wildwest"] = rawConfig.Contexts["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["wildwest"].Cluster = "wildwest"
 			kubelikeVWConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "kubelike", nil, nil).ClientConfig()
 			kubelikeVWConfig = rest.AddUserAgent(rest.CopyConfig(kubelikeVWConfig), t.Name())

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -147,9 +147,9 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 	server := framework.SharedKcpServer(t)
 	orgClusterName := framework.NewOrganizationFixture(t, server)
 
-	kubeClusterClient, err := kubernetesclientset.NewClusterForConfig(server.DefaultConfig(t))
+	kubeClusterClient, err := kubernetesclientset.NewClusterForConfig(server.BaseConfig(t))
 	require.NoError(t, err)
-	wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(server.DefaultConfig(t))
+	wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(server.BaseConfig(t))
 	require.NoError(t, err)
 
 	var testCases = []struct {
@@ -352,7 +352,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
-				wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(server.DefaultConfig(t))
+				wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(server.BaseConfig(t))
 				require.NoError(t, err)
 
 				t.Log("Create cowboy luckyluke")
@@ -427,7 +427,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
-				kcpClusterClient, err := kcpclient.NewClusterForConfig(server.DefaultConfig(t))
+				kcpClusterClient, err := kcpclient.NewClusterForConfig(server.BaseConfig(t))
 				require.NoError(t, err)
 
 				otherWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
@@ -474,7 +474,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 					return false
 				}, wait.ForeverTestTimeout, time.Millisecond*100)
 
-				wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(server.DefaultConfig(t))
+				wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(server.BaseConfig(t))
 				require.NoError(t, err)
 
 				t.Logf("Wait for being able to list cowboys in the other workspace (kubelike) through the virtual workspace")
@@ -614,7 +614,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			unrelatedWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 			unrelatedWorkspaceWorkspaceClient := wildwestClusterClient.Cluster(unrelatedWorkspace)
 
-			sourceCrdClient, err := apiextensionsclientset.NewClusterForConfig(server.DefaultConfig(t))
+			sourceCrdClient, err := apiextensionsclientset.NewClusterForConfig(server.BaseConfig(t))
 			require.NoError(t, err)
 
 			fixturewildwest.Create(t, sourceCrdClient.Cluster(unrelatedWorkspace).ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
@@ -673,12 +673,12 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			rawConfig, err := server.RawConfig()
 			require.NoError(t, err)
 			virtualWorkspaceRawConfig := rawConfig.DeepCopy()
-			virtualWorkspaceRawConfig.Clusters["kubelike"] = rawConfig.Clusters["system:admin"].DeepCopy()
-			virtualWorkspaceRawConfig.Clusters["kubelike"].Server = rawConfig.Clusters["system:admin"].Server + "/services/syncer/" + kubelikeWorkspace.String() + "/kubelike"
+			virtualWorkspaceRawConfig.Clusters["kubelike"] = rawConfig.Clusters["base"].DeepCopy()
+			virtualWorkspaceRawConfig.Clusters["kubelike"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + kubelikeWorkspace.String() + "/kubelike"
 			virtualWorkspaceRawConfig.Contexts["kubelike"] = rawConfig.Contexts["system:admin"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["kubelike"].Cluster = "kubelike"
-			virtualWorkspaceRawConfig.Clusters["wildwest"] = rawConfig.Clusters["system:admin"].DeepCopy()
-			virtualWorkspaceRawConfig.Clusters["wildwest"].Server = rawConfig.Clusters["system:admin"].Server + "/services/syncer/" + wildwestWorkspace.String() + "/" + wildwestSyncTargetName
+			virtualWorkspaceRawConfig.Clusters["wildwest"] = rawConfig.Clusters["base"].DeepCopy()
+			virtualWorkspaceRawConfig.Clusters["wildwest"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + wildwestWorkspace.String() + "/" + wildwestSyncTargetName
 			virtualWorkspaceRawConfig.Contexts["wildwest"] = rawConfig.Contexts["system:admin"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["wildwest"].Cluster = "wildwest"
 			kubelikeVWConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "kubelike", nil, nil).ClientConfig()

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -715,7 +715,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 
 		// write kubeconfig to disk, next to kcp kubeconfig
 		kcpAdminConfig, _ := server.RawConfig()
-		var baseCluster = *kcpAdminConfig.Clusters["system:admin"] // shallow copy
+		var baseCluster = *kcpAdminConfig.Clusters["base"] // shallow copy
 		virtualWorkspaceKubeConfig := clientcmdapi.Config{
 			Clusters: map[string]*clientcmdapi.Cluster{
 				"shard": &baseCluster,
@@ -727,7 +727,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 				},
 			},
 			AuthInfos: map[string]*clientcmdapi.AuthInfo{
-				"virtualworkspace": kcpAdminConfig.AuthInfos["admin"],
+				"virtualworkspace": kcpAdminConfig.AuthInfos["shard-admin"],
 			},
 			CurrentContext: "shard",
 		}
@@ -784,7 +784,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
 			// create non-virtual clients
-			kcpConfig := server.DefaultConfig(t)
+			kcpConfig := server.BaseConfig(t)
 			kubeClusterClient, err := kubernetes.NewClusterForConfig(kcpConfig)
 			require.NoError(t, err, "failed to construct client for server")
 			kcpClusterClient, err := kcpclientset.NewClusterForConfig(kcpConfig)

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -61,7 +61,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	org := framework.NewOrganizationFixture(t, server)
-	cluster := framework.NewWorkspaceFixture(t, server, org)
+	cluster := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
 	rootShardConfig := newRootShardConfig(t, server)
 	cowBoysGR := metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"}
 

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -125,8 +125,8 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 	require.NoError(t, err)
 
 	org := framework.NewOrganizationFixture(t, server)
-	wsExport1a := framework.NewWorkspaceFixture(t, server, org)
-	wsConsume1a := framework.NewWorkspaceFixture(t, server, org)
+	wsExport1a := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
+	wsConsume1a := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
 	group := "newyork.io"
 
 	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, wsExport1a, kcpClusterClient, group, "export1")
@@ -174,7 +174,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 	secretsGR := metav1.GroupResource{Group: "", Resource: "secrets"}
 
 	org := framework.NewOrganizationFixture(t, server)
-	cluster := framework.NewWorkspaceFixture(t, server, org)
+	cluster := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
 	kubeClient := kubeClusterClient.Cluster(cluster)
 
 	t.Logf("Creating a secret in the default namespace for %q cluster", cluster)

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -231,7 +231,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
-			cfg := server.DefaultConfig(t)
+			cfg := server.BaseConfig(t)
 			kcpClusterClient, err := kcpclientset.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")
 			orgKcpClient := kcpClusterClient.Cluster(orgClusterName)


### PR DESCRIPTION
## Summary
- This forbids `system:masters` access to kcp-front-proxy
- Factors existing e2e tests to access the kcp shard as admin

## Related issue(s)

Obsoletes #1413, #1369