### PR TITLE
cli/workload/sync: improve usability

### DIFF
--- a/config/crds/workload.kcp.dev_synctargets.yaml
+++ b/config/crds/workload.kcp.dev_synctargets.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -47,6 +45,11 @@ spec:
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
+            properties:
+              name:
+                maxLength: 234
+                minLength: 1
+                type: string
             type: object
           spec:
             description: Spec holds the desired state.

--- a/config/crds/workload.kcp.dev_synctargets.yaml-patch
+++ b/config/crds/workload.kcp.dev_synctargets.yaml-patch
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/versions/name=v1alpha1/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      minLength: 1
+      maxLength: 234 # 253 - 10 (prefix) - 9 (hash)
+      type: string

--- a/config/root-phase0/apiexport-workload.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.dev.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220706-3993e86b.synctargets.workload.kcp.dev
+  - v220709-4a74a96f.synctargets.workload.kcp.dev
 status: {}

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220706-3993e86b.synctargets.workload.kcp.dev
+  name: v220709-4a74a96f.synctargets.workload.kcp.dev
 spec:
   group: workload.kcp.dev
   names:
@@ -42,6 +42,11 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
+          properties:
+            name:
+              maxLength: 234
+              minLength: 1
+              type: string
           type: object
         spec:
           description: Spec holds the desired state.

--- a/docs/syncer.md
+++ b/docs/syncer.md
@@ -22,7 +22,7 @@ Current workspace is "root:default:my-workspace".
 1. Enable the syncer for a new cluster
 
 ```sh
-$ kubectl kcp workload sync <mycluster> --syncer-image <image name> > syncer.yaml
+$ kubectl kcp workload sync <mycluster> --syncer-image <image name> -o syncer.yaml
 ```
 
 1. Create a kind cluster to back the sync target

--- a/pkg/cliplugins/workload/cmd/cmd.go
+++ b/pkg/cliplugins/workload/cmd/cmd.go
@@ -32,10 +32,10 @@ var (
 	syncExample = `
 	# Ensure a syncer is running on the specified sync target.
 	%[1]s workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o syncer.yaml
-	kubectl apply -f syncer.yaml
+	KUBECONFIG=<pcluster-config> kubectl apply -f syncer.yaml
 
 	# Directly apply the manifest
-	%[1]s workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o - | kubectl apply -f -
+	%[1]s workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o - | KUBECONFIG=<pcluster-config> kubectl apply -f -
 `
 	cordonExample = `
 	# Mark a sync target as unschedulable.
@@ -78,7 +78,8 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	var syncerImage string
 	var replicas int = 1
 	var outputFile string
-	kcpNamespaceName := "default"
+	var downstreamNamespace string
+	kcpNamespace := "default"
 	enableSyncerCmd := &cobra.Command{
 		Use:          "sync <sync-target-name> --syncer-image <kcp-syncer-image> [--resources=<resource1>,<resource2>..] -o <output-file>",
 		Short:        "Create a synctarget in kcp with service account and RBAC permissions. Output a manifest to deploy a syncer for the given sync target in a physical cluster.",
@@ -101,7 +102,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 				return errors.New("a value must be specified for --syncer-image")
 			}
 
-			if len(kcpNamespaceName) == 0 {
+			if len(kcpNamespace) == 0 {
 				return errors.New("a value must be specified for --kcp-namespace")
 			}
 
@@ -117,20 +118,21 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 			}
 
 			syncTargetName := args[0]
-			if len(syncTargetName)+len(plugin.SyncerAuthResourcePrefix) > plugin.MaxSyncerAuthResourceName {
-				return fmt.Errorf("the maximum length of the sync-target-name is %d", plugin.MaxSyncerAuthResourceName)
+			if len(syncTargetName)+len(plugin.SyncerIDPrefix)+8 > 254 {
+				return fmt.Errorf("the maximum length of the sync-target-name is %d", plugin.MaxSyncTargetNameLength)
 			}
 
 			resourcesToSync := sets.NewString(userResourcesToSync...).Union(requiredResourcesToSync).List()
 
-			return kubeconfig.Sync(c.Context(), outputFile, syncTargetName, kcpNamespaceName, syncerImage, resourcesToSync, replicas)
+			return kubeconfig.Sync(c.Context(), outputFile, syncTargetName, kcpNamespace, downstreamNamespace, syncerImage, resourcesToSync, replicas)
 		},
 	}
 	enableSyncerCmd.Flags().StringSliceVar(&userResourcesToSync, "resources", userResourcesToSync, "Resources to synchronize with kcp.")
 	enableSyncerCmd.Flags().StringVar(&syncerImage, "syncer-image", syncerImage, "The syncer image to use in the syncer's deployment YAML. Images are published at https://github.com/kcp-dev/kcp/pkgs/container/kcp%2Fsyncer.")
 	enableSyncerCmd.Flags().IntVar(&replicas, "replicas", replicas, "Number of replicas of the syncer deployment.")
-	enableSyncerCmd.Flags().StringVar(&kcpNamespaceName, "kcp-namespace", kcpNamespaceName, "The name of the kcp namespace to create a service account in.")
+	enableSyncerCmd.Flags().StringVar(&kcpNamespace, "kcp-namespace", kcpNamespace, "The name of the kcp namespace to create a service account in.")
 	enableSyncerCmd.Flags().StringVarP(&outputFile, "output-file", "o", outputFile, "The manifest file to be created and applied to the physical cluster. Use - for stdout.")
+	enableSyncerCmd.Flags().StringVarP(&downstreamNamespace, "namespace", "n", downstreamNamespace, "The namespace to create the syncer in in the physical cluster. By default this is \"kcp-syncer-<synctarget-name>-<uid>\".")
 
 	cmd.AddCommand(enableSyncerCmd)
 

--- a/pkg/cliplugins/workload/cmd/cmd.go
+++ b/pkg/cliplugins/workload/cmd/cmd.go
@@ -31,7 +31,11 @@ import (
 var (
 	syncExample = `
 	# Ensure a syncer is running on the specified sync target.
-	%[1]s workload sync <sync-target-name> --syncer-image <kcp-syncer-image>
+	%[1]s workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o syncer.yaml
+	kubectl apply -f syncer.yaml
+
+	# Directly apply the manifest
+	%[1]s workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o - | kubectl apply -f -
 `
 	cordonExample = `
 	# Mark a sync target as unschedulable.
@@ -73,10 +77,11 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	var userResourcesToSync []string
 	var syncerImage string
 	var replicas int = 1
+	var outputFile string
 	kcpNamespaceName := "default"
 	enableSyncerCmd := &cobra.Command{
-		Use:          "sync <sync-target-name> --syncer-image <kcp-syncer-image> [--resources=<resource1>,<resource2>..]",
-		Short:        "Deploy a syncer for the given sync target",
+		Use:          "sync <sync-target-name> --syncer-image <kcp-syncer-image> [--resources=<resource1>,<resource2>..] -o <output-file>",
+		Short:        "Create a synctarget in kcp with service account and RBAC permissions. Output a manifest to deploy a syncer for the given sync target in a physical cluster.",
 		Example:      fmt.Sprintf(syncExample, "kubectl kcp"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -107,6 +112,9 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 				// TODO: relax when we have leader-election in the syncer
 				return errors.New("only 0 and 1 are allowed as --replicas values")
 			}
+			if len(outputFile) == 0 {
+				return errors.New("a value must be specified for --output-file")
+			}
 
 			syncTargetName := args[0]
 			if len(syncTargetName)+len(plugin.SyncerAuthResourcePrefix) > plugin.MaxSyncerAuthResourceName {
@@ -115,13 +123,14 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 
 			resourcesToSync := sets.NewString(userResourcesToSync...).Union(requiredResourcesToSync).List()
 
-			return kubeconfig.Sync(c.Context(), syncTargetName, kcpNamespaceName, syncerImage, resourcesToSync, replicas)
+			return kubeconfig.Sync(c.Context(), outputFile, syncTargetName, kcpNamespaceName, syncerImage, resourcesToSync, replicas)
 		},
 	}
 	enableSyncerCmd.Flags().StringSliceVar(&userResourcesToSync, "resources", userResourcesToSync, "Resources to synchronize with kcp.")
-	enableSyncerCmd.Flags().StringVar(&syncerImage, "syncer-image", syncerImage, "The syncer image to use in the syncer's deployment YAML.")
+	enableSyncerCmd.Flags().StringVar(&syncerImage, "syncer-image", syncerImage, "The syncer image to use in the syncer's deployment YAML. Images are published at https://github.com/kcp-dev/kcp/pkgs/container/kcp%2Fsyncer.")
 	enableSyncerCmd.Flags().IntVar(&replicas, "replicas", replicas, "Number of replicas of the syncer deployment.")
 	enableSyncerCmd.Flags().StringVar(&kcpNamespaceName, "kcp-namespace", kcpNamespaceName, "The name of the kcp namespace to create a service account in.")
+	enableSyncerCmd.Flags().StringVarP(&outputFile, "output-file", "o", outputFile, "The manifest file to be created and applied to the physical cluster. Use - for stdout.")
 
 	cmd.AddCommand(enableSyncerCmd)
 

--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -31,12 +31,14 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/martinlindhe/base36"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -53,31 +55,14 @@ import (
 var embeddedResources embed.FS
 
 const (
-	// These resource names include a kcp- due to the intended use in pclusters.
-	SyncerResourceName = "kcp-syncer"
-	SyncerSecretName   = "kcp-syncer-config"
-
-	// The name of the key for the upstream config in the pcluster secret.
-	SyncerSecretConfigKey = "kubeconfig"
-
-	// The prefix for syncer-supporting auth resources in kcp.
-	SyncerAuthResourcePrefix = "syncer-"
-
-	// Max length of service account name (cluster role has no limit)
-	MaxSyncerAuthResourceName = 254
-
-	// SyncerIDPrefix is the syncer id prefix is only 7 characters so that the 224 bits
-	// of an sha hash can be suffixed and still be within kube's 63
-	// char resource name limit.
-	//
-	// TODO(marun) This prefix should be reserved to avoid user resources being misidentified as syncer resources.
-	// TODO(marun) Would a shorter hash be sufficient?
-	SyncerIDPrefix = "kcpsync"
+	SyncerSecretConfigKey   = "kubeconfig"
+	SyncerIDPrefix          = "kcp-syncer-"
+	MaxSyncTargetNameLength = validation.DNS1123SubdomainMaxLength - 9 + len(SyncerIDPrefix)
 )
 
 // Sync prepares a kcp workspace for use with a syncer and outputs the
 // configuration required to deploy a syncer to the pcluster to stdout.
-func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNamespaceName, image string, resourcesToSync []string, replicas int) error {
+func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNamespaceName, downstreamNamespace, image string, resourcesToSync []string, replicas int) error {
 	config, err := clientcmd.NewDefaultClientConfig(*c.startingConfig, c.overrides).ClientConfig()
 	if err != nil {
 		return err
@@ -94,7 +79,7 @@ func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNa
 		defer outputFile.Close() // nolint: errcheck
 	}
 
-	token, err := c.enableSyncerForWorkspace(ctx, config, syncTargetName, kcpNamespaceName)
+	token, syncerID, err := c.enableSyncerForWorkspace(ctx, config, syncTargetName, kcpNamespaceName)
 	if err != nil {
 		return err
 	}
@@ -102,6 +87,10 @@ func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNa
 	configURL, currentClusterName, err := helpers.ParseClusterURL(config.Host)
 	if err != nil {
 		return fmt.Errorf("current URL %q does not point to cluster workspace", config.Host)
+	}
+
+	if downstreamNamespace == "" {
+		downstreamNamespace = syncerID
 	}
 
 	// Compose the syncer's upstream configuration server URL without any path. This is
@@ -116,6 +105,7 @@ func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNa
 		CAData:          base64.StdEncoding.EncodeToString(config.CAData),
 		Token:           token,
 		KCPNamespace:    kcpNamespaceName,
+		Namespace:       downstreamNamespace,
 		LogicalCluster:  currentClusterName.String(),
 		SyncTarget:      syncTargetName,
 		Image:           image,
@@ -123,33 +113,35 @@ func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNa
 		ResourcesToSync: resourcesToSync,
 	}
 
-	resources, err := renderSyncerResources(input)
+	resources, err := renderSyncerResources(input, syncerID)
 	if err != nil {
 		return err
 	}
 
 	_, err = outputFile.Write(resources)
 	if outputFilePath != "-" {
-		c.ErrOut.Write([]byte(fmt.Sprintf("Wrote physical cluster manifest to %s. Use\n\n  KUBECONFIG=<pcluster-config> kubectl apply -f %q\n\nto apply it.\n", outputFilePath, outputFilePath))) // nolint: errcheck
+		// nolint: errcheck
+		c.ErrOut.Write([]byte(fmt.Sprintf("\nWrote physical cluster manifest to %s for namespace %q. Use\n\n  KUBECONFIG=<pcluster-config> kubectl apply -f %q\n\nto apply it. "+
+			"Use\n\n  KUBECONFIG=<pcluster-config> kubectl get deployment -n %q %s\n\nto verify the syncer pod is running.\n", outputFilePath, downstreamNamespace, outputFilePath, downstreamNamespace, syncerID)))
 	}
 	return err
 }
 
-// GetSyncerID returns the resource identifier of a syncer for the given logical
-// cluster and sync target. The ID is unique for unique pairs of inputs to ensure
-// a pcluster can be configured with multiple syncers for a given kcp instance.
-func GetSyncerID(logicalClusterName string, syncTargetName string) string {
-	syncerHash := sha256.Sum224([]byte(logicalClusterName + syncTargetName))
-	return fmt.Sprintf("%s%x", SyncerIDPrefix, syncerHash)
+// getSyncerID returns a unique ID for a syncer derived from the name and its UID. It's
+// a valid DNS segment and can be used as namespace or object names.
+func getSyncerID(syncTarget *workloadv1alpha1.SyncTarget) string {
+	syncerHash := sha256.Sum224([]byte(syncTarget.UID))
+	base36hash := strings.ToLower(base36.EncodeBytes(syncerHash[:]))
+	return fmt.Sprintf("kcp-syncer-%s-%s", syncTarget.Name, base36hash[:8])
 }
 
 // enableSyncerForWorkspace creates a sync target with the given name and creates a service
 // account for the syncer in the given namespace. The expectation is that the provided config is
 // for a logical cluster (workspace). Returns the token the syncer will use to connect to kcp.
-func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Config, syncTargetName, namespace string) (string, error) {
+func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Config, syncTargetName, namespace string) (string, string, error) {
 	kcpClient, err := kcpclientset.NewForConfig(config)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kcp client: %w", err)
+		return "", "", fmt.Errorf("failed to create kcp client: %w", err)
 	}
 
 	syncTarget, err := kcpClient.WorkloadV1alpha1().SyncTargets().Get(ctx,
@@ -157,7 +149,7 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 		metav1.GetOptions{},
 	)
 	if err != nil && !errors.IsNotFound(err) {
-		return "", fmt.Errorf("failed to get synctarget %q: %w", syncTargetName, err)
+		return "", "", fmt.Errorf("failed to get synctarget %q: %w", syncTargetName, err)
 	} else if errors.IsNotFound(err) {
 		// Create the sync target that will serve as a point of coordination between
 		// kcp and the syncer (e.g. heartbeating from the syncer and virtual cluster urls
@@ -173,7 +165,7 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 			metav1.CreateOptions{},
 		)
 		if err != nil && !errors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("failed to create synctarget %q: %w", syncTargetName, err)
+			return "", "", fmt.Errorf("failed to create synctarget %q: %w", syncTargetName, err)
 		}
 	} else if err == nil {
 		// nolint: errcheck
@@ -182,8 +174,10 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 
 	kubeClient, err := kubernetesclientset.NewForConfig(config)
 	if err != nil {
-		return "", fmt.Errorf("failed to create kubernetes client: %w", err)
+		return "", "", fmt.Errorf("failed to create kubernetes client: %w", err)
 	}
+
+	syncerID := getSyncerID(syncTarget)
 
 	syncTargetOwnerReferences := []metav1.OwnerReference{{
 		APIVersion: workloadv1alpha1.SchemeGroupVersion.String(),
@@ -191,22 +185,18 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 		Name:       syncTarget.Name,
 		UID:        syncTarget.UID,
 	}}
-
-	// Create a service account for the syncer with the necessary permissions. It will
-	// be owned by the sync target to ensure cleanup.
-	authResourceName := SyncerAuthResourcePrefix + syncTargetName
-	sa, err := kubeClient.CoreV1().ServiceAccounts(namespace).Get(ctx, authResourceName, metav1.GetOptions{})
+	sa, err := kubeClient.CoreV1().ServiceAccounts(namespace).Get(ctx, syncerID, metav1.GetOptions{})
 
 	switch {
 	case errors.IsNotFound(err):
-		c.ErrOut.Write([]byte(fmt.Sprintf("Creating service account %q\n", authResourceName))) // nolint: errcheck
+		c.ErrOut.Write([]byte(fmt.Sprintf("Creating service account %q\n", syncerID))) // nolint: errcheck
 		if sa, err = kubeClient.CoreV1().ServiceAccounts(namespace).Create(ctx, &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            authResourceName,
+				Name:            syncerID,
 				OwnerReferences: syncTargetOwnerReferences,
 			},
 		}, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
-			return "", fmt.Errorf("failed to create ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, authResourceName, err)
+			return "", "", fmt.Errorf("failed to create ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, syncerID, err)
 		}
 	case err == nil:
 		oldData, err := json.Marshal(corev1.ServiceAccount{
@@ -215,7 +205,7 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal old data for ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, authResourceName, err)
+			return "", "", fmt.Errorf("failed to marshal old data for ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, syncerID, err)
 		}
 
 		newData, err := json.Marshal(corev1.ServiceAccount{
@@ -226,20 +216,20 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 			},
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal new data for ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, authResourceName, err)
+			return "", "", fmt.Errorf("failed to marshal new data for ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, syncerID, err)
 		}
 
 		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 		if err != nil {
-			return "", fmt.Errorf("failed to create patch for ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, authResourceName, err)
+			return "", "", fmt.Errorf("failed to create patch for ServiceAccount %s|%s/%s: %w", syncTargetName, namespace, syncerID, err)
 		}
 
-		c.ErrOut.Write([]byte(fmt.Sprintf("Updating service account %q.\n", authResourceName))) // nolint: errcheck
+		c.ErrOut.Write([]byte(fmt.Sprintf("Updating service account %q.\n", syncerID))) // nolint: errcheck
 		if sa, err = kubeClient.CoreV1().ServiceAccounts(namespace).Patch(ctx, sa.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-			return "", fmt.Errorf("failed to patch ServiceAccount %s|%s/%s: %w", syncTargetName, authResourceName, namespace, err)
+			return "", "", fmt.Errorf("failed to patch ServiceAccount %s|%s/%s: %w", syncTargetName, syncerID, namespace, err)
 		}
 	default:
-		return "", fmt.Errorf("failed to get the ServiceAccount %s|%s/%s: %w", syncTargetName, authResourceName, namespace, err)
+		return "", "", fmt.Errorf("failed to get the ServiceAccount %s|%s/%s: %w", syncTargetName, syncerID, namespace, err)
 	}
 
 	// Create a cluster role that provides the syncer the minimal permissions
@@ -271,19 +261,19 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 	}
 
 	cr, err := kubeClient.RbacV1().ClusterRoles().Get(ctx,
-		authResourceName,
+		syncerID,
 		metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
-		c.ErrOut.Write([]byte(fmt.Sprintf("Creating cluster role %q to give service account %q\n\n 1. write and sync access to the synctarget %q\n 2. write access to apiresourceimports.\n", authResourceName))) // nolint: errcheck
+		c.ErrOut.Write([]byte(fmt.Sprintf("Creating cluster role %q to give service account %q\n\n 1. write and sync access to the synctarget %q\n 2. write access to apiresourceimports.\n\n", syncerID, syncerID, syncerID))) // nolint: errcheck
 		if _, err = kubeClient.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            authResourceName,
+				Name:            syncerID,
 				OwnerReferences: syncTargetOwnerReferences,
 			},
 			Rules: rules,
 		}, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
-			return "", err
+			return "", "", err
 		}
 	case err == nil:
 		oldData, err := json.Marshal(rbacv1.ClusterRole{
@@ -293,7 +283,7 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 			Rules: cr.Rules,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal old data for ClusterRole %s|%s: %w", syncTargetName, authResourceName, err)
+			return "", "", fmt.Errorf("failed to marshal old data for ClusterRole %s|%s: %w", syncTargetName, syncerID, err)
 		}
 
 		newData, err := json.Marshal(rbacv1.ClusterRole{
@@ -305,56 +295,56 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 			Rules: rules,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to marshal new data for ClusterRole %s|%s: %w", syncTargetName, authResourceName, err)
+			return "", "", fmt.Errorf("failed to marshal new data for ClusterRole %s|%s: %w", syncTargetName, syncerID, err)
 		}
 
 		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 		if err != nil {
-			return "", fmt.Errorf("failed to create patch for ClusterRole %s|%s: %w", syncTargetName, authResourceName, err)
+			return "", "", fmt.Errorf("failed to create patch for ClusterRole %s|%s: %w", syncTargetName, syncerID, err)
 		}
 
-		c.ErrOut.Write([]byte(fmt.Sprintf("Updating cluster role %q with\n\n 1. write and sync access to the synctarget %q\n 2. write access to apiresourceimports.\n\n", authResourceName, authResourceName))) // nolint: errcheck
+		c.ErrOut.Write([]byte(fmt.Sprintf("Updating cluster role %q with\n\n 1. write and sync access to the synctarget %q\n 2. write access to apiresourceimports.\n\n", syncerID, syncerID))) // nolint: errcheck
 		if _, err = kubeClient.RbacV1().ClusterRoles().Patch(ctx, cr.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-			return "", fmt.Errorf("failed to patch ClusterRole %s|%s/%s: %w", syncTargetName, authResourceName, namespace, err)
+			return "", "", fmt.Errorf("failed to patch ClusterRole %s|%s/%s: %w", syncTargetName, syncerID, namespace, err)
 		}
 	default:
-		return "", err
+		return "", "", err
 	}
 
 	// Grant the service account the role created just above in the workspace
 	subjects := []rbacv1.Subject{{
 		Kind:      "ServiceAccount",
-		Name:      authResourceName,
+		Name:      syncerID,
 		Namespace: namespace,
 	}}
 	roleRef := rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     authResourceName,
+		Name:     syncerID,
 		APIGroup: "rbac.authorization.k8s.io",
 	}
 
 	_, err = kubeClient.RbacV1().ClusterRoleBindings().Get(ctx,
-		authResourceName,
+		syncerID,
 		metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
-		return "", err
+		return "", "", err
 	}
 	if err == nil {
-		if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, authResourceName, metav1.DeleteOptions{}); err != nil {
-			return "", err
+		if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, syncerID, metav1.DeleteOptions{}); err != nil {
+			return "", "", err
 		}
 	}
 
-	c.ErrOut.Write([]byte(fmt.Sprintf("Creating cluster role binding %q to bind service account %q to cluster role %q.\n", authResourceName, authResourceName, authResourceName))) // nolint: errcheck
+	c.ErrOut.Write([]byte(fmt.Sprintf("Creating or updating cluster role binding %q to bind service account %q to cluster role %q.\n", syncerID, syncerID, syncerID))) // nolint: errcheck
 	if _, err = kubeClient.RbacV1().ClusterRoleBindings().Create(ctx, &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            authResourceName,
+			Name:            syncerID,
 			OwnerReferences: syncTargetOwnerReferences,
 		},
 		Subjects: subjects,
 		RoleRef:  roleRef,
 	}, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
-		return "", err
+		return "", "", err
 	}
 
 	// Wait for the service account to be updated with the name of the token secret
@@ -372,20 +362,20 @@ func (c *Config) enableSyncerForWorkspace(ctx context.Context, config *rest.Conf
 		return true, nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("timed out waiting for token secret name to be set on ServiceAccount %s/%s", namespace, sa.Name)
+		return "", "", fmt.Errorf("timed out waiting for token secret name to be set on ServiceAccount %s/%s", namespace, sa.Name)
 	}
 
 	// Retrieve the token that the syncer will use to authenticate to kcp
 	tokenSecret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, tokenSecretName, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed to retrieve Secret: %w", err)
+		return "", "", fmt.Errorf("failed to retrieve Secret: %w", err)
 	}
 	saToken := tokenSecret.Data["token"]
 	if len(saToken) == 0 {
-		return "", fmt.Errorf("token secret %s/%s is missing a value for `token`", namespace, tokenSecretName)
+		return "", "", fmt.Errorf("token secret %s/%s is missing a value for `token`", namespace, tokenSecretName)
 	}
 
-	return string(saToken), nil
+	return string(saToken), syncerID, nil
 }
 
 // mergeOwnerReference: merge a slice of ownerReference with a given ownerReferences
@@ -423,6 +413,8 @@ type templateInput struct {
 	Token string
 	// KCPNamespace is the name of the kcp namespace of the syncer's service account
 	KCPNamespace string
+	// Namespace is the name of the syncer namespace on the pcluster
+	Namespace string
 	// LogicalCluster is the qualified kcp logical cluster name the syncer will sync from
 	LogicalCluster string
 	// SyncTarget is the name of the sync target the syncer will use to
@@ -445,8 +437,6 @@ type templateArgs struct {
 	// LabelSafeLogicalCluster is the qualified kcp logical cluster name that is
 	// safe to appear as a label value
 	LabelSafeLogicalCluster string
-	// Namespace is the name of the syncer namespace on the pcluster
-	Namespace string
 	// ServiceAccount is the name of the service account to create in the syncer
 	// namespace on the pcluster.
 	ServiceAccount string
@@ -479,20 +469,17 @@ type templateArgs struct {
 // TODO(marun) Is it possible to set owner references in a set of applied resources? Ideally the
 // cluster role and role binding would be owned by the namespace to ensure cleanup on deletion
 // of the namespace.
-func renderSyncerResources(input templateInput) ([]byte, error) {
-	syncerID := GetSyncerID(input.LogicalCluster, input.SyncTarget)
-
+func renderSyncerResources(input templateInput, syncerID string) ([]byte, error) {
 	tmplArgs := templateArgs{
 		templateInput:           input,
 		LabelSafeLogicalCluster: strings.ReplaceAll(input.LogicalCluster, ":", "_"),
-		Namespace:               syncerID,
-		ServiceAccount:          SyncerResourceName,
+		ServiceAccount:          syncerID,
 		ClusterRole:             syncerID,
 		ClusterRoleBinding:      syncerID,
 		GroupMappings:           getGroupMappings(input.ResourcesToSync),
-		Secret:                  SyncerSecretName,
+		Secret:                  syncerID,
 		SecretConfigKey:         SyncerSecretConfigKey,
-		Deployment:              SyncerResourceName,
+		Deployment:              syncerID,
 		DeploymentApp:           syncerID,
 	}
 

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -28,7 +28,7 @@ func TestNewSyncerYAML(t *testing.T) {
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
   labels:
     workload.kcp.io/logical-cluster: root_default_foo
     workload.kcp.io/sync-target: sync-target-name
@@ -36,13 +36,13 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kcp-syncer
-  namespace:  kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
 rules:
 - apiGroups:
   - ""
@@ -71,21 +71,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
 subjects:
 - kind: ServiceAccount
-  name: kcp-syncer
-  namespace:  kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kcp-syncer-config
-  namespace:  kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
 stringData:
   kubeconfig: |
     apiVersion: v1
@@ -110,19 +110,19 @@ stringData:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kcp-syncer
-  namespace:  kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app: kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+      app: kcp-syncer-sync-target-name-34b23c4k
   template:
     metadata:
       labels:
-        app: kcpsync3c05582c738de0f4d607d01f180062e37de58a9e3e6fd59b586bbccc
+        app: kcp-syncer-sync-target-name-34b23c4k
     spec:
       containers:
       - name: kcp-syncer
@@ -141,11 +141,11 @@ spec:
         - name: kcp-config
           mountPath: /kcp/
           readOnly: true
-      serviceAccountName: kcp-syncer
+      serviceAccountName: kcp-syncer-sync-target-name-34b23c4k
       volumes:
         - name: kcp-config
           secret:
-            secretName: kcp-syncer-config
+            secretName: kcp-syncer-sync-target-name-34b23c4k
             optional: false
 `
 	actualYAML, err := renderSyncerResources(templateInput{
@@ -153,12 +153,13 @@ spec:
 		Token:           "token",
 		CAData:          "ca-data",
 		KCPNamespace:    "kcp-namespace",
+		Namespace:       "kcp-syncer-sync-target-name-34b23c4k",
 		LogicalCluster:  "root:default:foo",
 		SyncTarget:      "sync-target-name",
 		Image:           "image",
 		Replicas:        1,
 		ResourcesToSync: []string{"resource1", "resource2"},
-	})
+	}, "kcp-syncer-sync-target-name-34b23c4k")
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))
 }

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{.ServiceAccount}}
-  namespace:  {{.Namespace}}
+  namespace: {{.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -56,13 +56,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{.ServiceAccount}}
-  namespace:  {{.Namespace}}
+  namespace: {{.Namespace}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{.Secret}}
-  namespace:  {{.Namespace}}
+  namespace: {{.Namespace}}
 stringData:
   {{.SecretConfigKey}}: |
     apiVersion: v1
@@ -88,7 +88,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{.Deployment}}
-  namespace:  {{.Namespace}}
+  namespace: {{.Namespace}}
 spec:
   replicas: {{.Replicas}}
   strategy:

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -40,7 +40,6 @@ import (
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	workloadcliplugin "github.com/kcp-dev/kcp/pkg/cliplugins/workload/plugin"
 	"github.com/kcp-dev/kcp/pkg/syncer/spec"
 	"github.com/kcp-dev/kcp/pkg/syncer/status"
 	"github.com/kcp-dev/kcp/third_party/keyfunctions"
@@ -67,10 +66,6 @@ type SyncerConfig struct {
 	ResourcesToSync  sets.String
 	KCPClusterName   logicalcluster.Name
 	SyncTargetName   string
-}
-
-func (sc *SyncerConfig) ID() string {
-	return workloadcliplugin.GetSyncerID(sc.KCPClusterName.String(), sc.SyncTargetName)
 }
 
 func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, importPollInterval time.Duration) error {

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -427,6 +427,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 		"sync",
 		sf.SyncTargetName,
 		"--syncer-image", syncerImage,
+		"--output-file", "-",
 	}
 	for _, resource := range sf.ResourcesToSync.List() {
 		pluginArgs = append(pluginArgs, "--resources", resource)
@@ -469,8 +470,20 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	// Extract the configuration for an in-process syncer from the resources that were
 	// applied to the downstream server. This maximizes the parity between the
 	// configuration of a deployed and in-process syncer.
-	syncerNamespace := workloadcliplugin.GetSyncerID(sf.WorkspaceClusterName.String(), sf.SyncTargetName)
-	syncerConfig := syncerConfigFromCluster(t, downstreamConfig, syncerNamespace)
+	var syncerID string
+	for _, doc := range strings.Split(string(syncerYAML), "\n---\n") {
+		var manifest struct {
+			metav1.ObjectMeta `json:"metadata"`
+		}
+		err := yaml.Unmarshal([]byte(doc), &manifest)
+		require.NoError(t, err)
+		if manifest.Namespace != "" {
+			syncerID = manifest.Namespace
+			break
+		}
+	}
+	require.NotEmpty(t, syncerID, "failed to extract syncer ID from yaml produced by plugin:\n%s", string(syncerYAML))
+	syncerConfig := syncerConfigFromCluster(t, downstreamConfig, syncerID, syncerID)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
@@ -524,7 +537,6 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	})
 
 	if useDeployedSyncer {
-		syncerID := syncerConfig.ID()
 		t.Cleanup(func() {
 			ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 			defer cancelFn()
@@ -672,7 +684,7 @@ func WriteLogicalClusterConfig(t *testing.T, rawConfig clientcmdapi.Config, clus
 
 // syncerConfigFromCluster reads the configuration needed to start an in-process
 // syncer from the resources applied to a cluster for a deployed syncer.
-func syncerConfigFromCluster(t *testing.T, config *rest.Config, namespace string) *syncer.SyncerConfig {
+func syncerConfigFromCluster(t *testing.T, config *rest.Config, namespace, syncerID string) *syncer.SyncerConfig {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
 
@@ -680,7 +692,7 @@ func syncerConfigFromCluster(t *testing.T, config *rest.Config, namespace string
 	require.NoError(t, err)
 
 	// Read the upstream kubeconfig from the syncer secret
-	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, workloadcliplugin.SyncerSecretName, metav1.GetOptions{})
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, syncerID, metav1.GetOptions{})
 	require.NoError(t, err)
 	upstreamConfigBytes := secret.Data[workloadcliplugin.SyncerSecretConfigKey]
 	require.NotEmpty(t, upstreamConfigBytes, "upstream config is required")
@@ -688,7 +700,7 @@ func syncerConfigFromCluster(t *testing.T, config *rest.Config, namespace string
 	require.NoError(t, err, "failed to load upstream config")
 
 	// Read the arguments from the syncer deployment
-	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, workloadcliplugin.SyncerResourceName, metav1.GetOptions{})
+	deployment, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, syncerID, metav1.GetOptions{})
 	require.NoError(t, err)
 	containers := deployment.Spec.Template.Spec.Containers
 	require.NotEmpty(t, containers, "expected at least one container in syncer deployment")
@@ -716,7 +728,7 @@ func syncerConfigFromCluster(t *testing.T, config *rest.Config, namespace string
 			return false
 		}
 		for _, secret := range secrets.Items {
-			if secret.Annotations[corev1.ServiceAccountNameKey] == workloadcliplugin.SyncerResourceName {
+			if secret.Annotations[corev1.ServiceAccountNameKey] == syncerID {
 				tokenSecret = secret
 				return true
 			}

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -457,6 +457,7 @@ func TestSyncWorkload(t *testing.T) {
 		syncTargetName,
 		"--syncer-image",
 		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
+		"--output-file", "-",
 	}
 
 	framework.RunKcpCliPlugin(t, kubeconfigPath, subCommand)


### PR DESCRIPTION
- add mandatory `--output-file | -o` flag. It works with `-`.
- shorten default syncer namespace to `kcp-syncer-<synctarget>-<8-char-hash-of-uid>`, and reuse this as syncer ID for all resources. With this you can run multiple syncer in the same namespace.
- add `--namespace | -n` flag to customize syncer namespace
- document how to `kubectl apply -f -` directly:
  ```
  $ kubectl kcp workload sync --help
  Create a synctarget in kcp with service account and RBAC permissions. Output a manifest to deploy a syncer for the given sync target in a physical cluster.

  Usage:
    kcp workload sync <sync-target-name> --syncer-image <kcp-syncer-image> [--resources=<resource1>,<resource2>..] -o <output-file> [flags]

  Examples:

	# Ensure a syncer is running on the specified sync target.
	kubectl kcp workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o syncer.yaml
	KUBECONFIG=<pcluster-config> kubectl apply -f syncer.yaml

	# Directly apply the manifest
	kubectl kcp workload sync <sync-target-name> --syncer-image <kcp-syncer-image> -o - | KUBECONFIG=<pcluster-config> kubectl apply -f -
  ```
- print what it does on stderr:
  ```
  $ kubectl kcp workload sync kind --syncer-image ghcr.io/kcp-dev/kcp/syncer:8a30b5d --output-file kind-syncer.yaml                                                                  sttts-syncer-usability
  Synctarget "kind" already exists.
  Updating service account "syncer-kind".
  Updating cluster role "syncer-kind" with

    1. write and sync access to the synctarget "syncer-kind"
    2. write access to apiresourceimports.

  Creating cluster role binding "syncer-kind" to bind service account "syncer-kind" to cluster role "syncer-kind".
  Wrote physical cluster manifest to kind-syncer.yaml. Use

    KUBECONFIG=<pcluster-config> kubectl apply -f "kind-syncer.yaml"

  to apply it.
  ```