### PR TITLE
Add KCP CLI arguments to enable home workspaces as well as specific options, especially the groups bound to the get/create ~ permissions

### DIFF
--- a/config/root/bootstrap.go
+++ b/config/root/bootstrap.go
@@ -35,7 +35,7 @@ var fs embed.FS
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, kubeconfig clientcmdapi.Config, homeWorkspaceGetterGroups []string, homeWorkspaceCreatorGroups []string) error {
+func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, kubeconfig clientcmdapi.Config, homePrefix string, homeWorkspaceCreatorGroups []string) error {
 	kubeconfigRaw, err := clientcmd.Write(kubeconfig)
 	if err != nil {
 		return err
@@ -52,21 +52,10 @@ func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInter
 		homeWorkspaceCreatorGroupReplacement = "[]"
 	}
 
-	homeWorkspaceGetterGroupReplacement := ""
-	for _, group := range homeWorkspaceGetterGroups {
-		homeWorkspaceGetterGroupReplacement += `
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: ` + group
-	}
-	if homeWorkspaceCreatorGroupReplacement == "" {
-		homeWorkspaceCreatorGroupReplacement = "[]"
-	}
-
 	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, fs, confighelpers.ReplaceOption(
 		"SHARD_NAME", shardName,
 		"SHARD_KUBECONFIG", base64.StdEncoding.EncodeToString(kubeconfigRaw),
-		"HOME_GETTER_GROUPS", homeWorkspaceGetterGroupReplacement,
 		"HOME_CREATOR_GROUPS", homeWorkspaceCreatorGroupReplacement,
+		"HOMEPREFIX", homePrefix,
 	))
 }

--- a/config/root/clusterrole-clusterworkspace-home-get.yaml
+++ b/config/root/clusterrole-clusterworkspace-home-get.yaml
@@ -1,9 +1,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: system:kcp:home-clusterworkspace-get
-rules:
-- apiGroups: ["tenancy.kcp.dev"]
-  resources: ["clusterworkspaces/workspace"]
-  resourceNames: ["~"]
-  verbs: ["get"]

--- a/config/root/clusterrole-clusterworkspace-home-prefix-access.yaml
+++ b/config/root/clusterrole-clusterworkspace-home-prefix-access.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:kcp:users-clusterworkspace-access
+  name: system:kcp:home-prefix-clusterworkspace-access
 rules:
 - apiGroups: ["tenancy.kcp.dev"]
   resources: ["clusterworkspaces/content"]
-  resourceNames: ["users"]
+  resourceNames: ["HOMEPREFIX"]
   verbs: ["access"]

--- a/config/root/clusterrolebinding-apiresource-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-apiresource-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:apiresource:bind
+  name: system:kcp:apiexport:apiresource:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-clusterworkspace-home-get.yaml
+++ b/config/root/clusterrolebinding-clusterworkspace-home-get.yaml
@@ -1,9 +1,0 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: system:kcp:configured-group:home-clusterworkspace-get
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:kcp:home-clusterworkspace-get
-subjects: HOME_GETTER_GROUPS

--- a/config/root/clusterrolebinding-clusterworkspace-home-prefix-access.yaml
+++ b/config/root/clusterrolebinding-clusterworkspace-home-prefix-access.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:kcp:authenticated:users-clusterworkspace-access
+  name: system:kcp:authenticated:home-prefix-clusterworkspace-access
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:users-clusterworkspace-access
+  name: system:kcp:home-prefix-clusterworkspace-access
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-scheduling-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-scheduling-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:scheduling:bind
+  name: system:kcp:apiexport:scheduling:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-tenancy-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-tenancy-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:tenancy:bind
+  name: system:kcp:apiexport:tenancy:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-workload-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-workload-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:workload:bind
+  name: system:kcp:apiexport:workload:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterworkspace-homeroot-home-prefix.yaml
+++ b/config/root/clusterworkspace-homeroot-home-prefix.yaml
@@ -1,7 +1,7 @@
 apiVersion: tenancy.kcp.dev/v1alpha1
 kind: ClusterWorkspace
 metadata:
-  name: users
+  name: HOMEPREFIX
   annotations:
     "bootstrap.kcp.dev/create-only": "true"
 spec:

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -37,6 +37,7 @@ var (
 		"KCP Authorization",
 		"KCP Virtual Workspaces",
 		"KCP Controllers",
+		"KCP Home Workspaces",
 		"KCP",
 	}
 
@@ -156,6 +157,14 @@ var (
 		"embedded-etcd-wal-size-bytes",      // Size of embedded etcd WAL
 		"embedded-etcd-quota-backend-bytes", // Alarm threshold for embedded etcd backend bytes
 		"embedded-etcd-force-new-cluster",   // Starts a new cluster from existing data restored from a different system
+
+		// Home workspaces flags
+		"enable-home-workspaces",                 // Enable the Home Workspaces feature (enabled by default). Home workspaces allow a personal home workspace to provisioned on first access per-user. A user is cluster-admin inside his personal Home workspace.
+		"home-workspaces-creation-delay-seconds", // Delay, in seconds, before accessing the Home is retried after its automatic creation. This value is used when sending 'retry-after' responses to the Kubernetes client.
+		"home-workspaces-bucket-levels",          // Number of levels of bucket workspaces when bucketing home workspaces
+		"home-workspaces-bucket-size",            // Number of characters of bucket workspace names used when bucketing home workspaces
+		"home-workspaces-home-creator-groups",    // Groups of users who can have their home workspace created automatically create when first accessing it.
+		"home-workspaces-root-prefix",            // Logical cluster name of the workspace that will contains home workspaces for all workspaces.
 
 		// KCP Controllers flags
 		"auto-publish-apis",                      // If true, the APIs imported from physical clusters will be published automatically as CRDs

--- a/pkg/server/options/homeworkspaces.go
+++ b/pkg/server/options/homeworkspaces.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+
+	"github.com/kcp-dev/logicalcluster"
+	"github.com/spf13/pflag"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+)
+
+type HomeWorkspaces struct {
+	Enabled bool
+
+	CreationDelaySeconds int
+	BucketLevels         int
+	BucketSize           int
+
+	HomeCreatorGroups []string
+	HomeRootPrefix    string
+}
+
+func NewHomeWorkspaces() *HomeWorkspaces {
+	return &HomeWorkspaces{
+		Enabled:              true,
+		CreationDelaySeconds: 2,
+		BucketLevels:         2,
+		BucketSize:           2,
+		HomeCreatorGroups:    []string{user.AllAuthenticated},
+		HomeRootPrefix:       "root:users",
+	}
+}
+
+func (hw *HomeWorkspaces) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&hw.Enabled, "enable-home-workspaces", hw.Enabled, "Enable the Home Workspaces feature. Home workspaces allow a personal home workspace to provisioned on first access per-user. A user is cluster-admin inside his personal Home workspace.")
+	fs.IntVar(&hw.CreationDelaySeconds, "home-workspaces-creation-delay-seconds", hw.CreationDelaySeconds, "Delay, in seconds, before retrying accessing the Home workspace after its automatic creation. This value is used when sending 'retry-after' responses to the Kubernetes client.")
+	fs.IntVar(&hw.BucketLevels, "home-workspaces-bucket-levels", hw.BucketLevels, "Number of levels of bucket workspaces when bucketing home workspaces")
+	fs.IntVar(&hw.BucketLevels, "home-workspaces-bucket-size", hw.BucketSize, "Number of characters of bucket workspace names used when bucketing home workspaces")
+	fs.StringSliceVar(&hw.HomeCreatorGroups, "home-workspaces-home-creator-groups", hw.HomeCreatorGroups, "Groups of users who can have their home workspace created automatically create when first accessing it.")
+	fs.StringVar(&hw.HomeRootPrefix, "home-workspaces-root-prefix", hw.HomeRootPrefix, "Logical cluster name of the workspace that will contains home workspaces for all workspaces.")
+}
+
+func (e *HomeWorkspaces) Validate() []error {
+	var errs []error
+
+	if e.Enabled {
+		if e.BucketLevels < 1 || e.BucketLevels > 5 {
+			errs = append(errs, fmt.Errorf("--home-workspaces-bucket-levels should be between 1 and 5"))
+		}
+		if e.BucketSize < 1 || e.BucketLevels > 4 {
+			errs = append(errs, fmt.Errorf("--home-workspaces-bucket-size should be between 1 and 4"))
+		}
+		if e.CreationDelaySeconds < 1 {
+			errs = append(errs, fmt.Errorf("--home-workspaces-creation-delay-seconds should be between 1"))
+		}
+		if homePrefix := logicalcluster.New(e.HomeRootPrefix); !homePrefix.IsValid() ||
+			homePrefix == logicalcluster.Wildcard ||
+			!homePrefix.HasPrefix(tenancyv1alpha1.RootCluster) {
+			errs = append(errs, fmt.Errorf("--home-workspaces-root-prefix should be a valid logical cluster name"))
+		} else if parent, ok := homePrefix.Parent(); !ok || parent != tenancyv1alpha1.RootCluster {
+			errs = append(errs, fmt.Errorf("--home-workspaces-root-prefix should be a direct child of the root logical cluster"))
+		}
+	}
+
+	return errs
+}

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -46,6 +46,7 @@ type Options struct {
 	Authorization       Authorization
 	AdminAuthentication AdminAuthentication
 	Virtual             Virtual
+	HomeWorkspaces      HomeWorkspaces
 
 	Extra ExtraOptions
 }
@@ -67,6 +68,7 @@ type completedOptions struct {
 	Authorization       Authorization
 	AdminAuthentication AdminAuthentication
 	Virtual             Virtual
+	HomeWorkspaces      HomeWorkspaces
 
 	Extra ExtraOptions
 }
@@ -86,6 +88,7 @@ func NewOptions(rootDir string) *Options {
 		Authorization:       *NewAuthorization(),
 		AdminAuthentication: *NewAdminAuthentication(rootDir),
 		Virtual:             *NewVirtual(),
+		HomeWorkspaces:      *NewHomeWorkspaces(),
 
 		Extra: ExtraOptions{
 			RootDirectory:            rootDir,
@@ -148,6 +151,7 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	o.Authorization.AddFlags(fss.FlagSet("KCP Authorization"))
 	o.AdminAuthentication.AddFlags(fss.FlagSet("KCP Authentication"))
 	o.Virtual.AddFlags(fss.FlagSet("KCP Virtual Workspaces"))
+	o.HomeWorkspaces.AddFlags(fss.FlagSet("KCP Home Workspaces"))
 
 	fs := fss.FlagSet("KCP")
 	fs.StringVar(&o.Extra.ProfilerAddress, "profiler-address", o.Extra.ProfilerAddress, "[Address]:port to bind the profiler to")
@@ -178,6 +182,7 @@ func (o *CompletedOptions) Validate() []error {
 	errs = append(errs, o.Authorization.Validate()...)
 	errs = append(errs, o.AdminAuthentication.Validate()...)
 	errs = append(errs, o.Virtual.Validate()...)
+	errs = append(errs, o.HomeWorkspaces.Validate()...)
 
 	if o.Extra.DiscoveryPollInterval == 0 {
 		errs = append(errs, fmt.Errorf("--discovery-poll-interval not set"))
@@ -278,6 +283,7 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 			Authorization:       o.Authorization,
 			AdminAuthentication: o.AdminAuthentication,
 			Virtual:             o.Virtual,
+			HomeWorkspaces:      o.HomeWorkspaces,
 			Extra:               o.Extra,
 		},
 	}, nil


### PR DESCRIPTION
## Summary

Add KCP CLI arguments to enable home workspaces as well as specific options, especially the groups bound to the get/create ~ permissions

This PR is based on PR https://github.com/kcp-dev/kcp/pull/1540 (== first commit) 

## Related issue(s)

Fixes #1457