### PR TITLE
Add shard-base-url flag to default clusterworkspaceshards

### DIFF
--- a/pkg/admission/clusterworkspaceshard/admission.go
+++ b/pkg/admission/clusterworkspaceshard/admission.go
@@ -52,6 +52,7 @@ func Register(plugins *admission.Plugins) {
 type clusterWorkspaceShard struct {
 	*admission.Handler
 
+	shardBaseURLProvider    func() string
 	externalAddressProvider func() string
 }
 
@@ -102,16 +103,28 @@ func (o *clusterWorkspaceShard) Admit(ctx context.Context, a admission.Attribute
 		return fmt.Errorf("failed to convert unstructured to ClusterWorkspaceShard: %w", err)
 	}
 
+	defaultShardBaseURL := ""
+	if o.shardBaseURLProvider != nil {
+		defaultShardBaseURL = o.shardBaseURLProvider()
+	}
+
+	defaultExternalAddress := ""
+	if o.externalAddressProvider != nil {
+		defaultExternalAddress = o.externalAddressProvider()
+	}
+
 	if cws.Spec.BaseURL == "" {
-		if o.externalAddressProvider == nil {
-			return fmt.Errorf("cannot default baseURL for ClusterWorkspaceShard %q: no external address provider", tenancyhelper.QualifiedObjectName(cws))
+		if defaultShardBaseURL == "" && defaultExternalAddress == "" {
+			return fmt.Errorf("cannot default baseURL for ClusterWorkspaceShard %q: no default shard base URL and no default external address provided", tenancyhelper.QualifiedObjectName(cws))
 		}
-		if externalAddress := o.externalAddressProvider(); externalAddress == "" {
-			return fmt.Errorf("cannot default baseURL for ClusterWorkspaceShard %q: external address is nil", tenancyhelper.QualifiedObjectName(cws))
+
+		if defaultShardBaseURL != "" {
+			cws.Spec.BaseURL = defaultShardBaseURL
 		} else {
-			cws.Spec.BaseURL = "https://" + externalAddress
+			cws.Spec.BaseURL = "https://" + defaultExternalAddress
 		}
 	}
+
 	if cws.Spec.ExternalURL == "" {
 		cws.Spec.ExternalURL = cws.Spec.BaseURL
 	}
@@ -123,6 +136,10 @@ func (o *clusterWorkspaceShard) Admit(ctx context.Context, a admission.Attribute
 	u.Object = raw
 
 	return nil
+}
+
+func (o *clusterWorkspaceShard) SetShardBaseURLProvider(shardBaseURLProvider func() string) {
+	o.shardBaseURLProvider = shardBaseURLProvider
 }
 
 func (o *clusterWorkspaceShard) SetExternalAddressProvider(externalAddressProvider func() string) {

--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -103,3 +103,21 @@ func (i *externalAddressInitializer) Initialize(plugin admission.Interface) {
 		wants.SetExternalAddressProvider(i.externalAddressProvider)
 	}
 }
+
+// NewShardBaseURLInitializer returns an admission plugin initializer that injects
+// the default shard base URL provider into the admission plugin.
+func NewShardBaseURLInitializer(shardBaseURLProvider func() string) *shardBaseURLInitializer {
+	return &shardBaseURLInitializer{
+		shardBaseURLProvider: shardBaseURLProvider,
+	}
+}
+
+type shardBaseURLInitializer struct {
+	shardBaseURLProvider func() string
+}
+
+func (i *shardBaseURLInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsShardBaseURLProvider); ok {
+		wants.SetShardBaseURLProvider(i.shardBaseURLProvider)
+	}
+}

--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -106,18 +106,18 @@ func (i *externalAddressInitializer) Initialize(plugin admission.Interface) {
 
 // NewShardBaseURLInitializer returns an admission plugin initializer that injects
 // the default shard base URL provider into the admission plugin.
-func NewShardBaseURLInitializer(shardBaseURLProvider func() string) *shardBaseURLInitializer {
+func NewShardBaseURLInitializer(shardBaseURL string) *shardBaseURLInitializer {
 	return &shardBaseURLInitializer{
-		shardBaseURLProvider: shardBaseURLProvider,
+		shardBaseURL: shardBaseURL,
 	}
 }
 
 type shardBaseURLInitializer struct {
-	shardBaseURLProvider func() string
+	shardBaseURL string
 }
 
 func (i *shardBaseURLInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantsShardBaseURLProvider); ok {
-		wants.SetShardBaseURLProvider(i.shardBaseURLProvider)
+	if wants, ok := plugin.(WantsShardBaseURL); ok {
+		wants.SetShardBaseURL(i.shardBaseURL)
 	}
 }

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -47,8 +47,8 @@ type WantsExternalAddressProvider interface {
 	SetExternalAddressProvider(externalAddressProvider func() string)
 }
 
-// WantsShardBaseURLProvider interface should be implemented by admission plugins
+// WantsShardBaseURL interface should be implemented by admission plugins
 // that want to have the default shard base url injected.
-type WantsShardBaseURLProvider interface {
-	SetShardBaseURLProvider(shardBaseURLProvider func() string)
+type WantsShardBaseURL interface {
+	SetShardBaseURL(shardBaseURL string)
 }

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -46,3 +46,9 @@ type WantsKcpClusterClient interface {
 type WantsExternalAddressProvider interface {
 	SetExternalAddressProvider(externalAddressProvider func() string)
 }
+
+// WantsShardBaseURLProvider interface should be implemented by admission plugins
+// that want to have the default shard base url injected.
+type WantsShardBaseURLProvider interface {
+	SetShardBaseURLProvider(shardBaseURLProvider func() string)
+}

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -131,6 +131,7 @@ var (
 		"enable-sharding",             // Enable delegating to peer kcp shards.
 		"profiler-address",            // [Address]:port to bind the profiler to
 		"root-directory",              // Root directory.
+		"shard-base-url",              // Base URL to the this kcp shard. Defaults to external address.
 		"shard-kubeconfig-file",       // Kubeconfig holding admin(!) credentials to peer kcp shards.
 		"experimental-bind-free-port", // Bind to a free port. --secure-bind-port must be 0. Use the admin.kubeconfig to extract the chosen port.
 

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -54,6 +54,7 @@ type ExtraOptions struct {
 	RootDirectory            string
 	ProfilerAddress          string
 	ShardKubeconfigFile      string
+	ShardBaseURL             string
 	EnableSharding           bool
 	DiscoveryPollInterval    time.Duration
 	ExperimentalBindFreePort bool
@@ -90,6 +91,7 @@ func NewOptions(rootDir string) *Options {
 			RootDirectory:            rootDir,
 			ProfilerAddress:          "",
 			ShardKubeconfigFile:      "",
+			ShardBaseURL:             "",
 			EnableSharding:           false,
 			DiscoveryPollInterval:    60 * time.Second,
 			ExperimentalBindFreePort: false,
@@ -150,6 +152,7 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs := fss.FlagSet("KCP")
 	fs.StringVar(&o.Extra.ProfilerAddress, "profiler-address", o.Extra.ProfilerAddress, "[Address]:port to bind the profiler to")
 	fs.StringVar(&o.Extra.ShardKubeconfigFile, "shard-kubeconfig-file", o.Extra.ShardKubeconfigFile, "Kubeconfig holding admin(!) credentials to peer kcp shards.")
+	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to the this kcp shard. Defaults to external address.")
 	fs.BoolVar(&o.Extra.EnableSharding, "enable-sharding", o.Extra.EnableSharding, "Enable delegating to peer kcp shards.")
 	fs.StringVar(&o.Extra.RootDirectory, "root-directory", o.Extra.RootDirectory, "Root directory.")
 	fs.DurationVar(&o.Extra.DiscoveryPollInterval, "discovery-poll-interval", o.Extra.DiscoveryPollInterval, "Polling interval for dynamic discovery informers.")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -284,6 +284,7 @@ func (s *Server) Run(ctx context.Context) error {
 		kcpadmissioninitializers.NewKcpInformersInitializer(s.kcpSharedInformerFactory),
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
+		kcpadmissioninitializers.NewShardBaseURLInitializer(func() string { return s.options.Extra.ShardBaseURL }),
 		// The external address is provided as a function, as its value may be updated
 		// with the default secure port, when the config is later completed.
 		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return genericConfig.ExternalAddress }),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -284,7 +284,7 @@ func (s *Server) Run(ctx context.Context) error {
 		kcpadmissioninitializers.NewKcpInformersInitializer(s.kcpSharedInformerFactory),
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
-		kcpadmissioninitializers.NewShardBaseURLInitializer(func() string { return s.options.Extra.ShardBaseURL }),
+		kcpadmissioninitializers.NewShardBaseURLInitializer(s.options.Extra.ShardBaseURL),
 		// The external address is provided as a function, as its value may be updated
 		// with the default secure port, when the config is later completed.
 		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return genericConfig.ExternalAddress }),


### PR DESCRIPTION
Add `shard-base-url` flag to make the `BaseURL` default value configurable for `ClusterWorkspaceShards`

Signed-off-by: Christopher Sams <csams@redhat.com>
