### PR TITLE
Syncer: add support for qps and burst

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -86,6 +86,9 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 		return err
 	}
 
+	kcpConfig.QPS = options.QPS
+	kcpConfig.Burst = options.Burst
+
 	toConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
 		&clientcmd.ConfigOverrides{
@@ -94,6 +97,9 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	toConfig.QPS = options.QPS
+	toConfig.Burst = options.Burst
 
 	if err := syncer.StartSyncer(
 		ctx,

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -30,6 +30,8 @@ import (
 )
 
 type Options struct {
+	QPS                 float32
+	Burst               int
 	FromKubeconfig      string
 	FromContext         string
 	FromClusterName     string
@@ -48,6 +50,8 @@ func NewOptions() *Options {
 	logs.Config.Verbosity = config.VerbosityLevel(2)
 
 	return &Options{
+		QPS:                   30,
+		Burst:                 20,
 		SyncedResourceTypes:   []string{},
 		Logs:                  logs,
 		APIImportPollInterval: 1 * time.Minute,
@@ -55,6 +59,8 @@ func NewOptions() *Options {
 }
 
 func (options *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.Float32Var(&options.QPS, "qps", options.QPS, "QPS to use when talking to API servers.")
+	fs.IntVar(&options.Burst, "burst", options.Burst, "Burst to use when talking to API servers.")
 	fs.StringVar(&options.FromKubeconfig, "from-kubeconfig", options.FromKubeconfig, "Kubeconfig file for -from cluster.")
 	fs.StringVar(&options.FromContext, "from-context", options.FromContext, "Context to use in the Kubeconfig file for -from cluster, instead of the current context.")
 	fs.StringVar(&options.FromClusterName, "from-cluster", options.FromClusterName, "Name of the -from logical cluster.")

--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -62,7 +62,14 @@ const (
 
 // Sync prepares a kcp workspace for use with a syncer and outputs the
 // configuration required to deploy a syncer to the pcluster to stdout.
-func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNamespaceName, downstreamNamespace, image string, resourcesToSync []string, replicas int) error {
+func (c *Config) Sync(
+	ctx context.Context,
+	outputFilePath, syncTargetName, kcpNamespaceName, downstreamNamespace, image string,
+	resourcesToSync []string,
+	replicas int,
+	qps float32,
+	burst int,
+) error {
 	config, err := clientcmd.NewDefaultClientConfig(*c.startingConfig, c.overrides).ClientConfig()
 	if err != nil {
 		return err
@@ -111,6 +118,8 @@ func (c *Config) Sync(ctx context.Context, outputFilePath, syncTargetName, kcpNa
 		Image:           image,
 		Replicas:        replicas,
 		ResourcesToSync: resourcesToSync,
+		QPS:             qps,
+		Burst:           burst,
 	}
 
 	resources, err := renderSyncerResources(input, syncerID)
@@ -428,6 +437,10 @@ type templateInput struct {
 	Image string
 	// Replicas is the number of syncer pods to run (should be 0 or 1).
 	Replicas int
+	// QPS is the qps the syncer uses when talking to an apiserver.
+	QPS float32
+	// Burst is the burst the syncer uses when talking to an apiserver.
+	Burst int
 }
 
 // templateArgs represents the full set of arguments required to render the resources

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -134,6 +134,8 @@ spec:
         - --from-cluster=root:default:foo
         - --resources=resource1
         - --resources=resource2
+        - --qps=123.4
+        - --burst=456
         image: image
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError
@@ -159,6 +161,8 @@ spec:
 		Image:           "image",
 		Replicas:        1,
 		ResourcesToSync: []string{"resource1", "resource2"},
+		QPS:             123.4,
+		Burst:           456,
 	}, "kcp-syncer-sync-target-name-34b23c4k")
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -112,6 +112,8 @@ spec:
 {{- range $resourceToSync := .ResourcesToSync}}
         - --resources={{$resourceToSync}}
 {{- end}}
+        - --qps={{.QPS}}
+        - --burst={{.Burst}}
         image: {{.Image}}
         imagePullPolicy: IfNotPresent
         terminationMessagePolicy: FallbackToLogsOnError

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -428,6 +428,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 		sf.SyncTargetName,
 		"--syncer-image", syncerImage,
 		"--output-file", "-",
+		"--qps", "-1",
 	}
 	for _, resource := range sf.ResourcesToSync.List() {
 		pluginArgs = append(pluginArgs, "--resources", resource)


### PR DESCRIPTION
## Summary
- Add `--qps` and `--burst` flags to the syncer and to the `kubectl kcp workload sync` command.
- Use --qps=-1 (no client-side throttling) for the syncer in e2e tests

## Related issue(s)

Fixes #