### PR TITLE
apis/workload: move workload.kcp.dev/skip-default-object-creation here from apis.kcp.dev/v1alpha1

### DIFF
--- a/pkg/admission/reservedmetadata/admission.go
+++ b/pkg/admission/reservedmetadata/admission.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/utils/strings/slices"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 )
 
 const (
@@ -34,11 +36,11 @@ const (
 )
 
 var (
-	annotationAllowList = []string{}
-
-	labelAllowList = []string{
-		"experimental.workload.kcp.dev/scheduling-disabled",
+	annotationAllowList = []string{
+		workloadv1alpha1.AnnotationSkipDefaultObjectCreation,
 	}
+
+	labelAllowList = []string{}
 )
 
 // Register registers the reserved metadata plugin for creation and updates.

--- a/pkg/apis/apis/v1alpha1/types.go
+++ b/pkg/apis/apis/v1alpha1/types.go
@@ -193,10 +193,6 @@ const (
 	// for the request. This data is synthetic; it is not stored in etcd and instead is only applied when retrieving
 	// CRs for the CRD.
 	AnnotationAPIIdentityKey = "apis.kcp.dev/identity"
-
-	// AnnotationDefaultCreated is the annotation key for an apiexport or apibinding indicating the other default resources
-	// has been created already. If the created default resource is deleted, it will not be recreated.
-	AnnotationSkipDefaultObjectCreation = "apis.kcp.dev/skip-default-object-creation"
 )
 
 // BoundAPIResource describes a bound GroupVersionResource through an APIResourceSchema of an APIExport..

--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -108,4 +108,8 @@ const (
 	// InternalDownstreamClusterLabel is a label with the upstream cluster name applied on the downstream cluster
 	// instead of state.workload.kcp.dev/<sync-target-name> which is used upstream.
 	InternalDownstreamClusterLabel = "internal.workload.kcp.dev/cluster"
+
+	// AnnotationSkipDefaultObjectCreation is the annotation key for an apiexport or apibinding indicating the other default resources
+	// has been created already. If the created default resource is deleted, it will not be recreated.
+	AnnotationSkipDefaultObjectCreation = "workload.kcp.dev/skip-default-object-creation"
 )

--- a/pkg/reconciler/workload/apiexportcreate/apiexportcreate_controller.go
+++ b/pkg/reconciler/workload/apiexportcreate/apiexportcreate_controller.go
@@ -37,6 +37,7 @@ import (
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
 	schedulinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
@@ -249,7 +250,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 		}
 	}
 
-	if value, found := export.Annotations[apisv1alpha1.AnnotationSkipDefaultObjectCreation]; found && value == "true" {
+	if value, found := export.Annotations[workloadv1alpha1.AnnotationSkipDefaultObjectCreation]; found && value == "true" {
 		return nil
 	}
 
@@ -324,7 +325,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 	// patch the apiexport, so we do not create the location/apibinding again even if it is deleted.
 	exportPatch := map[string]interface{}{}
 	expectedAnnotations := map[string]interface{}{
-		apisv1alpha1.AnnotationSkipDefaultObjectCreation: "true",
+		workloadv1alpha1.AnnotationSkipDefaultObjectCreation: "true",
 	}
 	if err := unstructured.SetNestedField(exportPatch, expectedAnnotations, "metadata", "annotations"); err != nil {
 		return err

--- a/pkg/reconciler/workload/defaultplacement/defaultplacement_controller.go
+++ b/pkg/reconciler/workload/defaultplacement/defaultplacement_controller.go
@@ -37,6 +37,7 @@ import (
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
 	schedulinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
@@ -199,7 +200,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	if value, found := workloadBinding.Annotations[apisv1alpha1.AnnotationSkipDefaultObjectCreation]; found && value == "true" {
+	if value, found := workloadBinding.Annotations[workloadv1alpha1.AnnotationSkipDefaultObjectCreation]; found && value == "true" {
 		return nil
 	}
 
@@ -235,7 +236,7 @@ func (c *controller) process(ctx context.Context, key string) error {
 	// patch the apibinding, so we do not create the placement again even if it is deleted.
 	bindingPatch := map[string]interface{}{}
 	expectedAnnotations := map[string]interface{}{
-		apisv1alpha1.AnnotationSkipDefaultObjectCreation: "true",
+		workloadv1alpha1.AnnotationSkipDefaultObjectCreation: "true",
 	}
 	if err := unstructured.SetNestedField(bindingPatch, expectedAnnotations, "metadata", "annotations"); err != nil {
 		return err


### PR DESCRIPTION
Does not have anything to do with apis.kcp.dev/v1alpha1 in general.