### PR TITLE
Remove non-existing scheduling-disabled label from ReservedMetadata allow list

### DIFF
--- a/pkg/admission/reservedmetadata/admission.go
+++ b/pkg/admission/reservedmetadata/admission.go
@@ -43,7 +43,6 @@ var (
 		syncer.AdvancedSchedulingFeatureAnnotation,
 	}
 	labelAllowList = []string{
-		"experimental.workload.kcp.dev/scheduling-disabled",
 		apisv1alpha1.APIExportPermissionClaimLabelPrefix + "*", // protected by the permissionclaim admission plugin
 	}
 )


### PR DESCRIPTION
The label doesn't exist anymore. No need to allow it.