### PR TITLE
cli/workload/sync: MaxSyncTargetNameLength decreased by SyncerIDPrefix length

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -57,7 +57,7 @@ var embeddedResources embed.FS
 const (
 	SyncerSecretConfigKey   = "kubeconfig"
 	SyncerIDPrefix          = "kcp-syncer-"
-	MaxSyncTargetNameLength = validation.DNS1123SubdomainMaxLength - 9 + len(SyncerIDPrefix)
+	MaxSyncTargetNameLength = validation.DNS1123SubdomainMaxLength - (9 + len(SyncerIDPrefix))
 )
 
 // Sync prepares a kcp workspace for use with a syncer and outputs the


### PR DESCRIPTION
## Summary
Fixes calculation of MaxSyncTargetNameLength. Currently MaxSyncTargetNameLength is 255, which is greater than DNS1123SubdomainMaxLength 253.
