### PR TITLE
Add shortName ws for workspace

### DIFF
--- a/config/crds/tenancy.kcp.dev_workspaces.yaml
+++ b/config/crds/tenancy.kcp.dev_workspaces.yaml
@@ -13,6 +13,8 @@ spec:
     kind: Workspace
     listKind: WorkspaceList
     plural: workspaces
+    shortNames:
+    - ws
     singular: workspace
   scope: Cluster
   versions:

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   latestResourceSchemas:
   - v220711-d5b6ca98.clusterworkspaces.tenancy.kcp.dev
-  - v220711-d5b6ca98.workspaces.tenancy.kcp.dev
   - v220713-f9bb7307.clusterworkspacetypes.tenancy.kcp.dev
+  - v220718-00525e83.workspaces.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220711-d5b6ca98.workspaces.tenancy.kcp.dev
+  name: v220718-00525e83.workspaces.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -11,6 +11,8 @@ spec:
     kind: Workspace
     listKind: WorkspaceList
     plural: workspaces
+    shortNames:
+    - ws
     singular: workspace
   scope: Cluster
   versions:

--- a/pkg/apis/tenancy/v1beta1/types.go
+++ b/pkg/apis/tenancy/v1beta1/types.go
@@ -36,7 +36,7 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:scope=Cluster,categories=kcp
+// +kubebuilder:resource:scope=Cluster,categories=kcp,shortName=ws
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`,description="The current phase (e.g. Scheduling, Initializing, Ready)"
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.type.name`,description="Type of the workspace"
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.URL`,description="URL to access the workspace"


### PR DESCRIPTION
## Summary
For command `kubectl get workspaces`, it is better (and feasible) to have a shortname like `kubectl get ws`. Checked existing resources via `kubectl api-resources | grep "\bw"`, no conflict found.
## Related issue(s)
N/A

@sttts @pweil- , could you help check / tag? Thanks