### PR TITLE
server: add --shard-external-url

### DIFF
--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -121,3 +121,21 @@ func (i *shardBaseURLInitializer) Initialize(plugin admission.Interface) {
 		wants.SetShardBaseURL(i.shardBaseURL)
 	}
 }
+
+// NewShardExternalURLInitializer returns an admission plugin initializer that injects
+// the default shard external URL provider into the admission plugin.
+func NewShardExternalURLInitializer(shardExternalURL string) *shardExternalURLInitializer {
+	return &shardExternalURLInitializer{
+		shardExternalURL: shardExternalURL,
+	}
+}
+
+type shardExternalURLInitializer struct {
+	shardExternalURL string
+}
+
+func (i *shardExternalURLInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsShardExternalURL); ok {
+		wants.SetShardExternalURL(i.shardExternalURL)
+	}
+}

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -52,3 +52,9 @@ type WantsExternalAddressProvider interface {
 type WantsShardBaseURL interface {
 	SetShardBaseURL(shardBaseURL string)
 }
+
+// WantsShardExternalURL interface should be implemented by admission plugins
+// that want to have the shard external url injected.
+type WantsShardExternalURL interface {
+	SetShardExternalURL(shardExternalURL string)
+}

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -130,7 +130,8 @@ var (
 		"discovery-poll-interval",     // Polling interval for dynamic discovery informers.
 		"profiler-address",            // [Address]:port to bind the profiler to
 		"root-directory",              // Root directory.
-		"shard-base-url",              // Base URL to the this kcp shard. Defaults to external address.
+		"shard-base-url",              // Base URL to this kcp shard. Defaults to external address.
+		"shard-external-url",          // URL used by outside clients to talk to this kcp shard. Defaults to external address.
 		"shard-name",                  // A name of this kcp shard.
 		"shard-kubeconfig-file",       // Kubeconfig holding admin(!) credentials to peer kcp shards.
 		"experimental-bind-free-port", // Bind to a free port. --secure-bind-port must be 0. Use the admin.kubeconfig to extract the chosen port.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -55,6 +55,7 @@ type ExtraOptions struct {
 	ProfilerAddress          string
 	ShardKubeconfigFile      string
 	ShardBaseURL             string
+	ShardExternalURL         string
 	ShardName                string
 	DiscoveryPollInterval    time.Duration
 	ExperimentalBindFreePort bool
@@ -92,6 +93,7 @@ func NewOptions(rootDir string) *Options {
 			ProfilerAddress:          "",
 			ShardKubeconfigFile:      "",
 			ShardBaseURL:             "",
+			ShardExternalURL:         "",
 			ShardName:                "root",
 			DiscoveryPollInterval:    60 * time.Second,
 			ExperimentalBindFreePort: false,
@@ -108,7 +110,7 @@ func NewOptions(rootDir string) *Options {
 		WithRequestHeader().
 		WithServiceAccounts().
 		WithTokenFile()
-	//WithWebHook()
+	// WithWebHook()
 	o.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{"https://kcp.default.svc"}
 	o.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = []string{"embedded"}
 
@@ -152,7 +154,8 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs := fss.FlagSet("KCP")
 	fs.StringVar(&o.Extra.ProfilerAddress, "profiler-address", o.Extra.ProfilerAddress, "[Address]:port to bind the profiler to")
 	fs.StringVar(&o.Extra.ShardKubeconfigFile, "shard-kubeconfig-file", o.Extra.ShardKubeconfigFile, "Kubeconfig holding admin(!) credentials to peer kcp shards.")
-	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to the this kcp shard. Defaults to external address.")
+	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to this kcp shard. Defaults to external address.")
+	fs.StringVar(&o.Extra.ShardExternalURL, "shard-external-url", o.Extra.ShardExternalURL, "URL used by outside clients to talk to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")
 	fs.StringVar(&o.Extra.RootDirectory, "root-directory", o.Extra.RootDirectory, "Root directory.")
 	fs.DurationVar(&o.Extra.DiscoveryPollInterval, "discovery-poll-interval", o.Extra.DiscoveryPollInterval, "Polling interval for dynamic discovery informers.")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -274,6 +274,7 @@ func (s *Server) Run(ctx context.Context) error {
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(kubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(kcpClusterClient),
 		kcpadmissioninitializers.NewShardBaseURLInitializer(s.options.Extra.ShardBaseURL),
+		kcpadmissioninitializers.NewShardExternalURLInitializer(s.options.Extra.ShardExternalURL),
 		// The external address is provided as a function, as its value may be updated
 		// with the default secure port, when the config is later completed.
 		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return genericConfig.ExternalAddress }),


### PR DESCRIPTION
## Summary
kcp deployers optionally need to be able to set the URL external clients
use when connecting to kcp (e.g., via a front proxy). Add a new
--shard-external-url flag that is used as the default value for
ClusterWorkspaceShard.Spec.ExternalURL.

## Related issue(s)

Fixes #