### PR TITLE
Fix typos in APIExport bootstrapped `ClusterRoleBinding`s

### DIFF
--- a/config/root/clusterrolebinding-apiresource-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-apiresource-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:apiresource:bind
+  name: system:kcp:apiexport:apiresource:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-scheduling-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-scheduling-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:scheduling:bind
+  name: system:kcp:apiexport:scheduling:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-tenancy-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-tenancy-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:tenancy:bind
+  name: system:kcp:apiexport:tenancy:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group

--- a/config/root/clusterrolebinding-workload-apiexport-bind.yaml
+++ b/config/root/clusterrolebinding-workload-apiexport-bind.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:kcp:system:kcp:apiexport:workload:bind
+  name: system:kcp:apiexport:workload:bind
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group


### PR DESCRIPTION
## Summary

Fix typos in APIExport bootstrapped `ClusterRoleBinding`s that prevented correct Authorization in some use-cases.

## Related issue(s)

No related issue. This was met when working on issue https://github.com/kcp-dev/kcp/issues/1457