### PR TITLE
[WIP][PROOF]: ddsif: replace discovery polling, switch to partial metadata informers

### DIFF
--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -40,7 +40,7 @@ import (
 
 // reconcileResource is responsible for setting the cluster for a resource of
 // any type, to match the cluster where its namespace is assigned.
-func (c *Controller) reconcileResource(ctx context.Context, lclusterName logicalcluster.Name, obj *unstructured.Unstructured, gvr *schema.GroupVersionResource) error {
+func (c *Controller) reconcileResource(ctx context.Context, lclusterName logicalcluster.Name, obj metav1.Object, gvr *schema.GroupVersionResource) error {
 	klog.V(4).Infof("Reconciling GVR %q %s|%s/%s", gvr.String(), lclusterName, obj.GetNamespace(), obj.GetName())
 
 	// If the resource is not namespaced (incl if the resource is itself a

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -128,7 +128,7 @@ var (
 		"tracing-config-file", // File with apiserver tracing configuration.
 
 		// KCP flags
-		"discovery-poll-interval",     // Polling interval for dynamic discovery informers.
+		"enable-sharding",             // Enable delegating to peer kcp shards.
 		"profiler-address",            // [Address]:port to bind the profiler to
 		"root-directory",              // Root directory.
 		"shard-base-url",              // Base URL to the this kcp shard. Defaults to external address.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -111,7 +111,7 @@ func NewOptions(rootDir string) *Options {
 		WithRequestHeader().
 		WithServiceAccounts().
 		WithTokenFile()
-	//WithWebHook()
+	// WithWebHook()
 	o.GenericControlPlane.Authentication.ServiceAccounts.Issuers = []string{"https://kcp.default.svc"}
 	o.GenericControlPlane.Etcd.StorageConfig.Transport.ServerList = []string{"embedded"}
 
@@ -159,7 +159,6 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to the this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")
 	fs.StringVar(&o.Extra.RootDirectory, "root-directory", o.Extra.RootDirectory, "Root directory.")
-	fs.DurationVar(&o.Extra.DiscoveryPollInterval, "discovery-poll-interval", o.Extra.DiscoveryPollInterval, "Polling interval for dynamic discovery informers.")
 
 	fs.BoolVar(&o.Extra.ExperimentalBindFreePort, "experimental-bind-free-port", o.Extra.ExperimentalBindFreePort, "Bind to a free port. --secure-port must be 0. Use the admin.kubeconfig to extract the chosen port.")
 	fs.MarkHidden("experimental-bind-free-port") // nolint:errcheck
@@ -183,10 +182,6 @@ func (o *CompletedOptions) Validate() []error {
 	errs = append(errs, o.AdminAuthentication.Validate()...)
 	errs = append(errs, o.Virtual.Validate()...)
 	errs = append(errs, o.HomeWorkspaces.Validate()...)
-
-	if o.Extra.DiscoveryPollInterval == 0 {
-		errs = append(errs, fmt.Errorf("--discovery-poll-interval not set"))
-	}
 
 	return errs
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,7 +59,6 @@ import (
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
-	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
 	boostrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
 	kcpserveroptions "github.com/kcp-dev/kcp/pkg/server/options"
 	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
@@ -352,13 +351,8 @@ func (s *Server) Run(ctx context.Context) error {
 		),
 	)
 
-	metadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(server.LoopbackClientConfig)
-	if err != nil {
-		return err
-	}
-
 	s.dynamicDiscoverySharedInformerFactory, err = informer.NewDynamicDiscoverySharedInformerFactory(
-		metadataClusterClient.Cluster(logicalcluster.Wildcard),
+		server.LoopbackClientConfig,
 		func(obj interface{}) bool { return true },
 		s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 		indexers.NamespaceScoped(),

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -30,6 +30,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,10 +44,9 @@ import (
 	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
-	bootstrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
@@ -160,8 +160,7 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 
 	// Make sure the informers aren't throttled because dynamic informers do lots of discovery which slows down tests
 	cfg := server.BaseConfig(t)
-	cfg.QPS = 500
-	cfg.Burst = 1000
+	cfg.QPS = -1
 	rootShardConfig := server.RootShardConfig(t)
 
 	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(cfg)
@@ -218,26 +217,32 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	_, err = rootShardMetadataClusterClient.Cluster(logicalcluster.Wildcard).Resource(sheriffsGVR).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "expected wildcard list to work with metadata client even though schemas are different")
 
-	t.Log("Start dynamic metadata informers")
-	identityRootCfg, resolve := bootstrap.NewConfigWithWildcardIdentities(rootShardConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
-	require.Eventually(t, func() bool {
-		return resolve(ctx) == nil
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-	identityRootKcpClusterClient, err := kcpclientset.NewClusterForConfig(identityRootCfg)
-	require.NoError(t, err, "failed to construct kcp cluster client for server with identitis")
-	rootShardKcpInformer := kcpinformers.NewSharedInformerFactoryWithOptions(identityRootKcpClusterClient.Cluster(logicalcluster.Wildcard), 0)
-	rootShardKcpInformer.Tenancy().V1alpha1().ClusterWorkspaces().Lister()
-	rootShardKcpInformer.Start(ctx.Done())
-	rootShardKcpInformer.WaitForCacheSync(ctx.Done())
+	rootShardCRDClusterClient, err := apiextensionsclient.NewClusterForConfig(rootShardConfig)
+	require.NoError(t, err, "error creating root shard crd client")
 
-	informerFactory := informer.NewDynamicDiscoverySharedInformerFactory(
-		rootShardKcpInformer.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
-		identityRootKcpClusterClient.DiscoveryClient,
+	apiExtensionsInformerFactory := apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
+		rootShardCRDClusterClient.Cluster(logicalcluster.Wildcard),
+		0,
+	)
+
+	informerFactory, err := informer.NewDynamicDiscoverySharedInformerFactory(
 		rootShardMetadataClusterClient.Cluster(logicalcluster.Wildcard),
 		func(obj interface{}) bool { return true },
-		time.Second*2,
+		apiExtensionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		indexers.NamespaceScoped(),
 	)
-	informerFactory.StartPolling(ctx)
+	require.NoError(t, err, "error creating DynamicDiscoverySharedInformerFactory")
+
+	// Have to start this after informer.NewDynamicDiscoverySharedInformerFactory() is invoked, as that adds an
+	// index to the crd informer that is required for the dynamic factory to work correctly.
+	t.Log("Start apiextensions informers")
+	apiExtensionsInformerFactory.Start(ctx.Done())
+	cacheSyncCtx, cacheSyncCancel := context.WithTimeout(ctx, wait.ForeverTestTimeout)
+	t.Cleanup(cacheSyncCancel)
+	apiExtensionsInformerFactory.WaitForCacheSync(cacheSyncCtx.Done())
+
+	t.Log("Start dynamic metadata informers")
+	go informerFactory.StartWorker(ctx)
 
 	t.Logf("Wait for the sheriff to show up in the informer")
 	// key := "default/" + clusters.ToClusterAwareKey(wsNormalCRD1a, "john-hicks-adams")

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -226,7 +226,7 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	)
 
 	informerFactory, err := informer.NewDynamicDiscoverySharedInformerFactory(
-		rootShardMetadataClusterClient.Cluster(logicalcluster.Wildcard),
+		rootShardConfig,
 		func(obj interface{}) bool { return true },
 		apiExtensionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 		indexers.NamespaceScoped(),

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -81,7 +81,6 @@ func TestServerArgs() []string {
 // start a test server with the given token auth file.
 func TestServerArgsWithTokenAuthFile(tokenAuthFile string) []string {
 	return []string{
-		"--discovery-poll-interval=5s",
 		"-v=4",
 		"--token-auth-file", tokenAuthFile,
 	}

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -45,7 +45,6 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	"github.com/kcp-dev/kcp/pkg/informer"
-	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
 	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
@@ -250,9 +249,6 @@ func collectCacheHitsFor(ctx context.Context, t *testing.T, rootCfg *rest.Config
 const byWorkspace = "byWorkspace"
 
 func testDynamicDiscoverySharedInformerFactory(ctx context.Context, t *testing.T, rootShardConfig *rest.Config, expectedGVR schema.GroupVersionResource, expectedResName string, expectedClusterName logicalcluster.Name) {
-	rootMetadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootShardConfig) // no identites necessary for partial metadata
-	require.NoError(t, err)
-
 	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(rootShardConfig)
 	require.NoError(t, err, "failed to construct apiextensions client")
 
@@ -262,7 +258,7 @@ func testDynamicDiscoverySharedInformerFactory(ctx context.Context, t *testing.T
 	)
 
 	ddsif, err := informer.NewDynamicDiscoverySharedInformerFactory(
-		rootMetadataClusterClient.Cluster(logicalcluster.Wildcard),
+		rootShardConfig,
 		func(obj interface{}) bool { return true },
 		apiExtensionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 		cache.Indexers{byWorkspace: indexByWorkspace},

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,14 +41,11 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
-	boostrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
 	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
@@ -249,43 +247,33 @@ func collectCacheHitsFor(ctx context.Context, t *testing.T, rootCfg *rest.Config
 	return totalCacheHits, prefixCacheHit
 }
 
-const resyncPeriod = 10 * time.Hour
 const byWorkspace = "byWorkspace"
 
 func testDynamicDiscoverySharedInformerFactory(ctx context.Context, t *testing.T, rootShardConfig *rest.Config, expectedGVR schema.GroupVersionResource, expectedResName string, expectedClusterName logicalcluster.Name) {
-	nonIdentityKcpClusterClient, err := kcpclientset.NewClusterForConfig(rootShardConfig) // can only used for wildcard requests of apis.kcp.dev
-	require.NoError(t, err)
-
-	// resolve identities for system APIBindings
-	identityRootConfig, resolveIdentities := boostrap.NewConfigWithWildcardIdentities(rootShardConfig, boostrap.KcpRootGroupExportNames, boostrap.KcpRootGroupResourceExportNames, nonIdentityKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
-	require.Eventually(t, func() bool {
-		if err := resolveIdentities(ctx); err != nil {
-			klog.Errorf("failed to resolve identities, keeping trying: %v", err)
-			return false
-		}
-		return true
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-
-	rootKcpClusterClient, err := kcpclientset.NewClusterForConfig(identityRootConfig)
-	require.NoError(t, err)
-	rootKcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(rootKcpClusterClient.Cluster(logicalcluster.Wildcard), resyncPeriod)
 	rootMetadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootShardConfig) // no identites necessary for partial metadata
 	require.NoError(t, err)
-	ddsif := informer.NewDynamicDiscoverySharedInformerFactory(
-		rootKcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
-		rootKcpClusterClient.DiscoveryClient,
-		rootMetadataClusterClient.Cluster(logicalcluster.Wildcard),
-		func(obj interface{}) bool { return true }, 5*time.Second,
-	)
-	err = ddsif.AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})
-	require.NoError(t, err)
 
-	t.Log("Starting KCP Shared Informer Factory")
-	rootKcpSharedInformerFactory.Start(ctx.Done())
-	t.Log("Waiting for KCP Shared Informer Factory to sync caches")
-	rootKcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
+	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(rootShardConfig)
+	require.NoError(t, err, "failed to construct apiextensions client")
+
+	apiExtensionsInformerFactory := apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
+		crdClusterClient.Cluster(logicalcluster.Wildcard),
+		0,
+	)
+
+	ddsif, err := informer.NewDynamicDiscoverySharedInformerFactory(
+		rootMetadataClusterClient.Cluster(logicalcluster.Wildcard),
+		func(obj interface{}) bool { return true },
+		apiExtensionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		cache.Indexers{byWorkspace: indexByWorkspace},
+	)
+	require.NoError(t, err, "error creating DynamicDiscoverySharedInformerFactory")
+
+	t.Log("Starting apiextensions shared informer factory")
+	apiExtensionsInformerFactory.Start(ctx.Done())
+
 	t.Log("Starting DynamicDiscoverySharedInformerFactory")
-	ddsif.StartPolling(context.Background())
+	go ddsif.StartWorker(ctx)
 
 	t.Logf("Checking if DynamicDiscoverySharedInformerFactory has %v with name %v in cluster %v", expectedGVR.String(), expectedResName, expectedClusterName)
 	framework.Eventually(t, func() (success bool, reason string) {


### PR DESCRIPTION
## Summary
Replace the polling mechanism that wouldn't scale as the number of
ClusterWorkspaces increased with one that is based on a fixed-set of
built-in types + a dynamic set of informers driven by all the unique
group-resources across all the CRDs in the system.

Switch to using real partial metadata informers from upstream.

## Related issue(s)

Variant of #1473 