### PR TITLE
e2e: reduce client-side throttling

### DIFF
--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -158,9 +158,7 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	// This workspace will consume from wsExport2
 	wsConsume2 := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyapi.ShardConstraints{Name: "root"}))
 
-	// Make sure the informers aren't throttled because dynamic informers do lots of discovery which slows down tests
 	cfg := server.BaseConfig(t)
-	cfg.QPS = -1
 	rootShardConfig := server.RootShardConfig(t)
 
 	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(cfg)

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -59,7 +59,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	t.Cleanup(cancel)
 	org := framework.NewOrganizationFixture(t, server)
 	cluster := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
-	rootShardConfig := newRootShardConfig(t, server)
+	rootShardConfig := server.RootShardConfig(t)
 	cowBoysGR := metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"}
 
 	t.Log("Creating wildwest.dev CRD")
@@ -115,7 +115,7 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 	server := framework.SharedKcpServer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	rootShardConfig := newRootShardConfig(t, server)
+	rootShardConfig := server.RootShardConfig(t)
 	kcpClusterClient, err := kcpclientset.NewClusterForConfig(rootShardConfig)
 	require.NoError(t, err)
 	dynamicClusterClient, err := dynamic.NewClusterForConfig(rootShardConfig)
@@ -165,7 +165,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 	server := framework.SharedKcpServer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	rootShardConfig := newRootShardConfig(t, server)
+	rootShardConfig := server.RootShardConfig(t)
 	kubeClusterClient, err := kubernetesclientset.NewClusterForConfig(rootShardConfig)
 	require.NoError(t, err)
 	secretsGR := metav1.GroupResource{Group: "", Resource: "secrets"}
@@ -312,11 +312,4 @@ func assertWatchCacheIsPrimed(t *testing.T, fn func() error) {
 		}
 		return true, ""
 	}, wait.ForeverTestTimeout, time.Millisecond*200, "the watch cache hasn't been primed in the allotted time")
-}
-
-func newRootShardConfig(t *testing.T, server framework.RunningServer) *rest.Config {
-	rootShardConfig := server.RootShardConfig(t)
-	rootShardConfig.QPS = 100
-	rootShardConfig.Burst = 200
-	return rootShardConfig
 }


### PR DESCRIPTION
## Summary
Disable client-side throttling in our e2e kcp server rest.Configs and in
the cross cluster list test, which uses discovery and is subject to
throttling.

## Related issue(s)

Fixes #