### PR TITLE
apis/tenancy: rename tenancy.kcp.dev/owner -> experimental.tenancy.kcp.dev/owner

### DIFF
--- a/pkg/admission/clusterworkspace/admission.go
+++ b/pkg/admission/clusterworkspace/admission.go
@@ -97,7 +97,7 @@ func (o *clusterWorkspace) Admit(ctx context.Context, a admission.Attributes, _ 
 			if cw.Annotations == nil {
 				cw.Annotations = map[string]string{}
 			}
-			cw.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey] = userInfo
+			cw.Annotations[tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey] = userInfo
 		}
 	}
 
@@ -162,8 +162,8 @@ func (o *clusterWorkspace) Validate(ctx context.Context, a admission.Attributes,
 			if cw.Annotations == nil {
 				cw.Annotations = map[string]string{}
 			}
-			if got := cw.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey]; got != userInfo {
-				return admission.NewForbidden(a, fmt.Errorf("expected user annotation %s=%s", tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey, userInfo))
+			if got := cw.Annotations[tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey]; got != userInfo {
+				return admission.NewForbidden(a, fmt.Errorf("expected user annotation %s=%s", tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey, userInfo))
 			}
 		}
 	}
@@ -194,7 +194,7 @@ func updateUnstructured(u *unstructured.Unstructured, cw *tenancyv1alpha1.Cluste
 	return nil
 }
 
-// ClusterWorkspaceOwnerAnnotationValue returns the value of the ClusterWorkspaceOwnerAnnotationKey annotation.
+// ClusterWorkspaceOwnerAnnotationValue returns the value of the ExperimentalClusterWorkspaceOwnerAnnotationKey annotation.
 func ClusterWorkspaceOwnerAnnotationValue(user kuser.Info) (string, error) {
 	info := &authenticationv1.UserInfo{
 		Username: user.GetName(),

--- a/pkg/admission/clusterworkspace/admission_test.go
+++ b/pkg/admission/clusterworkspace/admission_test.go
@@ -109,7 +109,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someone","uid":"id","groups":["a","b"],"extra":{"one":["1","01"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someone","uid":"id","groups":["a","b"],"extra":{"one":["1","01"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -126,7 +126,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -147,7 +147,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -164,7 +164,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -185,7 +185,7 @@ func TestAdmit(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someone","uid":"id","groups":["a","b"],"extra":{"one":["1","01"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someone","uid":"id","groups":["a","b"],"extra":{"one":["1","01"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -228,7 +228,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -240,7 +240,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -256,7 +256,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -272,7 +272,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -293,7 +293,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -306,7 +306,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -325,7 +325,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -343,7 +343,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -363,7 +363,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -381,7 +381,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -402,7 +402,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -420,7 +420,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -439,7 +439,7 @@ func TestValidate(t *testing.T) {
 			a: createAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -460,7 +460,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -477,7 +477,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -497,7 +497,7 @@ func TestValidate(t *testing.T) {
 			a: updateAttr(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -515,7 +515,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -538,7 +538,7 @@ func TestValidate(t *testing.T) {
 				&tenancyv1alpha1.ClusterWorkspaceShard{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "test",
-						Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+						Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 					},
 				},
 				nil,
@@ -558,7 +558,7 @@ func TestValidate(t *testing.T) {
 			a: createAttrWithUser(&tenancyv1alpha1.ClusterWorkspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test",
-					Annotations: map[string]string{"tenancy.kcp.dev/owner": "{}"},
+					Annotations: map[string]string{"experimental.tenancy.kcp.dev/owner": "{}"},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 					Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -574,7 +574,7 @@ func TestValidate(t *testing.T) {
 					"one": {"1", "01"},
 				},
 			}),
-			expectedErrors: []string{"expected user annotation tenancy.kcp.dev/owner={\"username\":\"someone\",\"uid\":\"id\",\"groups\":[\"a\",\"b\"],\"extra\":{\"one\":[\"1\",\"01\"]}}"},
+			expectedErrors: []string{"expected user annotation experimental.tenancy.kcp.dev/owner={\"username\":\"someone\",\"uid\":\"id\",\"groups\":[\"a\",\"b\"],\"extra\":{\"one\":[\"1\",\"01\"]}}"},
 		},
 		{
 			name: "accept user information on create when system:masters",
@@ -582,7 +582,7 @@ func TestValidate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -606,7 +606,7 @@ func TestValidate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
+						"experimental.tenancy.kcp.dev/owner": `{"username":"someoneelse","uid":"otherid","groups":["c","d"],"extra":{"two":["2","02"]}}`,
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
@@ -623,7 +623,7 @@ func TestValidate(t *testing.T) {
 					"one": {"1", "01"},
 				},
 			}),
-			expectedErrors: []string{"expected user annotation tenancy.kcp.dev/owner={\"username\":\"someone\",\"uid\":\"id\",\"groups\":[\"a\",\"b\"],\"extra\":{\"one\":[\"1\",\"01\"]}}"},
+			expectedErrors: []string{"expected user annotation experimental.tenancy.kcp.dev/owner={\"username\":\"someone\",\"uid\":\"id\",\"groups\":[\"a\",\"b\"],\"extra\":{\"one\":[\"1\",\"01\"]}}"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/admission/reservedmetadata/admission.go
+++ b/pkg/admission/reservedmetadata/admission.go
@@ -42,7 +42,7 @@ var (
 	annotationAllowList = []string{
 		workloadv1alpha1.AnnotationSkipDefaultObjectCreation,
 		syncer.AdvancedSchedulingFeatureAnnotation,
-		v1alpha1.ClusterWorkspaceOwnerAnnotationKey, // this is protected by clusterworkspace admission from non-system:admins
+		v1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey, // this is protected by clusterworkspace admission from non-system:admins
 	}
 	labelAllowList = []string{
 		apisv1alpha1.APIExportPermissionClaimLabelPrefix + "*", // protected by the permissionclaim admission plugin

--- a/pkg/apis/tenancy/projection/workspaces.go
+++ b/pkg/apis/tenancy/projection/workspaces.go
@@ -30,7 +30,7 @@ func ProjectClusterWorkspaceToWorkspace(from *tenancyv1alpha1.ClusterWorkspace, 
 
 	to.Annotations = make(map[string]string, len(from.Annotations))
 	for k, v := range from.Annotations {
-		if k == tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey {
+		if k == tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey {
 			// do not leak user information
 			continue
 		}

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -328,7 +328,7 @@ const (
 	ClusterWorkspacePhaseReady        ClusterWorkspacePhaseType = "Ready"
 )
 
-const ClusterWorkspaceOwnerAnnotationKey string = "tenancy.kcp.dev/owner"
+const ExperimentalClusterWorkspaceOwnerAnnotationKey string = "experimental.tenancy.kcp.dev/owner"
 
 // ClusterWorkspaceStatus communicates the observed state of the ClusterWorkspace.
 type ClusterWorkspaceStatus struct {

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go
@@ -64,20 +64,20 @@ func (r *metaDataReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 	}
 
 	if workspace.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady {
-		if value, found := workspace.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey]; found {
+		if value, found := workspace.Annotations[tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey]; found {
 			var info authenticationv1.UserInfo
 			err := json.Unmarshal([]byte(value), &info)
 			if err != nil {
-				klog.Warningf("Failed to unmarshal ClusterWorkspace %s|%s annotation %s=%q: %v", logicalcluster.From(workspace), workspace.Name, tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey, value, err)
-				delete(workspace.Annotations, tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey)
+				klog.Warningf("Failed to unmarshal ClusterWorkspace %s|%s annotation %s=%q: %v", logicalcluster.From(workspace), workspace.Name, tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey, value, err)
+				delete(workspace.Annotations, tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey)
 				changed = true
 			} else if userOnlyValue, err := json.Marshal(authenticationv1.UserInfo{Username: info.Username}); err != nil {
 				// should never happen
 				klog.Warningf("Failed to marshal ClusterWorkspace %s|%s user info: %v", logicalcluster.From(workspace), workspace.Name, err)
-				delete(workspace.Annotations, tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey)
+				delete(workspace.Annotations, tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey)
 				changed = true
 			} else if value != string(userOnlyValue) {
-				workspace.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey] = string(userOnlyValue)
+				workspace.Annotations[tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey] = string(userOnlyValue)
 				changed = true
 			}
 		}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata_test.go
@@ -143,8 +143,8 @@ func TestReconcileMetadata(t *testing.T) {
 						"internal.kcp.dev/phase": "Ready",
 					},
 					Annotations: map[string]string{
-						"a":                     "b",
-						"tenancy.kcp.dev/owner": `{"username":"user-1","groups":["a","b"],"uid":"123","extra":{"c":["d"]}}`,
+						"a":                                  "b",
+						"experimental.tenancy.kcp.dev/owner": `{"username":"user-1","groups":["a","b"],"uid":"123","extra":{"c":["d"]}}`,
 					},
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceStatus{
@@ -156,8 +156,8 @@ func TestReconcileMetadata(t *testing.T) {
 					"internal.kcp.dev/phase": "Ready",
 				},
 				Annotations: map[string]string{
-					"a":                     "b",
-					"tenancy.kcp.dev/owner": `{"username":"user-1"}`,
+					"a":                                  "b",
+					"experimental.tenancy.kcp.dev/owner": `{"username":"user-1"}`,
 				},
 			},
 			wantStatus: reconcileStatusStopAndRequeue,
@@ -170,8 +170,8 @@ func TestReconcileMetadata(t *testing.T) {
 						"internal.kcp.dev/phase": "Ready",
 					},
 					Annotations: map[string]string{
-						"a":                     "b",
-						"tenancy.kcp.dev/owner": `{"username":}`,
+						"a":                                  "b",
+						"experimental.tenancy.kcp.dev/owner": `{"username":}`,
 					},
 				},
 				Status: tenancyv1alpha1.ClusterWorkspaceStatus{

--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -512,10 +512,10 @@ func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, user kuser.Info, 
 	if workspaceType == HomeClusterWorkspaceType {
 		ownerRaw, err := clusterworkspaceadmission.ClusterWorkspaceOwnerAnnotationValue(user)
 		if err != nil {
-			return 0, fmt.Errorf("failed to create %s annotation value: %w", tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey, err)
+			return 0, fmt.Errorf("failed to create %s annotation value: %w", tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey, err)
 		}
 		ws.Annotations = map[string]string{
-			tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey: ownerRaw,
+			tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey: ownerRaw,
 		}
 	}
 
@@ -680,7 +680,7 @@ func workspaceUnschedulable(workspace *tenancyv1alpha1.ClusterWorkspace) bool {
 }
 
 func unmarshalOwner(cw *tenancyv1alpha1.ClusterWorkspace) (*authenticationv1.UserInfo, error) {
-	raw, found := cw.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey]
+	raw, found := cw.Annotations[tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey]
 	if !found {
 		return nil, nil
 	}

--- a/pkg/server/home_workspaces_test.go
+++ b/pkg/server/home_workspaces_test.go
@@ -529,7 +529,7 @@ func TestTryToCreate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "u--r-1",
 						Annotations: map[string]string{
-							"tenancy.kcp.dev/owner": "u§Ɛr-1",
+							"experimental.tenancy.kcp.dev/owner": "u§Ɛr-1",
 						},
 					},
 				}, nil
@@ -558,7 +558,7 @@ func TestTryToCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "user-1",
 					Annotations: map[string]string{
-						"tenancy.kcp.dev/owner": "{\"username\":\"user-1\"}",
+						"experimental.tenancy.kcp.dev/owner": "{\"username\":\"user-1\"}",
 					},
 				},
 				Spec: tenancyv1alpha1.ClusterWorkspaceSpec{Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -584,7 +584,7 @@ func TestTryToCreate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "user-1",
 						Annotations: map[string]string{
-							"tenancy.kcp.dev/owner": `{"username": "user-1"}`,
+							"experimental.tenancy.kcp.dev/owner": `{"username": "user-1"}`,
 						},
 					},
 				}, nil
@@ -615,7 +615,7 @@ func TestTryToCreate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "user-1",
 						Annotations: map[string]string{
-							"tenancy.kcp.dev/owner": `{"username":"user-1"}`,
+							"experimental.tenancy.kcp.dev/owner": `{"username":"user-1"}`,
 						},
 					},
 				}, nil
@@ -1755,7 +1755,7 @@ func (b wsBuilder) ownedBy(user string) wsBuilder {
 		panic(err)
 	}
 	return b.withAnnotations(map[string]string{
-		"tenancy.kcp.dev/owner": string(bs),
+		"experimental.tenancy.kcp.dev/owner": string(bs),
 	})
 }
 

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -243,7 +243,7 @@ func BuildVirtualWorkspace(
 					return
 				}
 
-				rawInfo, ok := clusterWorkspace.Annotations[tenancyv1alpha1.ClusterWorkspaceOwnerAnnotationKey]
+				rawInfo, ok := clusterWorkspace.Annotations[tenancyv1alpha1.ExperimentalClusterWorkspaceOwnerAnnotationKey]
 				if !ok {
 					http.Error(writer, fmt.Sprintf("cluster %q had no user recorded", parent), http.StatusInternalServerError)
 					return


### PR DESCRIPTION
We might change this annotation in the context of sharing. So better mark it as experimental.