### PR TITLE
Impersonation in `workspaces` virtual workspace SubjectAccessReview requests

### DIFF
--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -29,6 +29,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	rbacinformers "k8s.io/client-go/informers/rbac/v1"
 	"k8s.io/client-go/kubernetes"
+	clientrest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
@@ -47,7 +48,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/registry"
 )
 
-func BuildVirtualWorkspace(rootPathPrefix string, wildcardsClusterWorkspaces workspaceinformer.ClusterWorkspaceInformer, wildcardsRbacInformers rbacinformers.Interface, kubeClusterClient kubernetes.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface) framework.VirtualWorkspace {
+func BuildVirtualWorkspace(cfg *clientrest.Config, rootPathPrefix string, wildcardsClusterWorkspaces workspaceinformer.ClusterWorkspaceInformer, wildcardsRbacInformers rbacinformers.Interface, kubeClusterClient kubernetes.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface) framework.VirtualWorkspace {
 	crbInformer := wildcardsRbacInformers.ClusterRoleBindings()
 	_ = registry.AddNameIndexers(crbInformer)
 
@@ -144,7 +145,7 @@ func BuildVirtualWorkspace(rootPathPrefix string, wildcardsClusterWorkspaces wor
 						return nil, err
 					}
 
-					workspacesRest := registry.NewREST(kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1(), kubeClusterClient, kcpClusterClient, globalClusterWorkspaceCache, crbInformer, orgListener.FilteredClusterWorkspaces)
+					workspacesRest := registry.NewREST(cfg, kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1(), kubeClusterClient, kcpClusterClient, globalClusterWorkspaceCache, crbInformer, orgListener.FilteredClusterWorkspaces)
 					return map[string]fixedgvs.RestStorageBuilder{
 						"workspaces": func(apiGroupAPIServerConfig genericapiserver.CompletedConfig) (rest.Storage, error) {
 							return workspacesRest, nil

--- a/pkg/virtual/workspaces/options/options.go
+++ b/pkg/virtual/workspaces/options/options.go
@@ -69,7 +69,7 @@ func (o *Workspaces) NewVirtualWorkspaces(
 	}
 
 	virtualWorkspaces := map[string]framework.VirtualWorkspace{
-		"workspaces": builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient),
+		"workspaces": builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient),
 	}
 	return virtualWorkspaces, nil
 }

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -204,7 +204,10 @@ func applyTest(t *testing.T, test TestDescription) {
 		getFilteredClusterWorkspaces: func(orgName logicalcluster.Name) FilteredClusterWorkspaces {
 			return &clusterWorkspaces{clusterWorkspaceLister: clusterWorkspaceLister}
 		},
-		crbInformer:           crbInformer,
+		crbInformer: crbInformer,
+		impersonatedkubeClusterClient: func(user kuser.Info) (kubernetes.ClusterInterface, error) {
+			return mockKubeClusterClient(func(logicalcluster.Name) kubernetes.Interface { return mockKubeClient }), nil
+		},
 		kubeClusterClient:     mockKubeClusterClient(func(logicalcluster.Name) kubernetes.Interface { return mockKubeClient }),
 		kcpClusterClient:      mockKcpClusterClient(func(logicalcluster.Name) kcpclientset.Interface { return mockKCPClient }),
 		clusterWorkspaceCache: nil,


### PR DESCRIPTION
## Summary

The `SubjectAccessReview`s issued by the `workspaces` virtual workspace should be "softly" impersonated as the user.
By "softly" we mean that we should carry the user in the request so that the server have a way to know it, but still be the VW privileged user in KCP authorization (to have the right to create a SAR everywhere).

This is based on the following soft impersonation work: https://github.com/kcp-dev/kcp/pull/1468

This is required since the SAR call, which is systematically the first call to the KCP shard in the implementation of the REST endpoint, may trigger the creation of the user Home workspace, and then the user name
needs to be the one of the Home workspace owner.

## Related issue(s)

This PR is a pre-requisite for the [Home workspaces EPIC](https://github.com/kcp-dev/kcp/issues/1069) 