### PR TITLE
virtual/apiexport: serve wildcard apibindings

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -58,7 +58,6 @@
 /config/helpers/bootstrap.go:273:3: function "V" should not be used, convert to contextual logging
 /config/helpers/bootstrap.go:92:4: function "Infof" should not be used, convert to contextual logging
 /config/system-crds/bootstrap.go:58:4: function "Errorf" should not be used, convert to contextual logging
-/pkg/admission/apibinding/apibinding_admission.go:189:3: function "Errorf" should not be used, convert to contextual logging
 /pkg/admission/kubequota/kubequota_admission.go:217:3: function "InfoS" should not be used, convert to contextual logging
 /pkg/admission/kubequota/kubequota_admission.go:217:3: function "V" should not be used, convert to contextual logging
 /pkg/admission/kubequota/kubequota_admission.go:221:2: function "InfoS" should not be used, convert to contextual logging
@@ -98,22 +97,22 @@
 /pkg/informer/informer.go:376:3: function "V" should not be used, convert to contextual logging
 /pkg/informer/informer.go:417:2: function "InfoS" should not be used, convert to contextual logging
 /pkg/informer/informer.go:417:2: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:447:3: function "InfoS" should not be used, convert to contextual logging
-/pkg/informer/informer.go:447:3: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:459:3: function "InfoS" should not be used, convert to contextual logging
-/pkg/informer/informer.go:459:3: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:482:3: function "Infof" should not be used, convert to contextual logging
-/pkg/informer/informer.go:482:3: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:486:4: function "Infof" should not be used, convert to contextual logging
-/pkg/informer/informer.go:486:4: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:490:3: function "Infof" should not be used, convert to contextual logging
-/pkg/informer/informer.go:490:3: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:502:3: function "InfoS" should not be used, convert to contextual logging
-/pkg/informer/informer.go:502:3: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:505:4: function "InfoS" should not be used, convert to contextual logging
-/pkg/informer/informer.go:505:4: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:507:4: function "InfoS" should not be used, convert to contextual logging
-/pkg/informer/informer.go:507:4: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:448:3: function "InfoS" should not be used, convert to contextual logging
+/pkg/informer/informer.go:448:3: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:460:3: function "InfoS" should not be used, convert to contextual logging
+/pkg/informer/informer.go:460:3: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:483:3: function "Infof" should not be used, convert to contextual logging
+/pkg/informer/informer.go:483:3: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:487:4: function "Infof" should not be used, convert to contextual logging
+/pkg/informer/informer.go:487:4: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:491:3: function "Infof" should not be used, convert to contextual logging
+/pkg/informer/informer.go:491:3: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:503:3: function "InfoS" should not be used, convert to contextual logging
+/pkg/informer/informer.go:503:3: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:506:4: function "InfoS" should not be used, convert to contextual logging
+/pkg/informer/informer.go:506:4: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:508:4: function "InfoS" should not be used, convert to contextual logging
+/pkg/informer/informer.go:508:4: function "V" should not be used, convert to contextual logging
 /pkg/localenvoy/controllers/ingress/envoyingress.go:37:2: function "InfoS" should not be used, convert to contextual logging
 /pkg/localenvoy/controllers/ingress/envoyingress.go:59:3: function "Infof" should not be used, convert to contextual logging
 /pkg/localenvoy/controllers/ingress/envoyingresscontroller.go:125:2: function "InfoS" should not be used, convert to contextual logging
@@ -169,8 +168,8 @@
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:332:3: function "Errorf" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_reconcile.go:58:5: function "Warningf" should not be used, convert to contextual logging
 /pkg/server/controllers.go:1001:4: function "Errorf" should not be used, convert to contextual logging
-/pkg/server/home_workspaces.go:297:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
-/pkg/server/home_workspaces.go:567:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
+/pkg/server/home_workspaces.go:324:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
+/pkg/server/home_workspaces.go:609:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
 /pkg/syncer/apiimporter.go:139:2: function "Infof" should not be used, convert to contextual logging
 /pkg/syncer/apiimporter.go:151:2: function "Infof" should not be used, convert to contextual logging
@@ -266,24 +265,18 @@
 /pkg/syncer/syncer.go:329:4: function "Warningf" should not be used, convert to contextual logging
 /pkg/syncer/syncer.go:73:2: function "Infof" should not be used, convert to contextual logging
 /pkg/syncer/syncer.go:90:2: function "Infof" should not be used, convert to contextual logging
-/pkg/virtual/apiexport/builder/build.go:175:7: function "Errorf" should not be used, convert to contextual logging
+/pkg/virtual/apiexport/builder/build.go:166:7: function "Errorf" should not be used, convert to contextual logging
 /pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go:147:3: function "Infof" should not be used, convert to contextual logging
 /pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go:147:3: function "V" should not be used, convert to contextual logging
 /pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go:153:3: function "Infof" should not be used, convert to contextual logging
 /pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go:153:3: function "V" should not be used, convert to contextual logging
-/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go:255:4: function "Infof" should not be used, convert to contextual logging
-/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go:255:4: function "V" should not be used, convert to contextual logging
+/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go:270:4: function "Infof" should not be used, convert to contextual logging
+/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go:270:4: function "V" should not be used, convert to contextual logging
 /pkg/virtual/framework/dynamic/apiserver/serving_info.go:185:3: function "Infof" should not be used, convert to contextual logging
 /pkg/virtual/framework/dynamic/apiserver/serving_info.go:185:3: function "V" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/build.go:212:7: function "Errorf" should not be used, convert to contextual logging
+/pkg/virtual/initializingworkspaces/builder/build.go:202:7: function "Errorf" should not be used, convert to contextual logging
 /pkg/virtual/initializingworkspaces/builder/build.go:388:4: function "Info" should not be used, convert to contextual logging
 /pkg/virtual/initializingworkspaces/builder/build.go:388:4: function "V" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/build.go:77:4: function "Infof" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/build.go:77:4: function "V" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/forwarding.go:217:6: function "Infof" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/forwarding.go:217:6: function "V" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/forwarding.go:59:4: function "Info" should not be used, convert to contextual logging
-/pkg/virtual/initializingworkspaces/builder/forwarding.go:59:4: function "V" should not be used, convert to contextual logging
 /pkg/virtual/syncer/builder/build.go:212:7: function "Errorf" should not be used, convert to contextual logging
 /pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_controller.go:181:3: function "Infof" should not be used, convert to contextual logging
 /pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_controller.go:181:3: function "V" should not be used, convert to contextual logging

--- a/pkg/admission/apibinding/apibinding_admission.go
+++ b/pkg/admission/apibinding/apibinding_admission.go
@@ -208,10 +208,11 @@ func (o *apiBindingAdmission) Validate(ctx context.Context, a admission.Attribut
 }
 
 func (o *apiBindingAdmission) checkAPIExportAccess(ctx context.Context, user user.Info, apiExportClusterName logicalcluster.Name, apiExportName string) error {
+	logger := klog.FromContext(ctx)
 	authz, err := o.createAuthorizer(apiExportClusterName, o.deepSARClient)
 	if err != nil {
 		// Logging a more specific error for the operator
-		klog.Errorf("error creating authorizer from delegating authorizer config: %v", err)
+		logger.Error(err, "error creating authorizer from delegating authorizer config")
 		// Returning a less specific error to the end user
 		return errors.New("unable to authorize request")
 	}

--- a/pkg/admission/apibinding/apibinding_admission.go
+++ b/pkg/admission/apibinding/apibinding_admission.go
@@ -36,6 +36,7 @@ import (
 
 	kcpinitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1/permissionclaims"
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
 )
 
@@ -94,6 +95,19 @@ func (o *apiBindingAdmission) Admit(ctx context.Context, a admission.Attributes,
 	}
 	if apiBinding.Spec.Reference.Workspace.Path == "" {
 		apiBinding.Spec.Reference.Workspace.Path = cluster.Name.String()
+	}
+
+	// set labels
+	if apiBinding.Spec.Reference.Workspace == nil {
+		delete(apiBinding.Labels, apisv1alpha1.InternalAPIBindingExportLabelKey)
+	} else {
+		if apiBinding.Labels == nil {
+			apiBinding.Labels = make(map[string]string)
+		}
+		apiBinding.Labels[apisv1alpha1.InternalAPIBindingExportLabelKey] = permissionclaims.ToAPIBindingExportLabelValue(
+			logicalcluster.New(apiBinding.Spec.Reference.Workspace.Path),
+			apiBinding.Spec.Reference.Workspace.ExportName,
+		)
 	}
 
 	// write back
@@ -168,6 +182,17 @@ func (o *apiBindingAdmission) Validate(ctx context.Context, a admission.Attribut
 		apiExportClusterName = absoluteRef
 	default:
 		return admission.NewForbidden(a, fmt.Errorf("workspace reference is missing")) // this should not happen due to validation
+	}
+
+	// Verify the labels
+	value, found := apiBinding.Labels[apisv1alpha1.InternalAPIBindingExportLabelKey]
+	if apiBinding.Spec.Reference.Workspace == nil && found {
+		return admission.NewForbidden(a, field.Invalid(field.NewPath("metadata").Child("labels").Key(apisv1alpha1.InternalAPIBindingExportLabelKey), value, "must not be set"))
+	} else if expected := permissionclaims.ToAPIBindingExportLabelValue(
+		logicalcluster.New(apiBinding.Spec.Reference.Workspace.Path),
+		apiBinding.Spec.Reference.Workspace.ExportName,
+	); value != expected {
+		return admission.NewForbidden(a, field.Invalid(field.NewPath("metadata").Child("labels").Key(apisv1alpha1.InternalAPIBindingExportLabelKey), value, fmt.Sprintf("must be set to %q", expected)))
 	}
 
 	// Access check

--- a/pkg/admission/permissionclaims/mutating_permission_claims.go
+++ b/pkg/admission/permissionclaims/mutating_permission_claims.go
@@ -89,7 +89,7 @@ func (m *mutatingPermissionClaims) Admit(ctx context.Context, a admission.Attrib
 		return err
 	}
 
-	expectedLabels, err := m.permissionClaimLabeler.LabelsFor(ctx, clusterName, a.GetResource().GroupResource())
+	expectedLabels, err := m.permissionClaimLabeler.LabelsFor(ctx, clusterName, a.GetResource().GroupResource(), a.GetName())
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (m *mutatingPermissionClaims) Validate(ctx context.Context, a admission.Att
 		return err
 	}
 
-	expectedLabels, err := m.permissionClaimLabeler.LabelsFor(ctx, clusterName, a.GetResource().GroupResource())
+	expectedLabels, err := m.permissionClaimLabeler.LabelsFor(ctx, clusterName, a.GetResource().GroupResource(), a.GetName())
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/apis/v1alpha1/permissionclaims/labels.go
+++ b/pkg/apis/apis/v1alpha1/permissionclaims/labels.go
@@ -39,6 +39,20 @@ func ToLabelKeyAndValue(exportClusterName logicalcluster.Name, exportName string
 	return apisv1alpha1.APIExportPermissionClaimLabelPrefix + exportHash, claimHash, nil
 }
 
+// ToReflexiveAPIBindingLabelKeyAndValue returns label key and value that is set (as fallback for filtering)
+// on APIBindings that point to the given APIExport and the binding has not accepted a claim to it.
+func ToReflexiveAPIBindingLabelKeyAndValue(exportClusterName logicalcluster.Name, exportName string) (string, string) {
+	claimHash := toBase62([28]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7})
+	exportHash := toBase62(sha256.Sum224([]byte(exportClusterName.Join(exportName).String())))
+	return apisv1alpha1.APIExportPermissionClaimLabelPrefix + exportHash, claimHash
+}
+
+// ToAPIBindingExportLabelValue returns the label value for the internal.apis.kcp.dev/export label
+// on APIBindings to filter them by export.
+func ToAPIBindingExportLabelValue(clusterName logicalcluster.Name, exportName string) string {
+	return toBase62(sha256.Sum224([]byte(clusterName.Join(exportName).String())))
+}
+
 func toBase62(hash [28]byte) string {
 	var i big.Int
 	i.SetBytes(hash[:])

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -22,6 +22,12 @@ import (
 	conditionsv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
 )
 
+const (
+	// InternalAPIBindingExportLabelKey is the label key on an APIBinding with the
+	// base62(sha224(<clusterName>:<exportName>)) as value to filter bindings by export.
+	InternalAPIBindingExportLabelKey = "internal.apis.kcp.dev/export"
+)
+
 // APIBinding enables a set of resources and their behaviour through an external
 // service provider in this workspace.
 //

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go
@@ -39,7 +39,7 @@ func (c *resourceController) reconcile(ctx context.Context, obj *unstructured.Un
 	logger := klog.FromContext(ctx)
 
 	clusterName := logicalcluster.From(obj)
-	expectedLabels, err := c.permissionClaimLabeler.LabelsFor(ctx, clusterName, gvr.GroupResource())
+	expectedLabels, err := c.permissionClaimLabeler.LabelsFor(ctx, clusterName, gvr.GroupResource(), obj.GetName())
 	if err != nil {
 		return fmt.Errorf("error calculating permission claim labels for GVR %q %s/%s: %w", gvr, obj.GetNamespace(), obj.GetName(), err)
 	}

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -190,7 +190,6 @@ var resolver = requestinfo.NewFactory()
 func isAPIBindingRequest(path string) bool {
 	info, err := resolver.NewRequestInfo(&http.Request{URL: &url.URL{Path: path}})
 	if err != nil {
-		klog.V(2).Infof("failed to determine info for request: %v", err)
 		return false
 	}
 	return info.IsResourceRequest && info.APIGroup == apisv1alpha1.SchemeGroupVersion.Group && info.Resource == "apibindings"

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -37,7 +40,9 @@ import (
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
 	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/controllers/apireconciler"
+	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/schemas"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework"
 	virtualdynamic "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
@@ -62,66 +67,52 @@ func BuildVirtualWorkspace(
 
 	readyCh := make(chan struct{})
 
-	boundWorkspaceContent := &virtualdynamic.DynamicVirtualWorkspace{
-		RootPathResolver: framework.RootPathResolverFunc(func(path string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
-			completedContext = requestContext
-
-			if !strings.HasPrefix(path, rootPathPrefix) {
-				return
+	apiBindingsName := VirtualWorkspaceName + "-apibindings"
+	apiBindings := &virtualdynamic.DynamicVirtualWorkspace{
+		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, ctx context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)
+			if !ok {
+				return false, "", ctx
 			}
 
-			// Incoming requests to this virtual workspace will look like:
-			//  /services/apiexport/root:org:ws/<apiexport-name>/clusters/*/api/v1/configmaps
-			//                     └────────────────────────┐
-			// Where the withoutRootPathPrefix starts here: ┘
-			withoutRootPathPrefix := strings.TrimPrefix(path, rootPathPrefix)
-
-			parts := strings.SplitN(withoutRootPathPrefix, "/", 3)
-			if len(parts) < 3 {
-				return
+			if resourceURL := strings.TrimPrefix(urlPath, prefixToStrip); !isAPIBindingRequest(resourceURL) {
+				return false, "", ctx
 			}
 
-			apiExportClusterName, apiExportName := parts[0], parts[1]
-			if apiExportClusterName == "" {
-				return
+			completedContext = genericapirequest.WithCluster(ctx, cluster)
+			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, apiDomain)
+			return true, prefixToStrip, completedContext
+		}),
+		Authorizer: newAuthorizer(kubeClusterClient),
+		ReadyChecker: framework.ReadyFunc(func() error {
+			select {
+			case <-readyCh:
+				return nil
+			default:
+				return errors.New("apiexport virtual workspace controllers are not started")
 			}
-			if apiExportName == "" {
-				return
-			}
+		}),
+		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
+			return &apiSetRetriever{
+				config:               mainConfig,
+				dynamicClusterClient: dynamicClusterClient,
+				exposeSubresources:   true,
+				resource:             schemas.ApisKcpDevSchemas["apibindings"],
+				storageProvider:      provideAPIExportFilteredRestStorage,
+			}, nil
+		},
+	}
 
-			realPath := "/"
-			if len(parts) > 2 {
-				realPath += parts[2]
-			}
-
-			//  /services/apiexport/root:org:ws/<apiexport-name>/clusters/*/api/v1/configmaps
-			//                     ┌────────────────────────────┘
-			// We are now here: ───┘
-			// Now, we parse out the logical cluster.
-			if !strings.HasPrefix(realPath, "/clusters/") {
-				return // don't accept
-			}
-
-			withoutClustersPrefix := strings.TrimPrefix(realPath, "/clusters/")
-			parts = strings.SplitN(withoutClustersPrefix, "/", 2)
-			clusterName := parts[0]
-			realPath = "/"
-			if len(parts) > 1 {
-				realPath += parts[1]
-			}
-			cluster := genericapirequest.Cluster{Name: logicalcluster.New(clusterName)}
-			if clusterName == "*" {
-				cluster.Wildcard = true
+	boundOrClaimedWorkspaceContent := &virtualdynamic.DynamicVirtualWorkspace{
+		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, ctx context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
+			cluster, apiDomain, prefixToStrip, ok := digestUrl(urlPath, rootPathPrefix)
+			if !ok {
+				return false, "", ctx
 			}
 
-			completedContext = genericapirequest.WithCluster(requestContext, cluster)
-			key := fmt.Sprintf("%s/%s", apiExportClusterName, apiExportName)
-			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, dynamiccontext.APIDomainKey(key))
-
-			prefixToStrip = strings.TrimSuffix(path, realPath)
-			accepted = true
-
-			return
+			completedContext = genericapirequest.WithCluster(ctx, cluster)
+			completedContext = dynamiccontext.WithAPIDomainKey(completedContext, apiDomain)
+			return true, prefixToStrip, completedContext
 		}),
 
 		ReadyChecker: framework.ReadyFunc(func() error {
@@ -148,7 +139,7 @@ func BuildVirtualWorkspace(
 						})
 					}
 
-					storageBuilder := NewStorageBuilder(ctx, dynamicClusterClient, identityHash, wrapper)
+					storageBuilder := provideDelegatingRestStorage(ctx, dynamicClusterClient, identityHash, wrapper)
 					def, err := apiserver.CreateServingInfoFor(mainConfig, apiResourceSchema, version, storageBuilder)
 					if err != nil {
 						cancelFn()
@@ -185,15 +176,122 @@ func BuildVirtualWorkspace(
 
 			return apiReconciler, nil
 		},
-		Authorizer: getAuthorizer(kubeClusterClient),
+		Authorizer: newAuthorizer(kubeClusterClient),
 	}
 
 	return []rootapiserver.NamedVirtualWorkspace{
-		{Name: VirtualWorkspaceName, VirtualWorkspace: boundWorkspaceContent},
+		{Name: VirtualWorkspaceName, VirtualWorkspace: boundOrClaimedWorkspaceContent}, // this must come first because a claim will show all bindings, not only those for the export
+		{Name: apiBindingsName, VirtualWorkspace: apiBindings},
 	}, nil
 }
 
-func getAuthorizer(client kubernetesclient.ClusterInterface) authorizer.AuthorizerFunc {
+var resolver = requestinfo.NewFactory()
+
+func isAPIBindingRequest(path string) bool {
+	info, err := resolver.NewRequestInfo(&http.Request{URL: &url.URL{Path: path}})
+	if err != nil {
+		klog.V(2).Infof("failed to determine info for request: %v", err)
+		return false
+	}
+	return info.IsResourceRequest && info.APIGroup == apisv1alpha1.SchemeGroupVersion.Group && info.Resource == "apibindings"
+}
+
+func digestUrl(urlPath, rootPathPrefix string) (
+	cluster genericapirequest.Cluster,
+	domainKey dynamiccontext.APIDomainKey,
+	logicalPath string,
+	accepted bool,
+) {
+	if !strings.HasPrefix(urlPath, rootPathPrefix) {
+		return genericapirequest.Cluster{}, "", "", false
+	}
+
+	// Incoming requests to this virtual workspace will look like:
+	//  /services/apiexport/root:org:ws/<apiexport-name>/clusters/*/api/v1/configmaps
+	//                     └────────────────────────┐
+	// Where the withoutRootPathPrefix starts here: ┘
+	withoutRootPathPrefix := strings.TrimPrefix(urlPath, rootPathPrefix)
+
+	parts := strings.SplitN(withoutRootPathPrefix, "/", 3)
+	if len(parts) < 3 {
+		return genericapirequest.Cluster{}, "", "", false
+	}
+
+	apiExportClusterName, apiExportName := parts[0], parts[1]
+	if apiExportClusterName == "" {
+		return genericapirequest.Cluster{}, "", "", false
+	}
+	if apiExportName == "" {
+		return genericapirequest.Cluster{}, "", "", false
+	}
+
+	realPath := "/"
+	if len(parts) > 2 {
+		realPath += parts[2]
+	}
+
+	//  /services/apiexport/root:org:ws/<apiexport-name>/clusters/*/api/v1/configmaps
+	//                     ┌────────────────────────────┘
+	// We are now here: ───┘
+	// Now, we parse out the logical cluster.
+	if !strings.HasPrefix(realPath, "/clusters/") {
+		return genericapirequest.Cluster{}, "", "", false
+	}
+
+	withoutClustersPrefix := strings.TrimPrefix(realPath, "/clusters/")
+	parts = strings.SplitN(withoutClustersPrefix, "/", 2)
+	clusterName := logicalcluster.New(parts[0])
+	realPath = "/"
+	if len(parts) > 1 {
+		realPath += parts[1]
+	}
+
+	key := fmt.Sprintf("%s/%s", apiExportClusterName, apiExportName)
+	return genericapirequest.Cluster{Name: clusterName, Wildcard: clusterName == logicalcluster.Wildcard}, dynamiccontext.APIDomainKey(key), strings.TrimSuffix(urlPath, realPath), true
+}
+
+type apiSetRetriever struct {
+	config               genericapiserver.CompletedConfig
+	dynamicClusterClient dynamic.ClusterInterface
+	resource             *apisv1alpha1.APIResourceSchema
+	exposeSubresources   bool
+	storageProvider      func(ctx context.Context, clusterClient dynamic.ClusterInterface, exportCluster logicalcluster.Name, exportName string) (apiserver.RestProviderFunc, error)
+}
+
+func (a *apiSetRetriever) GetAPIDefinitionSet(ctx context.Context, key dynamiccontext.APIDomainKey) (apis apidefinition.APIDefinitionSet, apisExist bool, err error) {
+	comps := strings.SplitN(string(key), "/", 2)
+	if len(comps) != 2 {
+		return nil, false, fmt.Errorf("invalid key: %s", key)
+	}
+	restProvider, err := a.storageProvider(ctx, a.dynamicClusterClient, logicalcluster.New(comps[0]), comps[1])
+	if err != nil {
+		return nil, false, err
+	}
+
+	apiDefinition, err := apiserver.CreateServingInfoFor(
+		a.config,
+		a.resource,
+		apisv1alpha1.SchemeGroupVersion.Version,
+		restProvider,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create serving info: %w", err)
+	}
+
+	apis = apidefinition.APIDefinitionSet{
+		schema.GroupVersionResource{
+			Group:    apisv1alpha1.SchemeGroupVersion.Group,
+			Version:  apisv1alpha1.SchemeGroupVersion.Version,
+			Resource: "apibindings",
+		}: apiDefinition,
+	}
+
+	return apis, len(apis) > 0, nil
+}
+
+var _ apidefinition.APIDefinitionSetGetter = &apiSetRetriever{}
+
+func newAuthorizer(client kubernetesclient.ClusterInterface) authorizer.AuthorizerFunc {
 	return func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 		apiDomainKey := dynamiccontext.APIDomainKeyFrom(ctx)
 		parts := strings.Split(string(apiDomainKey), "/")

--- a/pkg/virtual/apiexport/schemas/apis.go
+++ b/pkg/virtual/apiexport/schemas/apis.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemas
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/pointer"
+
+	configcrds "github.com/kcp-dev/kcp/config/crds"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+var ApisKcpDevSchemas = map[string]*apisv1alpha1.APIResourceSchema{}
+
+func init() {
+	for _, resource := range []string{"apibindings", "apiresourceschemas", "apiexports"} {
+		// get APIBindings resource schema
+		crd := apiextensionsv1.CustomResourceDefinition{}
+		if err := configcrds.Unmarshal(fmt.Sprintf("apis.kcp.dev_%s.yaml", resource), &crd); err != nil {
+			panic(fmt.Sprintf("failed to unmarshal apibindings resource: %v", err))
+		}
+		schema, err := apisv1alpha1.CRDToAPIResourceSchema(&crd, "crd")
+		if err != nil {
+			panic(fmt.Sprintf("failed to convert CRD %s.%s to APIResourceSchema: %v", crd.Spec.Names.Plural, crd.Spec.Group, err))
+		}
+		bs, err := json.Marshal(&apiextensionsv1.JSONSchemaProps{
+			Type:                   "object",
+			XPreserveUnknownFields: pointer.BoolPtr(true),
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal JSONSchemaProps: %v", err))
+		}
+		for i := range schema.Spec.Versions {
+			v := &schema.Spec.Versions[i]
+			v.Schema.Raw = bs // wipe schemas. We don't want validation here.
+		}
+
+		ApisKcpDevSchemas[resource] = schema
+	}
+}

--- a/pkg/virtual/framework/forwardingregistry/rest.go
+++ b/pkg/virtual/framework/forwardingregistry/rest.go
@@ -19,6 +19,7 @@ package forwardingregistry
 import (
 	"context"
 
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
 	"k8s.io/apiextensions-apiserver/pkg/registry/customresource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,6 +30,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/kube-openapi/pkg/validation/validate"
+
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
 )
 
 // StorageWrapper allows consumers to wrap the delegating Store in order to add custom behavior around it.
@@ -84,4 +88,65 @@ func NewStorage(ctx context.Context, resource schema.GroupVersionResource, apiEx
 	}
 	statusStore := wrapper(resource.GroupResource(), statusDelegate)
 	return store, statusStore
+}
+
+// ProvideReadOnlyRestStorage returns a commonly used REST storage that forwards calls to a dynamic client,
+// but only for read-only requests.
+func ProvideReadOnlyRestStorage(ctx context.Context, clusterClient dynamic.ClusterInterface, wrapper StorageWrapper) (apiserver.RestProviderFunc, error) {
+	return func(resource schema.GroupVersionResource, kind schema.GroupVersionKind, listKind schema.GroupVersionKind, typer runtime.ObjectTyper, tableConvertor rest.TableConvertor, namespaceScoped bool, schemaValidator *validate.SchemaValidator, subresourcesSchemaValidator map[string]*validate.SchemaValidator, structuralSchema *structuralschema.Structural) (mainStorage rest.Storage, subresourceStorages map[string]rest.Storage) {
+		statusSchemaValidate := subresourcesSchemaValidator["status"]
+
+		strategy := customresource.NewStrategy(
+			typer,
+			namespaceScoped,
+			kind,
+			schemaValidator,
+			statusSchemaValidate,
+			map[string]*structuralschema.Structural{resource.Version: structuralSchema},
+			nil, // no status here
+			nil, // no scale here
+		)
+
+		storage, _ := NewStorage(
+			ctx,
+			resource,
+			"", // ClusterWorkspaces have no identity
+			kind,
+			listKind,
+			strategy,
+			nil,
+			tableConvertor,
+			nil,
+			clusterClient,
+			nil,
+			wrapper,
+		)
+
+		// only expose LIST+WATCH
+		return &struct {
+			FactoryFunc
+			ListFactoryFunc
+			DestroyerFunc
+
+			GetterFunc
+			ListerFunc
+			WatcherFunc
+
+			TableConvertorFunc
+			CategoriesProviderFunc
+			ResetFieldsStrategyFunc
+		}{
+			FactoryFunc:     storage.FactoryFunc,
+			ListFactoryFunc: storage.ListFactoryFunc,
+			DestroyerFunc:   storage.DestroyerFunc,
+
+			GetterFunc:  storage.GetterFunc,
+			ListerFunc:  storage.ListerFunc,
+			WatcherFunc: storage.WatcherFunc,
+
+			TableConvertorFunc:      storage.TableConvertorFunc,
+			CategoriesProviderFunc:  storage.CategoriesProviderFunc,
+			ResetFieldsStrategyFunc: storage.ResetFieldsStrategyFunc,
+		}, nil // no subresources
+	}, nil
 }

--- a/pkg/virtual/framework/forwardingregistry/rest.go
+++ b/pkg/virtual/framework/forwardingregistry/rest.go
@@ -110,7 +110,7 @@ func ProvideReadOnlyRestStorage(ctx context.Context, clusterClient dynamic.Clust
 		storage, _ := NewStorage(
 			ctx,
 			resource,
-			"", // ClusterWorkspaces have no identity
+			"",
 			kind,
 			listKind,
 			strategy,

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -298,7 +298,6 @@ var resolver = requestinfo.NewFactory()
 func isClusterWorkspaceRequest(path string) bool {
 	info, err := resolver.NewRequestInfo(&http.Request{URL: &url.URL{Path: path}})
 	if err != nil {
-		klog.V(2).Infof("failed to determine info for request: %v", err)
 		return false
 	}
 	return info.IsResourceRequest && info.APIGroup == tenancyv1alpha1.SchemeGroupVersion.Group && info.Resource == "clusterworkspaces"

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -304,7 +304,12 @@ func isClusterWorkspaceRequest(path string) bool {
 	return info.IsResourceRequest && info.APIGroup == tenancyv1alpha1.SchemeGroupVersion.Group && info.Resource == "clusterworkspaces"
 }
 
-func digestUrl(urlPath, rootPathPrefix string) (genericapirequest.Cluster, dynamiccontext.APIDomainKey, string, bool) {
+func digestUrl(urlPath, rootPathPrefix string) (
+	cluster genericapirequest.Cluster,
+	key dynamiccontext.APIDomainKey,
+	logicalPath string,
+	accepted bool,
+) {
 	if !strings.HasPrefix(urlPath, rootPathPrefix) {
 		return genericapirequest.Cluster{}, dynamiccontext.APIDomainKey(""), "", false
 	}

--- a/pkg/virtual/initializingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/initializingworkspaces/builder/forwarding.go
@@ -150,13 +150,14 @@ func withUpdateValidation(initializer tenancyv1alpha1.ClusterWorkspaceInitialize
 		delegateUpdater := storage.UpdaterFunc
 		storage.UpdaterFunc = func(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 			validation := rest.ValidateObjectUpdateFunc(func(ctx context.Context, obj, old runtime.Object) error {
+				logger := klog.FromContext(ctx)
 				previous, _, err := unstructured.NestedStringSlice(old.(*unstructured.Unstructured).UnstructuredContent(), "status", "initializers")
 				if err != nil {
 					return errors.NewInternalError(fmt.Errorf("error accessing initializers from old object: %w", err))
 				}
 				current, _, err := unstructured.NestedStringSlice(obj.(*unstructured.Unstructured).UnstructuredContent(), "status", "initializers")
 				if err != nil {
-					klog.V(2).Infof("error accessing initializers from new object: %v", err)
+					logger.Error(err, "error accessing initializers from new object")
 					return errors.NewInternalError(fmt.Errorf("error accessing initializers from old object: %w", err))
 				}
 				invalidUpdateErr := errors.NewInvalid(

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -77,7 +77,7 @@ func TestInitializingWorkspacesVirtualWorkspaceDiscovery(t *testing.T) {
 				Name:               "clusterworkspaces",
 				SingularName:       "clusterworkspace",
 				Categories:         []string{"kcp"},
-				Verbs:              metav1.Verbs{"list", "watch"},
+				Verbs:              metav1.Verbs{"get", "list", "watch"},
 				StorageVersionHash: discovery.StorageVersionHash(logicalcluster.New(""), "tenancy.kcp.dev", "v1alpha1", "ClusterWorkspace"),
 			},
 			{


### PR DESCRIPTION
Virtual workspaces should make the defining objects of workspaces visible. For APIExports, this is the APIBindings, for initializing workspace this would be the Workspace.

This PR adds the APIBindings (both wildcard requests and normal requests) to the APIExport VW.

It does that by adding a "reflexive claim label" to APIBindings marking the binding visible for the corresponding APIExport. The APIExport VW then can filter via a "IN" label selector, matching either the reflexive label or a real claim label:

```golang
// ToReflexiveAPIBindingLabelKeyAndValue returns label key and value that is set (as fallback for filtering)
// on APIBindings that point to the given APIExport and the binding has not accepted a claim to it.
func ToReflexiveAPIBindingLabelKeyAndValue(exportClusterName logicalcluster.Name, exportName string) (string, string) {
  claimHash := toBase62([28]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7})
  exportHash := toBase62(sha256.Sum224([]byte(exportClusterName.Join(exportName).String())))
  return apisv1alpha1.APIExportPermissionClaimLabelPrefix + exportHash, claimHash
}
```

This way the APIExport owners will always see "their own" bindings, but are able to claim access to all bindings, overriding the reflexive labels.