### PR TITLE
separate server config initialization from run

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -109,8 +109,16 @@ func main() {
 			if errs := completed.Validate(); len(errs) > 0 {
 				return errors.NewAggregate(errs)
 			}
+			config, err := server.NewConfig(completed)
+			if err != nil {
+				return err
+			}
+			completedConfig, err := config.Complete()
+			if err != nil {
+				return err
+			}
 
-			s, err := server.NewServer(completed)
+			s, err := server.NewServer(completedConfig)
 			if err != nil {
 				return err
 			}

--- a/docs/developers/library-structure.md
+++ b/docs/developers/library-structure.md
@@ -1,0 +1,39 @@
+# Library Structure
+
+The kcp library is set up and initialized in several phases. This document describes those phases and the responsibilities of each.
+
+```go
+opts := options.NewOptions()
+completedOptions := opts.Complete()
+conf := config.NewConfig(completedOptions)
+completedConfig := conf.Complete()
+srv := server.NewServer(completedConfig)
+srv.Init()
+srv.Run(ctx)
+```
+
+## Options
+
+Options parses basic configuration options, such as flags or environment variables. `NewOptions()` does default parsing
+of environment variables and CLI flags and sets defaults. You then can change options properties
+as you see fit.
+
+With `Options` in hand, you need to run `opts.Complete()`. This ensures that any modifications necessary,
+such as defaults, are in place.
+
+## Config
+
+Config includes all of the structures required for the server to operate properly. It can include handlers,
+callbacks, and other structures. These settings are informed by the values of `Options`, and so
+take `Options` as a parameter.
+
+With `Config` in hand, you need to run `conf.Complete()`. This ensures that any modifications necessary,
+such as defaults, are in place.
+
+## Server
+
+Server is the actual structure that handles the inbound requests, passing them through RBAC, storing data, invoking handlers, etc.
+It is, in effect, the API server.
+
+To create a Server, you must call `NewServer()`, passing it the `CompletedOptions`. Then you initialize it with `Init()`, and finally
+you `Run()` it.

--- a/docs/developers/library-usage.md
+++ b/docs/developers/library-usage.md
@@ -47,3 +47,5 @@ if err := srv.Run(ctx); err != nil {
     panic(err)
 }
 ```
+
+To understand the stages of setting up and initializing the library, read [library-structure.md](./library-structure.md).

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/kcp-dev/logicalcluster"
-	"github.com/munnerz/goautoneg"
 
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -157,26 +156,6 @@ func (c *apiBindingAwareCRDLister) List(ctx context.Context, selector labels.Sel
 	}
 
 	return ret, nil
-}
-
-func isPartialMetadataRequest(ctx context.Context) bool {
-	accept := ctx.Value(acceptHeaderContextKey).(string)
-	if accept == "" {
-		return false
-	}
-
-	return isPartialMetadataHeader(accept)
-}
-
-func isPartialMetadataHeader(accept string) bool {
-	clauses := goautoneg.ParseAccept(accept)
-	for _, clause := range clauses {
-		if clause.Params["as"] == "PartialObjectMetadata" || clause.Params["as"] == "PartialObjectMetadataList" {
-			return true
-		}
-	}
-
-	return false
 }
 
 func (c *apiBindingAwareCRDLister) Refresh(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,0 +1,418 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+
+	kcpadmissioninitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/etcd"
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/informer"
+	boostrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
+	"github.com/kcp-dev/kcp/pkg/server/options"
+	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
+	"github.com/kcp-dev/logicalcluster"
+	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/endpoints/filters"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/client-go/dynamic"
+	coreexternalversions "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/genericcontrolplane"
+	"k8s.io/kubernetes/pkg/genericcontrolplane/apis"
+)
+
+type tokenAuth struct {
+	kcp       string
+	shard     string
+	shardHash []byte
+}
+type Config struct {
+	options                    *options.CompletedOptions
+	EtcdServer                 *etcd.Server
+	identityConfig             *rest.Config
+	resolveIdentities          func(ctx context.Context) error
+	genericConfig              *genericapiserver.Config
+	apisConfig                 *apis.Config
+	apiExtensionsConfig        *apiextensionsapiserver.Config
+	preHandlerChain            handlerChainMuxes
+	dynamicClusterClient       *dynamic.Cluster
+	apiextensionsClusterClient *apiextensionsclient.Cluster
+	kcpClusterClient           *kcpclient.Cluster
+	kubeClusterClient          *kubernetes.Cluster
+	tokenAuth
+	apiBindingAwareCRDLister *apiBindingAwareCRDLister
+
+	kcpSharedInformerFactory              kcpexternalversions.SharedInformerFactory
+	kubeSharedInformerFactory             coreexternalversions.SharedInformerFactory
+	apiextensionsSharedInformerFactory    apiextensionsexternalversions.SharedInformerFactory
+	dynamicDiscoverySharedInformerFactory *informer.DynamicDiscoverySharedInformerFactory
+	// TODO(sttts): get rid of these. We have wildcard informers already.
+	rootKcpSharedInformerFactory  kcpexternalversions.SharedInformerFactory
+	rootKubeSharedInformerFactory coreexternalversions.SharedInformerFactory
+}
+
+type CompletedConfig struct {
+	EtcdServer            *etcd.Server
+	config                *Config
+	preHandlerChain       handlerChainMuxes
+	profilerAddress       string
+	enabledControllers    sets.String
+	enabledAllControllers bool
+	apiExtensionsConfig   apiextensionsapiserver.CompletedConfig
+	apisConfig            apis.CompletedConfig
+}
+
+func (c *CompletedConfig) Factories() (kcpexternalversions.SharedInformerFactory, coreexternalversions.SharedInformerFactory, apiextensionsexternalversions.SharedInformerFactory, *informer.DynamicDiscoverySharedInformerFactory, kcpexternalversions.SharedInformerFactory, coreexternalversions.SharedInformerFactory) {
+	return c.config.kcpSharedInformerFactory,
+		c.config.kubeSharedInformerFactory,
+		c.config.apiextensionsSharedInformerFactory,
+		c.config.dynamicDiscoverySharedInformerFactory,
+		c.config.rootKcpSharedInformerFactory,
+		c.config.rootKubeSharedInformerFactory
+}
+
+func (c *CompletedConfig) IdentityConfig() *rest.Config {
+	return rest.CopyConfig(c.config.identityConfig)
+}
+
+func (c *CompletedConfig) GenericConfig() *genericapiserver.Config {
+	return c.config.genericConfig
+}
+func (c *CompletedConfig) PreHandlerChain() handlerChainMuxes {
+	return c.preHandlerChain
+}
+func (c *CompletedConfig) ProfilerAddress() string {
+	return c.profilerAddress
+}
+func (c *CompletedConfig) IsControllerEnabled(name string) bool {
+	return c.enabledAllControllers || c.enabledControllers.Has(name)
+}
+func (c *CompletedConfig) VirtualEnabled() bool {
+	return c.config.options.Virtual.Enabled
+}
+func (c *CompletedConfig) Virtual() options.Virtual {
+	return c.config.options.Virtual
+}
+func (c *CompletedConfig) Controllers() options.Controllers {
+	return c.config.options.Controllers
+}
+func (c *CompletedConfig) Authorization() options.Authorization {
+	return c.config.options.Authorization
+}
+func (c *CompletedConfig) ServerKeyCert() (keyFile string, certFile string) {
+	keyFile = c.config.options.GenericControlPlane.SecureServing.SecureServingOptions.ServerCert.CertKey.KeyFile
+	certFile = c.config.options.GenericControlPlane.SecureServing.SecureServingOptions.ServerCert.CertKey.CertFile
+	return
+}
+func (c *CompletedConfig) DynamicClusterClient() *dynamic.Cluster {
+	return c.config.dynamicClusterClient
+}
+func (c *CompletedConfig) ResolveIdentitiesFunc() func(context.Context) error {
+	return c.config.resolveIdentities
+}
+func (c *CompletedConfig) APIExtensionsConfig() *apiextensionsapiserver.Config {
+	return c.config.apiExtensionsConfig
+}
+func (c *CompletedConfig) APIBindingAwareCRDLister() *apiBindingAwareCRDLister {
+	return c.config.apiBindingAwareCRDLister
+}
+func (c *CompletedConfig) APIExtensionsClusterClient() *apiextensionsclient.Cluster {
+	return c.config.apiextensionsClusterClient
+}
+func (c *CompletedConfig) KCPClusterClient() *kcpclient.Cluster {
+	return c.config.kcpClusterClient
+}
+func (c *CompletedConfig) KubeClusterClient() *kubernetes.Cluster {
+	return c.config.kubeClusterClient
+}
+func (c *CompletedConfig) WriteKubeConfig() error {
+	return c.config.options.AdminAuthentication.WriteKubeConfig(c.config.genericConfig, c.config.tokenAuth.kcp, c.config.tokenAuth.shard, c.config.tokenAuth.shardHash)
+}
+func (c *CompletedConfig) ShardName() string {
+	return c.config.options.Extra.ShardName
+}
+func (c *CompletedConfig) HomeWorkspaces() options.HomeWorkspaces {
+	return c.config.options.HomeWorkspaces
+}
+
+func NewConfig(opts *options.CompletedOptions) (Config, error) {
+	c := Config{
+		options: opts,
+	}
+
+	// set up embedded etcd, if requested
+	embedEtcd := c.options.EmbeddedEtcd
+	if embedEtcd.Enabled {
+		es := &etcd.Server{
+			Dir: embedEtcd.Directory,
+		}
+		var listenMetricsURLs []url.URL
+		if len(embedEtcd.ListenMetricsURLs) > 0 {
+			var err error
+			listenMetricsURLs, err = etcdtypes.NewURLs(embedEtcd.ListenMetricsURLs)
+			if err != nil {
+				return c, err
+			}
+		}
+		clientInfo, err := es.Init(embedEtcd.PeerPort, embedEtcd.ClientPort, listenMetricsURLs, embedEtcd.WalSizeBytes, embedEtcd.QuotaBackendBytes, embedEtcd.ForceNewCluster)
+		if err != nil {
+			return c, err
+		}
+		transport := c.options.GenericControlPlane.Etcd.StorageConfig.Transport
+		transport.ServerList = clientInfo.Endpoints
+		transport.KeyFile = clientInfo.KeyFile
+		transport.CertFile = clientInfo.CertFile
+		transport.TrustedCAFile = clientInfo.TrustedCAFile
+		c.EtcdServer = es
+	}
+
+	// set up kcpSharedInformerFactory
+	genericConfig, storageFactory, err := genericcontrolplane.BuildGenericConfig(c.options.GenericControlPlane)
+	if err != nil {
+		return c, err
+	}
+	c.genericConfig = genericConfig
+
+	genericConfig.RequestInfoResolver = requestinfo.NewFactory() // must be set here early to avoid a crash in the EnableMultiCluster roundtrip wrapper
+
+	// Setup kcp * informers, but those will need the identities for the APIExports used to make the APIs available.
+	// The identities are not known before we can get them from the APIExports via the loopback client, hence we postpone
+	// this to getOrCreateKcpIdentities() in the kcp-start-informers post-start hook.
+	// The informers here are not  used before the informers are actually started (i.e. no race).
+	nonIdentityKcpClusterClient, err := kcpclient.NewClusterForConfig(genericConfig.LoopbackClientConfig) // can only used for wildcard requests of apis.kcp.dev
+	if err != nil {
+		return c, err
+	}
+	c.identityConfig, c.resolveIdentities = boostrap.NewConfigWithWildcardIdentities(genericConfig.LoopbackClientConfig, boostrap.KcpRootGroupExportNames, boostrap.KcpRootGroupResourceExportNames, nonIdentityKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
+	kcpClusterClient, err := kcpclient.NewClusterForConfig(c.identityConfig) // this is now generic to be used for all kcp API groups
+	if err != nil {
+		return c, err
+	}
+	c.kcpClusterClient = kcpClusterClient
+	kcpClient := kcpClusterClient.Cluster(logicalcluster.Wildcard)
+	c.kcpSharedInformerFactory = kcpexternalversions.NewSharedInformerFactoryWithOptions(
+		kcpClient,
+		resyncPeriod,
+		kcpexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
+		kcpexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
+	)
+
+	// Setup kube * informers
+	kubeClusterClient, err := kubernetes.NewClusterForConfig(genericConfig.LoopbackClientConfig)
+	if err != nil {
+		return c, err
+	}
+	kubeClient := kubeClusterClient.Cluster(logicalcluster.Wildcard)
+	c.kubeSharedInformerFactory = coreexternalversions.NewSharedInformerFactoryWithOptions(
+		kubeClient,
+		resyncPeriod,
+		coreexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
+		coreexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
+	)
+
+	// Setup apiextensions * informers
+	apiextensionsClusterClient, err := apiextensionsclient.NewClusterForConfig(genericConfig.LoopbackClientConfig)
+	if err != nil {
+		return c, err
+	}
+	apiextensionsCrossClusterClient := apiextensionsClusterClient.Cluster(logicalcluster.Wildcard)
+	c.apiextensionsSharedInformerFactory = apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
+		apiextensionsCrossClusterClient,
+		resyncPeriod,
+		apiextensionsexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
+		apiextensionsexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
+	)
+
+	// Setup root informers
+	c.rootKcpSharedInformerFactory = kcpexternalversions.NewSharedInformerFactoryWithOptions(kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster), resyncPeriod)
+	c.rootKubeSharedInformerFactory = coreexternalversions.NewSharedInformerFactoryWithOptions(kubeClusterClient.Cluster(tenancyv1alpha1.RootCluster), resyncPeriod)
+
+	// Setup dynamic client
+	dynamicClusterClient, err := dynamic.NewClusterForConfig(genericConfig.LoopbackClientConfig)
+	if err != nil {
+		return c, err
+	}
+	c.dynamicClusterClient = dynamicClusterClient
+
+	if err := c.options.Authorization.ApplyTo(genericConfig, c.kubeSharedInformerFactory, c.kcpSharedInformerFactory); err != nil {
+		return c, err
+	}
+	kcpAdminToken, shardAdminToken, shardAdminTokenHash, err := c.options.AdminAuthentication.ApplyTo(genericConfig)
+	if err != nil {
+		return c, err
+	}
+	c.tokenAuth = tokenAuth{
+		kcp:       kcpAdminToken,
+		shard:     shardAdminToken,
+		shardHash: shardAdminTokenHash,
+	}
+
+	if err := c.options.GenericControlPlane.Audit.ApplyTo(genericConfig); err != nil {
+		return c, err
+	}
+
+	// preHandlerChainMux is called before the actual handler chain. Note that BuildHandlerChainFunc below
+	// is called multiple times, but only one of the handler chain will actually be used. Hence, we wrap it
+	// to give handlers below one mux.Handle func to call.
+	var preHandlerChainMux handlerChainMuxes
+	kubeSharedInformerFactory, kcpSharedInformerFactory := c.kubeSharedInformerFactory, c.kcpSharedInformerFactory
+	genericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, c *genericapiserver.Config) (secure http.Handler) {
+		apiHandler = WithWildcardListWatchGuard(apiHandler)
+		apiHandler = WithWildcardIdentity(apiHandler)
+
+		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, c)
+
+		// TODO(david): Add options to drive the various Home workspace parameters.
+		// For now default values are:
+		//   - Creation delay (returned in the retry-afterof the http responses): 2 seconds
+		//   - Home root workspace: root:users
+		//   - Home bucket levels: 2
+		//   - home bucket name size: 2
+		apiHandler = WithHomeWorkspaces(apiHandler, c.Authorization.Authorizer, kubeClusterClient, kcpClusterClient, kubeSharedInformerFactory, kcpSharedInformerFactory, genericConfig.ExternalAddress, 2, logicalcluster.New("root:users"), 2, 2)
+
+		apiHandler = genericapiserver.DefaultBuildHandlerChainBeforeAuthz(apiHandler, c)
+
+		// this will be replaced in DefaultBuildHandlerChain. So at worst we get twice as many warning.
+		// But this is not harmful as the kcp warnings are not many.
+		apiHandler = filters.WithWarningRecorder(apiHandler)
+
+		// add a mux before the chain, for other handlers with their own handler chain to hook in
+		mux := http.NewServeMux()
+		mux.Handle("/", apiHandler)
+		preHandlerChainMux = append(preHandlerChainMux, mux)
+		apiHandler = mux
+
+		apiHandler = WithWorkspaceProjection(apiHandler)
+		apiHandler = WithClusterAnnotation(apiHandler)
+		apiHandler = WithAuditAnnotation(apiHandler) // Must run before any audit annotation is made
+		apiHandler = WithClusterScope(apiHandler)
+		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler)
+		apiHandler = WithAcceptHeader(apiHandler)
+		apiHandler = WithUserAgent(apiHandler)
+
+		return apiHandler
+	}
+	c.preHandlerChain = preHandlerChainMux
+
+	admissionPluginInitializers := []admission.PluginInitializer{
+		kcpadmissioninitializers.NewKcpInformersInitializer(kcpSharedInformerFactory),
+		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
+		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
+		kcpadmissioninitializers.NewShardBaseURLInitializer(c.options.Extra.ShardBaseURL),
+		// The external address is provided as a function, as its value may be updated
+		// with the default secure port, when the config is later completed.
+		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return genericConfig.ExternalAddress }),
+	}
+
+	apisConfig, err := genericcontrolplane.CreateKubeAPIServerConfig(genericConfig, c.options.GenericControlPlane, kubeSharedInformerFactory, admissionPluginInitializers, storageFactory)
+	if err != nil {
+		return c, err
+	}
+	c.apisConfig = apisConfig
+
+	// If additional API servers are added, they should be gated.
+	apiExtensionsConfig, err := genericcontrolplane.CreateAPIExtensionsConfig(
+		*apisConfig.GenericConfig,
+		apisConfig.ExtraConfig.VersionedInformers,
+		admissionPluginInitializers,
+		c.options.GenericControlPlane,
+
+		// Wire in a ServiceResolver that always returns an error that ResolveEndpoint is not yet
+		// supported. The effect is that CRD webhook conversions are not supported and will always get an
+		// error.
+		&unimplementedServiceResolver{},
+
+		webhook.NewDefaultAuthenticationInfoResolverWrapper(
+			nil,
+			apisConfig.GenericConfig.EgressSelector,
+			apisConfig.GenericConfig.LoopbackClientConfig,
+			apisConfig.GenericConfig.TracerProvider,
+		),
+	)
+	if err != nil {
+		return c, fmt.Errorf("configure api extensions: %w", err)
+	}
+	c.apiExtensionsConfig = apiExtensionsConfig
+
+	c.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                               // nolint: errcheck
+	c.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                    // nolint: errcheck
+	c.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byGroupResourceName: indexCRDByGroupResourceName}) // nolint: errcheck
+	c.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                               // nolint: errcheck
+	c.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byIdentityGroupResource: indexAPIBindingByIdentityGroupResource})             // nolint: errcheck
+
+	apiBindingAwareCRDLister := &apiBindingAwareCRDLister{
+		kcpClusterClient:  kcpClusterClient,
+		crdLister:         c.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Lister(),
+		crdIndexer:        c.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer(),
+		workspaceLister:   c.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
+		apiBindingLister:  c.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Lister(),
+		apiBindingIndexer: c.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer(),
+		apiExportIndexer:  c.kcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().GetIndexer(),
+		getAPIResourceSchema: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
+			key := clusters.ToClusterAwareKey(clusterName, name)
+			return c.kcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Lister().Get(key)
+		},
+	}
+	apiExtensionsConfig.ExtraConfig.ClusterAwareCRDLister = apiBindingAwareCRDLister
+	c.apiBindingAwareCRDLister = apiBindingAwareCRDLister
+
+	apiExtensionsConfig.ExtraConfig.TableConverterProvider = NewTableConverterProvider()
+
+	return c, nil
+}
+
+func (c *Config) Complete() (*CompletedConfig, error) {
+	cc := &CompletedConfig{}
+
+	cc.profilerAddress = c.options.Extra.ProfilerAddress
+	cc.enabledControllers = sets.NewString(c.options.Controllers.IndividuallyEnabled...)
+	cc.enabledAllControllers = c.options.Controllers.EnableAll
+	cc.config = c
+	cc.apisConfig = c.apisConfig.Complete()
+	cc.apiExtensionsConfig = c.apiExtensionsConfig.Complete()
+
+	return cc, nil
+}
+
+type informerFactory interface {
+	Start(stopCh <-chan struct{})
+	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
+}
+
+// generateInformerStartAndWait generates a postStartHook that starts and waits for cache sync for one or more informerFactories
+func generateInformerStartAndWait(msg string, factories ...informerFactory) func(ctx genericapiserver.PostStartHookContext) error {
+	return func(ctx genericapiserver.PostStartHookContext) error {
+		for _, factory := range factories {
+			factory.Start(ctx.StopCh)
+		}
+		for _, factory := range factories {
+			factory.WaitForCacheSync(ctx.StopCh)
+		}
+		select {
+		case <-ctx.StopCh:
+			return nil // context closed, avoid reporting success below
+		default:
+		}
+
+		klog.Infof("Finished start informer factories: %s", msg)
+		return nil
+	}
+}

--- a/pkg/server/const.go
+++ b/pkg/server/const.go
@@ -1,0 +1,19 @@
+package server
+
+const (
+	PassthroughHeader   = "X-Kcp-Api-V1-Discovery-Passthrough"
+	WorkspaceAnnotation = "tenancy.kcp.dev/workspace"
+)
+
+type (
+	acceptHeaderContextKeyType int
+	userAgentContextKeyType    int
+)
+
+const (
+	// acceptHeaderContextKey is the context key for the request namespace.
+	acceptHeaderContextKey acceptHeaderContextKeyType = iota
+
+	// userAgentContextKey is the context key for the request user-agent.
+	userAgentContextKey userAgentContextKeyType = iota
+)

--- a/pkg/server/metadata.go
+++ b/pkg/server/metadata.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"context"
+
+	"github.com/munnerz/goautoneg"
+)
+
+func isPartialMetadataRequest(ctx context.Context) bool {
+	accept := ctx.Value(acceptHeaderContextKey).(string)
+	if accept == "" {
+		return false
+	}
+
+	return isPartialMetadataHeader(accept)
+}
+
+func isPartialMetadataHeader(accept string) bool {
+	clauses := goautoneg.ParseAccept(accept)
+	for _, clause := range clauses {
+		if clause.Params["as"] == "PartialObjectMetadata" || clause.Params["as"] == "PartialObjectMetadataList" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,50 +18,32 @@ package server
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	_ "net/http/pprof"
-	"net/url"
 	"time"
 
-	"github.com/kcp-dev/logicalcluster"
-	etcdtypes "go.etcd.io/etcd/client/pkg/v3/types"
-
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/apiserver/pkg/endpoints/filters"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/apiserver/pkg/util/webhook"
-	"k8s.io/client-go/dynamic"
 	coreexternalversions "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
 
 	configroot "github.com/kcp-dev/kcp/config/root"
 	configrootphase0 "github.com/kcp-dev/kcp/config/root-phase0"
 	systemcrds "github.com/kcp-dev/kcp/config/system-crds"
-	kcpadmissioninitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
-	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	bootstrappolicy "github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
-	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/etcd"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
-	boostrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
-	kcpserveroptions "github.com/kcp-dev/kcp/pkg/server/options"
-	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
+	"github.com/kcp-dev/kcp/pkg/server/options"
+	"github.com/kcp-dev/logicalcluster"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const resyncPeriod = 10 * time.Hour
@@ -70,7 +52,12 @@ const resyncPeriod = 10 * time.Hour
 // as a library rather than as a single binary. Using its constructor function, you can easily
 // setup a new api-server and start it:
 //
-//   srv := server.NewServer(server.BaseConfig())
+//   opts := options.NewOptions()
+//   completedOptions := opts.Complete()
+//   conf := config.NewConfig(completedOptions)
+//   completedConfig := conf.Complete()
+//   srv := server.NewServer(completedConfig)
+//   srv.Init()
 //   srv.Run(ctx)
 //
 // You may optionally provide PostStartHookFunc and PreShutdownHookFunc hooks before starting
@@ -81,7 +68,12 @@ const resyncPeriod = 10 * time.Hour
 //       client := clientset.NewForConfigOrDie(context.LoopbackClientConfig)
 //   })
 type Server struct {
-	options *kcpserveroptions.CompletedOptions
+	initialized     bool
+	config          *CompletedConfig
+	genericServer   *genericapiserver.GenericAPIServer
+	genericConfig   *genericapiserver.Config
+	serverChain     *genericcontrolplane.ServerChain
+	preHandlerChain handlerChainMuxes
 
 	postStartHooks   []postStartHookEntry
 	preShutdownHooks []preShutdownHookEntry
@@ -99,11 +91,153 @@ type Server struct {
 }
 
 // NewServer creates a new instance of Server which manages the KCP api-server.
-func NewServer(o *kcpserveroptions.CompletedOptions) (*Server, error) {
-	return &Server{
-		options:  o,
-		syncedCh: make(chan struct{}),
-	}, nil
+func NewServer(c *CompletedConfig) (*Server, error) {
+	if c == nil {
+		return nil, errors.New("must pass valid CompletedConfig")
+	}
+
+	kcpSharedInformerFactory, kubeSharedInformerFactory, apiextensionsSharedInformerFactory, dynamicDiscoverySharedInformerFactory, rootKcpSharedInformerFactory, rootKubeSharedInformerFactory := c.Factories()
+	dynamicClusterClient := c.DynamicClusterClient()
+	resolveIdentities := c.ResolveIdentitiesFunc()
+	apiextensionsClusterClient := c.APIExtensionsClusterClient()
+	kcpClusterClient := c.KCPClusterClient()
+	genericConfig := c.GenericConfig()
+
+	serverChain, err := genericcontrolplane.CreateServerChain(c.apisConfig, c.apiExtensionsConfig)
+	if err != nil {
+		return nil, err
+	}
+	server := serverChain.MiniAggregator.GenericAPIServer
+	serverChain.GenericControlPlane.GenericAPIServer.Handler.GoRestfulContainer.Filter(
+		mergeCRDsIntoCoreGroup(
+			c.APIBindingAwareCRDLister(),
+			serverChain.CustomResourceDefinitions.GenericAPIServer.Handler.NonGoRestfulMux.ServeHTTP,
+			serverChain.GenericControlPlane.GenericAPIServer.Handler.GoRestfulContainer.ServeHTTP,
+		),
+	)
+
+	dynamicDiscoverySharedInformerFactory, err = informer.NewDynamicDiscoverySharedInformerFactory(
+		server.LoopbackClientConfig,
+		func(obj interface{}) bool { return true },
+		apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		indexers.NamespaceScoped(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	server.AddPostStartHook("kcp-bootstrap-policy", bootstrappolicy.Policy().EnsureRBACPolicy())
+	server.AddPostStartHook("kcp-start-informers", generateInformerStartAndWait("kube", kubeSharedInformerFactory, apiextensionsSharedInformerFactory, rootKubeSharedInformerFactory))
+	server.AddPostStartHook("kcp-bootstrap-system-crds", func(ctx genericapiserver.PostStartHookContext) error {
+		if err := systemcrds.Bootstrap(
+			goContext(ctx),
+			apiextensionsClusterClient.Cluster(SystemCRDLogicalCluster),
+			apiextensionsClusterClient.Cluster(SystemCRDLogicalCluster).Discovery(),
+			dynamicClusterClient.Cluster(SystemCRDLogicalCluster),
+		); err != nil {
+			klog.Errorf("failed to bootstrap system CRDs: %v", err)
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+		klog.Infof("Finished bootstrapping system CRDs")
+		return nil
+	})
+	server.AddPostStartHook("kcp-run-api-informers", func(ctx genericapiserver.PostStartHookContext) error {
+		go kcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().Run(ctx.StopCh)
+		go kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().Run(ctx.StopCh)
+		if err := wait.PollInfiniteWithContext(goContext(ctx), time.Millisecond*100, func(ctx context.Context) (bool, error) {
+			exportsSynced := kcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
+			bindingsSynced := kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
+			return exportsSynced && bindingsSynced, nil
+		}); err != nil {
+			klog.Errorf("failed to start APIExport and/or APIBinding informers: %v", err)
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		klog.Infof("Finished starting APIExport and APIBinding informers")
+		return nil
+	})
+	server.AddPostStartHook("kcp-bootstrap-workspace-phase-0", func(ctx genericapiserver.PostStartHookContext) error {
+		// bootstrap root workspace phase 0, no APIBinding resources yet
+		if err := configrootphase0.Bootstrap(goContext(ctx),
+			kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster),
+			apiextensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
+			dynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
+		); err != nil {
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		klog.Infof("Bootstrapped root workspace phase 0")
+		return nil
+	})
+	server.AddPostStartHook("kcp-get-api-export-identities", func(ctx genericapiserver.PostStartHookContext) error {
+		klog.Infof("Getting kcp APIExport identities")
+
+		if err := wait.PollImmediateInfiniteWithContext(goContext(ctx), time.Millisecond*500, func(ctx context.Context) (bool, error) {
+			if err := resolveIdentities(ctx); err != nil {
+				klog.V(3).Infof("failed to resolve identities, keeping trying: %v", err)
+				return false, nil
+			}
+			return true, nil
+		}); err != nil {
+			klog.Errorf("failed to get or create identities: %v", err)
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		klog.Infof("Finished getting kcp APIExport identities")
+		return nil
+	})
+	server.AddPostStartHook("kcp-start-remaining-informers", generateInformerStartAndWait("remaining kcp", kcpSharedInformerFactory, rootKcpSharedInformerFactory))
+	server.AddPostStartHook("kcp-bootstrap-workspace-phase-1", func(ctx genericapiserver.PostStartHookContext) error {
+		klog.Infof("Starting bootstrapping root workspace phase 1")
+		servingCert, _ := server.SecureServingInfo.Cert.CurrentCertKeyContent()
+		if err := configroot.Bootstrap(goContext(ctx),
+			apiextensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
+			dynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
+			c.ShardName(),
+			clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					// cross-cluster is the virtual cluster running by default
+					"shard": {
+						Server:                   "https://" + server.ExternalAddress,
+						CertificateAuthorityData: servingCert, // TODO(sttts): wire controller updating this when it changes, or use CA
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"shard": {Cluster: "shard"},
+				},
+				CurrentContext: "shard",
+			},
+			logicalcluster.New(c.HomeWorkspaces().HomeRootPrefix).Base(),
+			c.HomeWorkspaces().HomeCreatorGroups,
+		); err != nil {
+			// nolint:nilerr
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+		klog.Infof("Finished bootstrapping root workspace phase 1")
+		return nil
+	})
+
+	if err := c.WriteKubeConfig(); err != nil {
+		return nil, err
+	}
+
+	s := &Server{
+		kcpSharedInformerFactory:              kcpSharedInformerFactory,
+		kubeSharedInformerFactory:             kubeSharedInformerFactory,
+		apiextensionsSharedInformerFactory:    apiextensionsSharedInformerFactory,
+		dynamicDiscoverySharedInformerFactory: dynamicDiscoverySharedInformerFactory,
+		config:                                c,
+		genericServer:                         server,
+		genericConfig:                         genericConfig,
+		preHandlerChain:                       c.PreHandlerChain(),
+		serverChain:                           serverChain,
+		syncedCh:                              make(chan struct{}),
+	}
+	return s, nil
 }
 
 // postStartHookEntry groups a PostStartHookFunc with a name. We're not storing these hooks
@@ -121,496 +255,72 @@ type preShutdownHookEntry struct {
 	hook genericapiserver.PreShutdownHookFunc
 }
 
+// Init initializes the KCP api-server. It does not start it
+func (s *Server) Init() error {
+	s.initialized = true
+	return nil
+}
+
 // Run starts the KCP api-server. This function blocks until the api-server stops or an error.
 func (s *Server) Run(ctx context.Context) error {
-	if s.options.Extra.ProfilerAddress != "" {
-		// nolint:errcheck
-		go http.ListenAndServe(s.options.Extra.ProfilerAddress, nil)
+	if !s.initialized {
+		return errors.New("must initialize server with srv.Init() prior to Run()")
 	}
-	if s.options.EmbeddedEtcd.Enabled {
-		es := &etcd.Server{
-			Dir: s.options.EmbeddedEtcd.Directory,
-		}
-		var listenMetricsURLs []url.URL
-		if len(s.options.EmbeddedEtcd.ListenMetricsURLs) > 0 {
-			var err error
-			listenMetricsURLs, err = etcdtypes.NewURLs(s.options.EmbeddedEtcd.ListenMetricsURLs)
-			if err != nil {
-				return err
-			}
-		}
-		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, listenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.QuotaBackendBytes, s.options.EmbeddedEtcd.ForceNewCluster)
-		if err != nil {
+
+	// start the profiler
+	if s.config.ProfilerAddress() != "" {
+		// nolint:errcheck
+		go http.ListenAndServe(s.config.ProfilerAddress(), nil)
+	}
+
+	// if an embedded etcd server is configured, start it
+	if s.config.EtcdServer != nil {
+		if err := s.config.EtcdServer.Run(ctx); err != nil {
 			return err
 		}
-
-		s.options.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = embeddedClientInfo.Endpoints
-		s.options.GenericControlPlane.Etcd.StorageConfig.Transport.KeyFile = embeddedClientInfo.KeyFile
-		s.options.GenericControlPlane.Etcd.StorageConfig.Transport.CertFile = embeddedClientInfo.CertFile
-		s.options.GenericControlPlane.Etcd.StorageConfig.Transport.TrustedCAFile = embeddedClientInfo.TrustedCAFile
 	}
-
-	genericConfig, storageFactory, err := genericcontrolplane.BuildGenericConfig(s.options.GenericControlPlane)
-	if err != nil {
-		return err
-	}
-
-	genericConfig.RequestInfoResolver = requestinfo.NewFactory() // must be set here early to avoid a crash in the EnableMultiCluster roundtrip wrapper
-
-	// Setup kcp * informers, but those will need the identities for the APIExports used to make the APIs available.
-	// The identities are not known before we can get them from the APIExports via the loopback client, hence we postpone
-	// this to getOrCreateKcpIdentities() in the kcp-start-informers post-start hook.
-	// The informers here are not  used before the informers are actually started (i.e. no race).
-	nonIdentityKcpClusterClient, err := kcpclient.NewClusterForConfig(genericConfig.LoopbackClientConfig) // can only used for wildcard requests of apis.kcp.dev
-	if err != nil {
-		return err
-	}
-	identityConfig, resolveIdentities := boostrap.NewConfigWithWildcardIdentities(genericConfig.LoopbackClientConfig, boostrap.KcpRootGroupExportNames, boostrap.KcpRootGroupResourceExportNames, nonIdentityKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
-	kcpClusterClient, err := kcpclient.NewClusterForConfig(identityConfig) // this is now generic to be used for all kcp API groups
-	if err != nil {
-		return err
-	}
-	kcpClient := kcpClusterClient.Cluster(logicalcluster.Wildcard)
-	s.kcpSharedInformerFactory = kcpexternalversions.NewSharedInformerFactoryWithOptions(
-		kcpClient,
-		resyncPeriod,
-		kcpexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
-		kcpexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
-	)
-
-	// Setup kube * informers
-	kubeClusterClient, err := kubernetes.NewClusterForConfig(genericConfig.LoopbackClientConfig)
-	if err != nil {
-		return err
-	}
-	kubeClient := kubeClusterClient.Cluster(logicalcluster.Wildcard)
-	s.kubeSharedInformerFactory = coreexternalversions.NewSharedInformerFactoryWithOptions(
-		kubeClient,
-		resyncPeriod,
-		coreexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
-		coreexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
-	)
-
-	// Setup apiextensions * informers
-	apiextensionsClusterClient, err := apiextensionsclient.NewClusterForConfig(genericConfig.LoopbackClientConfig)
-	if err != nil {
-		return err
-	}
-	apiextensionsCrossClusterClient := apiextensionsClusterClient.Cluster(logicalcluster.Wildcard)
-	s.apiextensionsSharedInformerFactory = apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
-		apiextensionsCrossClusterClient,
-		resyncPeriod,
-		apiextensionsexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
-		apiextensionsexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
-	)
-
-	// Setup root informers
-	s.rootKcpSharedInformerFactory = kcpexternalversions.NewSharedInformerFactoryWithOptions(kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster), resyncPeriod)
-	s.rootKubeSharedInformerFactory = coreexternalversions.NewSharedInformerFactoryWithOptions(kubeClusterClient.Cluster(tenancyv1alpha1.RootCluster), resyncPeriod)
-
-	// Setup dynamic client
-	dynamicClusterClient, err := dynamic.NewClusterForConfig(genericConfig.LoopbackClientConfig)
-	if err != nil {
-		return err
-	}
-
-	if err := s.options.Authorization.ApplyTo(genericConfig, s.kubeSharedInformerFactory, s.kcpSharedInformerFactory); err != nil {
-		return err
-	}
-	kcpAdminToken, shardAdminToken, shardAdminTokenHash, err := s.options.AdminAuthentication.ApplyTo(genericConfig)
-	if err != nil {
-		return err
-	}
-
-	if err := s.options.GenericControlPlane.Audit.ApplyTo(genericConfig); err != nil {
-		return err
-	}
-
-	// preHandlerChainMux is called before the actual handler chain. Note that BuildHandlerChainFunc below
-	// is called multiple times, but only one of the handler chain will actually be used. Hence, we wrap it
-	// to give handlers below one mux.Handle func to call.
-	var preHandlerChainMux handlerChainMuxes
-	genericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, c *genericapiserver.Config) (secure http.Handler) {
-		apiHandler = WithWildcardListWatchGuard(apiHandler)
-		apiHandler = WithWildcardIdentity(apiHandler)
-
-		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, c)
-
-		if s.options.HomeWorkspaces.Enabled {
-			apiHandler = WithHomeWorkspaces(
-				apiHandler,
-				c.Authorization.Authorizer,
-				kubeClusterClient,
-				kcpClusterClient,
-				s.kubeSharedInformerFactory,
-				s.kcpSharedInformerFactory,
-				genericConfig.ExternalAddress,
-				s.options.HomeWorkspaces.CreationDelaySeconds,
-				logicalcluster.New(s.options.HomeWorkspaces.HomeRootPrefix),
-				s.options.HomeWorkspaces.BucketLevels,
-				s.options.HomeWorkspaces.BucketSize,
-			)
-		}
-
-		apiHandler = genericapiserver.DefaultBuildHandlerChainBeforeAuthz(apiHandler, c)
-
-		// this will be replaced in DefaultBuildHandlerChain. So at worst we get twice as many warning.
-		// But this is not harmful as the kcp warnings are not many.
-		apiHandler = filters.WithWarningRecorder(apiHandler)
-
-		// add a mux before the chain, for other handlers with their own handler chain to hook in
-		mux := http.NewServeMux()
-		mux.Handle("/", apiHandler)
-		preHandlerChainMux = append(preHandlerChainMux, mux)
-		apiHandler = mux
-
-		apiHandler = WithWorkspaceProjection(apiHandler)
-		apiHandler = WithClusterAnnotation(apiHandler)
-		apiHandler = WithAuditAnnotation(apiHandler) // Must run before any audit annotation is made
-		apiHandler = WithClusterScope(apiHandler)
-		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler)
-		apiHandler = WithAcceptHeader(apiHandler)
-		apiHandler = WithUserAgent(apiHandler)
-
-		return apiHandler
-	}
-
-	admissionPluginInitializers := []admission.PluginInitializer{
-		kcpadmissioninitializers.NewKcpInformersInitializer(s.kcpSharedInformerFactory),
-		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
-		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
-		kcpadmissioninitializers.NewShardBaseURLInitializer(s.options.Extra.ShardBaseURL),
-		kcpadmissioninitializers.NewShardExternalURLInitializer(s.options.Extra.ShardExternalURL),
-		// The external address is provided as a function, as its value may be updated
-		// with the default secure port, when the config is later completed.
-		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return genericConfig.ExternalAddress }),
-	}
-
-	apisConfig, err := genericcontrolplane.CreateKubeAPIServerConfig(genericConfig, s.options.GenericControlPlane, s.kubeSharedInformerFactory, admissionPluginInitializers, storageFactory)
-	if err != nil {
-		return err
-	}
-
-	s.AddPostStartHook("kcp-bootstrap-policy", bootstrappolicy.Policy().EnsureRBACPolicy())
-
-	// If additional API servers are added, they should be gated.
-	apiExtensionsConfig, err := genericcontrolplane.CreateAPIExtensionsConfig(
-		*apisConfig.GenericConfig,
-		apisConfig.ExtraConfig.VersionedInformers,
-		admissionPluginInitializers,
-		s.options.GenericControlPlane,
-
-		// Wire in a ServiceResolver that always returns an error that ResolveEndpoint is not yet
-		// supported. The effect is that CRD webhook conversions are not supported and will always get an
-		// error.
-		&unimplementedServiceResolver{},
-
-		webhook.NewDefaultAuthenticationInfoResolverWrapper(
-			nil,
-			apisConfig.GenericConfig.EgressSelector,
-			apisConfig.GenericConfig.LoopbackClientConfig,
-			apisConfig.GenericConfig.TracerProvider,
-		),
-	)
-	if err != nil {
-		return fmt.Errorf("configure api extensions: %w", err)
-	}
-
-	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                               // nolint: errcheck
-	s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                    // nolint: errcheck
-	s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer().AddIndexers(cache.Indexers{byGroupResourceName: indexCRDByGroupResourceName}) // nolint: errcheck
-	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})                                               // nolint: errcheck
-	s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer().AddIndexers(cache.Indexers{byIdentityGroupResource: indexAPIBindingByIdentityGroupResource})             // nolint: errcheck
-
-	apiBindingAwareCRDLister := &apiBindingAwareCRDLister{
-		kcpClusterClient:  kcpClusterClient,
-		crdLister:         s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Lister(),
-		crdIndexer:        s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().GetIndexer(),
-		workspaceLister:   s.kcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
-		apiBindingLister:  s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Lister(),
-		apiBindingIndexer: s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().GetIndexer(),
-		apiExportIndexer:  s.kcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().GetIndexer(),
-		getAPIResourceSchema: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIResourceSchema, error) {
-			key := clusters.ToClusterAwareKey(clusterName, name)
-			return s.kcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Lister().Get(key)
-		},
-	}
-	apiExtensionsConfig.ExtraConfig.ClusterAwareCRDLister = apiBindingAwareCRDLister
-
-	apiExtensionsConfig.ExtraConfig.TableConverterProvider = NewTableConverterProvider()
-
-	serverChain, err := genericcontrolplane.CreateServerChain(apisConfig.Complete(), apiExtensionsConfig.Complete())
-	if err != nil {
-		return err
-	}
-	server := serverChain.MiniAggregator.GenericAPIServer
-	serverChain.GenericControlPlane.GenericAPIServer.Handler.GoRestfulContainer.Filter(
-		mergeCRDsIntoCoreGroup(
-			apiBindingAwareCRDLister,
-			serverChain.CustomResourceDefinitions.GenericAPIServer.Handler.NonGoRestfulMux.ServeHTTP,
-			serverChain.GenericControlPlane.GenericAPIServer.Handler.GoRestfulContainer.ServeHTTP,
-		),
-	)
-
-	s.dynamicDiscoverySharedInformerFactory, err = informer.NewDynamicDiscoverySharedInformerFactory(
-		server.LoopbackClientConfig,
-		func(obj interface{}) bool { return true },
-		s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
-		indexers.NamespaceScoped(),
-	)
-	if err != nil {
-		return err
-	}
-
-	s.AddPostStartHook("kcp-start-informers", func(ctx genericapiserver.PostStartHookContext) error {
-		s.kubeSharedInformerFactory.Start(ctx.StopCh)
-		s.apiextensionsSharedInformerFactory.Start(ctx.StopCh)
-		s.rootKubeSharedInformerFactory.Start(ctx.StopCh)
-
-		s.kubeSharedInformerFactory.WaitForCacheSync(ctx.StopCh)
-		s.apiextensionsSharedInformerFactory.WaitForCacheSync(ctx.StopCh)
-		s.rootKubeSharedInformerFactory.WaitForCacheSync(ctx.StopCh)
-
-		select {
-		case <-ctx.StopCh:
-			return nil // context closed, avoid reporting success below
-		default:
-		}
-
-		klog.Infof("Finished start kube informers")
-
-		if err := systemcrds.Bootstrap(
-			goContext(ctx),
-			apiextensionsClusterClient.Cluster(SystemCRDLogicalCluster),
-			apiextensionsClusterClient.Cluster(SystemCRDLogicalCluster).Discovery(),
-			dynamicClusterClient.Cluster(SystemCRDLogicalCluster),
-		); err != nil {
-			klog.Errorf("failed to bootstrap system CRDs: %v", err)
-			// nolint:nilerr
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-		klog.Infof("Finished bootstrapping system CRDs")
-
-		go s.kcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().Run(ctx.StopCh)
-		go s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().Run(ctx.StopCh)
-
-		if err := wait.PollInfiniteWithContext(goContext(ctx), time.Millisecond*100, func(ctx context.Context) (bool, error) {
-			exportsSynced := s.kcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
-			bindingsSynced := s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
-			return exportsSynced && bindingsSynced, nil
-		}); err != nil {
-			klog.Errorf("failed to start APIExport and/or APIBinding informers: %v", err)
-			// nolint:nilerr
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-
-		klog.Infof("Finished starting APIExport and APIBinding informers")
-
-		// bootstrap root workspace phase 0, no APIBinding resources yet
-		if err := configrootphase0.Bootstrap(goContext(ctx),
-			kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster),
-			apiextensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
-			dynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
-		); err != nil {
-			// nolint:nilerr
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-
-		klog.Infof("Bootstrapped root workspace phase 0")
-
-		klog.Infof("Getting kcp APIExport identities")
-
-		if err := wait.PollImmediateInfiniteWithContext(goContext(ctx), time.Millisecond*500, func(ctx context.Context) (bool, error) {
-			if err := resolveIdentities(ctx); err != nil {
-				klog.V(3).Infof("failed to resolve identities, keeping trying: %v", err)
-				return false, nil
-			}
-			return true, nil
-		}); err != nil {
-			klog.Errorf("failed to get or create identities: %v", err)
-			// nolint:nilerr
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-
-		klog.Infof("Finished getting kcp APIExport identities")
-
-		s.kcpSharedInformerFactory.Start(ctx.StopCh)
-		s.rootKcpSharedInformerFactory.Start(ctx.StopCh)
-
-		s.kcpSharedInformerFactory.WaitForCacheSync(ctx.StopCh)
-		s.rootKcpSharedInformerFactory.WaitForCacheSync(ctx.StopCh)
-
-		select {
-		case <-ctx.StopCh:
-			return nil // context closed, avoid reporting success below
-		default:
-		}
-
-		klog.Infof("Finished starting (remaining) kcp informers")
-
-		klog.Infof("Starting dynamic metadata informer worker")
-		go s.dynamicDiscoverySharedInformerFactory.StartWorker(goContext(ctx))
-
-		klog.Infof("Synced all informers. Ready to start controllers")
-		close(s.syncedCh)
-
-		klog.Infof("Starting bootstrapping root workspace phase 1")
-		servingCert, _ := server.SecureServingInfo.Cert.CurrentCertKeyContent()
-		if err := configroot.Bootstrap(goContext(ctx),
-			apiextensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
-			dynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
-			s.options.Extra.ShardName,
-			clientcmdapi.Config{
-				Clusters: map[string]*clientcmdapi.Cluster{
-					// cross-cluster is the virtual cluster running by default
-					"shard": {
-						Server:                   "https://" + server.ExternalAddress,
-						CertificateAuthorityData: servingCert, // TODO(sttts): wire controller updating this when it changes, or use CA
-					},
-				},
-				Contexts: map[string]*clientcmdapi.Context{
-					"shard": {Cluster: "shard"},
-				},
-				CurrentContext: "shard",
-			},
-			logicalcluster.New(s.options.HomeWorkspaces.HomeRootPrefix).Base(),
-			s.options.HomeWorkspaces.HomeCreatorGroups,
-		); err != nil {
-			// nolint:nilerr
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-		klog.Infof("Finished bootstrapping root workspace phase 1")
-
-		return nil
-	})
 
 	// ========================================================================================================
 	// TODO: split apart everything after this line, into their own commands, optional launched in this process
 
-	controllerConfig := rest.CopyConfig(identityConfig)
-
-	if err := s.installKubeNamespaceController(ctx, controllerConfig); err != nil {
+	controllerConfig := s.config.IdentityConfig()
+	_, certFile := s.config.ServerKeyCert()
+	if err := s.installControllers(ctx, controllerConfig, s.serverChain.GenericControlPlane.GenericAPIServer.LoopbackClientConfig, s.config, s.genericServer, s.config.Controllers(), certFile); err != nil {
 		return err
 	}
 
-	if err := s.installClusterRoleAggregationController(ctx, controllerConfig); err != nil {
+	if s.config.VirtualEnabled() {
+		if err := s.installVirtualWorkspaces(ctx, controllerConfig, s.genericServer, s.genericConfig.Authentication, s.genericConfig.ExternalAddress, s.preHandlerChain, s.config.Virtual(), s.config.Authorization()); err != nil {
+			return err
+		}
+	} else if err := s.installVirtualWorkspacesRedirect(ctx, s.preHandlerChain, s.config.Virtual()); err != nil {
 		return err
 	}
+	s.genericServer.AddPostStartHook("kcp-start-dynamic-informer", func(ctx genericapiserver.PostStartHookContext) error {
+		klog.Infof("Starting dynamic metadata informer")
+		go s.dynamicDiscoverySharedInformerFactory.StartWorker(goContext(ctx))
 
-	if err := s.installKubeServiceAccountController(ctx, controllerConfig); err != nil {
-		return err
-	}
-
-	if err := s.installKubeServiceAccountTokenController(ctx, controllerConfig); err != nil {
-		return err
-	}
-
-	if err := s.installRootCAConfigMapController(ctx, serverChain.GenericControlPlane.GenericAPIServer.LoopbackClientConfig); err != nil {
-		return err
-	}
-
-	enabled := sets.NewString(s.options.Controllers.IndividuallyEnabled...)
-	if len(enabled) > 0 {
-		klog.Infof("Starting controllers individually: %v", enabled)
-	}
-
-	if s.options.Controllers.EnableAll || enabled.Has("cluster") {
-		// TODO(marun) Consider enabling each controller via a separate flag
-
-		if err := s.installApiResourceController(ctx, controllerConfig); err != nil {
-			return err
-		}
-		if err := s.installSyncTargetHeartbeatController(ctx, controllerConfig); err != nil {
-			return err
-		}
-		if err := s.installVirtualWorkspaceURLsController(ctx, controllerConfig, server); err != nil {
-			return err
-		}
-	}
-
-	if s.options.Controllers.EnableAll || enabled.Has("workspace-scheduler") {
-		if err := s.installWorkspaceScheduler(ctx, controllerConfig); err != nil {
-			return err
-		}
-		if err := s.installWorkspaceDeletionController(ctx, controllerConfig); err != nil {
-			return err
-		}
-	}
-
-	if s.options.HomeWorkspaces.Enabled {
-		if err := s.installHomeWorkspaces(ctx, controllerConfig); err != nil {
-			return err
-		}
-	}
-
-	if s.options.Controllers.EnableAll || enabled.Has("resource-scheduler") {
-		if err := s.installWorkloadResourceScheduler(ctx, controllerConfig, s.dynamicDiscoverySharedInformerFactory); err != nil {
-			return err
-		}
-	}
-
-	if s.options.Controllers.EnableAll || enabled.Has("apibinding") {
-		if err := s.installAPIBindingController(ctx, controllerConfig, server, s.dynamicDiscoverySharedInformerFactory); err != nil {
-			return err
-		}
-	}
-
-	if s.options.Controllers.EnableAll || enabled.Has("apiexport") {
-		if err := s.installAPIExportController(ctx, controllerConfig, server); err != nil {
-			return err
-		}
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(kcpfeatures.LocationAPI) {
-		if s.options.Controllers.EnableAll || enabled.Has("scheduling") {
-			if err := s.installWorkloadNamespaceScheduler(ctx, controllerConfig, server); err != nil {
-				return err
-			}
-			if err := s.installSchedulingLocationStatusController(ctx, controllerConfig, server); err != nil {
-				return err
-			}
-			if err := s.installSchedulingPlacementController(ctx, controllerConfig, server); err != nil {
-				return err
-			}
-			if err := s.installWorkloadsAPIExportController(ctx, controllerConfig, server); err != nil {
-				return err
-			}
-			if err := s.installWorkloadsAPIExportCreateController(ctx, controllerConfig, server); err != nil {
-				return err
-			}
-			if err := s.installDefaultPlacementController(ctx, controllerConfig, server); err != nil {
-				return err
-			}
-		}
-	}
-
-	if s.options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, controllerConfig, server, genericConfig.Authentication, genericConfig.ExternalAddress, preHandlerChainMux); err != nil {
-			return err
-		}
-	} else if err := s.installVirtualWorkspacesRedirect(ctx, preHandlerChainMux); err != nil {
-		return err
-	}
+		klog.Infof("Synced all informers. Ready to start controllers")
+		close(s.syncedCh)
+		return nil
+	})
 
 	// Add our custom hooks to the underlying api server
+	// this does get a little odd, in that we add hooks in the Config, but also here. it may be unavoidable.
 	for _, entry := range s.postStartHooks {
-		err := server.AddPostStartHook(entry.name, entry.hook)
+		err := s.genericServer.AddPostStartHook(entry.name, entry.hook)
 		if err != nil {
 			return err
 		}
 	}
 	for _, entry := range s.preShutdownHooks {
-		err := server.AddPreShutdownHook(entry.name, entry.hook)
+		err := s.genericServer.AddPreShutdownHook(entry.name, entry.hook)
 		if err != nil {
 			return err
 		}
 	}
 
-	if err := s.options.AdminAuthentication.WriteKubeConfig(genericConfig, kcpAdminToken, shardAdminToken, shardAdminTokenHash); err != nil {
-		return err
-	}
-
-	return server.PrepareRun().Run(ctx.Done())
+	return s.genericServer.PrepareRun().Run(ctx.Done())
 }
 
 // AddPostStartHook allows you to add a PostStartHook that gets passed to the underlying genericapiserver implementation.
@@ -651,4 +361,95 @@ func (mxs handlerChainMuxes) Handle(pattern string, handler http.Handler) {
 	for _, mx := range mxs {
 		mx.Handle(pattern, handler)
 	}
+}
+
+func (s *Server) installControllers(ctx context.Context, controllerConfig, clientConfig *rest.Config, kcpConfig *CompletedConfig, server *genericapiserver.GenericAPIServer, controllers options.Controllers, certFile string) error {
+	if err := s.installKubeNamespaceController(ctx, controllerConfig); err != nil {
+		return err
+	}
+
+	if err := s.installClusterRoleAggregationController(ctx, controllerConfig); err != nil {
+		return err
+	}
+
+	if err := s.installKubeServiceAccountController(ctx, controllerConfig); err != nil {
+		return err
+	}
+
+	if err := s.installKubeServiceAccountTokenController(ctx, controllerConfig, controllers); err != nil {
+		return err
+	}
+
+	if err := s.installRootCAConfigMapController(ctx, clientConfig, controllers, certFile); err != nil {
+		return err
+	}
+
+	if kcpConfig.IsControllerEnabled("cluster") {
+		// TODO(marun) Consider enabling each controller via a separate flag
+
+		if err := s.installApiResourceController(ctx, controllerConfig); err != nil {
+			return err
+		}
+		if err := s.installSyncTargetHeartbeatController(ctx, controllerConfig, controllers); err != nil {
+			return err
+		}
+		if err := s.installVirtualWorkspaceURLsController(ctx, controllerConfig, server); err != nil {
+			return err
+		}
+	}
+
+	if kcpConfig.IsControllerEnabled("workspace-scheduler") {
+		if err := s.installWorkspaceScheduler(ctx, controllerConfig); err != nil {
+			return err
+		}
+		if err := s.installWorkspaceDeletionController(ctx, controllerConfig); err != nil {
+			return err
+		}
+	}
+
+	if err := s.installHomeWorkspaces(ctx, controllerConfig); err != nil {
+		return err
+	}
+
+	if kcpConfig.IsControllerEnabled("resource-scheduler") {
+		if err := s.installWorkloadResourceScheduler(ctx, controllerConfig, s.dynamicDiscoverySharedInformerFactory); err != nil {
+			return err
+		}
+	}
+
+	if kcpConfig.IsControllerEnabled("apibinding") {
+		if err := s.installAPIBindingController(ctx, controllerConfig, server, s.dynamicDiscoverySharedInformerFactory); err != nil {
+			return err
+		}
+	}
+
+	if kcpConfig.IsControllerEnabled("apiexport") {
+		if err := s.installAPIExportController(ctx, controllerConfig, server); err != nil {
+			return err
+		}
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(kcpfeatures.LocationAPI) {
+		if kcpConfig.IsControllerEnabled("scheduling") {
+			if err := s.installWorkloadNamespaceScheduler(ctx, controllerConfig, server); err != nil {
+				return err
+			}
+			if err := s.installSchedulingLocationStatusController(ctx, controllerConfig, server); err != nil {
+				return err
+			}
+			if err := s.installSchedulingPlacementController(ctx, controllerConfig, server); err != nil {
+				return err
+			}
+			if err := s.installWorkloadsAPIExportController(ctx, controllerConfig, server); err != nil {
+				return err
+			}
+			if err := s.installWorkloadsAPIExportCreateController(ctx, controllerConfig, server); err != nil {
+				return err
+			}
+			if err := s.installDefaultPlacementController(ctx, controllerConfig, server); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -263,7 +263,18 @@ func (c *kcpServer) Run(opts ...RunOption) error {
 			return apierrors.NewAggregate(errs)
 		}
 
-		s, err := server.NewServer(completed)
+		config, err := server.NewConfig(completed)
+		if err != nil {
+			cleanup()
+			return err
+		}
+		completedConfig, err := config.Complete()
+		if err != nil {
+			cleanup()
+			return err
+		}
+
+		s, err := server.NewServer(completedConfig)
 		if err != nil {
 			cleanup()
 			return err


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

* Create a `Config`, which is higher level abstraction than `Options`, lower than `Server`
* Moves all of the configuration work from `server.Run()` into `config.Complete()`

The purpose of this is to make `Server` a more flexible, composable and useful component. Currently, `Run()` does an enormous amount of setup, which, in turn, means that you cannot choose which components to use or not. It also makes "kcp-as-a-library" painfully heavy to use.

This structure was suggested by @sttts as a first step. Nothing should change in functionality. Once this is in place, we can start to break it apart further, by having `Config` options that are enabled or not, which, in turn, should enable us to tweak the knobs.

This first PR changes the API to something like:

```go
opts := NewOptions()
completedOpts := opts.Complete()
config := NewConfig(completedOpts)
completedConfig := config.Complete()
server := NewServer(completedConfig)
server.Run()
```

This already isolates `Run()` just to starting things, other than those that were set up to run in post-start-hooks. It isn't 100% isolation yet, but a big step forward.

The next API steps would be (in no particular order):

* plug `server` into other listeners, e.g. an already running http server
* move the `install*Controller()` funcs into config, so that `Server` itself is ignorant of what is installed, which in turn enables:
* different configs, lightweight for the basics, heavier for all of the kcp goodies. Either way, you end up with a `CompletedConfig` which is passed to a `NewServer()`