### PR TITLE
server/home: check owner properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,8 @@ test-e2e-shared: build-all
 	NO_GORUN=1 ./bin/test-server --log-file-path="$(LOG_DIR)/kcp.log" $(TEST_SERVER_ARGS) 2>&1 & PID=$$!; echo "PID $$PID"; \
 	trap 'kill -TERM $$PID' TERM INT EXIT; \
 	while [ ! -f .kcp/admin.kubeconfig ]; do sleep 1; done; \
-	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) \
-		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
+	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS) \
+		-args --use-default-kcp-server --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig"
 
 .PHONY: test-e2e-sharded
 ifdef USE_GOTESTSUM
@@ -217,8 +217,8 @@ test-e2e-sharded: build-all
 	NO_GORUN=1 ./bin/sharded-test-server --v=2 --log-dir-path="$(LOG_DIR)" $(TEST_SERVER_ARGS) 2>&1 & PID=$$!; echo "PID $$PID"; \
 	trap 'kill -TERM $$PID' TERM INT EXIT; \
 	while [ ! -f .kcp/admin.kubeconfig ]; do sleep 1; done; \
-	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) \
-		-args --use-default-kcp-server --root-shard-kubeconfig=$(PWD)/.kcp-0/admin.kubeconfig --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig" $(TEST_ARGS)
+	NO_GORUN=1 $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS) \
+		-args --use-default-kcp-server --root-shard-kubeconfig=$(PWD)/.kcp-0/admin.kubeconfig --syncer-image="$${SYNCER_IMAGE}" --kcp-test-image="$${TEST_IMAGE}" --pcluster-kubeconfig="$(PWD)/kind.kubeconfig"
 
 .PHONY: test
 ifdef USE_GOTESTSUM

--- a/pkg/admission/clusterworkspace/admission.go
+++ b/pkg/admission/clusterworkspace/admission.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
 )
 
 // Validate ClusterWorkspace creation and updates for
@@ -87,7 +88,7 @@ func (o *clusterWorkspace) Admit(ctx context.Context, a admission.Attributes, _ 
 	}
 
 	if a.GetOperation() == admission.Create {
-		userInfo, err := userAnnotationValue(a)
+		userInfo, err := ClusterWorkspaceOwnerAnnotationValue(a.GetUserInfo())
 		if err != nil {
 			return admission.NewForbidden(a, err)
 		}
@@ -150,7 +151,7 @@ func (o *clusterWorkspace) Validate(ctx context.Context, a admission.Attributes,
 	}
 
 	if a.GetOperation() == admission.Create {
-		userInfo, err := userAnnotationValue(a)
+		userInfo, err := ClusterWorkspaceOwnerAnnotationValue(a.GetUserInfo())
 		if err != nil {
 			return admission.NewForbidden(a, err)
 		}
@@ -188,8 +189,8 @@ func updateUnstructured(u *unstructured.Unstructured, cw *tenancyv1alpha1.Cluste
 	return nil
 }
 
-func userAnnotationValue(a admission.Attributes) (string, error) {
-	user := a.GetUserInfo()
+// ClusterWorkspaceOwnerAnnotationValue returns the value of the ClusterWorkspaceOwnerAnnotationKey annotation.
+func ClusterWorkspaceOwnerAnnotationValue(user kuser.Info) (string, error) {
 	info := &authenticationv1.UserInfo{
 		Username: user.GetName(),
 		UID:      user.GetUID(),

--- a/pkg/admission/reservedmetadata/admission.go
+++ b/pkg/admission/reservedmetadata/admission.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/strings/slices"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/syncer"
 )
@@ -41,6 +42,7 @@ var (
 	annotationAllowList = []string{
 		workloadv1alpha1.AnnotationSkipDefaultObjectCreation,
 		syncer.AdvancedSchedulingFeatureAnnotation,
+		v1alpha1.ClusterWorkspaceOwnerAnnotationKey, // this is protected by clusterworkspace admission from non-system:admins
 	}
 	labelAllowList = []string{
 		apisv1alpha1.APIExportPermissionClaimLabelPrefix + "*", // protected by the permissionclaim admission plugin

--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/kcp-dev/logicalcluster"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +48,7 @@ import (
 	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog/v2"
 
+	clusterworkspaceadmission "github.com/kcp-dev/kcp/pkg/admission/clusterworkspace"
 	"github.com/kcp-dev/kcp/pkg/apis/tenancy/projection"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
@@ -193,7 +196,7 @@ type homeWorkspaceFeatureLogic struct {
 	searchForHomeWorkspaceRBACResourcesInLocalInformers func(homeWorkspace logicalcluster.Name) (found bool, err error)
 	createHomeWorkspaceRBACResources                    func(ctx context.Context, userName string, homeWorkspace logicalcluster.Name) error
 	searchForWorkspaceAndRBACInLocalInformers           func(logicalClusterName logicalcluster.Name, isHome bool, userName string) (readyAndRBACAsExpected bool, retryAfterSeconds int, checkError error)
-	tryToCreate                                         func(ctx context.Context, userName string, workspaceToCheck logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error)
+	tryToCreate                                         func(ctx context.Context, user kuser.Info, workspaceToCheck logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error)
 }
 
 type homeWorkspaceHandler struct {
@@ -214,8 +217,8 @@ func (b homeWorkspaceHandlerBuilder) build() *homeWorkspaceHandler {
 		searchForWorkspaceAndRBACInLocalInformers: func(logicalClusterName logicalcluster.Name, isHome bool, userName string) (found bool, retryAfterSeconds int, checkError error) {
 			return searchForWorkspaceAndRBACInLocalInformers(h, logicalClusterName, isHome, userName)
 		},
-		tryToCreate: func(ctx context.Context, userName string, logicalClusterName logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
-			return tryToCreate(h, ctx, userName, logicalClusterName, workspaceType)
+		tryToCreate: func(ctx context.Context, user kuser.Info, logicalClusterName logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
+			return tryToCreate(h, ctx, user, logicalClusterName, workspaceType)
 		},
 	}
 
@@ -347,7 +350,7 @@ func (h *homeWorkspaceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	if retryAfterSeconds, err := h.tryToCreate(ctx, effectiveUser.GetName(), lcluster.Name, workspaceType); err != nil {
+	if retryAfterSeconds, err := h.tryToCreate(ctx, effectiveUser, lcluster.Name, workspaceType); err != nil {
 		klog.Errorf("failed to create %s workspace %s for user %q: %w", workspaceType, lcluster.Name, effectiveUser.GetName(), err)
 		responsewriters.ErrorNegotiated(err, errorCodecs, schema.GroupVersion{}, rw, req)
 		return
@@ -478,23 +481,33 @@ func searchForWorkspaceAndRBACInLocalInformers(h *homeWorkspaceHandler, logicalC
 
 // tryToCreate tries to create, with an external client, the home or home bucket workspace
 // corresponding to a given logical cluster name.
-// Of course it can be that it has been created in the meantime (either concurrently on the current shard or
+// Of course, it can be that it has been created in the meantime (either concurrently on the current shard or
 // on another shard). We don't error in this case, but ask for a retry.
 // If it cannot be created because the parent home bucket doesn't exist, create the parent first and
 // retry the creation of the current workspace later.
 // When creating a Home workspace, we also create the related RBAC resources.
-func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, userName string, logicalClusterName logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
+func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, user kuser.Info, logicalClusterName logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
 	// Try to create it in the parent workspace
 	parent, name := logicalClusterName.Split()
-	err := h.kcp.createClusterWorkspace(ctx, parent, &tenancyv1alpha1.ClusterWorkspace{
+	ws := &tenancyv1alpha1.ClusterWorkspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 			Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: tenancyv1alpha1.RootCluster.String(), Name: workspaceType},
 		},
-	})
+	}
+	if workspaceType == HomeClusterWorkspaceType {
+		ownerRaw, err := clusterworkspaceadmission.ClusterWorkspaceOwnerAnnotationValue(user)
+		if err != nil {
+			return 0, fmt.Errorf("failed to create %s annotation value: %w", tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey, err)
+		}
+		ws.Annotations = map[string]string{
+			tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey: ownerRaw,
+		}
+	}
 
+	err := h.kcp.createClusterWorkspace(ctx, parent, ws)
 	if err == nil || kerrors.IsAlreadyExists(err) {
 		if workspaceType == HomeClusterWorkspaceType {
 			if kerrors.IsAlreadyExists(err) {
@@ -503,12 +516,12 @@ func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, userName string, 
 					return 0, err
 				}
 
-				if cw.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey] != userName {
+				if info, _ := unmarshalOwner(cw); info == nil || info.Username != user.GetName() {
 					return 0, kerrors.NewForbidden(tenancyv1alpha1.SchemeGroupVersion.WithResource("clusterworkspaces").GroupResource(), cw.Name, errors.New(authorization.WorkspaceAcccessNotPermittedReason))
 				}
 			}
 
-			if err := h.createHomeWorkspaceRBACResources(ctx, userName, logicalClusterName); err != nil {
+			if err := h.createHomeWorkspaceRBACResources(ctx, user.GetName(), logicalClusterName); err != nil {
 				return 0, err
 			}
 		}
@@ -545,7 +558,7 @@ func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, userName string, 
 	if parentWorkspace == nil {
 		// The parent simply probably does not exist => try to create it first
 		_, parentWorkspaceType := h.needsAutomaticCreation(parent)
-		return h.tryToCreate(ctx, userName, parent, parentWorkspaceType)
+		return h.tryToCreate(ctx, user, parent, parentWorkspaceType)
 	}
 
 	// The parent exists: check its status
@@ -649,4 +662,17 @@ func workspaceUnschedulable(workspace *tenancyv1alpha1.ClusterWorkspace) bool {
 		return true
 	}
 	return false
+}
+
+func unmarshalOwner(cw *tenancyv1alpha1.ClusterWorkspace) (*authenticationv1.UserInfo, error) {
+	raw, found := cw.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey]
+	if !found {
+		return nil, nil
+	}
+	var info authenticationv1.UserInfo
+	err := json.Unmarshal([]byte(raw), &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, err
 }

--- a/pkg/softimpersonation/softimpersonation.go
+++ b/pkg/softimpersonation/softimpersonation.go
@@ -38,7 +38,7 @@ const (
 func WithSoftImpersonatedConfig(config *rest.Config, userInfo kuser.Info) (*rest.Config, error) {
 	impersonatedonfig := *config
 
-	userInfoJson, err := MarshalUserInfo(userInfo)
+	userInfoJson, err := marshalUserInfo(userInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -65,9 +65,9 @@ func (t *softImpersonationTransport) RoundTrip(req *http.Request) (*http.Respons
 	return t.RoundTripper.RoundTrip(req)
 }
 
-// MarshalUserInfo builds a string that contains
+// marshalUserInfo builds a string that contains
 // the user information, marshalled as json.
-func MarshalUserInfo(userInfo kuser.Info) (string, error) {
+func marshalUserInfo(userInfo kuser.Info) (string, error) {
 	if userInfo == nil {
 		return "", errors.New("no user info")
 	}
@@ -89,9 +89,9 @@ func MarshalUserInfo(userInfo kuser.Info) (string, error) {
 	return string(rawInfo), nil
 }
 
-// UnmarshalUserInfo builds a user.Info object from a string
+// unmarshalUserInfo builds a user.Info object from a string
 // that contains the user information marshalled as json.
-func UnmarshalUserInfo(userInfoJson string) (kuser.Info, error) {
+func unmarshalUserInfo(userInfoJson string) (kuser.Info, error) {
 	info := authenticationv1.UserInfo{}
 	if err := json.Unmarshal([]byte(userInfoJson), &info); err != nil {
 		return nil, err
@@ -128,5 +128,5 @@ func UserInfoFromRequestHeader(r *http.Request) (kuser.Info, error) {
 	if !sets.NewString(user.GetGroups()...).Has(kuser.SystemPrivilegedGroup) {
 		return nil, errors.New("soft impersonation not allowed")
 	}
-	return UnmarshalUserInfo(val)
+	return unmarshalUserInfo(val)
 }


### PR DESCRIPTION
- fix home workspace logic to conside the owner annotation as JSON, not just a string
- allow system master to pre-set the owner
- keep the owner username on a workspace when ready
- check the owner on GET `~`