### PR TITLE
ddsif: fix lost event handlers

### DIFF
--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -234,7 +234,7 @@ func (d *DynamicDiscoverySharedInformerFactory) AddEventHandler(handler GVREvent
 
 	handlers := d.handlers.Load().([]GVREventHandler)
 
-	var newHandlers []GVREventHandler
+	newHandlers := make([]GVREventHandler, len(handlers))
 	copy(newHandlers, handlers)
 
 	newHandlers = append(newHandlers, handler)


### PR DESCRIPTION
> The function copy copies slice elements from a source src to a destination dst and returns the number of elements copied. The core types of both arguments must be slices with identical element type. The number of elements copied is the minimum of len(src) and len(dst).