### PR TITLE
API: Rename and make ClusterResourceStateLabelPrefix public

### DIFF
--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -61,7 +61,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
 	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
 	fs.StringVar(&options.PclusterID, "sync-target-name", options.PclusterID,
-		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", workloadv1alpha1.InternalClusterResourceStateLabelPrefix+"<ClusterID>"))
+		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", workloadv1alpha1.ClusterResourceStateLabelPrefix+"<ClusterID>"))
 	fs.StringArrayVarP(&options.SyncedResourceTypes, "resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
 	fs.DurationVar(&options.APIImportPollInterval, "api-import-poll-interval", options.APIImportPollInterval, "Polling interval for API import.")
 

--- a/docs/locations-and-scheduling.md
+++ b/docs/locations-and-scheduling.md
@@ -85,7 +85,7 @@ spec:
 
 A matched location will be selected for this `Placement` at first, which makes the `Placement` turns from `Pending` to `Unbound`. Then if there is at
 least one matchins Namespace, the Namespace will be annotated with `scheduling.kcp.dev/placement` and the placement turns from `Unbound` to `Bound`. 
-After this, a `SyncTarget` will be selected from the location picked by the placement.  `state.internal.workload.kcp.dev/<cluster-id>` label with value of `Sync` will be set if a valid `SyncTarget` is selected.
+After this, a `SyncTarget` will be selected from the location picked by the placement.  `state.workload.kcp.dev/<cluster-id>` label with value of `Sync` will be set if a valid `SyncTarget` is selected.
 
 The user can create another placement targeted to a different location for this Namespace, e.g. 
 
@@ -104,8 +104,8 @@ spec:
   locationWorkspace: root:default:location-ws
 ```
 
-which will result in another `state.internal.workload.kcp.dev/<cluster-id>` label added to the Namespace, and the Namespace will have two different
-`state.internal.workload.kcp.dev/<cluster-id>` label.
+which will result in another `state.workload.kcp.dev/<cluster-id>` label added to the Namespace, and the Namespace will have two different
+`state.workload.kcp.dev/<cluster-id>` label.
 
 Placement is in the `Ready` status condition when
 
@@ -120,13 +120,13 @@ A sync target will be removed when:
 2. corresponding `Placement` is not in `Ready` condition.
 3. corresponding `SyncTarget` is evicting/not Ready/deleted
 
-All above cases will make the `SyncTraget` represented in the label `state.internal.workload.kcp.dev/<cluster-id>` invalid, which will cause
+All above cases will make the `SyncTraget` represented in the label `state.workload.kcp.dev/<cluster-id>` invalid, which will cause
 `finalizers.workload.kcp.dev/<cluster-id>` annotation with removing time in the format of RFC-3339 added on the Namespace.
 
 ### Resource Syncing
 
-As soon as the `state.internal.workload.kcp.dev/<cluster-id>` label is set on the Namespace, the workload resource controller will 
-copy the `state.internal.workload.kcp.dev/<cluster-id>` label to the resources in that namespace.
+As soon as the `state.workload.kcp.dev/<cluster-id>` label is set on the Namespace, the workload resource controller will 
+copy the `state.workload.kcp.dev/<cluster-id>` label to the resources in that namespace.
 
 Note: in the future, the label on the resources is first set to empty string `""`, and a coordination controller will be 
 able to apply changes before syncing starts. This includes the ability to add per-location finalizers through the
@@ -146,10 +146,10 @@ notices that as a started deletion flow. As soon as there are no coordination co
 `finalizers.workload.kcp.dev/<cluster-id>` annotation anymore, the syncer will start a deletion of the downstream object.
 
 When the downstream deletion is complete, the syncer will remove the finalizer from the upstream object, and the
-`state.internal.workload.kcp.dev/<cluster-id>` labels gets deleted as well. The syncer stops seeing the object in the virtual
+`state.workload.kcp.dev/<cluster-id>` labels gets deleted as well. The syncer stops seeing the object in the virtual
 workspace.
 
 
-Note: there is a missing bit in the implementation (in v0.5) about removal of the `state.internal.workload.kcp.dev/<cluster-id>` 
+Note: there is a missing bit in the implementation (in v0.5) about removal of the `state.workload.kcp.dev/<cluster-id>` 
 label from namespaces: the syncer currently does not participate in the namespace deletion state-machine, but has to and signal finished
-downstream namespace deletion via `state.internal.workload.kcp.dev/<cluster-id>` label removal.
+downstream namespace deletion via `state.workload.kcp.dev/<cluster-id>` label removal.

--- a/pkg/apis/workload/v1alpha1/helpers.go
+++ b/pkg/apis/workload/v1alpha1/helpers.go
@@ -23,6 +23,6 @@ import (
 // GetResourceState returns the state of the resource for the given sync target, and
 // whether the state value is a valid state. A missing label is considered invalid.
 func GetResourceState(obj metav1.Object, cluster string) (state ResourceState, valid bool) {
-	value, found := obj.GetLabels()[InternalClusterResourceStateLabelPrefix+cluster]
+	value, found := obj.GetLabels()[ClusterResourceStateLabelPrefix+cluster]
 	return ResourceState(value), found && (value == "" || ResourceState(value) == ResourceStateSync)
 }

--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -25,7 +25,7 @@ const (
 	ResourceStatePending ResourceState = ""
 	// ResourceStateSync is the state of a resource when it is synced to the sync target.
 	// This includes the deletion process until the resource is deleted downstream and the
-	// syncer removes the state.internal.workload.kcp.dev/<sync-target-name> label.
+	// syncer removes the state.workload.kcp.dev/<sync-target-name> label.
 	ResourceStateSync ResourceState = "Sync"
 )
 
@@ -55,9 +55,9 @@ const (
 	// TODO(sttts): use sync-target-uid instead of sync-target-name
 	ClusterFinalizerAnnotationPrefix = "finalizers.workload.kcp.dev/"
 
-	// InternalClusterResourceStateLabelPrefix is the prefix of the label
+	// ClusterResourceStateLabelPrefix is the prefix of the label
 	//
-	//   state.internal.workload.kcp.dev/<sync-target-name>
+	//   state.workload.kcp.dev/<sync-target-name>
 	//
 	// on upstream resources storing the state of the sync target syncer state machine.
 	// The workload controllers will set this label and the syncer will react and drive the
@@ -73,12 +73,12 @@ const (
 	// will signal the start of the deletion process of the object. During the deletion process
 	// the object will stay in "Sync" state. The syncer will block deletion while
 	// finalizers.workload.kcp.dev/<sync-target-name> exists and is non-empty, and it
-	// will eventually remove state.internal.workload.kcp.dev/<sync-target-name> after
+	// will eventually remove state.workload.kcp.dev/<sync-target-name> after
 	// the object has been deleted downstream.
 	//
 	// The workload controllers will consider the object deleted from the sync target when
 	// the label is removed. They then set the placement state to "Unbound".
-	InternalClusterResourceStateLabelPrefix = "state.internal.workload.kcp.dev/"
+	ClusterResourceStateLabelPrefix = "state.workload.kcp.dev/"
 
 	// InternalClusterStatusAnnotationPrefix is the prefix of the annotation
 	//
@@ -106,6 +106,6 @@ const (
 	ClusterSpecDiffAnnotationPrefix = "experimental.spec-diff.workload.kcp.dev/"
 
 	// InternalDownstreamClusterLabel is a label with the upstream cluster name applied on the downstream cluster
-	// instead of state.internal.workload.kcp.dev/<sync-target-name> which is used upstream.
+	// instead of state.workload.kcp.dev/<sync-target-name> which is used upstream.
 	InternalDownstreamClusterLabel = "internal.workload.kcp.dev/cluster"
 )

--- a/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_reconcile.go
+++ b/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_reconcile.go
@@ -154,7 +154,7 @@ func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) e
 		if vd.Labels == nil {
 			vd.Labels = map[string]string{}
 		}
-		vd.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+cl.Name] = string(workloadv1alpha1.ResourceStateSync)
+		vd.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+cl.Name] = string(workloadv1alpha1.ResourceStateSync)
 		vd.Labels[ownedByLabel] = root.Name
 
 		replicasToSet := replicasEach

--- a/pkg/reconciler/workload/ingresssplitter/ingresssplitter_reconcile.go
+++ b/pkg/reconciler/workload/ingresssplitter/ingresssplitter_reconcile.go
@@ -234,7 +234,7 @@ func (c *Controller) desiredLeaves(ctx context.Context, root *networkingv1.Ingre
 		vd.Name = root.Name + "-" + cl
 
 		vd.Labels = map[string]string{}
-		vd.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+cl] = string(workloadv1alpha1.ResourceStateSync)
+		vd.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+cl] = string(workloadv1alpha1.ResourceStateSync)
 
 		// Label the leaf with the rootIngress information, so we can construct the ingress key
 		// from it.

--- a/pkg/reconciler/workload/namespace/namespace_reconcile_scheduling.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile_scheduling.go
@@ -181,7 +181,7 @@ func (r *placementSchedulingReconciler) reconcile(ctx context.Context, ns *corev
 		}
 
 		if removingTime.Add(removingGracePeriod).Before(r.now()) {
-			expectedLabels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+cluster] = nil
+			expectedLabels[workloadv1alpha1.ClusterResourceStateLabelPrefix+cluster] = nil
 			expectedAnnotations[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+cluster] = nil
 			klog.V(4).Infof("remove cluster %s for ns %s|%s", cluster, clusterName, ns.Name)
 		} else {
@@ -206,7 +206,7 @@ func (r *placementSchedulingReconciler) reconcile(ctx context.Context, ns *corev
 			continue
 		}
 
-		expectedLabels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+chosenCluster.Name] = string(workloadv1alpha1.ResourceStateSync)
+		expectedLabels[workloadv1alpha1.ClusterResourceStateLabelPrefix+chosenCluster.Name] = string(workloadv1alpha1.ResourceStateSync)
 		klog.V(4).Infof("set cluster %s sync for ns %s|%s", chosenCluster.Name, clusterName, ns.Name)
 	}
 
@@ -288,11 +288,11 @@ func syncedRemovingCluster(ns *corev1.Namespace) ([]string, map[string]time.Time
 	synced := []string{}
 	removing := map[string]time.Time{}
 	for k := range ns.Labels {
-		if !strings.HasPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix) {
+		if !strings.HasPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix) {
 			continue
 		}
 
-		syncTarget := strings.TrimPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix)
+		syncTarget := strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix)
 
 		deletionAnnotationKey := workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + syncTarget
 

--- a/pkg/reconciler/workload/namespace/namespace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile_scheduling_test.go
@@ -61,7 +61,7 @@ func TestScheduling(t *testing.T) {
 		{
 			name: "placement not found",
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "cluster1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "cluster1": string(workloadv1alpha1.ResourceStateSync),
 			},
 			annotations: map[string]string{
 				schedulingv1alpha1.PlacementAnnotationKey: "",
@@ -73,7 +73,7 @@ func TestScheduling(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "cluster1": now3339,
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "cluster1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "cluster1": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestScheduling(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -127,7 +127,7 @@ func TestScheduling(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 			placement: testPlacement,
 			location:  testLocation,
@@ -139,7 +139,7 @@ func TestScheduling(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -148,7 +148,7 @@ func TestScheduling(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 			placement: testPlacement,
 			location:  testLocation,
@@ -161,7 +161,7 @@ func TestScheduling(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "test-cluster": now3339,
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestScheduling(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 			placement: testPlacement,
 			location:  testLocation,
@@ -184,8 +184,8 @@ func TestScheduling(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "test-cluster": now3339,
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster":   string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster-2": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster":   string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster-2": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -195,7 +195,7 @@ func TestScheduling(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "test-cluster": now3339,
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 			placement: testPlacement,
 			location:  testLocation,
@@ -209,8 +209,8 @@ func TestScheduling(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "test-cluster": now3339,
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster":   string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster-1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster":   string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster-1": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -220,7 +220,7 @@ func TestScheduling(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "test-cluster": time.Now().Add(-1 * (removingGracePeriod + 1)).UTC().Format(time.RFC3339),
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "test-cluster": string(workloadv1alpha1.ResourceStateSync),
 			},
 			placement: testPlacement,
 			location:  testLocation,
@@ -323,8 +323,8 @@ func TestMultiplePlacements(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -347,7 +347,7 @@ func TestMultiplePlacements(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -370,16 +370,16 @@ func TestMultiplePlacements(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
 			},
 			wantPatch: false,
 			expectedAnnotations: map[string]string{
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 		{
@@ -404,8 +404,8 @@ func TestMultiplePlacements(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "c2": now3339,
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
 			},
 			wantPatch: true,
 			expectedAnnotations: map[string]string{
@@ -414,10 +414,10 @@ func TestMultiplePlacements(t *testing.T) {
 				workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix + "c2": now3339,
 			},
 			expectedLabels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c3": string(workloadv1alpha1.ResourceStateSync),
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "c4": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c2": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c3": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "c4": string(workloadv1alpha1.ResourceStateSync),
 			},
 		},
 	}

--- a/pkg/reconciler/workload/namespace/namespace_reconcile_status_test.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile_status_test.go
@@ -42,7 +42,7 @@ func TestSetScheduledCondition(t *testing.T) {
 				schedulingv1alpha1.PlacementAnnotationKey: "",
 			},
 			labels: map[string]string{
-				workloadv1alpha1.InternalClusterResourceStateLabelPrefix + "cluster1": string(workloadv1alpha1.ResourceStateSync),
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "cluster1": string(workloadv1alpha1.ResourceStateSync),
 			},
 			scheduled: true,
 		},

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -100,7 +100,7 @@ func NewController(
 func scheduleStateLabels(ls map[string]string) map[string]string {
 	ret := make(map[string]string, len(ls))
 	for k, v := range ls {
-		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix) {
+		if strings.HasPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix) {
 			ret[k] = v
 		}
 	}
@@ -349,13 +349,13 @@ func locations(annotations, labels map[string]string, skipPending bool) (locatio
 	deleting = sets.NewString()
 
 	for k, v := range labels {
-		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix) && (!skipPending || v == string(workloadv1alpha1.ResourceStateSync)) {
-			locations.Insert(strings.TrimPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix))
+		if strings.HasPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix) && (!skipPending || v == string(workloadv1alpha1.ResourceStateSync)) {
+			locations.Insert(strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix))
 		}
 	}
 	for k := range annotations {
 		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix) {
-			deleting.Insert(strings.TrimPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix))
+			deleting.Insert(strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix))
 		}
 	}
 	return

--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -135,7 +135,7 @@ func computePlacement(ns *corev1.Namespace, obj metav1.Object) (annotationPatch 
 	labelPatch = map[string]interface{}{}
 	for _, loc := range objLocations.Difference(nsLocations).List() {
 		// location was removed from namespace, but is still on the object
-		labelPatch[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+loc] = nil
+		labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = nil
 		if _, found := obj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc]; found {
 			annotationPatch[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc] = nil
 		}
@@ -151,7 +151,7 @@ func computePlacement(ns *corev1.Namespace, obj metav1.Object) (annotationPatch 
 	for _, loc := range nsLocations.Difference(objLocations).List() {
 		// location was missing on the object
 		// TODO(sttts): add way to go into pending state first, maybe with a namespace annotation
-		labelPatch[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+loc] = string(workloadv1alpha1.ResourceStateSync)
+		labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = string(workloadv1alpha1.ResourceStateSync)
 	}
 
 	if len(annotationPatch) == 0 {

--- a/pkg/reconciler/workload/resource/resource_reconcile_test.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile_test.go
@@ -59,45 +59,45 @@ func TestComputePlacement(t *testing.T) {
 		},
 		{name: "pending namespace, unscheduled object",
 			ns: namespace(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "",
+				"state.workload.kcp.dev/cluster-1": "",
 			}),
 			obj: object(nil, nil, nil),
 		},
 		{name: "invalid state value on namespace",
 			ns: namespace(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Foo",
+				"state.workload.kcp.dev/cluster-1": "Foo",
 			}),
 			obj: object(nil, nil, nil),
 		},
 		{name: "syncing namespace, unscheduled object",
 			ns: namespace(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			}),
 			obj: object(nil, nil, nil),
 			wantLabelPatch: map[string]interface{}{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			},
 		},
 		{name: "new location on namespace",
 			ns: namespace(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
-				"state.internal.workload.kcp.dev/cluster-2": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-2": "Sync",
 			}),
 			obj: object(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			}, nil),
 			wantLabelPatch: map[string]interface{}{
-				"state.internal.workload.kcp.dev/cluster-2": "Sync",
+				"state.workload.kcp.dev/cluster-2": "Sync",
 			},
 		},
 		{name: "new deletion on namespace",
 			ns: namespace(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-4": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-4": "Sync",
+				"state.workload.kcp.dev/cluster-4": "Sync",
 			}),
 			obj: object(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-4": "Sync",
+				"state.workload.kcp.dev/cluster-4": "Sync",
 			}, nil),
 			wantLabelPatch: nil,
 			wantAnnotationPatch: map[string]interface{}{
@@ -108,12 +108,12 @@ func TestComputePlacement(t *testing.T) {
 			ns: namespace(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-3": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-3": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync",
 			}),
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-3": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-3": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync",
 			}, nil),
 		},
 		{name: "hard delete after namespace is not scheduled",
@@ -121,10 +121,10 @@ func TestComputePlacement(t *testing.T) {
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-3": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-3": "Sync", // removed hard because namespace is not scheduled
+				"state.workload.kcp.dev/cluster-3": "Sync", // removed hard because namespace is not scheduled
 			}, nil),
 			wantLabelPatch: map[string]interface{}{
-				"state.internal.workload.kcp.dev/cluster-3": nil,
+				"state.workload.kcp.dev/cluster-3": nil,
 			},
 			wantAnnotationPatch: map[string]interface{}{
 				"deletion.internal.workload.kcp.dev/cluster-3": nil,
@@ -135,10 +135,10 @@ func TestComputePlacement(t *testing.T) {
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-3": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-3": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync",
 			}, nil),
 			wantLabelPatch: map[string]interface{}{
-				"state.internal.workload.kcp.dev/cluster-3": nil,
+				"state.workload.kcp.dev/cluster-3": nil,
 			},
 			wantAnnotationPatch: map[string]interface{}{
 				"deletion.internal.workload.kcp.dev/cluster-3": nil,
@@ -146,32 +146,32 @@ func TestComputePlacement(t *testing.T) {
 		},
 		{name: "existing deletion on object, rescheduled namespace",
 			ns: namespace(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-3": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync",
 			}),
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-3": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-3": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync",
 			}, nil),
 		},
 		{name: "multiple locations, added and removed on namespace and object",
 			ns: namespace(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-4": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
-				"state.internal.workload.kcp.dev/cluster-2": "Sync",
-				"state.internal.workload.kcp.dev/cluster-4": "Sync", // deleting
+				"state.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-2": "Sync",
+				"state.workload.kcp.dev/cluster-4": "Sync", // deleting
 			}),
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-3": "2002-10-02T10:00:00-05:00",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-2": "Sync",
-				"state.internal.workload.kcp.dev/cluster-3": "Sync", // removed hard
-				"state.internal.workload.kcp.dev/cluster-4": "Sync",
+				"state.workload.kcp.dev/cluster-2": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync", // removed hard
+				"state.workload.kcp.dev/cluster-4": "Sync",
 			}, nil),
 			wantLabelPatch: map[string]interface{}{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
-				"state.internal.workload.kcp.dev/cluster-3": nil,
+				"state.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-3": nil,
 			},
 			wantAnnotationPatch: map[string]interface{}{
 				"deletion.internal.workload.kcp.dev/cluster-4": "2002-10-02T10:00:00-05:00",
@@ -201,16 +201,16 @@ func TestPropagateDeletionTimestamp(t *testing.T) {
 	}{
 		{name: "Object is marked for deletion and has one location",
 			obj: object(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			}, &metav1.Time{Time: time.Date(2002, 10, 2, 10, 0, 0, 0, time.UTC)}),
 			wantAnnotationPatch: map[string]interface{}{
 				"deletion.internal.workload.kcp.dev/cluster-1": "2002-10-02T10:00:00Z",
 			},
 		}, {name: "Object is marked for deletion and has multiple locations",
 			obj: object(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
-				"state.internal.workload.kcp.dev/cluster-2": "Sync",
-				"state.internal.workload.kcp.dev/cluster-3": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-2": "Sync",
+				"state.workload.kcp.dev/cluster-3": "Sync",
 			}, &metav1.Time{Time: time.Date(2002, 10, 2, 10, 0, 0, 0, time.UTC)}),
 			wantAnnotationPatch: map[string]interface{}{
 				"deletion.internal.workload.kcp.dev/cluster-1": "2002-10-02T10:00:00Z",
@@ -220,7 +220,7 @@ func TestPropagateDeletionTimestamp(t *testing.T) {
 		},
 		{name: "Object is marked for deletion, has one location and the annotationPatch has some value, should be maintained",
 			obj: object(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			}, &metav1.Time{Time: time.Date(2002, 10, 2, 10, 0, 0, 0, time.UTC)}),
 			annotationPatch: map[string]interface{}{
 				"new-annotation-that-we-dont-care-about": "new-value",
@@ -234,7 +234,7 @@ func TestPropagateDeletionTimestamp(t *testing.T) {
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-1": "2002-10-02T10:00:00Z",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			}, &metav1.Time{Time: time.Date(2002, 10, 2, 10, 0, 0, 0, time.UTC)}),
 			wantAnnotationPatch: map[string]interface{}{},
 		},
@@ -242,13 +242,13 @@ func TestPropagateDeletionTimestamp(t *testing.T) {
 			obj: object(map[string]string{
 				"deletion.internal.workload.kcp.dev/cluster-1": "2000-01-01 10:00:00 +0000 UTC",
 			}, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "Sync",
+				"state.workload.kcp.dev/cluster-1": "Sync",
 			}, &metav1.Time{Time: time.Date(2002, 10, 2, 10, 0, 0, 0, time.UTC)}),
 			wantAnnotationPatch: map[string]interface{}{},
 		},
 		{name: "Object is marked for deletion, has one pending location, the deletionTimestamp of that location should be set",
 			obj: object(nil, map[string]string{
-				"state.internal.workload.kcp.dev/cluster-1": "",
+				"state.workload.kcp.dev/cluster-1": "",
 			}, &metav1.Time{Time: time.Date(2002, 10, 2, 10, 0, 0, 0, time.UTC)}),
 			wantAnnotationPatch: map[string]interface{}{
 				"deletion.internal.workload.kcp.dev/cluster-1": "2002-10-02T10:00:00Z",

--- a/pkg/syncer/shared/finalizer.go
+++ b/pkg/syncer/shared/finalizer.go
@@ -73,7 +73,7 @@ func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersion
 
 	// remove the cluster label.
 	upstreamLabels := upstreamObj.GetLabels()
-	delete(upstreamLabels, workloadv1alpha1.InternalClusterResourceStateLabelPrefix+syncTargetName)
+	delete(upstreamLabels, workloadv1alpha1.ClusterResourceStateLabelPrefix+syncTargetName)
 	upstreamObj.SetLabels(upstreamLabels)
 	// - End of block to be removed once the virtual workspace syncer is integrated -
 

--- a/pkg/syncer/shared/helpers.go
+++ b/pkg/syncer/shared/helpers.go
@@ -28,8 +28,8 @@ import (
 // Deprecated: use GetResourceState per cluster instead.
 func DeprecatedGetAssignedSyncTarget(labels map[string]string) string {
 	for k, v := range labels {
-		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix) && v == string(workloadv1alpha1.ResourceStateSync) {
-			return strings.TrimPrefix(k, workloadv1alpha1.InternalClusterResourceStateLabelPrefix)
+		if strings.HasPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix) && v == string(workloadv1alpha1.ResourceStateSync) {
+			return strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix)
 		}
 	}
 	return ""

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -296,7 +296,7 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	// replace upstream state label with downstream cluster label. We don't want to leak upstream state machine
 	// state to downstream, and also we don't need downstream updates every time the upstream state machine changes.
 	labels := downstreamObj.GetLabels()
-	delete(labels, workloadv1alpha1.InternalClusterResourceStateLabelPrefix+c.syncTargetName)
+	delete(labels, workloadv1alpha1.ClusterResourceStateLabelPrefix+c.syncTargetName)
 	labels[workloadv1alpha1.InternalDownstreamClusterLabel] = c.syncTargetName
 	downstreamObj.SetLabels(labels)
 

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -487,14 +487,14 @@ func TestSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, nil),
 			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
@@ -505,7 +505,7 @@ func TestSyncerProcess(t *testing.T) {
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
 						deployment("theDeployment", "test", "root:org:ws", map[string]string{
-							"state.internal.workload.kcp.dev/us-west1": "Sync",
+							"state.workload.kcp.dev/us-west1": "Sync",
 						}, nil, []string{"workload.kcp.dev/syncer-us-west1"}),
 					))),
 			},
@@ -542,19 +542,19 @@ func TestSyncerProcess(t *testing.T) {
 		"SpecSyncer sync to downstream, syncer finalizer already there": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
-				"state.internal.workload.kcp.dev/us-west1": "Sync",
+				"state.workload.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, []string{"workload.kcp.dev/syncer-us-west1"}),
 			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
@@ -592,15 +592,15 @@ func TestSyncerProcess(t *testing.T) {
 				),
 			},
 		},
-		"SpecSyncer upstream resource has state.internal annotation removed, expect deletion downstream": {
+		"SpecSyncer upstream resource has the state workload annotation removed, expect deletion downstream": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
-				"state.internal.workload.kcp.dev/us-west1": "Sync",
+				"state.workload.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
@@ -623,12 +623,12 @@ func TestSyncerProcess(t *testing.T) {
 		"SpecSyncer deletion: object exist downstream": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
-				"state.internal.workload.kcp.dev/us-west1": "Sync",
+				"state.workload.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
 				namespace("kcp-2r7hmup1y2r1", "", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				},
 					map[string]string{
 						"kcp.dev/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"test"}`,
@@ -639,14 +639,14 @@ func TestSyncerProcess(t *testing.T) {
 			},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"deletion.internal.workload.kcp.dev/us-west1": time.Now().Format(time.RFC3339)},
 					[]string{"workload.kcp.dev/syncer-us-west1"}),
 			},
@@ -670,7 +670,7 @@ func TestSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
 				namespace("kcp-2r7hmup1y2r1", "", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				},
 					map[string]string{
 						"kcp.dev/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"test"}`,
@@ -678,14 +678,14 @@ func TestSyncerProcess(t *testing.T) {
 			},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"another.valid.annotation/this": "value",
 						"deletion.internal.workload.kcp.dev/us-west1": time.Now().Format(time.RFC3339)},
 					[]string{"workload.kcp.dev/syncer-us-west1"}),
@@ -718,13 +718,13 @@ func TestSyncerProcess(t *testing.T) {
 		"SpecSyncer deletion: upstream object has external finalizer, the object shouldn't be deleted": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
-				"state.internal.workload.kcp.dev/us-west1": "Sync",
+				"state.workload.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
 				namespace("kcp-2r7hmup1y2r1", "", map[string]string{
-					"internal.workload.kcp.dev/cluster":        "us-west1",
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"internal.workload.kcp.dev/cluster": "us-west1",
+					"state.workload.kcp.dev/us-west1":   "Sync",
 				},
 					map[string]string{
 						"kcp.dev/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"test"}`,
@@ -735,14 +735,14 @@ func TestSyncerProcess(t *testing.T) {
 			},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{
 						"deletion.internal.workload.kcp.dev/us-west1": time.Now().Format(time.RFC3339),
 						"finalizers.workload.kcp.dev/us-west1":        "another-controller-finalizer",
@@ -794,14 +794,14 @@ func TestSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, map[string]string{"experimental.spec-diff.workload.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, nil),
 			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
@@ -813,7 +813,7 @@ func TestSyncerProcess(t *testing.T) {
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
 						deployment("theDeployment", "test", "root:org:ws", map[string]string{
-							"state.internal.workload.kcp.dev/us-west1": "Sync",
+							"state.workload.kcp.dev/us-west1": "Sync",
 						}, map[string]string{"experimental.spec-diff.workload.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, []string{shared.SyncerFinalizerNamePrefix + "us-west1"}),
 					))),
 			},
@@ -869,20 +869,20 @@ func TestSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, []string{"workload.kcp.dev/syncer-us-west1"}),
 			},
 			toResources: []runtime.Object{
 				namespace("kcp-2r7hmup1y2r1", "", map[string]string{
-					"internal.workload.kcp.dev/cluster":        "us-west1",
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"internal.workload.kcp.dev/cluster": "us-west1",
+					"state.workload.kcp.dev/us-west1":   "Sync",
 				}, map[string]string{
 					"kcp.dev/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"ANOTHERNAMESPACE"}`,
 				}),
@@ -897,25 +897,25 @@ func TestSyncerProcess(t *testing.T) {
 		"SpecSyncer namespace conflict: try to sync to an already existing namespace without a namespace-locator, expect error": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
-				"state.internal.workload.kcp.dev/us-west1": "Sync",
+				"state.workload.kcp.dev/us-west1": "Sync",
 			}, nil),
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResources: []runtime.Object{
 				secret("default-token-abc", "test", "root:org:ws",
-					map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"},
+					map[string]string{"state.workload.kcp.dev/us-west1": "Sync"},
 					map[string]string{"kubernetes.io/service-account.name": "default"},
 					map[string][]byte{
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, []string{"workload.kcp.dev/syncer-us-west1"}),
 			},
 			toResources: []runtime.Object{
 				namespace("kcp-2r7hmup1y2r1", "", map[string]string{
-					"internal.workload.kcp.dev/cluster":        "us-west1",
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"internal.workload.kcp.dev/cluster": "us-west1",
+					"state.workload.kcp.dev/us-west1":   "Sync",
 				}, map[string]string{},
 				),
 			},
@@ -953,10 +953,10 @@ func TestSyncerProcess(t *testing.T) {
 			toClient := dynamicfake.NewSimpleDynamicClient(scheme, tc.toResources...)
 
 			fromInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fromClusterClient.Cluster(logicalcluster.Wildcard), time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.InternalClusterResourceStateLabelPrefix + tc.syncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
+				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + tc.syncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
 			})
 			toInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(toClient, time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.InternalClusterResourceStateLabelPrefix + tc.syncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
+				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + tc.syncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
 			})
 
 			setupServersideApplyPatchReactor(toClient)

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -138,7 +138,7 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 
 	labels := upstreamObj.GetLabels()
 	delete(labels, workloadv1alpha1.InternalDownstreamClusterLabel)
-	labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+c.syncTargetName] = string(workloadv1alpha1.ResourceStateSync)
+	labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+c.syncTargetName] = string(workloadv1alpha1.ResourceStateSync)
 	upstreamObj.SetLabels(labels)
 
 	// TODO: verify that we really only update status, and not some non-status fields in ObjectMeta.

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -338,7 +338,7 @@ func TestSyncerProcess(t *testing.T) {
 				})),
 			toResources: []runtime.Object{
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, nil),
 			},
 			resourceToProcessLogicalClusterName: "",
@@ -351,7 +351,7 @@ func TestSyncerProcess(t *testing.T) {
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
 						deployment("theDeployment", "test", "", map[string]string{
-							"state.internal.workload.kcp.dev/us-west1": "Sync",
+							"state.workload.kcp.dev/us-west1": "Sync",
 						}, nil, nil),
 						addDeploymentStatus(appsv1.DeploymentStatus{
 							Replicas: 15,
@@ -376,7 +376,7 @@ func TestSyncerProcess(t *testing.T) {
 				})),
 			toResources: []runtime.Object{
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, nil),
 			},
 			resourceToProcessLogicalClusterName: "",
@@ -407,7 +407,7 @@ func TestSyncerProcess(t *testing.T) {
 				})),
 			toResources: []runtime.Object{
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, nil, nil),
 			},
 			resourceToProcessLogicalClusterName: "",
@@ -421,7 +421,7 @@ func TestSyncerProcess(t *testing.T) {
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
 						deployment("theDeployment", "test", "root:org:ws", map[string]string{
-							"state.internal.workload.kcp.dev/us-west1": "Sync",
+							"state.workload.kcp.dev/us-west1": "Sync",
 						}, map[string]string{
 							"experimental.status.workload.kcp.dev/us-west1": "{\"replicas\":15}",
 						}, nil)))),
@@ -446,7 +446,7 @@ func TestSyncerProcess(t *testing.T) {
 				})),
 			toResources: []runtime.Object{
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, map[string]string{
 					"deletion.internal.workload.kcp.dev/us-west1":   time.Now().Format(time.RFC3339),
 					"experimental.status.workload.kcp.dev/us-west1": "{\"replicas\":15}",
@@ -474,9 +474,9 @@ func TestSyncerProcess(t *testing.T) {
 			gvr:          schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			fromResource: nil,
 			toResources: []runtime.Object{
-				namespace("test", "root:org:ws", map[string]string{"state.internal.workload.kcp.dev/us-west1": "Sync"}, nil),
+				namespace("test", "root:org:ws", map[string]string{"state.workload.kcp.dev/us-west1": "Sync"}, nil),
 				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.internal.workload.kcp.dev/us-west1": "Sync",
+					"state.workload.kcp.dev/us-west1": "Sync",
 				}, map[string]string{
 					"deletion.internal.workload.kcp.dev/us-west1":   time.Now().Format(time.RFC3339),
 					"experimental.status.workload.kcp.dev/us-west1": `{"replicas":15}`,
@@ -532,7 +532,7 @@ func TestSyncerProcess(t *testing.T) {
 				o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + tc.syncTargetName
 			})
 			toInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(toClusterClient.Cluster(logicalcluster.Wildcard), time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.InternalClusterResourceStateLabelPrefix + tc.syncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
+				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + tc.syncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
 			})
 
 			setupServersideApplyPatchReactor(toClient)

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -144,7 +144,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	upstreamDiscoveryClient := upstreamDiscoveryClusterClient.WithCluster(logicalcluster.Wildcard)
 
 	upstreamInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(upstreamDynamicClusterClient.Cluster(logicalcluster.Wildcard), resyncPeriod, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-		o.LabelSelector = workloadv1alpha1.InternalClusterResourceStateLabelPrefix + cfg.SyncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
+		o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + cfg.SyncTargetName + "=" + string(workloadv1alpha1.ResourceStateSync)
 	})
 	downstreamInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactoryWithOptions(downstreamDynamicClient, metav1.NamespaceAll, func(o *metav1.ListOptions) {
 		o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + cfg.SyncTargetName

--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -159,7 +159,7 @@ func BuildVirtualWorkspace(
 				wildcardKcpInformers.Apis().V1alpha1().APIExports(),
 				func(syncTargetName string, apiResourceSchema *apisv1alpha1.APIResourceSchema, version string, apiExportIdentityHash string) (apidefinition.APIDefinition, error) {
 					requirements, selectable := labels.SelectorFromSet(map[string]string{
-						workloadv1alpha1.InternalClusterResourceStateLabelPrefix + syncTargetName: string(workloadv1alpha1.ResourceStateSync),
+						workloadv1alpha1.ClusterResourceStateLabelPrefix + syncTargetName: string(workloadv1alpha1.ResourceStateSync),
 					}).Requirements()
 					if !selectable {
 						return nil, fmt.Errorf("unable to create a selector from the provided labels")

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -72,7 +72,7 @@ func TestClusterController(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "timothy",
 						Labels: map[string]string{
-							"state.internal.workload.kcp.dev/" + sinkClusterName: string(workloadv1alpha1.ResourceStateSync),
+							"state.workload.kcp.dev/" + sinkClusterName: string(workloadv1alpha1.ResourceStateSync),
 						},
 					},
 					Spec: wildwestv1alpha1.CowboySpec{Intent: "yeehaw"},

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -284,7 +284,7 @@ func TestIngressController(t *testing.T) {
 					klog.Error(err)
 					return false
 				}
-				return ns.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+syncerFixture.SyncerConfig.SyncTargetName] != ""
+				return ns.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncerFixture.SyncerConfig.SyncTargetName] != ""
 			}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 			t.Log("Creating service in source cluster")
@@ -316,7 +316,7 @@ func TestIngressController(t *testing.T) {
 					klog.Error(err)
 					return false
 				}
-				return ns.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+syncerFixture.SyncerConfig.SyncTargetName] != ""
+				return ns.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+syncerFixture.SyncerConfig.SyncTargetName] != ""
 			}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 			t.Log("Starting ingress-controller...")

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -195,7 +195,7 @@ func TestNamespaceScheduler(t *testing.T) {
 						klog.Errorf("failed to get sheriff: %v", err)
 						return false
 					}
-					return obj.GetLabels()[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+cluster.Name] != ""
+					return obj.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+cluster.Name] != ""
 				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see sheriff scheduled")
 
 				t.Log("Delete the sheriff and the sheriff CRD")
@@ -221,7 +221,7 @@ func TestNamespaceScheduler(t *testing.T) {
 						klog.Errorf("failed to get sheriff: %v", err)
 						return false
 					}
-					return obj.GetLabels()[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+cluster.Name] != ""
+					return obj.GetLabels()[workloadv1alpha1.ClusterResourceStateLabelPrefix+cluster.Name] != ""
 				}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to see sheriff scheduled")
 			},
 		},
@@ -296,7 +296,7 @@ func unscheduledMatcher(reason string) namespaceExpectation {
 
 func scheduledMatcher(target string) namespaceExpectation {
 	return func(object *corev1.Namespace) error {
-		if _, found := object.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+target]; found {
+		if _, found := object.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+target]; found {
 			return nil
 		}
 		return fmt.Errorf("expected a scheduled namespace, got status.conditions: %#v", object.Status.Conditions)

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -263,7 +263,7 @@ func TestScheduling(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "first",
 			Labels: map[string]string{
-				"state.internal.workload.kcp.dev/" + syncTargetName: "Sync",
+				"state.workload.kcp.dev/" + syncTargetName: "Sync",
 			},
 		},
 		Spec: corev1.ServiceSpec{
@@ -282,7 +282,7 @@ func TestScheduling(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "second",
 			Labels: map[string]string{
-				"state.internal.workload.kcp.dev/" + syncTargetName: "Sync",
+				"state.workload.kcp.dev/" + syncTargetName: "Sync",
 			},
 		},
 		Spec: corev1.ServiceSpec{

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -278,11 +278,11 @@ func TestMultiPlacement(t *testing.T) {
 			return false, fmt.Sprintf("Failed to get service: %v", err)
 		}
 
-		if svc.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+firstSyncTargetName] != string(workloadv1alpha1.ResourceStateSync) {
+		if svc.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+firstSyncTargetName] != string(workloadv1alpha1.ResourceStateSync) {
 			return false, fmt.Sprintf("%s is not added to ns annotation", firstSyncTargetName)
 		}
 
-		if svc.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+secondSyncTargetName] != string(workloadv1alpha1.ResourceStateSync) {
+		if svc.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+secondSyncTargetName] != string(workloadv1alpha1.ResourceStateSync) {
 			return false, fmt.Sprintf("%s is not added to ns annotation", secondSyncTargetName)
 		}
 

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -165,7 +165,7 @@ func TestPlacementUpdate(t *testing.T) {
 			return false, fmt.Sprintf("Failed to get service: %v", err)
 		}
 
-		return svc.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+firstSyncTargetName] == string(workloadv1alpha1.ResourceStateSync), ""
+		return svc.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+firstSyncTargetName] == string(workloadv1alpha1.ResourceStateSync), ""
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Wait for the service to be sync to the downstream cluster")
@@ -320,7 +320,7 @@ func TestPlacementUpdate(t *testing.T) {
 		if len(svc.Annotations[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+firstSyncTargetName]) != 0 {
 			return false, fmt.Sprintf("resource should not be removed but got %s", toYaml(svc))
 		}
-		return svc.Labels[workloadv1alpha1.InternalClusterResourceStateLabelPrefix+firstSyncTargetName] == string(workloadv1alpha1.ResourceStateSync), ""
+		return svc.Labels[workloadv1alpha1.ClusterResourceStateLabelPrefix+firstSyncTargetName] == string(workloadv1alpha1.ResourceStateSync), ""
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Wait for the service to be sync to the downstream cluster")


### PR DESCRIPTION
## Summary

As we need external coordinators to be able to use this API, this PR renames and makes public the workload state label:

- from: `InternalClusterResourceStateLabelPrefix: state.internal.workload.kcp.dev/<cluster-id>`
- to: `ClusterResourceStateLabelPrefix: state.workload.kcp.dev/<cluster-id>`
