### PR TITLE
admission/clusteworkspacetypeexists: lower-case types, dashes, cli type search

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -141,7 +141,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[a-z][a-z0-9]+$
+                    pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that

--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -150,7 +150,6 @@ spec:
                     type: string
                 required:
                 - name
-                - path
                 type: object
             type: object
           status:

--- a/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaces.yaml
@@ -141,7 +141,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[A-Z][a-zA-Z0-9]+$
+                    pattern: ^[a-z][a-z0-9]+$
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that
@@ -219,7 +219,7 @@ spec:
                   description: ClusterWorkspaceInitializer is a unique string corresponding
                     to a cluster workspace initialization controller for the given
                     type of workspaces.
-                  pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[A-Z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                  pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[a-z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
                   type: string
                 type: array
               location:

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -64,7 +64,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[a-z][a-z0-9]+$
+                    pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that
@@ -96,7 +96,7 @@ spec:
                       properties:
                         name:
                           description: name is the name of the ClusterWorkspaceType
-                          pattern: ^[a-z][a-z0-9]+$
+                          pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                           type: string
                         path:
                           description: path is an absolute reference to the workspace
@@ -144,7 +144,7 @@ spec:
                       properties:
                         name:
                           description: name is the name of the ClusterWorkspaceType
-                          pattern: ^[a-z][a-z0-9]+$
+                          pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                           type: string
                         path:
                           description: path is an absolute reference to the workspace
@@ -176,7 +176,7 @@ spec:
                       properties:
                         name:
                           description: name is the name of the ClusterWorkspaceType
-                          pattern: ^[a-z][a-z0-9]+$
+                          pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                           type: string
                         path:
                           description: path is an absolute reference to the workspace

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -76,14 +76,14 @@ spec:
                 type: object
               extend:
                 description: "extend is a list of other ClusterWorkspaceTypes whose
-                  initializers and allowedChildren and allowedParents this ClusterWorkspaceType
-                  is inheriting. By (transitively) extending another ClusterWorkspaceType,
-                  this ClusterWorkspaceType will be considered as that other type
-                  in evaluation of allowedChildren and allowedParents constraints.
-                  \n A dependency cycle stop this ClusterWorkspaceType from being
-                  admitted as the type of a ClusterWorkspace. \n A non-existing dependency
-                  stop this ClusterWorkspaceType from being admitted as the type of
-                  a ClusterWorkspace."
+                  initializers and limitAllowedChildren and limitAllowedParents this
+                  ClusterWorkspaceType is inheriting. By (transitively) extending
+                  another ClusterWorkspaceType, this ClusterWorkspaceType will be
+                  considered as that other type in evaluation of limitAllowedChildren
+                  and limitAllowedParents constraints. \n A dependency cycle stop
+                  this ClusterWorkspaceType from being admitted as the type of a ClusterWorkspace.
+                  \n A non-existing dependency stop this ClusterWorkspaceType from
+                  being admitted as the type of a ClusterWorkspace."
                 properties:
                   with:
                     description: with are ClusterWorkspaceTypes whose initializers

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -74,7 +74,6 @@ spec:
                     type: string
                 required:
                 - name
-                - path
                 type: object
               extend:
                 description: "extend is a list of other ClusterWorkspaceTypes whose
@@ -107,7 +106,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - path
                       type: object
                     type: array
                 type: object
@@ -156,7 +154,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - path
                       type: object
                     minItems: 1
                     type: array
@@ -189,7 +186,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - path
                       type: object
                     minItems: 1
                     type: array

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -39,7 +39,6 @@ spec:
                 minLength: 1
                 not:
                   enum:
-                  - root
                   - system
                   - any
                 pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml
@@ -55,7 +55,7 @@ spec:
                 type: object
               defaultChildWorkspaceType:
                 default:
-                  name: Universal
+                  name: universal
                   path: root
                 description: defaultChildWorkspaceType is the ClusterWorkspaceType
                   that will be used by default if another, nested ClusterWorkspace
@@ -65,7 +65,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[A-Z][a-zA-Z0-9]+$
+                    pattern: ^[a-z][a-z0-9]+$
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that
@@ -98,7 +98,7 @@ spec:
                       properties:
                         name:
                           description: name is the name of the ClusterWorkspaceType
-                          pattern: ^[A-Z][a-zA-Z0-9]+$
+                          pattern: ^[a-z][a-z0-9]+$
                           type: string
                         path:
                           description: path is an absolute reference to the workspace
@@ -147,7 +147,7 @@ spec:
                       properties:
                         name:
                           description: name is the name of the ClusterWorkspaceType
-                          pattern: ^[A-Z][a-zA-Z0-9]+$
+                          pattern: ^[a-z][a-z0-9]+$
                           type: string
                         path:
                           description: path is an absolute reference to the workspace
@@ -180,7 +180,7 @@ spec:
                       properties:
                         name:
                           description: name is the name of the ClusterWorkspaceType
-                          pattern: ^[A-Z][a-zA-Z0-9]+$
+                          pattern: ^[a-z][a-z0-9]+$
                           type: string
                         path:
                           description: path is an absolute reference to the workspace

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml-patch
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml-patch
@@ -21,5 +21,5 @@
 - op: add
   path: /spec/versions/name=v1alpha1/schema/openAPIV3Schema/properties/spec/properties/defaultChildWorkspaceType/default
   value:
-    name: Universal
+    name: universal
     path: root

--- a/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml-patch
+++ b/config/crds/tenancy.kcp.dev_clusterworkspacetypes.yaml-patch
@@ -8,7 +8,6 @@
       type: string
       not:
         enum:
-        - root
         - system
         - any
 

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -78,7 +78,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[a-z][a-z0-9]+$
+                    pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -78,7 +78,7 @@ spec:
                 properties:
                   name:
                     description: name is the name of the ClusterWorkspaceType
-                    pattern: ^[A-Z][a-zA-Z0-9]+$
+                    pattern: ^[a-z][a-z0-9]+$
                     type: string
                   path:
                     description: path is an absolute reference to the workspace that
@@ -154,7 +154,7 @@ spec:
                   description: ClusterWorkspaceInitializer is a unique string corresponding
                     to a cluster workspace initialization controller for the given
                     type of workspaces.
-                  pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[A-Z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                  pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[a-z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
                   type: string
                 type: array
               phase:

--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -87,7 +87,6 @@ spec:
                     type: string
                 required:
                 - name
-                - path
                 type: object
             type: object
           status:

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -5,9 +5,9 @@ metadata:
   name: tenancy.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220628-546034da.clusterworkspaces.tenancy.kcp.dev
-  - v220628-546034da.workspaces.tenancy.kcp.dev
-  - v220711-77953523.clusterworkspacetypes.tenancy.kcp.dev
+  - v220711-1fe32801.clusterworkspaces.tenancy.kcp.dev
+  - v220711-1fe32801.clusterworkspacetypes.tenancy.kcp.dev
+  - v220711-1fe32801.workspaces.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -5,9 +5,9 @@ metadata:
   name: tenancy.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220711-1fe32801.clusterworkspaces.tenancy.kcp.dev
-  - v220711-1fe32801.workspaces.tenancy.kcp.dev
-  - v220711-e9c8ae2c.clusterworkspacetypes.tenancy.kcp.dev
+  - v220711-d5b6ca98.clusterworkspaces.tenancy.kcp.dev
+  - v220711-d5b6ca98.clusterworkspacetypes.tenancy.kcp.dev
+  - v220711-d5b6ca98.workspaces.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   latestResourceSchemas:
   - v220711-1fe32801.clusterworkspaces.tenancy.kcp.dev
-  - v220711-1fe32801.clusterworkspacetypes.tenancy.kcp.dev
   - v220711-1fe32801.workspaces.tenancy.kcp.dev
+  - v220711-e9c8ae2c.clusterworkspacetypes.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   latestResourceSchemas:
   - v220711-d5b6ca98.clusterworkspaces.tenancy.kcp.dev
-  - v220711-d5b6ca98.clusterworkspacetypes.tenancy.kcp.dev
   - v220711-d5b6ca98.workspaces.tenancy.kcp.dev
+  - v220713-f9bb7307.clusterworkspacetypes.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
@@ -147,7 +147,6 @@ spec:
                   type: string
               required:
               - name
-              - path
               type: object
           type: object
         status:

--- a/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220628-546034da.clusterworkspaces.tenancy.kcp.dev
+  name: v220711-1fe32801.clusterworkspaces.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -138,7 +138,7 @@ spec:
               properties:
                 name:
                   description: name is the name of the ClusterWorkspaceType
-                  pattern: ^[A-Z][a-zA-Z0-9]+$
+                  pattern: ^[a-z][a-z0-9]+$
                   type: string
                 path:
                   description: path is an absolute reference to the workspace that
@@ -214,7 +214,7 @@ spec:
                 description: ClusterWorkspaceInitializer is a unique string corresponding
                   to a cluster workspace initialization controller for the given type
                   of workspaces.
-                pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[A-Z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[a-z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
                 type: string
               type: array
             location:

--- a/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-1fe32801.clusterworkspaces.tenancy.kcp.dev
+  name: v220711-d5b6ca98.clusterworkspaces.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -138,7 +138,7 @@ spec:
               properties:
                 name:
                   description: name is the name of the ClusterWorkspaceType
-                  pattern: ^[a-z][a-z0-9]+$
+                  pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                   type: string
                 path:
                   description: path is an absolute reference to the workspace that

--- a/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-77953523.clusterworkspacetypes.tenancy.kcp.dev
+  name: v220711-1fe32801.clusterworkspacetypes.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -52,7 +52,7 @@ spec:
               type: object
             defaultChildWorkspaceType:
               default:
-                name: Universal
+                name: universal
                 path: root
               description: defaultChildWorkspaceType is the ClusterWorkspaceType that
                 will be used by default if another, nested ClusterWorkspace is created
@@ -62,7 +62,7 @@ spec:
               properties:
                 name:
                   description: name is the name of the ClusterWorkspaceType
-                  pattern: ^[A-Z][a-zA-Z0-9]+$
+                  pattern: ^[a-z][a-z0-9]+$
                   type: string
                 path:
                   description: path is an absolute reference to the workspace that
@@ -94,7 +94,7 @@ spec:
                     properties:
                       name:
                         description: name is the name of the ClusterWorkspaceType
-                        pattern: ^[A-Z][a-zA-Z0-9]+$
+                        pattern: ^[a-z][a-z0-9]+$
                         type: string
                       path:
                         description: path is an absolute reference to the workspace
@@ -142,7 +142,7 @@ spec:
                     properties:
                       name:
                         description: name is the name of the ClusterWorkspaceType
-                        pattern: ^[A-Z][a-zA-Z0-9]+$
+                        pattern: ^[a-z][a-z0-9]+$
                         type: string
                       path:
                         description: path is an absolute reference to the workspace
@@ -175,7 +175,7 @@ spec:
                     properties:
                       name:
                         description: name is the name of the ClusterWorkspaceType
-                        pattern: ^[A-Z][a-zA-Z0-9]+$
+                        pattern: ^[a-z][a-z0-9]+$
                         type: string
                       path:
                         description: path is an absolute reference to the workspace

--- a/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-e9c8ae2c.clusterworkspacetypes.tenancy.kcp.dev
+  name: v220711-d5b6ca98.clusterworkspacetypes.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -61,7 +61,7 @@ spec:
               properties:
                 name:
                   description: name is the name of the ClusterWorkspaceType
-                  pattern: ^[a-z][a-z0-9]+$
+                  pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                   type: string
                 path:
                   description: path is an absolute reference to the workspace that
@@ -92,7 +92,7 @@ spec:
                     properties:
                       name:
                         description: name is the name of the ClusterWorkspaceType
-                        pattern: ^[a-z][a-z0-9]+$
+                        pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                         type: string
                       path:
                         description: path is an absolute reference to the workspace
@@ -139,7 +139,7 @@ spec:
                     properties:
                       name:
                         description: name is the name of the ClusterWorkspaceType
-                        pattern: ^[a-z][a-z0-9]+$
+                        pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                         type: string
                       path:
                         description: path is an absolute reference to the workspace
@@ -171,7 +171,7 @@ spec:
                     properties:
                       name:
                         description: name is the name of the ClusterWorkspaceType
-                        pattern: ^[a-z][a-z0-9]+$
+                        pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                         type: string
                       path:
                         description: path is an absolute reference to the workspace

--- a/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
@@ -36,7 +36,6 @@ spec:
               minLength: 1
               not:
                 enum:
-                - root
                 - system
                 - any
               pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$

--- a/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-1fe32801.clusterworkspacetypes.tenancy.kcp.dev
+  name: v220711-e9c8ae2c.clusterworkspacetypes.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -71,7 +71,6 @@ spec:
                   type: string
               required:
               - name
-              - path
               type: object
             extend:
               description: "extend is a list of other ClusterWorkspaceTypes whose
@@ -103,7 +102,6 @@ spec:
                         type: string
                     required:
                     - name
-                    - path
                     type: object
                   type: array
               type: object
@@ -151,7 +149,6 @@ spec:
                         type: string
                     required:
                     - name
-                    - path
                     type: object
                   minItems: 1
                   type: array
@@ -184,7 +181,6 @@ spec:
                         type: string
                     required:
                     - name
-                    - path
                     type: object
                   minItems: 1
                   type: array

--- a/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-d5b6ca98.clusterworkspacetypes.tenancy.kcp.dev
+  name: v220713-f9bb7307.clusterworkspacetypes.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -73,13 +73,14 @@ spec:
               type: object
             extend:
               description: "extend is a list of other ClusterWorkspaceTypes whose
-                initializers and allowedChildren and allowedParents this ClusterWorkspaceType
-                is inheriting. By (transitively) extending another ClusterWorkspaceType,
-                this ClusterWorkspaceType will be considered as that other type in
-                evaluation of allowedChildren and allowedParents constraints. \n A
-                dependency cycle stop this ClusterWorkspaceType from being admitted
-                as the type of a ClusterWorkspace. \n A non-existing dependency stop
-                this ClusterWorkspaceType from being admitted as the type of a ClusterWorkspace."
+                initializers and limitAllowedChildren and limitAllowedParents this
+                ClusterWorkspaceType is inheriting. By (transitively) extending another
+                ClusterWorkspaceType, this ClusterWorkspaceType will be considered
+                as that other type in evaluation of limitAllowedChildren and limitAllowedParents
+                constraints. \n A dependency cycle stop this ClusterWorkspaceType
+                from being admitted as the type of a ClusterWorkspace. \n A non-existing
+                dependency stop this ClusterWorkspaceType from being admitted as the
+                type of a ClusterWorkspace."
               properties:
                 with:
                   description: with are ClusterWorkspaceTypes whose initializers are

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
@@ -84,7 +84,6 @@ spec:
                   type: string
               required:
               - name
-              - path
               type: object
           type: object
         status:

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-1fe32801.workspaces.tenancy.kcp.dev
+  name: v220711-d5b6ca98.workspaces.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -75,7 +75,7 @@ spec:
               properties:
                 name:
                   description: name is the name of the ClusterWorkspaceType
-                  pattern: ^[a-z][a-z0-9]+$
+                  pattern: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?
                   type: string
                 path:
                   description: path is an absolute reference to the workspace that

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220628-546034da.workspaces.tenancy.kcp.dev
+  name: v220711-1fe32801.workspaces.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -75,7 +75,7 @@ spec:
               properties:
                 name:
                   description: name is the name of the ClusterWorkspaceType
-                  pattern: ^[A-Z][a-zA-Z0-9]+$
+                  pattern: ^[a-z][a-z0-9]+$
                   type: string
                 path:
                   description: path is an absolute reference to the workspace that
@@ -149,7 +149,7 @@ spec:
                 description: ClusterWorkspaceInitializer is a unique string corresponding
                   to a cluster workspace initialization controller for the given type
                   of workspaces.
-                pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[A-Z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
+                pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[a-z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$
                 type: string
               type: array
             phase:

--- a/config/root/clusterworkspace-homeroot-users.yaml
+++ b/config/root/clusterworkspace-homeroot-users.yaml
@@ -6,5 +6,5 @@ metadata:
     "bootstrap.kcp.dev/create-only": "true"
 spec:
   type:
-    name: Homeroot
+    name: homeroot
     path: root

--- a/config/root/clusterworkspacetype-home.yaml
+++ b/config/root/clusterworkspacetype-home.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   initializer: true
   defaultChildWorkspaceType:
-    name: Universal
+    name: universal
     path: root
   limitAllowedParents:
     types:
-    - name: Homebucket
+    - name: homebucket
       path: root

--- a/config/root/clusterworkspacetype-homebucket.yaml
+++ b/config/root/clusterworkspacetype-homebucket.yaml
@@ -5,17 +5,17 @@ metadata:
 spec:
   initializer: true
   defaultChildWorkspaceType:
-    name: Home
+    name: home
     path: root
   limitAllowedChildren:
     types:
-    - name: Homebucket
+    - name: homebucket
       path: root
-    - name: Home
+    - name: home
       path: root
   limitAllowedParents:
     types:
-    - name: Homebucket
+    - name: homebucket
       path: root
-    - name: Homeroot
+    - name: homeroot
       path: root

--- a/config/root/clusterworkspacetype-homeroot.yaml
+++ b/config/root/clusterworkspacetype-homeroot.yaml
@@ -5,13 +5,13 @@ metadata:
 spec:
   initializer: true
   defaultChildWorkspaceType:
-    name: Homebucket
+    name: homebucket
     path: root
   limitAllowedChildren:
     types:
-    - name: Homebucket
+    - name: homebucket
       path: root
   limitAllowedParents:
     types:
-    - name: Root
+    - name: root
       path: root

--- a/config/root/clusterworkspacetype-organization.yaml
+++ b/config/root/clusterworkspacetype-organization.yaml
@@ -5,15 +5,15 @@ metadata:
 spec:
   initializer: true
   defaultChildWorkspaceType:
-    name: Universal
+    name: universal
     path: root
   limitAllowedChildren:
     types:
-    - name: Team
+    - name: team
       path: root
-    - name: Universal
+    - name: universal
       path: root
   limitAllowedParents:
     types:
-    - name: Root
+    - name: root
       path: root

--- a/config/root/clusterworkspacetype-root.yaml
+++ b/config/root/clusterworkspacetype-root.yaml
@@ -1,0 +1,14 @@
+apiVersion: tenancy.kcp.dev/v1alpha1
+kind: ClusterWorkspaceType
+metadata:
+  name: root
+spec:
+  defaultChildWorkspaceType:
+    name: organization
+    path: root
+  parentConstraints:
+    none: true
+  extend:
+    with:
+    - name: universal
+      path: root

--- a/config/root/clusterworkspacetype-team.yaml
+++ b/config/root/clusterworkspacetype-team.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   initializer: true
   defaultChildWorkspaceType:
-    name: Universal
+    name: universal
     path: root
   limitAllowedParents:
     types:
-    - name: Organization
+    - name: organization
       path: root

--- a/config/root/clusterworkspacetype-universal.yaml
+++ b/config/root/clusterworkspacetype-universal.yaml
@@ -6,5 +6,5 @@ spec:
   initializer: true
   defaultChildren:
     types:
-    - name: Universal
+    - name: universal
       path: root

--- a/pkg/admission/clusterworkspace/admission_test.go
+++ b/pkg/admission/clusterworkspace/admission_test.go
@@ -156,7 +156,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -168,7 +168,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Universal",
+							Name: "universal",
 							Path: "root:org",
 						},
 					},
@@ -184,7 +184,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -200,7 +200,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},
@@ -221,7 +221,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -234,7 +234,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},
@@ -253,7 +253,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -271,7 +271,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},
@@ -291,7 +291,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -309,7 +309,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},
@@ -330,7 +330,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -348,7 +348,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},
@@ -367,7 +367,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -388,7 +388,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -405,7 +405,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},
@@ -425,7 +425,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root:org",
 					},
 				},
@@ -443,7 +443,7 @@ func TestValidate(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: "root:org",
 						},
 					},

--- a/pkg/admission/clusterworkspacetype/admission.go
+++ b/pkg/admission/clusterworkspacetype/admission.go
@@ -65,5 +65,25 @@ func (o *clusterWorkspaceType) Validate(ctx context.Context, a admission.Attribu
 		return fmt.Errorf("failed to convert unstructured to ClusterWorkspaceType: %w", err)
 	}
 
+	if cwt.Spec.DefaultChildWorkspaceType != nil && cwt.Spec.DefaultChildWorkspaceType.Path == "" {
+		return admission.NewForbidden(a, fmt.Errorf(".spec.defaultChildWorkspaceType.path must be set"))
+	}
+
+	if cwt.Spec.LimitAllowedChildren != nil {
+		for i, t := range cwt.Spec.LimitAllowedChildren.Types {
+			if t.Path == "" {
+				return admission.NewForbidden(a, fmt.Errorf(".spec.limitAllowedChildren.types[%d].path must be set", i))
+			}
+		}
+	}
+
+	if cwt.Spec.LimitAllowedParents != nil {
+		for i, t := range cwt.Spec.LimitAllowedParents.Types {
+			if t.Path == "" {
+				return admission.NewForbidden(a, fmt.Errorf(".spec.limitAllowedParents.types[%d].path must be set", i))
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/admission/clusterworkspacetype/admission.go
+++ b/pkg/admission/clusterworkspacetype/admission.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"io"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
@@ -52,6 +54,11 @@ type clusterWorkspaceType struct {
 var _ = admission.ValidationInterface(&clusterWorkspaceType{})
 
 func (o *clusterWorkspaceType) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
 	if a.GetResource().GroupResource() != tenancyv1alpha1.Resource("clusterworkspacetypes") {
 		return nil
 	}
@@ -63,6 +70,10 @@ func (o *clusterWorkspaceType) Validate(ctx context.Context, a admission.Attribu
 	cwt := &tenancyv1alpha1.ClusterWorkspaceType{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cwt); err != nil {
 		return fmt.Errorf("failed to convert unstructured to ClusterWorkspaceType: %w", err)
+	}
+
+	if cwt.Name == "root" && clusterName != tenancyv1alpha1.RootCluster {
+		return admission.NewForbidden(a, fmt.Errorf("root workspace type can only be created in root cluster"))
 	}
 
 	if cwt.Spec.DefaultChildWorkspaceType != nil && cwt.Spec.DefaultChildWorkspaceType.Path == "" {

--- a/pkg/admission/clusterworkspacetypeexists/admission.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission.go
@@ -181,7 +181,7 @@ func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attr
 
 func (o *clusterWorkspaceTypeExists) resolveTypeRef(ref tenancyv1alpha1.ClusterWorkspaceTypeReference) (*tenancyv1alpha1.ClusterWorkspaceType, error) {
 	var cwt *tenancyv1alpha1.ClusterWorkspaceType
-	if ref.Name == "Root" && ref.Path == "root" {
+	if ref.Name == "root" && ref.Path == "root" {
 		cwt = tenancyv1alpha1.RootWorkspaceType
 	} else {
 		var err error
@@ -202,7 +202,7 @@ func (o *clusterWorkspaceTypeExists) resolveParentType(parentClusterName logical
 		// the clusterWorkspace exists in the root logical cluster, and therefore there is no
 		// higher clusterWorkspaceType to check for allowed sub-types; the mere presence of the
 		// clusterWorkspaceType is enough. We return a fake object here to express this behavior
-		return tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Root"}, nil
+		return tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "root"}, nil
 	}
 	parentCluster, err := o.workspaceLister.Get(clusters.ToClusterAwareKey(grandparent, parentClusterName.Base()))
 	if err != nil {

--- a/pkg/admission/clusterworkspacetypeexists/admission.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission.go
@@ -183,14 +183,13 @@ func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attr
 }
 
 func (o *clusterWorkspaceTypeExists) resolveTypeRef(clusterName logicalcluster.Name, ref tenancyv1alpha1.ClusterWorkspaceTypeReference) (*tenancyv1alpha1.ClusterWorkspaceType, error) {
-	if ref.Name == "root" && ref.Path == "root" {
-		return tenancyv1alpha1.RootWorkspaceType, nil
-	}
-
 	if ref.Path != "" {
 		cwt, err := o.typeLister.Get(clusters.ToClusterAwareKey(logicalcluster.New(ref.Path), tenancyv1alpha1.ObjectName(ref.Name)))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
+				if ref.Name == "root" && ref.Path == "root" {
+					return tenancyv1alpha1.RootWorkspaceType, nil
+				}
 				return nil, fmt.Errorf("workspace type %s does not exist", ref.String())
 			}
 			return nil, apierrors.NewInternalError(err)

--- a/pkg/admission/clusterworkspacetypeexists/admission.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission.go
@@ -87,6 +87,11 @@ var _ = kcpinitializers.WantsKubeClusterClient(&clusterWorkspaceTypeExists{})
 
 // Admit adds type initializer on transition to initializing phase.
 func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
 	if a.GetResource().GroupResource() != tenancyv1alpha1.Resource("clusterworkspaces") {
 		return nil
 	}
@@ -111,15 +116,11 @@ func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attr
 		// if the user has not provided any type, use the default from the parent workspace
 		empty := tenancyv1alpha1.ClusterWorkspaceTypeReference{}
 		if cw.Spec.Type == empty {
-			clusterName, err := genericapirequest.ClusterNameFrom(ctx)
-			if err != nil {
-				return apierrors.NewInternalError(err)
-			}
 			parentTypeRef, err := o.resolveParentType(clusterName)
 			if err != nil {
 				return admission.NewForbidden(a, err)
 			}
-			parentCwt, err := o.resolveTypeRef(parentTypeRef)
+			parentCwt, err := o.resolveTypeRef(clusterName, parentTypeRef)
 			if err != nil {
 				return admission.NewForbidden(a, err)
 			}
@@ -128,10 +129,12 @@ func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attr
 			}
 			cw.Spec.Type = *parentCwt.Spec.DefaultChildWorkspaceType
 		}
-		cwt, err := o.resolveTypeRef(cw.Spec.Type)
+		cwt, err := o.resolveTypeRef(clusterName, cw.Spec.Type)
 		if err != nil {
 			return admission.NewForbidden(a, err)
 		}
+		cw.Spec.Type.Path = logicalcluster.From(cwt).String()
+
 		addAdditionalWorkspaceLabels(cwt, cw)
 
 		return updateUnstructured(u, cw)
@@ -162,7 +165,7 @@ func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attr
 	}
 
 	// add initializers from type and aliases to workspace
-	cwt, err := o.resolveTypeRef(cw.Spec.Type)
+	cwt, err := o.resolveTypeRef(clusterName, cw.Spec.Type)
 	if err != nil {
 		return admission.NewForbidden(a, err)
 	}
@@ -179,21 +182,38 @@ func (o *clusterWorkspaceTypeExists) Admit(ctx context.Context, a admission.Attr
 	return updateUnstructured(u, cw)
 }
 
-func (o *clusterWorkspaceTypeExists) resolveTypeRef(ref tenancyv1alpha1.ClusterWorkspaceTypeReference) (*tenancyv1alpha1.ClusterWorkspaceType, error) {
-	var cwt *tenancyv1alpha1.ClusterWorkspaceType
+func (o *clusterWorkspaceTypeExists) resolveTypeRef(clusterName logicalcluster.Name, ref tenancyv1alpha1.ClusterWorkspaceTypeReference) (*tenancyv1alpha1.ClusterWorkspaceType, error) {
 	if ref.Name == "root" && ref.Path == "root" {
-		cwt = tenancyv1alpha1.RootWorkspaceType
-	} else {
-		var err error
-		cwt, err = o.typeLister.Get(clusters.ToClusterAwareKey(logicalcluster.New(ref.Path), tenancyv1alpha1.ObjectName(ref.Name)))
+		return tenancyv1alpha1.RootWorkspaceType, nil
+	}
+
+	if ref.Path != "" {
+		cwt, err := o.typeLister.Get(clusters.ToClusterAwareKey(logicalcluster.New(ref.Path), tenancyv1alpha1.ObjectName(ref.Name)))
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil, fmt.Errorf("workspace type %s does not exist", ref.String())
 			}
 			return nil, apierrors.NewInternalError(err)
 		}
+
+		return cwt, err
 	}
-	return cwt, nil
+
+	for {
+		cwt, err := o.typeLister.Get(clusters.ToClusterAwareKey(clusterName, tenancyv1alpha1.ObjectName(ref.Name)))
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				var hasParent bool
+				clusterName, hasParent = clusterName.Parent()
+				if !hasParent {
+					return nil, fmt.Errorf("workspace type %s does not exist", ref.String())
+				}
+				continue
+			}
+			return nil, apierrors.NewInternalError(err)
+		}
+		return cwt, err
+	}
 }
 
 func (o *clusterWorkspaceTypeExists) resolveParentType(parentClusterName logicalcluster.Name) (tenancyv1alpha1.ClusterWorkspaceTypeReference, error) {
@@ -216,6 +236,11 @@ func (o *clusterWorkspaceTypeExists) resolveParentType(parentClusterName logical
 // - has a valid type
 // - has valid initializers when transitioning to initializing
 func (o *clusterWorkspaceTypeExists) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
 	if a.GetResource().GroupResource() != tenancyv1alpha1.Resource("clusterworkspaces") {
 		return nil
 	}
@@ -270,7 +295,7 @@ func (o *clusterWorkspaceTypeExists) Validate(ctx context.Context, a admission.A
 	//              show it failing.
 	var cwtAliases []*tenancyv1alpha1.ClusterWorkspaceType
 	if (a.GetOperation() == admission.Update && transitioningToInitializing) || a.GetOperation() == admission.Create {
-		cwt, err := o.resolveTypeRef(cw.Spec.Type)
+		cwt, err := o.resolveTypeRef(clusterName, cw.Spec.Type)
 		if err != nil {
 			return admission.NewForbidden(a, err)
 		}
@@ -295,6 +320,10 @@ func (o *clusterWorkspaceTypeExists) Validate(ctx context.Context, a admission.A
 
 	// verify that the type can be used by the given user
 	if a.GetOperation() == admission.Create {
+		if cw.Spec.Type.Path == "" {
+			return admission.NewForbidden(a, fmt.Errorf("spec.type.path must be set"))
+		}
+
 		for _, alias := range cwtAliases {
 			authz, err := o.createAuthorizer(logicalcluster.From(alias), o.kubeClusterClient)
 			if err != nil {
@@ -318,12 +347,11 @@ func (o *clusterWorkspaceTypeExists) Validate(ctx context.Context, a admission.A
 		}
 
 		// validate whether the workspace type is allowed in its parent, and the workspace type allows that parent
-		clusterName := genericapirequest.ClusterFrom(ctx)
-		parentTypeRef, err := o.resolveParentType(clusterName.Name)
+		parentTypeRef, err := o.resolveParentType(clusterName)
 		if err != nil {
 			return admission.NewForbidden(a, err)
 		}
-		parentCwt, err := o.resolveTypeRef(parentTypeRef)
+		parentCwt, err := o.resolveTypeRef(clusterName, parentTypeRef)
 		if err != nil {
 			return admission.NewForbidden(a, err)
 		}

--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -88,22 +88,22 @@ func TestAdmit(t *testing.T) {
 			name: "adds initializers during transition to initializing",
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:org:other").withInitializer().ClusterWorkspaceType,
-				newType("root:org:foo").withInitializer().extending("root:org:Other").ClusterWorkspaceType,
+				newType("root:org:foo").withInitializer().extending("root:org:other").ClusterWorkspaceType,
 			},
 			a: updateAttr(
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:    tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
 					Location: tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 					BaseURL:  "https://kcp.bigcorp.com/clusters/org:test",
 				}).ClusterWorkspace,
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
 					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
 				}).ClusterWorkspace,
 			),
-			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 				Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
-				Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"root:org:Other", "root:org:Foo"},
+				Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"root:org:other", "root:org:foo"},
 				Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 				BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
 			}).ClusterWorkspace,
@@ -114,17 +114,17 @@ func TestAdmit(t *testing.T) {
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
 			a: updateAttr(
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:    tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
 					Location: tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 					BaseURL:  "https://kcp.bigcorp.com/clusters/org:test",
 				}).ClusterWorkspace,
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
 					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
 				}).ClusterWorkspace,
 			),
-			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 				Phase:    tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
 				Location: tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 				BaseURL:  "https://kcp.bigcorp.com/clusters/org:test",
@@ -136,18 +136,18 @@ func TestAdmit(t *testing.T) {
 				newType("root:org:foo").withInitializer().ClusterWorkspaceType,
 			},
 			a: updateAttr(
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseReady,
 					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
 					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
 				}).ClusterWorkspace,
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
 					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{},
 				}).ClusterWorkspace,
 			),
-			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 				Phase:    tenancyv1alpha1.ClusterWorkspacePhaseReady,
 				Location: tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 				BaseURL:  "https://kcp.bigcorp.com/clusters/org:test",
@@ -198,11 +198,11 @@ func TestAdmit(t *testing.T) {
 				}).ClusterWorkspaceType,
 			},
 			a: createAttr(
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withLabels(map[string]string{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withLabels(map[string]string{
 					"existing-label": "non-default",
 				}).ClusterWorkspace,
 			),
-			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:Foo").withLabels(map[string]string{
+			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:foo").withLabels(map[string]string{
 				"new-label":      "default",
 				"existing-label": "non-default",
 			}).ClusterWorkspace,
@@ -210,14 +210,14 @@ func TestAdmit(t *testing.T) {
 		{
 			name: "adds default workspace type if missing",
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").withDefault("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").withDefault("root:org:foo").ClusterWorkspaceType,
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
 			a:           createAttr(newWorkspace("root:org:ws:test").ClusterWorkspace),
-			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace,
+			expectedObj: newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace,
 		},
 	}
 	for _, tt := range tests {
@@ -265,68 +265,68 @@ func TestValidate(t *testing.T) {
 			name: "passes create if type exists",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:universal").ClusterWorkspaceType,
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
-				newType("root:org:foo").allowingParent("root:org:Parent").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
+				newType("root:org:foo").allowingParent("root:org:parent").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
 			name: "passes create if parent type allows all children",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:org:parent").ClusterWorkspaceType,
-				newType("root:org:foo").allowingParent("root:org:Parent").ClusterWorkspaceType,
+				newType("root:org:foo").allowingParent("root:org:parent").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
 			name: "passes create if child type allows all parents",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
 			name: "passes create if parent type allows an alias of the child type",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:org:fooalias").ClusterWorkspaceType,
-				newType("root:org:parent").allowingChild("root:org:Fooalias").ClusterWorkspaceType,
-				newType("root:org:foo").extending("root:org:Fooalias").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:fooalias").ClusterWorkspaceType,
+				newType("root:org:foo").extending("root:org:fooalias").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:org:ws:Test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:Test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
 			name: "passes create if child type allows an alias of the parent type",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:org:parentalias").ClusterWorkspaceType,
-				newType("root:org:parent").extending("root:org:Parentalias").ClusterWorkspaceType,
-				newType("root:org:foo").allowingParent("root:org:Parentalias").ClusterWorkspaceType,
+				newType("root:org:parent").extending("root:org:parentalias").ClusterWorkspaceType,
+				newType("root:org:foo").allowingParent("root:org:parentalias").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
@@ -337,58 +337,58 @@ func TestValidate(t *testing.T) {
 				newType("root:universal").ClusterWorkspaceType,
 				newType("root:foo").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:test").withType("root:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:test").withType("root:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
 			name:    "fails if type does not exist",
 			path:    logicalcluster.New("root:org:ws"),
-			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			wantErr: true,
 		},
 		{
 			name: "fails if type only exists in unrelated workspace",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
 				newType("root:bigcorp:foo").ClusterWorkspaceType,
 			},
-			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			wantErr: true,
 		},
 		{
 			name: "fails if parent type doesn't allow child workspaces",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:org:parent").ClusterWorkspaceType,
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
-			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			wantErr: true,
 		},
 		{
 			name: "fails if child type doesn't allow parent workspaces",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:org:parent").ClusterWorkspaceType,
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
-			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:    createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			wantErr: true,
 		},
 		{
 			name:          "fails if not allowed",
 			path:          logicalcluster.New("root:org:ws"),
-			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionNoOpinion,
 			wantErr:       true,
 		},
@@ -396,13 +396,13 @@ func TestValidate(t *testing.T) {
 			name: "fails if denied",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
-			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:          createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzDecision: authorizer.DecisionDeny,
 			wantErr:       true,
 		},
@@ -410,13 +410,13 @@ func TestValidate(t *testing.T) {
 			name: "fails if authz error",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
 				newType("root:org:foo").ClusterWorkspaceType,
 			},
-			attr:       createAttr(newWorkspace("root:org:ws:test").withType("root:org:Foo").ClusterWorkspace),
+			attr:       createAttr(newWorkspace("root:org:ws:test").withType("root:org:foo").ClusterWorkspace),
 			authzError: errors.New("authorizer error"),
 			wantErr:    true,
 		},
@@ -424,18 +424,18 @@ func TestValidate(t *testing.T) {
 			name: "validates initializers on phase transition",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
 				newType("root:org:foo").withInitializer().ClusterWorkspaceType,
 			},
 			attr: updateAttr(
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
-					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{}, // root:org:Foo missing
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{}, // root:org:foo missing
 				}).ClusterWorkspace,
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase: tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
 				}).ClusterWorkspace,
 			),
@@ -445,20 +445,20 @@ func TestValidate(t *testing.T) {
 			name: "passes with all initializers or more on phase transition",
 			path: logicalcluster.New("root:org:ws"),
 			workspaces: []*tenancyv1alpha1.ClusterWorkspace{
-				newWorkspace("root:org:ws").withType("root:org:Parent").ClusterWorkspace,
+				newWorkspace("root:org:ws").withType("root:org:parent").ClusterWorkspace,
 			},
 			types: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:org:parent").allowingChild("root:org:Foo").ClusterWorkspaceType,
+				newType("root:org:parent").allowingChild("root:org:foo").ClusterWorkspaceType,
 				newType("root:org:foo").withInitializer().ClusterWorkspaceType,
 			},
 			attr: updateAttr(
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:        tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
-					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"root:org:Foo", "unrelated"},
+					Initializers: []tenancyv1alpha1.ClusterWorkspaceInitializer{"root:org:foo", "unrelated"},
 					Location:     tenancyv1alpha1.ClusterWorkspaceLocation{Current: "somewhere"},
 					BaseURL:      "https://kcp.bigcorp.com/clusters/org:test",
 				}).ClusterWorkspace,
-				newWorkspace("root:org:ws:test").withType("root:org:Foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+				newWorkspace("root:org:ws:test").withType("root:org:foo").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase: tenancyv1alpha1.ClusterWorkspacePhaseScheduling,
 				}).ClusterWorkspace,
 			),
@@ -592,28 +592,28 @@ func TestTransitiveTypeResolverResolve(t *testing.T) {
 				"root:universal":    newType("root:universal").ClusterWorkspaceType,
 				"root:organization": newType("root:organization").ClusterWorkspaceType,
 			},
-			input: newType("root:org:type").extending("root:Universal").extending("root:Organization").ClusterWorkspaceType,
+			input: newType("root:org:type").extending("root:universal").extending("root:organization").ClusterWorkspaceType,
 			want:  sets.NewString("root:universal", "root:organization", "root:org:type"),
 		},
 		{
 			name:    "missing types",
-			input:   newType("root:org:type").extending("root:Universal").extending("root:Organization").ClusterWorkspaceType,
-			want:    sets.NewString("root:Universal", "root:organization", "root:org:Type"),
+			input:   newType("root:org:type").extending("root:universal").extending("root:organization").ClusterWorkspaceType,
+			want:    sets.NewString("root:universal", "root:organization", "root:org:type"),
 			wantErr: true,
 		},
 		{
 			name: "extending types transitively",
 			types: map[string]*tenancyv1alpha1.ClusterWorkspaceType{
 				"root:universal":    newType("root:universal").ClusterWorkspaceType,
-				"root:organization": newType("root:organization").extending("root:Universal").ClusterWorkspaceType,
+				"root:organization": newType("root:organization").extending("root:universal").ClusterWorkspaceType,
 			},
-			input: newType("root:org:type").extending("root:Organization").ClusterWorkspaceType,
+			input: newType("root:org:type").extending("root:organization").ClusterWorkspaceType,
 			want:  sets.NewString("root:universal", "root:organization", "root:org:type"),
 		},
 		{
 			name: "extending types transitively, one missing",
 			types: map[string]*tenancyv1alpha1.ClusterWorkspaceType{
-				"root:organization": newType("root:Organization").extending("root:Universal").ClusterWorkspaceType,
+				"root:organization": newType("root:organization").extending("root:universal").ClusterWorkspaceType,
 			},
 			input:   newType("root:org:type").extending("root:organization").ClusterWorkspaceType,
 			want:    sets.NewString("root:universal", "root:organization", "root:org:type"),
@@ -622,21 +622,21 @@ func TestTransitiveTypeResolverResolve(t *testing.T) {
 		{
 			name: "cycle",
 			types: map[string]*tenancyv1alpha1.ClusterWorkspaceType{
-				"root:a": newType("root:a").extending("root:B").ClusterWorkspaceType,
-				"root:b": newType("root:b").extending("root:C").ClusterWorkspaceType,
-				"root:c": newType("root:c").extending("root:A").ClusterWorkspaceType,
+				"root:a": newType("root:a").extending("root:b").ClusterWorkspaceType,
+				"root:b": newType("root:b").extending("root:c").ClusterWorkspaceType,
+				"root:c": newType("root:c").extending("root:a").ClusterWorkspaceType,
 			},
-			input:   newType("root:org:Type").extending("root:A").ClusterWorkspaceType,
+			input:   newType("root:org:type").extending("root:a").ClusterWorkspaceType,
 			want:    sets.NewString("root:universal", "root:organization", "root:org:type"),
 			wantErr: true,
 		},
 		{
 			name: "cycle starting at input",
 			types: map[string]*tenancyv1alpha1.ClusterWorkspaceType{
-				"root:b": newType("root:b").extending("root:C").ClusterWorkspaceType,
-				"root:c": newType("root:c").extending("root:A").ClusterWorkspaceType,
+				"root:b": newType("root:b").extending("root:c").ClusterWorkspaceType,
+				"root:c": newType("root:c").extending("root:a").ClusterWorkspaceType,
 			},
-			input:   newType("root:org:a").extending("root:B").ClusterWorkspaceType,
+			input:   newType("root:org:a").extending("root:b").ClusterWorkspaceType,
 			want:    sets.NewString("root:universal", "root:organization", "root:org:type"),
 			wantErr: true,
 		},
@@ -686,48 +686,48 @@ func TestValidateAllowedParents(t *testing.T) {
 		},
 		{
 			name:       "no parents",
-			childType:  "root:A",
-			parentType: "root:C",
+			childType:  "root:a",
+			parentType: "root:c",
 			childAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:a").allowingParent("root:B").ClusterWorkspaceType,
+				newType("root:a").allowingParent("root:b").ClusterWorkspaceType,
 			},
-			wantErr: "workspace type root:A only allows [root:B] parent workspaces, but parent type root:C only implements []",
+			wantErr: "workspace type root:a only allows [root:b] parent workspaces, but parent type root:c only implements []",
 		},
 		{
 			name:       "no parents, any allowed parent",
-			childType:  "root:A",
-			parentType: "root:B",
+			childType:  "root:a",
+			parentType: "root:b",
 			childAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:a").ClusterWorkspaceType,
 			},
 		},
 		{
 			name:       "all parents allowed",
-			childType:  "root:A",
-			parentType: "root:A",
+			childType:  "root:a",
+			parentType: "root:a",
 			parentAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:a").ClusterWorkspaceType,
 				newType("root:b").ClusterWorkspaceType,
 			},
 			childAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:a").allowingParent("root:A").allowingParent("root:D").ClusterWorkspaceType,
-				newType("root:b").allowingParent("root:B").allowingParent("root:D").ClusterWorkspaceType,
-				newType("root:c").allowingParent("root:A").allowingParent("root:B").allowingParent("root:D").ClusterWorkspaceType,
+				newType("root:a").allowingParent("root:a").allowingParent("root:d").ClusterWorkspaceType,
+				newType("root:b").allowingParent("root:b").allowingParent("root:d").ClusterWorkspaceType,
+				newType("root:c").allowingParent("root:a").allowingParent("root:b").allowingParent("root:d").ClusterWorkspaceType,
 			},
 			wantErr: "",
 		},
 		{
 			name:       "missing parent alias",
-			childType:  "root:A",
-			parentType: "root:A",
+			childType:  "root:a",
+			parentType: "root:a",
 			parentAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:a").ClusterWorkspaceType,
 			},
 			childAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:a").allowingParent("root:A").allowingParent("root:D").ClusterWorkspaceType,
-				newType("root:b").allowingParent("root:B").allowingParent("root:D").ClusterWorkspaceType,
+				newType("root:a").allowingParent("root:a").allowingParent("root:d").ClusterWorkspaceType,
+				newType("root:b").allowingParent("root:b").allowingParent("root:d").ClusterWorkspaceType,
 			},
-			wantErr: "workspace type root:A extends root:B, which only allows [root:B root:D] parent workspaces, but parent type root:A only implements [root:A]",
+			wantErr: "workspace type root:a extends root:b, which only allows [root:b root:d] parent workspaces, but parent type root:a only implements [root:a]",
 		},
 	}
 	for _, tt := range tests {
@@ -773,16 +773,16 @@ func TestValidateAllowedChildren(t *testing.T) {
 	}{
 		{
 			name:       "some type disallows children",
-			childType:  "root:A",
-			parentType: "root:A",
+			childType:  "root:a",
+			parentType: "root:a",
 			parentAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
 				newType("root:a").ClusterWorkspaceType,
 				newType("root:b").disallowingChildren().ClusterWorkspaceType,
 			},
 			childAliases: []*tenancyv1alpha1.ClusterWorkspaceType{
-				newType("root:a").allowingParent("root:A").allowingParent("root:D").ClusterWorkspaceType,
-				newType("root:b").allowingParent("root:B").allowingParent("root:D").ClusterWorkspaceType,
-				newType("root:c").allowingParent("root:A").allowingParent("root:B").allowingParent("root:D").ClusterWorkspaceType,
+				newType("root:a").allowingParent("root:a").allowingParent("root:d").ClusterWorkspaceType,
+				newType("root:b").allowingParent("root:b").allowingParent("root:d").ClusterWorkspaceType,
+				newType("root:c").allowingParent("root:a").allowingParent("root:b").allowingParent("root:d").ClusterWorkspaceType,
 			},
 			wantErr: "",
 		},

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/kcp-dev/logicalcluster"
 
@@ -132,7 +131,7 @@ type ClusterWorkspaceTypeReference struct {
 
 // ClusterWorkspaceTypeName is a name of a ClusterWorkspaceType
 //
-// +kubebuilder:validation:Pattern=`^[A-Z][a-zA-Z0-9]+$`
+// +kubebuilder:validation:Pattern=`^[a-z][a-z0-9]+$`
 type ClusterWorkspaceTypeName string
 
 func (r ClusterWorkspaceTypeReference) String() string {
@@ -288,13 +287,13 @@ func (in *ClusterWorkspaceType) SetConditions(conditions conditionsv1alpha1.Cond
 // ObjectName converts the proper name of a type that users interact with to the
 // metadata.name of the ClusterWorkspaceType object.
 func ObjectName(typeName ClusterWorkspaceTypeName) string {
-	return strings.ToLower(string(typeName))
+	return string(typeName)
 }
 
 // TypeName converts the metadata.name of a ClusterWorkspaceType to the proper
 // name of a type, as users interact with it.
 func TypeName(objectName string) ClusterWorkspaceTypeName {
-	return ClusterWorkspaceTypeName(strings.ToUpper(string(objectName[0])) + objectName[1:])
+	return ClusterWorkspaceTypeName(objectName)
 }
 
 // ReferenceFor returns a reference to the type.
@@ -318,7 +317,7 @@ type ClusterWorkspaceTypeList struct {
 // ClusterWorkspaceInitializer is a unique string corresponding to a cluster workspace
 // initialization controller for the given type of workspaces.
 //
-// +kubebuilder:validation:Pattern:="^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[A-Z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$"
+// +kubebuilder:validation:Pattern:="^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(:[a-z][a-z0-9]([-a-z0-9]*[a-z0-9])?)$"
 type ClusterWorkspaceInitializer string
 
 // ClusterWorkspacePhaseType is the type of the current phase of the workspace
@@ -528,7 +527,7 @@ const (
 
 const (
 	// RootWorkspaceTypeName is a reference to the root logical cluster, which has no cluster workspace type
-	RootWorkspaceTypeName = ClusterWorkspaceTypeName("Root")
+	RootWorkspaceTypeName = ClusterWorkspaceTypeName("root")
 )
 
 var (
@@ -547,7 +546,7 @@ var (
 		Spec: ClusterWorkspaceTypeSpec{
 			Extend: ClusterWorkspaceTypeExtension{
 				With: []ClusterWorkspaceTypeReference{
-					{Path: "root", Name: "Universal"},
+					{Path: "root", Name: "universal"},
 				},
 			},
 		},

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -543,12 +543,9 @@ var (
 			ClusterName: RootWorkspaceTypeReference.Path,
 		},
 		Spec: ClusterWorkspaceTypeSpec{
-			Extend: ClusterWorkspaceTypeExtension{
-				With: []ClusterWorkspaceTypeReference{
-					{Path: "root", Name: "universal"},
-				},
+			LimitAllowedParents: &ClusterWorkspaceTypeSelector{
+				None: true,
 			},
 		},
-		Status: ClusterWorkspaceTypeStatus{},
 	}
 )

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -123,8 +123,7 @@ type ClusterWorkspaceTypeReference struct {
 
 	// path is an absolute reference to the workspace that owns this type, e.g. root:org:ws.
 	//
-	// +required
-	// +kubebuilder:validation:Required
+	// +optional
 	// +kubebuilder:validation:Pattern:="^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	Path string `json:"path"`
 }

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -130,7 +130,7 @@ type ClusterWorkspaceTypeReference struct {
 
 // ClusterWorkspaceTypeName is a name of a ClusterWorkspaceType
 //
-// +kubebuilder:validation:Pattern=`^[a-z][a-z0-9]+$`
+// +kubebuilder:validation:Pattern=`^[a-z]([a-z0-9-]{0,61}[a-z0-9])?`
 type ClusterWorkspaceTypeName string
 
 func (r ClusterWorkspaceTypeReference) String() string {

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -176,10 +176,10 @@ type ClusterWorkspaceTypeSpec struct {
 	// +optional
 	Initializer bool `json:"initializer,omitempty"`
 
-	// extend is a list of other ClusterWorkspaceTypes whose initializers and allowedChildren
-	// and allowedParents this ClusterWorkspaceType is inheriting. By (transitively) extending
+	// extend is a list of other ClusterWorkspaceTypes whose initializers and limitAllowedChildren
+	// and limitAllowedParents this ClusterWorkspaceType is inheriting. By (transitively) extending
 	// another ClusterWorkspaceType, this ClusterWorkspaceType will be considered as that
-	// other type in evaluation of allowedChildren and allowedParents constraints.
+	// other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.
 	//
 	// A dependency cycle stop this ClusterWorkspaceType from being admitted as the type
 	// of a ClusterWorkspace.

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -330,12 +330,12 @@ func (kc *KubeConfig) CreateWorkspace(ctx context.Context, workspaceName string,
 		switch separatorIndex {
 		case -1:
 			structuredWorkspaceType = tenancyv1alpha1.ClusterWorkspaceTypeReference{
-				Name: tenancyv1alpha1.ClusterWorkspaceTypeName(workspaceType),
+				Name: tenancyv1alpha1.ClusterWorkspaceTypeName(strings.ToLower(workspaceType)),
 				Path: currentClusterName.String(),
 			}
 		default:
 			structuredWorkspaceType = tenancyv1alpha1.ClusterWorkspaceTypeReference{
-				Name: tenancyv1alpha1.ClusterWorkspaceTypeName(workspaceType[separatorIndex+1:]),
+				Name: tenancyv1alpha1.ClusterWorkspaceTypeName(strings.ToLower(workspaceType[separatorIndex+1:])),
 				Path: workspaceType[:separatorIndex],
 			}
 		}
@@ -355,7 +355,7 @@ func (kc *KubeConfig) CreateWorkspace(ctx context.Context, workspaceName string,
 		// indpenedently whether the CRD is installed in the workspace. Universal workspaces though don't have that
 		// resource, but the virtual apiserver return 404 in that case, confusingly for clients.
 		// This hack avoids a message confusing for the user.
-		return fmt.Errorf("creating a workspace under a Universal type workspace is not supported")
+		return fmt.Errorf("creating a workspace under a universal type workspace is not supported")
 	}
 	if apierrors.IsAlreadyExists(err) && ignoreExisting {
 		preExisting = true

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -331,7 +331,7 @@ func (kc *KubeConfig) CreateWorkspace(ctx context.Context, workspaceName string,
 		case -1:
 			structuredWorkspaceType = tenancyv1alpha1.ClusterWorkspaceTypeReference{
 				Name: tenancyv1alpha1.ClusterWorkspaceTypeName(strings.ToLower(workspaceType)),
-				Path: currentClusterName.String(),
+				// path is defaulted through admission
 			}
 		default:
 			structuredWorkspaceType = tenancyv1alpha1.ClusterWorkspaceTypeReference{

--- a/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
@@ -157,7 +157,7 @@ func TestCreate(t *testing.T) {
 					},
 					Spec: tenancyv1beta1.WorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Universal",
+							Name: "universal",
 							Path: "root",
 						},
 					},
@@ -173,7 +173,7 @@ func TestCreate(t *testing.T) {
 			empty := tenancyv1alpha1.ClusterWorkspaceTypeReference{}
 			if workspaceType == empty {
 				workspaceType = tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Name: "Universal",
+					Name: "universal",
 					Path: "root",
 				}
 			}
@@ -694,7 +694,7 @@ func TestUse(t *testing.T) {
 						},
 						Spec: tenancyv1beta1.WorkspaceSpec{
 							Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-								Name: "Universal",
+								Name: "universal",
 								Path: "root",
 							},
 						},
@@ -723,7 +723,7 @@ func TestUse(t *testing.T) {
 								},
 								Spec: tenancyv1beta1.WorkspaceSpec{
 									Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-										Name: "Home",
+										Name: "home",
 										Path: "root",
 									},
 								},

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -3027,7 +3027,7 @@ func schema_pkg_apis_tenancy_v1alpha1_ClusterWorkspaceTypeReference(ref common.R
 						},
 					},
 				},
-				Required: []string{"name", "path"},
+				Required: []string{"name"},
 			},
 		},
 	}

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -3084,7 +3084,7 @@ func schema_pkg_apis_tenancy_v1alpha1_ClusterWorkspaceTypeSpec(ref common.Refere
 					},
 					"extend": {
 						SchemaProps: spec.SchemaProps{
-							Description: "extend is a list of other ClusterWorkspaceTypes whose initializers and allowedChildren and allowedParents this ClusterWorkspaceType is inheriting. By (transitively) extending another ClusterWorkspaceType, this ClusterWorkspaceType will be considered as that other type in evaluation of allowedChildren and allowedParents constraints.\n\nA dependency cycle stop this ClusterWorkspaceType from being admitted as the type of a ClusterWorkspace.\n\nA non-existing dependency stop this ClusterWorkspaceType from being admitted as the type of a ClusterWorkspace.",
+							Description: "extend is a list of other ClusterWorkspaceTypes whose initializers and limitAllowedChildren and limitAllowedParents this ClusterWorkspaceType is inheriting. By (transitively) extending another ClusterWorkspaceType, this ClusterWorkspaceType will be considered as that other type in evaluation of limitAllowedChildren and limitAllowedParents constraints.\n\nA dependency cycle stop this ClusterWorkspaceType from being admitted as the type of a ClusterWorkspace.\n\nA non-existing dependency stop this ClusterWorkspaceType from being admitted as the type of a ClusterWorkspace.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1.ClusterWorkspaceTypeExtension"),
 						},

--- a/pkg/reconciler/tenancy/clusterworkspacetype/clusterworkspacetype_controller_reconcile_test.go
+++ b/pkg/reconciler/tenancy/clusterworkspacetype/clusterworkspacetype_controller_reconcile_test.go
@@ -45,13 +45,13 @@ func TestReconcile(t *testing.T) {
 			name: "no shards, no URLs in status",
 			cwt: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 			},
 			expected: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceTypeStatus{
@@ -74,13 +74,13 @@ func TestReconcile(t *testing.T) {
 			listErr: fmt.Errorf("oops"),
 			cwt: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 			},
 			expected: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceTypeStatus{
@@ -112,20 +112,20 @@ func TestReconcile(t *testing.T) {
 			},
 			cwt: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 			},
 			expected: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceTypeStatus{
 					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{
-						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
-						{URL: "https://something.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
-						{URL: "https://whatever.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
+						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype"},
+						{URL: "https://something.com/services/initializingworkspaces/root:org:team:ws:sometype"},
+						{URL: "https://whatever.com/services/initializingworkspaces/root:org:team:ws:sometype"},
 					},
 					Conditions: conditionsv1alpha1.Conditions{
 						{
@@ -149,12 +149,12 @@ func TestReconcile(t *testing.T) {
 			},
 			cwt: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceTypeStatus{
 					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{
-						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
+						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype"},
 					},
 					Conditions: conditionsv1alpha1.Conditions{
 						{
@@ -170,14 +170,14 @@ func TestReconcile(t *testing.T) {
 			},
 			expected: &tenancyv1alpha1.ClusterWorkspaceType{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "someType",
+					Name:        "sometype",
 					ClusterName: "root:org:team:ws",
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceTypeStatus{
 					VirtualWorkspaces: []tenancyv1alpha1.VirtualWorkspace{
-						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
-						{URL: "https://something.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
-						{URL: "https://whatever.com/services/initializingworkspaces/root:org:team:ws:SomeType"},
+						{URL: "https://item.com/services/initializingworkspaces/root:org:team:ws:sometype"},
+						{URL: "https://something.com/services/initializingworkspaces/root:org:team:ws:sometype"},
+						{URL: "https://whatever.com/services/initializingworkspaces/root:org:team:ws:sometype"},
 					},
 					Conditions: conditionsv1alpha1.Conditions{
 						{

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -410,7 +410,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 		crdClusterClient,
 		kcpClusterClient,
 		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
-		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Organization"},
+		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "organization"},
 		configorganization.Bootstrap,
 	)
 	if err != nil {
@@ -422,7 +422,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 		crdClusterClient,
 		kcpClusterClient,
 		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
-		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Team"},
+		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "team"},
 		configteam.Bootstrap,
 	)
 	if err != nil {
@@ -434,7 +434,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 		crdClusterClient,
 		kcpClusterClient,
 		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
-		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Universal"},
+		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "universal"},
 		configuniversal.Bootstrap,
 	)
 	if err != nil {
@@ -482,7 +482,7 @@ func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config)
 		crdClusterClient,
 		kcpClusterClient,
 		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
-		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Homeroot"},
+		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "homeroot"},
 		confighomeroot.Bootstrap,
 	)
 	if err != nil {
@@ -494,7 +494,7 @@ func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config)
 		crdClusterClient,
 		kcpClusterClient,
 		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
-		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Homebucket"},
+		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "homebucket"},
 		confighomebucket.Bootstrap,
 	)
 	if err != nil {
@@ -506,7 +506,7 @@ func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config)
 		crdClusterClient,
 		kcpClusterClient,
 		s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
-		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "Home"},
+		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "home"},
 		confighome.Bootstrap,
 	)
 	if err != nil {

--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -59,8 +59,8 @@ import (
 
 const (
 	homeOwnerClusterRolePrefix     = "system:kcp:tenancy:home-owner:"
-	HomeBucketClusterWorkspaceType = "Homebucket"
-	HomeClusterWorkspaceType       = "Home"
+	HomeBucketClusterWorkspaceType = "homebucket"
+	HomeClusterWorkspaceType       = "home"
 
 	// the amount of time while the create delay is repeatedly returned to the client
 	createDelayTimeout = time.Minute
@@ -328,7 +328,7 @@ func (h *homeWorkspaceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 			},
 			Spec: tenancyv1beta1.WorkspaceSpec{
 				Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Home"),
+					Name: tenancyv1alpha1.ClusterWorkspaceTypeName("home"),
 					Path: tenancyv1alpha1.RootCluster.String(),
 				},
 			},
@@ -347,7 +347,7 @@ func (h *homeWorkspaceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	isHome := workspaceType == "Home"
+	isHome := workspaceType == HomeClusterWorkspaceType
 	if foundLocally, retryAfterSeconds, err := h.searchForReadyWorkspaceInLocalInformers(lcluster.Name, isHome, effectiveUser.GetName()); err != nil {
 		responsewriters.InternalError(rw, req, err)
 		return
@@ -539,7 +539,7 @@ func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, userName string, 
 	})
 
 	if err == nil || kerrors.IsAlreadyExists(err) {
-		if workspaceType == "Home" {
+		if workspaceType == "home" {
 			if kerrors.IsAlreadyExists(err) {
 				cw, err := h.kcp.getClusterWorkspace(ctx, parent, name)
 				if err != nil {

--- a/pkg/server/home_workspaces_test.go
+++ b/pkg/server/home_workspaces_test.go
@@ -136,7 +136,7 @@ func TestNeedsAutomaticCreation(t *testing.T) {
 
 			workspaceName:         "root:users:ab:cd:user-1",
 			expectedNeedsCheck:    true,
-			expectedWorkspaceType: "Home",
+			expectedWorkspaceType: "home",
 		},
 		{
 			bucketLevels: 1,
@@ -151,7 +151,7 @@ func TestNeedsAutomaticCreation(t *testing.T) {
 
 			workspaceName:         "root:users:ab:cd",
 			expectedNeedsCheck:    true,
-			expectedWorkspaceType: "Homebucket",
+			expectedWorkspaceType: "homebucket",
 		},
 		{
 			bucketLevels: 2,
@@ -159,7 +159,7 @@ func TestNeedsAutomaticCreation(t *testing.T) {
 
 			workspaceName:         "root:users:ab",
 			expectedNeedsCheck:    true,
-			expectedWorkspaceType: "Homebucket",
+			expectedWorkspaceType: "homebucket",
 		},
 		{
 			bucketLevels: 2,
@@ -520,7 +520,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "retry quicky when success creating non-home ClusterWorkspace",
 
 			workspaceName: "root:users:ab:cd",
-			workspaceType: "Homebucket",
+			workspaceType: "homebucket",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -529,7 +529,7 @@ func TestTryToCreate(t *testing.T) {
 			expectedCreatedWorkspace: &tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 				}},
 			},
 			expectedRetryAfterSeconds: 1,
@@ -538,7 +538,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "retry quicky when success creating non-home ClusterWorkspace",
 
 			workspaceName: "root:users:ab:cd",
-			workspaceType: "Homebucket",
+			workspaceType: "homebucket",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -547,7 +547,7 @@ func TestTryToCreate(t *testing.T) {
 			expectedCreatedWorkspace: &tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 				}},
 			},
 			expectedRetryAfterSeconds: 1,
@@ -556,7 +556,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "retry quicky when non-home ClusterWorkspace already exists",
 
 			workspaceName: "root:users:ab:cd",
-			workspaceType: "Homebucket",
+			workspaceType: "homebucket",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -568,7 +568,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "return error when the owner does not match",
 
 			workspaceName: "root:users:ab:cd:u--r-1",
-			workspaceType: "Home",
+			workspaceType: "home",
 			userName:      "u$€r-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -592,7 +592,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "create RBAC and retry quicky when success creating home ClusterWorkspace",
 
 			workspaceName: "root:users:ab:cd:user-1",
-			workspaceType: "Home",
+			workspaceType: "home",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -608,7 +608,7 @@ func TestTryToCreate(t *testing.T) {
 			expectedCreatedWorkspace: &tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-1"},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Home"),
+					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("home"),
 				}},
 			},
 			expectedRetryAfterSeconds: 1,
@@ -618,7 +618,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "create RBAC and retry quicky when home ClusterWorkspace already exists",
 
 			workspaceName: "root:users:ab:cd:user-1",
-			workspaceType: "Home",
+			workspaceType: "home",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -649,7 +649,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "return error when error trying to create RBAC after home ClusterWorkspace exists",
 
 			workspaceName: "root:users:ab:cd:user-1",
-			workspaceType: "Home",
+			workspaceType: "home",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -680,7 +680,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "retry later when creating ClusterWorkspace returns error suggesting delay",
 
 			workspaceName: "root:users:ab:cd",
-			workspaceType: "Homebucket",
+			workspaceType: "homebucket",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -716,7 +716,7 @@ func TestTryToCreate(t *testing.T) {
 				return &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 						Path: "root",
 					}},
 					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
@@ -742,7 +742,7 @@ func TestTryToCreate(t *testing.T) {
 				return &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 						Path: "root",
 					}},
 					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
@@ -775,7 +775,7 @@ func TestTryToCreate(t *testing.T) {
 				return &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 						Path: "root",
 					}},
 					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
@@ -808,7 +808,7 @@ func TestTryToCreate(t *testing.T) {
 				return &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 						Path: "root",
 					}},
 					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
@@ -841,7 +841,7 @@ func TestTryToCreate(t *testing.T) {
 				return &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+						Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 						Path: "root",
 					}},
 					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
@@ -856,7 +856,7 @@ func TestTryToCreate(t *testing.T) {
 			testName: "Go down one level, create parent and return quickly, on Forbidden error and the parent doesn't exist",
 
 			workspaceName: "root:users:ab:cd:user-1",
-			workspaceType: "Home",
+			workspaceType: "home",
 			userName:      "user-1",
 
 			createClusterWorkspace: func(ctx context.Context, workspace logicalcluster.Name, cw *tenancyv1alpha1.ClusterWorkspace) error {
@@ -870,7 +870,7 @@ func TestTryToCreate(t *testing.T) {
 					return &tenancyv1alpha1.ClusterWorkspace{
 						ObjectMeta: metav1.ObjectMeta{Name: "ab"},
 						Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 							Path: "root",
 						}},
 					}, nil
@@ -882,7 +882,7 @@ func TestTryToCreate(t *testing.T) {
 			expectedCreatedWorkspace: &tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "cd"},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Homebucket"),
+					Path: "root", Name: tenancyv1alpha1.ClusterWorkspaceTypeName("homebucket"),
 				}},
 			},
 		},
@@ -1398,7 +1398,7 @@ func TestServeHTTP(t *testing.T) {
 
 			expectedStatusCode:   200,
 			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"Home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
+			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
 		},
 		{
 			testName:       "return error if error when getting home workspace in the local informers",
@@ -1492,7 +1492,7 @@ func TestServeHTTP(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Home"),
+							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("home"),
 							Path: "root",
 						},
 					},
@@ -1505,7 +1505,7 @@ func TestServeHTTP(t *testing.T) {
 
 			expectedStatusCode:   200,
 			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","resourceVersion":"someRealResourceVersion","creationTimestamp":"2022-07-05T15:46:00Z","clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"Home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1","phase":"Ready"}}`,
+			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","resourceVersion":"someRealResourceVersion","creationTimestamp":"2022-07-05T15:46:00Z","clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1","phase":"Ready"}}`,
 		},
 		{
 			testName:       "return 429 with retry-after header when the home workspace is not ready yet",

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -601,7 +601,7 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	}
 
 	if workspace.Spec.Type.Name == "" && workspace.Spec.Type.Path == "" {
-		workspace.Spec.Type.Name = "Universal"
+		workspace.Spec.Type.Name = "universal"
 		workspace.Spec.Type.Path = "root"
 	}
 

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -600,36 +600,6 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), "", fmt.Errorf("creating a workspace is only possible in the personal workspaces scope for now"))
 	}
 
-	if workspace.Spec.Type.Name == "" && workspace.Spec.Type.Path == "" {
-		workspace.Spec.Type.Name = "universal"
-		workspace.Spec.Type.Path = "root"
-	}
-
-	// check whether the user is allowed to use the cluster workspace type
-	authz, err := s.delegatedAuthz(logicalcluster.New(workspace.Spec.Type.Path), s.kubeClusterClient)
-	if err != nil {
-		klog.Errorf("failed to get delegated authorizer for logical cluster %s", userInfo.GetName(), orgClusterName)
-		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), "", fmt.Errorf("use of the cluster workspace type %q in workspace %q is not allowed", workspace.Spec.Type, orgClusterName))
-	}
-
-	typeName := tenancyv1alpha1.ObjectName(workspace.Spec.Type.Name)
-	typeUseAttr := authorizer.AttributesRecord{
-		User:            userInfo,
-		Verb:            "use",
-		APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
-		APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
-		Resource:        "clusterworkspacetypes",
-		Name:            typeName,
-		ResourceRequest: true,
-	}
-	if decision, reason, err := authz.Authorize(ctx, typeUseAttr); err != nil {
-		klog.Errorf("failed to authorize user %q to %q clusterworkspacetypes name %q in %s", userInfo.GetName(), "use", typeName, orgClusterName)
-		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), workspace.Name, fmt.Errorf("use of the cluster workspace type %q in workspace %q is not allowed", workspace.Spec.Type, orgClusterName))
-	} else if decision != authorizer.DecisionAllow {
-		klog.Errorf("user %q lacks (%s) clusterworkspacetypes %q permission for %q in %s: %s", userInfo.GetName(), decisions[decision], "use", typeName, orgClusterName, reason)
-		return nil, kerrors.NewForbidden(tenancyv1beta1.Resource("workspaces"), workspace.Name, fmt.Errorf("use of the cluster workspace type %q in workspace %q is not allowed", workspace.Spec.Type, orgClusterName))
-	}
-
 	ownerRoleBindingName := getRoleBindingName(OwnerRoleType, workspace.Name, userInfo)
 
 	// First create the ClusterRoleBinding that will link the workspace cluster role with the user Subject

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -1106,7 +1106,7 @@ func TestCreateWorkspaceFailNoPermissionForType(t *testing.T) {
 				},
 			}
 			response, err := storage.Create(ctx, &newWorkspace, nil, &metav1.CreateOptions{})
-			require.EqualError(t, err, `workspaces.tenancy.kcp.dev "foo" is forbidden: use of the cluster workspace type "root:Universal" in workspace "root:orgName" is not allowed`)
+			require.EqualError(t, err, `workspaces.tenancy.kcp.dev "foo" is forbidden: use of the cluster workspace type "root:universal" in workspace "root:orgName" is not allowed`)
 			require.Nil(t, response)
 		},
 	}
@@ -1323,7 +1323,7 @@ func TestCreateWorkspaceWithPrettyName(t *testing.T) {
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Universal"),
+							Name: "universal",
 							Path: "root",
 						},
 					},

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -217,7 +217,7 @@ func NewOrganizationFixture(t *testing.T, server RunningServer, options ...Clust
 		},
 		Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 			Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-				Name: "Organization",
+				Name: "organization",
 				Path: "root",
 			},
 		},
@@ -314,7 +314,7 @@ func NewWorkspaceFixture(t *testing.T, server RunningServer, orgClusterName logi
 		},
 		Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 			Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-				Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Universal"),
+				Name: tenancyv1alpha1.ClusterWorkspaceTypeName("universal"),
 				Path: "root",
 			},
 		},

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -60,7 +60,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "ws-cleanup"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Universal",
+							Name: "universal",
 							Path: "root",
 						},
 						Shard: &tenancyv1alpha1.ShardConstraints{

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -303,15 +303,15 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 				}, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create ClusterRoleBinding 'user1-workspace-create'")
 
-				t.Logf("Create custom ClusterWorkspaceType 'Custom'")
+				t.Logf("Create custom ClusterWorkspaceType 'custom'")
 				cwt, err := server.kcpClusterClient.Cluster(parentCluster).TenancyV1alpha1().ClusterWorkspaceTypes().Create(ctx, &tenancyv1alpha1.ClusterWorkspaceType{
 					ObjectMeta: metav1.ObjectMeta{Name: "custom"},
 				}, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create custom ClusterWorkspaceType 'Custom'")
+				require.NoError(t, err, "failed to create custom ClusterWorkspaceType 'custom'")
 				server.Artifact(t, func() (runtime.Object, error) {
 					return server.kcpClusterClient.Cluster(parentCluster).TenancyV1alpha1().ClusterWorkspaceTypes().Get(ctx, "custom", metav1.GetOptions{})
 				})
-				t.Logf("Wait for type Custom to be usable")
+				t.Logf("Wait for type custom to be usable")
 				cwtName := cwt.Name
 				framework.EventuallyReady(t, func() (conditions.Getter, error) {
 					return server.kcpClusterClient.Cluster(parentCluster).TenancyV1alpha1().ClusterWorkspaceTypes().Get(ctx, cwtName, metav1.GetOptions{})
@@ -360,7 +360,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 						ObjectMeta: metav1.ObjectMeta{Name: testData.workspace1.Name},
 						Spec: tenancyv1beta1.WorkspaceSpec{
 							Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-								Name: "Custom",
+								Name: "custom",
 								Path: logicalcluster.From(cwt).String(),
 							},
 						},
@@ -378,9 +378,9 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 					return server.kcpClusterClient.Cluster(parentCluster).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, testData.workspace1.Name, metav1.GetOptions{})
 				})
 				require.Equal(t, tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Name: "Custom",
+					Name: "custom",
 					Path: logicalcluster.From(cwt).String(),
-				}, workspace1.Spec.Type, "expected workspace1 to be of type Custom")
+				}, workspace1.Spec.Type, "expected workspace1 to be of type custom")
 
 				t.Logf("Create Workspace workspace2 in the virtual workspace")
 
@@ -389,7 +389,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 					ObjectMeta: metav1.ObjectMeta{Name: testData.workspace2.Name},
 					Spec: tenancyv1beta1.WorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Custom",
+							Name: "custom",
 							Path: logicalcluster.From(cwt).String(),
 						},
 					},
@@ -401,7 +401,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 					ObjectMeta: metav1.ObjectMeta{Name: testData.workspace2.Name},
 					Spec: tenancyv1beta1.WorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Custom2",
+							Name: "custom2",
 							Path: logicalcluster.From(cwt).String(),
 						},
 					},
@@ -541,7 +541,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 						ObjectMeta: metav1.ObjectMeta{Name: testData.workspace1.Name},
 						Spec: tenancyv1beta1.WorkspaceSpec{
 							Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-								Name: "Universal",
+								Name: "universal",
 								Path: "root",
 							},
 						},

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -71,11 +71,11 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 					return err == nil && workspace.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
 				}, wait.ForeverTestTimeout, 100*time.Millisecond, "workspace should be ready")
 
-				t.Logf("Expect workspace to be of Universal type, and no initializers")
+				t.Logf("Expect workspace to be of universal type, and no initializers")
 				workspace, err = server.orgKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				require.NoError(t, err, "failed to get workspace")
 				require.Equalf(t, workspace.Spec.Type, tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Name: "Universal",
+					Name: "universal",
 					Path: "root",
 				}, "workspace type is not universal")
 				require.Emptyf(t, workspace.Status.Initializers, "workspace has initializers")
@@ -89,7 +89,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 				workspace, err := server.kcpClusterClient.Cluster(universal).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "myapp"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-						Name: "Foo",
+						Name: "foo",
 						Path: "root",
 					}},
 				}, metav1.CreateOptions{})
@@ -125,7 +125,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 					return server.kcpClusterClient.Cluster(universal).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, "myapp", metav1.GetOptions{})
 				})
 				require.Equal(t, workspace.Spec.Type, tenancyv1alpha1.ClusterWorkspaceTypeReference{
-					Name: "Foo",
+					Name: "foo",
 					Path: logicalcluster.From(cwt).String(),
 				})
 
@@ -167,7 +167,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 					workspace, err = server.kcpClusterClient.Cluster(universal).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
 						ObjectMeta: metav1.ObjectMeta{Name: "myapp"},
 						Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: "Foo",
+							Name: "foo",
 							Path: logicalcluster.From(cwt).String(),
 						}},
 					}, metav1.CreateOptions{})
@@ -210,7 +210,7 @@ func TestClusterWorkspaceTypes(t *testing.T) {
 			name: "create a workspace with deeper nesting",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
 				org := framework.NewOrganizationFixture(t, server)
-				team := framework.NewWorkspaceFixture(t, server, org, framework.WithType(tenancyv1alpha1.RootCluster, "Team"))
+				team := framework.NewWorkspaceFixture(t, server, org, framework.WithType(tenancyv1alpha1.RootCluster, "team"))
 				universal := framework.NewWorkspaceFixture(t, server, team)
 
 				require.Len(t, strings.Split(universal.String(), ":"), 4, "expecting root:org:team:universal, i.e. 4 levels")


### PR DESCRIPTION
- add `root:root` type to set default workspace type
- lower-case CWT references (fixes https://github.com/kcp-dev/kcp/issues/1398)
- use CWT name pattern also for references. This will bring `-` support.