### PR TITLE
Wipe owner info as soon as possible

### DIFF
--- a/pkg/apis/tenancy/projection/workspaces.go
+++ b/pkg/apis/tenancy/projection/workspaces.go
@@ -28,6 +28,15 @@ func ProjectClusterWorkspaceToWorkspace(from *tenancyv1alpha1.ClusterWorkspace, 
 	to.Status.Phase = from.Status.Phase
 	to.Status.Initializers = from.Status.Initializers
 
+	to.Annotations = make(map[string]string, len(from.Annotations))
+	for k, v := range from.Annotations {
+		if k == tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey {
+			// do not leak user information
+			continue
+		}
+		to.Annotations[k] = v
+	}
+
 	for i := range from.Status.Conditions {
 		c := &from.Status.Conditions[i]
 		switch c.Type {

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go
@@ -58,6 +58,13 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 		}
 	}
 
+	if workspace.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady {
+		if _, found := workspace.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey]; found {
+			delete(workspace.Annotations, tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey)
+			changed = true
+		}
+	}
+
 	if changed {
 		// first update ObjectMeta before status
 		return reconcileStatusStopAndRequeue, nil

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
@@ -135,6 +135,32 @@ func TestReconcileMetadata(t *testing.T) {
 			},
 			wantStatus: reconcileStatusContinue,
 		},
+		{
+			name: "removes owner when ready",
+			input: &tenancyv1alpha1.ClusterWorkspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"internal.kcp.dev/phase": "Ready",
+					},
+					Annotations: map[string]string{
+						"a":                     "b",
+						"tenancy.kcp.dev/owner": `{"username":"user-1"}`,
+					},
+				},
+				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase: tenancyv1alpha1.ClusterWorkspacePhaseReady,
+				},
+			},
+			expected: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"internal.kcp.dev/phase": "Ready",
+				},
+				Annotations: map[string]string{
+					"a": "b",
+				},
+			},
+			wantStatus: reconcileStatusStopAndRequeue,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			reconciler := metaDataReconciler{}


### PR DESCRIPTION
We don't need the user info on a) ready workspaces b) on user-visible Workspaces.