### PR TITLE
server/home: create home workspace with final URL on ~ access

### DIFF
--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -478,7 +478,7 @@ func searchForWorkspaceAndRBACInLocalInformers(h *homeWorkspaceHandler, logicalC
 
 	// Workspace has been found in local informer: check its status.
 	if workspaceUnschedulable(workspace) {
-		return false, 0, kerrors.NewForbidden(tenancyv1alpha1.SchemeGroupVersion.WithResource("clusterworkspaces").GroupResource(), workspace.Name, errors.New("unschedulable workspace cannot be accessed"))
+		return false, 0, kerrors.NewForbidden(tenancyv1alpha1.SchemeGroupVersion.WithResource("clusterworkspaces").GroupResource(), logicalClusterName.String(), errors.New("unschedulable workspace cannot be accessed"))
 	}
 
 	if !isHome {

--- a/pkg/server/home_workspaces_test.go
+++ b/pkg/server/home_workspaces_test.go
@@ -236,10 +236,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status:     tenancyv1alpha1.ClusterWorkspaceStatus{Phase: tenancyv1alpha1.ClusterWorkspacePhaseReady},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").inPhase(tenancyv1alpha1.ClusterWorkspacePhaseReady).ClusterWorkspace, nil
 			},
 
 			mocks: homeWorkspaceFeatureLogic{
@@ -259,10 +256,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status:     tenancyv1alpha1.ClusterWorkspaceStatus{Phase: tenancyv1alpha1.ClusterWorkspacePhaseReady},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").inPhase(tenancyv1alpha1.ClusterWorkspacePhaseReady).ClusterWorkspace, nil
 			},
 
 			mocks: homeWorkspaceFeatureLogic{
@@ -283,10 +277,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status:     tenancyv1alpha1.ClusterWorkspaceStatus{Phase: tenancyv1alpha1.ClusterWorkspacePhaseReady},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").inPhase(tenancyv1alpha1.ClusterWorkspacePhaseReady).ClusterWorkspace, nil
 			},
 
 			mocks: homeWorkspaceFeatureLogic{
@@ -308,10 +299,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status:     tenancyv1alpha1.ClusterWorkspaceStatus{Phase: ""},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").ClusterWorkspace, nil
 			},
 
 			mocks: homeWorkspaceFeatureLogic{
@@ -332,10 +320,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status:     tenancyv1alpha1.ClusterWorkspaceStatus{Phase: tenancyv1alpha1.ClusterWorkspacePhaseInitializing},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").inPhase(tenancyv1alpha1.ClusterWorkspacePhaseInitializing).ClusterWorkspace, nil
 			},
 
 			mocks: homeWorkspaceFeatureLogic{
@@ -356,18 +341,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Conditions: v1alpha1.Conditions{
-							v1alpha1.Condition{
-								Type:   tenancyv1alpha1.WorkspaceScheduled,
-								Status: corev1.ConditionFalse,
-								Reason: tenancyv1alpha1.WorkspaceReasonUnschedulable,
-							},
-						},
-					},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").unschedulable().ClusterWorkspace, nil
 			},
 
 			expectedFound:             false,
@@ -383,18 +357,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Conditions: v1alpha1.Conditions{
-							v1alpha1.Condition{
-								Type:   tenancyv1alpha1.WorkspaceScheduled,
-								Status: corev1.ConditionFalse,
-								Reason: tenancyv1alpha1.WorkspaceReasonReasonUnknown,
-							},
-						},
-					},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").unschedulable().ClusterWorkspace, nil
 			},
 
 			expectedFound:             false,
@@ -410,18 +373,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Conditions: v1alpha1.Conditions{
-							v1alpha1.Condition{
-								Type:   tenancyv1alpha1.WorkspaceScheduled,
-								Status: corev1.ConditionFalse,
-								Reason: tenancyv1alpha1.WorkspaceReasonUnreschedulable,
-							},
-						},
-					},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").unschedulable().ClusterWorkspace, nil
 			},
 
 			expectedFound:             false,
@@ -437,10 +389,7 @@ func TestSearchForReadyWorkspaceInLocalInformers(t *testing.T) {
 			userName:      "user-1",
 
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{Name: "root:users:ab:cd:user-1"},
-					Status:     tenancyv1alpha1.ClusterWorkspaceStatus{Phase: ""},
-				}, nil
+				return newWorkspace("root:users:ab:cd:user-1").ClusterWorkspace, nil
 			},
 
 			expectedFound:           true,
@@ -1360,32 +1309,20 @@ func TestServeHTTP(t *testing.T) {
 			expectedToDelegate: true,
 		},
 		{
-			testName:       "delegate to next handler when handler informers are not synced",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
-			synced: false,
+			testName:           "delegate to next handler when handler informers are not synced",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
+			synced:             false,
 
 			expectedStatusCode: 200,
 			expectedToDelegate: true,
 		},
 		{
-			testName:       "Return virtual home workspace resource when it still doesn't exist",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "Return virtual home workspace resource when it still doesn't exist",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
@@ -1400,16 +1337,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
 		},
 		{
-			testName:       "return error if error when getting home workspace in the local informers",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "return error if error when getting home workspace in the local informers",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
@@ -1421,16 +1352,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `Internal Server Error: "/dummy-target": an error`,
 		},
 		{
-			testName:       "return Forbidden if no permission to get the virtual home workspace resource when it still doesn't exist",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "return Forbidden if no permission to get the virtual home workspace resource when it still doesn't exist",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
@@ -1445,16 +1370,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-1\" cannot get resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: some reason","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
 		},
 		{
-			testName:       "return error if could not check the permission to get the virtual home workspace resource when it still doesn't exist",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "return error if could not check the permission to get the virtual home workspace resource when it still doesn't exist",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
@@ -1469,36 +1388,17 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-1\" cannot get resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: workspace access not permitted","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
 		},
 		{
-			testName:       "return the real home workspace when it already exists and is ready in informer, and RBAC objects are in informer",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "return the real home workspace when it already exists and is ready in informer, and RBAC objects are in informer",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "user-1",
-						ClusterName:     "root:users:bi:ie",
-						ResourceVersion: "someRealResourceVersion",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("home"),
-							Path: "root",
-						},
-					},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Phase:   tenancyv1alpha1.ClusterWorkspacePhaseReady,
-						BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
-					},
-				}, nil
+				return newWorkspace("root:users:bi:ie:user-1").withType("root:home").withRV("someRealResourceVersion").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:   tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
+				}).ClusterWorkspace, nil
 			},
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionAllow, "", nil
@@ -1514,36 +1414,17 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","resourceVersion":"someRealResourceVersion","creationTimestamp":null,"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1","phase":"Ready"}}`,
 		},
 		{
-			testName:       "return virtual home workspace when the home workspace is not ready yet",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "return virtual home workspace when the home workspace is not ready yet",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "user-1",
-						ClusterName:     "root:users:bi:ie",
-						ResourceVersion: "someRealResourceVersion",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("Home"),
-							Path: "root",
-						},
-					},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Phase:   tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
-						BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
-					},
-				}, nil
+				return newWorkspace("root:users:bi:ie:user-1").withType("root:home").withRV("someRealResourceVersion").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:   tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
+					BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
+				}).ClusterWorkspace, nil
 			},
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionAllow, "", nil
@@ -1559,36 +1440,17 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
 		},
 		{
-			testName:       "return virtual home workspace when home already exists, but RBAC objects are not in informer",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "~",
-				Verb:              "get",
-			},
+			testName:           "return virtual home workspace when home already exists, but RBAC objects are not in informer",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return &tenancyv1alpha1.ClusterWorkspace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "user-1",
-						ClusterName:     "root:users:bi:ie",
-						ResourceVersion: "someRealResourceVersion",
-					},
-					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
-						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
-							Name: tenancyv1alpha1.ClusterWorkspaceTypeName("home"),
-							Path: "root",
-						},
-					},
-					Status: tenancyv1alpha1.ClusterWorkspaceStatus{
-						Phase:   tenancyv1alpha1.ClusterWorkspacePhaseReady,
-						BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
-					},
-				}, nil
+				return newWorkspace("root:users:bi:ie:user-1").withType("root:home").withRV("someRealResourceVersion").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
+					Phase:   tenancyv1alpha1.ClusterWorkspacePhaseReady,
+					BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
+				}).ClusterWorkspace, nil
 			},
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionAllow, "", nil
@@ -1604,16 +1466,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
 		},
 		{
-			testName:       "return error when workspace cannot be checked in local informers",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "user-1",
-				Verb:              "create",
-			},
+			testName:           "return error when workspace cannot be checked in local informers",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "user-1", Verb: "create"},
 
 			synced: true,
 			mocks: homeWorkspaceFeatureLogic{
@@ -1626,16 +1482,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `Internal Server Error: "/dummy-target": an error`,
 		},
 		{
-			testName:       "retry later if instructed so when checking for the workspace in local informers",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "user-1",
-				Verb:              "create",
-			},
+			testName:           "retry later if instructed so when checking for the workspace in local informers",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "user-1", Verb: "create"},
 
 			synced: true,
 			mocks: homeWorkspaceFeatureLogic{
@@ -1654,16 +1504,10 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
-			testName:       "return Forbidden and don't try to create home workspace because user is the wrong one",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-2"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "create-test",
-				Verb:              "create",
-			},
+			testName:           "return Forbidden and don't try to create home workspace because user is the wrong one",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-2"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "create-test", Verb: "create"},
 
 			synced: true,
 			mocks: homeWorkspaceFeatureLogic{
@@ -1676,16 +1520,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-2\" cannot create resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: workspace access not permitted","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
 		},
 		{
-			testName:       "return Forbidden and don't try to create home workspace because user doesn't have permission",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "create-test",
-				Verb:              "create",
-			},
+			testName:           "return Forbidden and don't try to create home workspace because user doesn't have permission",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "create-test", Verb: "create"},
 
 			synced: true,
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -1701,16 +1539,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-1\" cannot create resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: refused for a given reason","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
 		},
 		{
-			testName:       "return Forbidden and don't try to create home workspace because unable to check user permission",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "create-test",
-				Verb:              "create",
-			},
+			testName:           "return Forbidden and don't try to create home workspace because unable to check user permission",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "create-test", Verb: "create"},
 
 			synced: true,
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -1726,16 +1558,10 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-1\" cannot create resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: workspace access not permitted","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
 		},
 		{
-			testName:       "try to create when home workspace doesn't exist and user has permission",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "create-test",
-				Verb:              "create",
-			},
+			testName:           "try to create when home workspace doesn't exist and user has permission",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "create-test", Verb: "create"},
 
 			synced: true,
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -1759,16 +1585,10 @@ func TestServeHTTP(t *testing.T) {
 			},
 		},
 		{
-			testName:       "try to create when home workspace doesn't exist and user has permission, but creation failed",
-			contextCluster: &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
-			contextUser:    &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{
-				IsResourceRequest: true,
-				APIGroup:          "tenancy.kcp.dev",
-				Resource:          "workspaces",
-				Name:              "create-test",
-				Verb:              "create",
-			},
+			testName:           "try to create when home workspace doesn't exist and user has permission, but creation failed",
+			contextCluster:     &request.Cluster{Name: logicalcluster.New("root:users:bi:ie:user-1")},
+			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
+			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "create-test", Verb: "create"},
 
 			synced: true,
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
@@ -1856,4 +1676,56 @@ func overrideLogic(handler *homeWorkspaceHandler, overridenLogic homeWorkspaceFe
 		handler.tryToCreate = overridenLogic.tryToCreate
 	}
 	return handler
+}
+
+type wsBuilder struct {
+	*tenancyv1alpha1.ClusterWorkspace
+}
+
+func newWorkspace(qualifiedName string) wsBuilder {
+	path, name := logicalcluster.New(qualifiedName).Split()
+	return wsBuilder{&tenancyv1alpha1.ClusterWorkspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			ClusterName: path.String(),
+		},
+	}}
+}
+
+func (b wsBuilder) inPhase(phase tenancyv1alpha1.ClusterWorkspacePhaseType) wsBuilder {
+	b.Status.Phase = phase
+	return b
+}
+
+func (b wsBuilder) withRV(rv string) wsBuilder {
+	b.ResourceVersion = rv
+	return b
+}
+
+func (b wsBuilder) withType(qualifiedName string) wsBuilder {
+	path, name := logicalcluster.New(qualifiedName).Split()
+	b.Spec.Type = tenancyv1alpha1.ClusterWorkspaceTypeReference{
+		Path: path.String(),
+		Name: tenancyv1alpha1.ClusterWorkspaceTypeName(name),
+	}
+	return b
+}
+
+func (b wsBuilder) withStatus(status tenancyv1alpha1.ClusterWorkspaceStatus) wsBuilder {
+	b.Status = status
+	return b
+}
+
+func (b wsBuilder) withLabels(labels map[string]string) wsBuilder {
+	b.Labels = labels
+	return b
+}
+
+func (b wsBuilder) unschedulable() wsBuilder {
+	b.Status.Conditions = append(b.Status.Conditions, v1alpha1.Condition{
+		Type:   tenancyv1alpha1.WorkspaceScheduled,
+		Status: corev1.ConditionFalse,
+		Reason: tenancyv1alpha1.WorkspaceReasonReasonUnknown,
+	})
+	return b
 }

--- a/pkg/server/home_workspaces_test.go
+++ b/pkg/server/home_workspaces_test.go
@@ -1296,7 +1296,7 @@ func TestServeHTTP(t *testing.T) {
 
 			expectedStatusCode:   500,
 			expectedToDelegate:   false,
-			expectedResponseBody: `Internal Server Error: "/dummy-target": No request Info`,
+			expectedResponseBody: `Internal Server Error: "/dummy-target": no request Info`,
 		},
 		{
 			testName:           "delegate to next handler when request not under home root nor a 'get ~' request",
@@ -1319,22 +1319,34 @@ func TestServeHTTP(t *testing.T) {
 			expectedToDelegate: true,
 		},
 		{
-			testName:           "Return virtual home workspace resource when it still doesn't exist",
+			testName:           "try to create home workspace when it doesn't exist",
 			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
 			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
 			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
-			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return nil, nil
-			},
 			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionAllow, "", nil
 			},
+			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
+				return nil, nil
+			},
+			mocks: homeWorkspaceFeatureLogic{
+				searchForWorkspaceAndRBACInLocalInformers: func(workspaceName logicalcluster.Name, isHome bool, userName string) (found bool, retryAfterSeconds int, checkError error) {
+					return
+				},
+				tryToCreate: func(ctx context.Context, userName string, workspaceToCheck logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
+					retryAfterSeconds = 11
+					return
+				},
+			},
 
-			expectedStatusCode:   200,
+			expectedStatusCode:   429,
 			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
+			expectedResponseBody: "Creating the home workspace",
+			expectedResponseHeaders: map[string]string{
+				"Retry-After": "11",
+			},
 		},
 		{
 			testName:           "return error if error when getting home workspace in the local informers",
@@ -1350,42 +1362,6 @@ func TestServeHTTP(t *testing.T) {
 			expectedStatusCode:   500,
 			expectedToDelegate:   false,
 			expectedResponseBody: `Internal Server Error: "/dummy-target": an error`,
-		},
-		{
-			testName:           "return Forbidden if no permission to get the virtual home workspace resource when it still doesn't exist",
-			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
-
-			synced: true,
-			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return nil, nil
-			},
-			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-				return authorizer.DecisionDeny, "some reason", nil
-			},
-
-			expectedStatusCode:   403,
-			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-1\" cannot get resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: some reason","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
-		},
-		{
-			testName:           "return error if could not check the permission to get the virtual home workspace resource when it still doesn't exist",
-			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
-			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
-			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
-
-			synced: true,
-			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
-				return nil, nil
-			},
-			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-				return authorizer.DecisionDeny, "", errors.New("an error")
-			},
-
-			expectedStatusCode:   403,
-			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterworkspaces.tenancy.kcp.dev \"~\" is forbidden: User \"user-1\" cannot get resource \"clusterworkspaces/workspace\" in API group \"tenancy.kcp.dev\" at the cluster scope: workspace access not permitted","reason":"Forbidden","details":{"name":"~","group":"tenancy.kcp.dev","kind":"clusterworkspaces"},"code":403}`,
 		},
 		{
 			testName:           "return the real home workspace when it already exists and is ready in informer, and RBAC objects are in informer",
@@ -1414,30 +1390,40 @@ func TestServeHTTP(t *testing.T) {
 			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","resourceVersion":"someRealResourceVersion","creationTimestamp":null,"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1","phase":"Ready"}}`,
 		},
 		{
-			testName:           "return virtual home workspace when the home workspace is not ready yet",
+			testName:           "try to create home workspace when the home workspace is not ready yet",
 			contextCluster:     &request.Cluster{Name: logicalcluster.New("root")},
 			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
 			contextRequestInfo: &request.RequestInfo{IsResourceRequest: true, APIGroup: "tenancy.kcp.dev", Resource: "workspaces", Name: "~", Verb: "get"},
 
 			synced: true,
+			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			},
 			getLocalClusterWorkspace: func(fullName logicalcluster.Name) (*tenancyv1alpha1.ClusterWorkspace, error) {
 				return newWorkspace("root:users:bi:ie:user-1").withType("root:home").withRV("someRealResourceVersion").withStatus(tenancyv1alpha1.ClusterWorkspaceStatus{
 					Phase:   tenancyv1alpha1.ClusterWorkspacePhaseInitializing,
 					BaseURL: "https://example.com/clusters/root:users:bi:ie:user-1",
 				}).ClusterWorkspace, nil
 			},
-			authz: func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-				return authorizer.DecisionAllow, "", nil
-			},
 			mocks: homeWorkspaceFeatureLogic{
-				searchForHomeWorkspaceRBACResourcesInLocalInformers: func(logicalClusterName logicalcluster.Name) (found bool, err error) {
-					return true, nil
+				searchForWorkspaceAndRBACInLocalInformers: func(workspaceName logicalcluster.Name, isHome bool, userName string) (found bool, retryAfterSeconds int, checkError error) {
+					return false, 0, nil
+				},
+				searchForHomeWorkspaceRBACResourcesInLocalInformers: func(logicalClusterName logicalcluster.Name) (bool, error) {
+					return false, nil
+				},
+				tryToCreate: func(ctx context.Context, userName string, workspaceToCheck logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
+					retryAfterSeconds = 11
+					return
 				},
 			},
 
-			expectedStatusCode:   200,
+			expectedStatusCode:   429,
 			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
+			expectedResponseBody: "Creating the home workspace",
+			expectedResponseHeaders: map[string]string{
+				"Retry-After": "11",
+			},
 		},
 		{
 			testName:           "return virtual home workspace when home already exists, but RBAC objects are not in informer",
@@ -1459,11 +1445,21 @@ func TestServeHTTP(t *testing.T) {
 				searchForHomeWorkspaceRBACResourcesInLocalInformers: func(logicalClusterName logicalcluster.Name) (found bool, err error) {
 					return false, nil
 				},
+				searchForWorkspaceAndRBACInLocalInformers: func(workspaceName logicalcluster.Name, isHome bool, userName string) (found bool, retryAfterSeconds int, checkError error) {
+					return
+				},
+				tryToCreate: func(ctx context.Context, userName string, workspaceToCheck logicalcluster.Name, workspaceType tenancyv1alpha1.ClusterWorkspaceTypeName) (retryAfterSeconds int, createError error) {
+					retryAfterSeconds = 11
+					return
+				},
 			},
 
-			expectedStatusCode:   200,
+			expectedStatusCode:   429,
 			expectedToDelegate:   false,
-			expectedResponseBody: `{"kind":"Workspace","apiVersion":"tenancy.kcp.dev/v1beta1","metadata":{"name":"user-1","creationTimestamp":null,"annotations":{"tenancy.kcp.dev/owner":"user-1"},"clusterName":"root:users:bi:ie"},"spec":{"type":{"name":"home","path":"root"}},"status":{"URL":"https://example.com/clusters/root:users:bi:ie:user-1"}}`,
+			expectedResponseBody: "Creating the home workspace",
+			expectedResponseHeaders: map[string]string{
+				"Retry-After": "11",
+			},
 		},
 		{
 			testName:           "return error when workspace cannot be checked in local informers",

--- a/test/e2e/homeworkspaces/home_workspaces_test.go
+++ b/test/e2e/homeworkspaces/home_workspaces_test.go
@@ -18,7 +18,6 @@ package homeworkspaces
 
 import (
 	"context"
-	"net/url"
 	"path"
 	"testing"
 	"time"
@@ -53,54 +52,42 @@ func TestUserHomeWorkspaces(t *testing.T) {
 	}
 
 	var testCases = []struct {
-		name        string
-		clientInfos []clientInfo
-		work        func(ctx context.Context, t *testing.T, server runningServer)
+		name string
+		work func(ctx context.Context, t *testing.T, server runningServer)
 	}{
 		{
-			name: "Create a workspace in the non-existing home and have it created automatically",
-			clientInfos: []clientInfo{
-				{
-					Token: "user-1-token",
-				},
-				{
-					Token: "user-2-token",
-				},
+			name: "Create a workspace in the non-existing home and have it created automatically through ~",
+			work: func(ctx context.Context, t *testing.T, server runningServer) {
+				kcpUser1Client := server.kcpUserClusterClients[0]
+
+				t.Logf("Get ~ Home workspace URL for user-1")
+				createdHome, err := kcpUser1Client.Cluster(tenancyv1alpha1.RootCluster).TenancyV1beta1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
+				require.NoError(t, err, "user-1 should be able to get ~ workspace")
+				require.NotEqual(t, metav1.Time{}, createdHome.CreationTimestamp, "should have a creation timestamp, i.e. is not virtual")
+				require.Equal(t, tenancyv1alpha1.ClusterWorkspacePhaseReady, createdHome.Status.Phase, "created home workspace should be ready")
 			},
+		},
+		{
+			name: "Create a workspace in the non-existing home and have it created automatically in-workspace request",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
 				vwUser1Client := server.virtualPersonalClusterClients[0]
 				kcpUser1Client := server.kcpUserClusterClients[0]
 
 				vwUser2Client := server.virtualPersonalClusterClients[1]
 
-				t.Logf("Get ~ Home workspace URL for user-1")
-				nonExistingHomeWorkspace, err := kcpUser1Client.Cluster(tenancyv1alpha1.RootCluster).TenancyV1beta1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
-				require.NoError(t, err, "user-1 should be allowed to get his home wporkspace even before it exists")
-				require.NotNil(t, nonExistingHomeWorkspace, "home workspace should not be nil, even before it exists")
-				require.Equal(t, metav1.Time{}, nonExistingHomeWorkspace.CreationTimestamp, "Non-existing home workspace should not have a creation timestamp")
-				require.Equal(t, tenancyv1alpha1.ClusterWorkspacePhaseType(""), nonExistingHomeWorkspace.Status.Phase, "Non-existing home workspace should have an empty phase")
-
-				homeWorkspaceURL := nonExistingHomeWorkspace.Status.URL
-				u, err := url.Parse(homeWorkspaceURL)
-				require.NoError(t, err)
-				homeWorkspaceName := logicalcluster.New(path.Base(u.Path))
-				t.Logf("Home workspace for user-1 is: %s", homeWorkspaceName)
-
-				require.Equal(t, "user-1", homeWorkspaceName.Base(), "Home workspace for the wrong user")
-
 				t.Logf("Create Workspace workspace1 in the user-1 non-existing home as user-1")
-				_, err = vwUser1Client.Cluster(homeWorkspaceName).TenancyV1beta1().Workspaces().Create(ctx, &tenancyv1beta1.Workspace{
+				homeWorkspaceName := logicalcluster.New("root:users:bi:ie:user-1")
+				_, err := vwUser1Client.Cluster(homeWorkspaceName).TenancyV1beta1().Workspaces().Create(ctx, &tenancyv1beta1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "workspace1",
 					},
 				}, metav1.CreateOptions{})
 				require.NoError(t, err, "user-1 should be able to create a workspace inside his home workspace even though it doesn't exist")
 
+				t.Logf("Get ~ workspace of user-1")
 				existingHomeWorkspace, err := kcpUser1Client.Cluster(tenancyv1alpha1.RootCluster).TenancyV1beta1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
-				require.NoError(t, err, "user-1 should get his home workspace through '~' even after it exists")
-				require.NotNil(t, nonExistingHomeWorkspace, "home workspace should not be nil, even after it exists")
-				require.NotEqual(t, metav1.Time{}, existingHomeWorkspace.CreationTimestamp, "Existing home workspace retrieved from '~' should have a valid creation timestamp")
-				require.Equal(t, tenancyv1alpha1.ClusterWorkspacePhaseReady, existingHomeWorkspace.Status.Phase, "The existing home workspace (created automatically), when retrieved from '~', should be READY")
+				require.NoError(t, err, "user-1 should get his home workspace through ~")
+				require.Equal(t, tenancyv1alpha1.ClusterWorkspacePhaseReady, existingHomeWorkspace.Status.Phase, "created home workspace should be ready")
 
 				t.Logf("Workspace will show up in list of workspaces of user-1")
 				require.Eventually(t, func() bool {
@@ -114,41 +101,16 @@ func TestUserHomeWorkspaces(t *testing.T) {
 				t.Logf("user-2 doesn't have the right to acces user-1 home workspace")
 				_, err = vwUser2Client.Cluster(homeWorkspaceName).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
 				require.EqualError(t, err, `workspaces.tenancy.kcp.dev is forbidden: "list" workspace "" in workspace "root:users:bi:ie:user-1" is not allowed`, "user-1 should be able to create a workspace inside his home workspace even though it doesn't exist")
-
 			},
 		},
 		{
 			name: "Cannot trigger automatic creation of a Home workspace for the wrong user",
-			clientInfos: []clientInfo{
-				{
-					Token: "user-1-token",
-				},
-				{
-					Token: "user-2-token",
-				},
-			},
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				kcpUser1Client := server.kcpUserClusterClients[0]
-
 				vwUser2Client := server.virtualPersonalClusterClients[1]
 
-				t.Logf("Get ~ Home workspace URL for user-1")
-				nonExistingHomeWorkspace, err := kcpUser1Client.Cluster(tenancyv1alpha1.RootCluster).TenancyV1beta1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
-				require.NoError(t, err, "user-1 should be allowed to get his home wporkspace even before it exists")
-				require.NotNil(t, nonExistingHomeWorkspace, "home workspace should not be nil, even before it exists")
-				require.Equal(t, metav1.Time{}, nonExistingHomeWorkspace.CreationTimestamp, "Non-existing home workspace should not have a creation timestamp")
-				require.Equal(t, tenancyv1alpha1.ClusterWorkspacePhaseType(""), nonExistingHomeWorkspace.Status.Phase, "Non-existing home workspace should have an empty phase")
-
-				homeWorkspaceURL := nonExistingHomeWorkspace.Status.URL
-				u, err := url.Parse(homeWorkspaceURL)
-				require.NoError(t, err)
-				homeWorkspaceName := logicalcluster.New(path.Base(u.Path))
-				t.Logf("Home workspace for user-1 is: %s", homeWorkspaceName)
-
-				require.Equal(t, "user-1", homeWorkspaceName.Base(), "Home workspace for the wrong user")
-
 				t.Logf("Try to create Workspace workspace1 in the non-existing user-1 home as user-2")
-				_, err = vwUser2Client.Cluster(homeWorkspaceName).TenancyV1beta1().Workspaces().Create(ctx, &tenancyv1beta1.Workspace{
+				homeWorkspaceName := logicalcluster.New("root:users:bi:ie:user-1")
+				_, err := vwUser2Client.Cluster(homeWorkspaceName).TenancyV1beta1().Workspaces().Create(ctx, &tenancyv1beta1.Workspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "workspace1",
 					},
@@ -158,34 +120,10 @@ func TestUserHomeWorkspaces(t *testing.T) {
 		},
 		{
 			name: "Cannot trigger automatic creation of a Home workspace for the wrong user, even as system-masters",
-			clientInfos: []clientInfo{
-				{
-					Token: "user-1-token",
-				},
-				{
-					Token: "user-2-token",
-				},
-			},
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
-				kcpUser1Client := server.kcpUserClusterClients[0]
-
-				t.Logf("Get ~ Home workspace URL for user-1")
-				nonExistingHomeWorkspace, err := kcpUser1Client.Cluster(tenancyv1alpha1.RootCluster).TenancyV1beta1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
-				require.NoError(t, err, "user-1 should be allowed to get his home wporkspace even before it exists")
-				require.NotNil(t, nonExistingHomeWorkspace, "home workspace should not be nil, even before it exists")
-				require.Equal(t, metav1.Time{}, nonExistingHomeWorkspace.CreationTimestamp, "Non-existing home workspace should not have a creation timestamp")
-				require.Equal(t, tenancyv1alpha1.ClusterWorkspacePhaseType(""), nonExistingHomeWorkspace.Status.Phase, "Non-existing home workspace should have an empty phase")
-
-				homeWorkspaceURL := nonExistingHomeWorkspace.Status.URL
-				u, err := url.Parse(homeWorkspaceURL)
-				require.NoError(t, err)
-				homeWorkspaceName := logicalcluster.New(path.Base(u.Path))
-				t.Logf("Home workspace for user-1 is: %s", homeWorkspaceName)
-
-				require.Equal(t, "user-1", homeWorkspaceName.Base(), "Home workspace for the wrong user")
-
 				t.Logf("Try to create a ClusterWorkspace workspace1 in the non-existing user-1 home as system:masters")
-				_, err = server.kcpClusterClient.Cluster(homeWorkspaceName).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
+				homeWorkspaceName := logicalcluster.New("root:users:bi:ie:user-1")
+				_, err := server.kcpClusterClient.Cluster(homeWorkspaceName).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "workspace1",
 					},
@@ -216,7 +154,7 @@ func TestUserHomeWorkspaces(t *testing.T) {
 			// create kcp client and virtual clients for all users requested
 			var kcpUserClusterClients []kcpclientset.ClusterInterface
 			var virtualPersonalClusterClients []kcpclientset.ClusterInterface
-			for _, ci := range testCase.clientInfos {
+			for _, ci := range []clientInfo{{Token: "user-1-token"}, {Token: "user-2-token"}} {
 				userConfig := framework.ConfigWithToken(ci.Token, rest.CopyConfig(kcpConfig))
 				virtualPersonalClusterClients = append(virtualPersonalClusterClients, &virtualClusterClient{scope: "personal", config: userConfig})
 				kcpUserClusterClient, err := kcpclientset.NewClusterForConfig(userConfig)


### PR DESCRIPTION
Solving this TODO:
```
// TODO: The way we build this URL here is not fully compatible with sharding long-term:
// - short term (what is done now): use genericConfig.ExternalAddress
// - medium term: shards will know their name eventually, and with that we can lookup the external URL of the shard
// - long-term: create home workspace already on `~` access in order to make scheduling happen and then we know the real external URL.
```