### PR TITLE
adds a shard-name flag for assigning a name to a shard instance

### DIFF
--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -132,6 +132,7 @@ var (
 		"profiler-address",            // [Address]:port to bind the profiler to
 		"root-directory",              // Root directory.
 		"shard-base-url",              // Base URL to the this kcp shard. Defaults to external address.
+		"shard-name",                  // A name of this kcp shard.
 		"shard-kubeconfig-file",       // Kubeconfig holding admin(!) credentials to peer kcp shards.
 		"experimental-bind-free-port", // Bind to a free port. --secure-bind-port must be 0. Use the admin.kubeconfig to extract the chosen port.
 

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -55,6 +55,7 @@ type ExtraOptions struct {
 	ProfilerAddress          string
 	ShardKubeconfigFile      string
 	ShardBaseURL             string
+	ShardName                string
 	EnableSharding           bool
 	DiscoveryPollInterval    time.Duration
 	ExperimentalBindFreePort bool
@@ -92,6 +93,7 @@ func NewOptions(rootDir string) *Options {
 			ProfilerAddress:          "",
 			ShardKubeconfigFile:      "",
 			ShardBaseURL:             "",
+			ShardName:                "root",
 			EnableSharding:           false,
 			DiscoveryPollInterval:    60 * time.Second,
 			ExperimentalBindFreePort: false,
@@ -153,6 +155,7 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.Extra.ProfilerAddress, "profiler-address", o.Extra.ProfilerAddress, "[Address]:port to bind the profiler to")
 	fs.StringVar(&o.Extra.ShardKubeconfigFile, "shard-kubeconfig-file", o.Extra.ShardKubeconfigFile, "Kubeconfig holding admin(!) credentials to peer kcp shards.")
 	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to the this kcp shard. Defaults to external address.")
+	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")
 	fs.BoolVar(&o.Extra.EnableSharding, "enable-sharding", o.Extra.EnableSharding, "Enable delegating to peer kcp shards.")
 	fs.StringVar(&o.Extra.RootDirectory, "root-directory", o.Extra.RootDirectory, "Root directory.")
 	fs.DurationVar(&o.Extra.DiscoveryPollInterval, "discovery-poll-interval", o.Extra.DiscoveryPollInterval, "Polling interval for dynamic discovery informers.")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -467,7 +467,7 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := configroot.Bootstrap(goContext(ctx),
 			apiextensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
 			dynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
-			"root",
+			s.options.Extra.ShardName,
 			clientcmdapi.Config{
 				Clusters: map[string]*clientcmdapi.Cluster{
 					// cross-cluster is the virtual cluster running by default


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
the flag will be used to:
- create/update the correct ClusterWorkspaceShard 
- to have custom logic to setup the two informers and the merging, i.e. to know whether this is the root shard or the other one.

the default value of the flag is the `root` name.
## Related issue(s)

Fixes #