### PR TITLE
e2e/clusterworkspacedeletion: use correct root shard system:master client for deletion checks

### DIFF
--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -61,7 +61,7 @@ func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
 	kcpClusterClient, err := clientset.NewClusterForConfig(server.BaseConfig(t))
 	require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 
-	rootKcpClusterClient, err := clientset.NewClusterForConfig(server.RootShardConfig(t))
+	rootKcpClusterClient, err := clientset.NewClusterForConfig(server.RootShardSystemMasterBaseConfig(t))
 	require.NoError(t, err)
 
 	t.Logf("Creating workspace")

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -66,7 +66,7 @@ func TestAPIBinding(t *testing.T) {
 	consumer3Workspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 	cfg := server.BaseConfig(t)
-	rootShardCfg := server.RootShardConfig(t)
+	rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
 
 	kcpClients, err := clientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -55,7 +55,7 @@ func TestAuthorizer(t *testing.T) {
 
 	server := framework.SharedKcpServer(t)
 	cfg := server.BaseConfig(t)
-	rootShardCfg := server.RootShardConfig(t)
+	rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
 
 	kubeClusterClient, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err)

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -60,7 +60,7 @@ func TestCrossLogicalClusterList(t *testing.T) {
 	t.Cleanup(cancelFunc)
 
 	cfg := server.BaseConfig(t)
-	rootShardCfg := server.RootShardConfig(t)
+	rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
 
 	kcpClients, err := kcpclientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp client for server")
@@ -159,7 +159,7 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	wsConsume2 := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyapi.ShardConstraints{Name: "root"}))
 
 	cfg := server.BaseConfig(t)
-	rootShardConfig := server.RootShardConfig(t)
+	rootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 
 	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct apiextensions client for server")
@@ -274,7 +274,7 @@ func TestBuiltInCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	org := framework.NewOrganizationFixture(t, server)
 
 	cfg := server.BaseConfig(t)
-	rootShardCfg := server.RootShardConfig(t)
+	rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
 
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(cfg)
 	require.NoError(t, err, "error creating kube cluster client")

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -63,7 +63,7 @@ type RunningServer interface {
 	KubeconfigPath() string
 	RawConfig() (clientcmdapi.Config, error)
 	BaseConfig(t *testing.T) *rest.Config
-	RootShardConfig(t *testing.T) *rest.Config
+	RootShardSystemMasterBaseConfig(t *testing.T) *rest.Config
 	Artifact(t *testing.T, producer func() (runtime.Object, error))
 }
 
@@ -408,8 +408,8 @@ func (c *kcpServer) BaseConfig(t *testing.T) *rest.Config {
 	return rest.AddUserAgent(rest.CopyConfig(cfg), t.Name())
 }
 
-// RootShardConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
-func (c *kcpServer) RootShardConfig(t *testing.T) *rest.Config {
+// RootShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
+func (c *kcpServer) RootShardSystemMasterBaseConfig(t *testing.T) *rest.Config {
 	cfg, err := c.config("system:admin")
 	require.NoError(t, err)
 	cfg = kcpclienthelper.NewClusterConfig(cfg)
@@ -685,8 +685,8 @@ func (s *unmanagedKCPServer) BaseConfig(t *testing.T) *rest.Config {
 	return wrappedCfg
 }
 
-// RootShardConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
-func (s *unmanagedKCPServer) RootShardConfig(t *testing.T) *rest.Config {
+// RootShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
+func (s *unmanagedKCPServer) RootShardSystemMasterBaseConfig(t *testing.T) *rest.Config {
 	raw, err := s.rootShardCfg.RawConfig()
 	require.NoError(t, err)
 

--- a/test/e2e/homeworkspaces/home_workspaces_test.go
+++ b/test/e2e/homeworkspaces/home_workspaces_test.go
@@ -157,7 +157,7 @@ func TestUserHomeWorkspaces(t *testing.T) {
 
 			// create non-virtual clients
 			kcpConfig := server.BaseConfig(t)
-			rootShardCfg := server.RootShardConfig(t)
+			rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
 			kubeClusterClient, err := kubernetes.NewClusterForConfig(kcpConfig)
 			require.NoError(t, err, "failed to construct client for server")
 			rootShardKcpClusterClient, err := kcpclientset.NewClusterForConfig(rootShardCfg)

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kcp-dev/logicalcluster"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
@@ -44,7 +42,6 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 	type runningServer struct {
 		framework.RunningServer
-		orgClusterName    logicalcluster.Name
 		kcpClusterClient  clientset.ClusterInterface
 		kubeClusterClient kubernetesclientset.ClusterInterface
 	}
@@ -56,8 +53,10 @@ func TestWorkspaceDeletionController(t *testing.T) {
 		{
 			name: "create and clean workspace",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
+				orgClusterName := framework.NewOrganizationFixture(t, server)
+
 				t.Logf("Create a workspace with a shard")
-				workspace, err := server.kcpClusterClient.Cluster(server.orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
+				workspace, err := server.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Create(ctx, &tenancyv1alpha1.ClusterWorkspace{
 					ObjectMeta: metav1.ObjectMeta{Name: "ws-cleanup"},
 					Spec: tenancyv1alpha1.ClusterWorkspaceSpec{
 						Type: tenancyv1alpha1.ClusterWorkspaceTypeReference{
@@ -73,7 +72,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				t.Logf("Should have finalizer added in workspace")
 				require.Eventually(t, func() bool {
-					workspace, err := server.kcpClusterClient.Cluster(server.orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+					workspace, err := server.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 					if err != nil {
 						return false
 					}
@@ -85,7 +84,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					return conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
 				}, wait.ForeverTestTimeout, 1*time.Second)
 
-				workspaceCluster := server.orgClusterName.Join(workspace.Name)
+				workspaceCluster := orgClusterName.Join(workspace.Name)
 				kubeClient := server.kubeClusterClient.Cluster(workspaceCluster)
 
 				t.Logf("Wait for default namespace to be created")
@@ -124,12 +123,12 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				_, err = kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create ns in workspace %s", workspace.Name)
 
-				err = server.kcpClusterClient.Cluster(server.orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Delete(ctx, workspace.Name, metav1.DeleteOptions{})
+				err = server.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Delete(ctx, workspace.Name, metav1.DeleteOptions{})
 				require.NoError(t, err, "failed to delete workspace %s", workspace.Name)
 
 				t.Logf("The workspace condition should be updated since there is resource in the workspace pending finalization.")
 				require.Eventually(t, func() bool {
-					workspace, err := server.kcpClusterClient.Cluster(server.orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+					workspace, err := server.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 					if err != nil {
 						return false
 					}
@@ -151,14 +150,14 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				t.Logf("Ensure workspace is removed")
 				require.Eventually(t, func() bool {
-					_, err := server.kcpClusterClient.Cluster(server.orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
+					_, err := server.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}, wait.ForeverTestTimeout, 1*time.Second)
 
 				t.Logf("Finally check if all resources has been removed")
 
 				// Note: we have to access the shard direction to access a logical cluster without workspace
-				rootShardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(server.RunningServer.RootShardConfig(t))
+				rootShardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(server.RunningServer.RootShardSystemMasterBaseConfig(t))
 
 				nslist, err := rootShardKubeClusterClient.Cluster(workspaceCluster).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 				require.NoError(t, err, "failed to list namespaces in workspace %s", workspace.Name)
@@ -172,8 +171,10 @@ func TestWorkspaceDeletionController(t *testing.T) {
 		{
 			name: "nested worksapce cleanup when an org workspace is deleted",
 			work: func(ctx context.Context, t *testing.T, server runningServer) {
+				orgClusterName := framework.NewOrganizationFixture(t, server, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
+
 				t.Logf("Should have finalizer in org workspace")
-				orgWorkspaceName := server.orgClusterName.Base()
+				orgWorkspaceName := orgClusterName.Base()
 				require.Eventually(t, func() bool {
 					orgWorkspace, err := server.kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, orgWorkspaceName, metav1.GetOptions{})
 					require.NoError(t, err, "failed to get org workspace %s", orgWorkspaceName)
@@ -181,12 +182,12 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Create a workspace with in the org workspace")
-				workspaceClusterName := framework.NewWorkspaceFixture(t, server.RunningServer, server.orgClusterName, framework.WithName("org-ws-cleanup"))
+				workspaceClusterName := framework.NewWorkspaceFixture(t, server.RunningServer, orgClusterName, framework.WithName("org-ws-cleanup"), framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
 				workspaceName := workspaceClusterName.Base()
 
 				t.Logf("Should have finalizer added in workspace")
 				require.Eventually(t, func() bool {
-					workspace, err := server.kcpClusterClient.Cluster(server.orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspaceName, metav1.GetOptions{})
+					workspace, err := server.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspaceName, metav1.GetOptions{})
 					require.NoError(t, err, "failed to get workspace %s", workspaceName)
 					return len(workspace.Finalizers) > 0
 				}, wait.ForeverTestTimeout, 1*time.Second)
@@ -201,18 +202,16 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 				require.NoError(t, err, "failed to create ns in workspace %s", workspaceClusterName)
 
-				orgKubeClient := server.kubeClusterClient.Cluster(server.orgClusterName)
+				orgKubeClient := server.kubeClusterClient.Cluster(orgClusterName)
 				_, err = orgKubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-				require.NoError(t, err, "failed to create ns in workspace %s", server.orgClusterName)
+				require.NoError(t, err, "failed to create ns in workspace %s", orgClusterName)
 
 				// get clients for the right shards. We have to access the shards directly to see object (Namespace and ClusterWorkspace) deletion
 				// without being stopped at the (front-proxy) gate because the parent workspace is already gone.
-				rootShardConfig := framework.ShardConfig(t, server.kcpClusterClient, "root", server.RunningServer.BaseConfig(t))
-				rootShardKcpClusterClient, err := clientset.NewClusterForConfig(rootShardConfig)
+				rootShardKcpClusterClient, err := clientset.NewClusterForConfig(server.RunningServer.RootShardSystemMasterBaseConfig(t))
+				require.NoError(t, err, "failed to create kcp client for root shard")
+				rootShardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(server.RunningServer.RootShardSystemMasterBaseConfig(t))
 				require.NoError(t, err, "failed to create kube client for root shard")
-				rootShardKcpClient := rootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster)
-				orgShardKcpClient, orgShardKubeClient := shardClients(t, server.kcpClusterClient, server.BaseConfig(t), server.orgClusterName)
-				_, wsShardKubeClient := shardClients(t, server.kcpClusterClient, server.BaseConfig(t), workspaceClusterName)
 
 				t.Logf("Delete org workspace")
 				err = server.kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaces().Delete(ctx, orgWorkspaceName, metav1.DeleteOptions{})
@@ -220,7 +219,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				t.Logf("Ensure namespace in the workspace is deleted")
 				require.Eventually(t, func() bool {
-					nslist, err := wsShardKubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+					nslist, err := rootShardKubeClusterClient.Cluster(workspaceClusterName).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 					if err != nil {
 						return false
 					}
@@ -230,7 +229,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				t.Logf("Ensure namespace in the org workspace is deleted")
 				require.Eventually(t, func() bool {
-					nslist, err := orgShardKubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+					nslist, err := rootShardKubeClusterClient.Cluster(orgClusterName).CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 					if err != nil {
 						return false
 					}
@@ -239,7 +238,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				t.Logf("Ensure workspace in the org workspace is deleted")
 				require.Eventually(t, func() bool {
-					wslist, err := orgShardKcpClient.TenancyV1alpha1().ClusterWorkspaces().List(ctx, metav1.ListOptions{})
+					wslist, err := rootShardKcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().List(ctx, metav1.ListOptions{})
 					// 404 could be returned if the org workspace is deleted.
 					if apierrors.IsNotFound(err) {
 						return true
@@ -250,7 +249,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 				t.Logf("Ensure the org workspace is deleted")
 				require.Eventually(t, func() bool {
-					_, err := rootShardKcpClient.TenancyV1alpha1().ClusterWorkspaces().Get(ctx, orgWorkspaceName, metav1.GetOptions{})
+					_, err := rootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, orgWorkspaceName, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
 				}, wait.ForeverTestTimeout, 1*time.Second)
 			},
@@ -271,8 +270,6 @@ func TestWorkspaceDeletionController(t *testing.T) {
 
 			cfg := server.BaseConfig(t)
 
-			orgClusterName := framework.NewOrganizationFixture(t, server)
-
 			kcpClusterClient, err := clientset.NewClusterForConfig(cfg)
 			require.NoError(t, err, "failed to construct client for server")
 
@@ -280,32 +277,10 @@ func TestWorkspaceDeletionController(t *testing.T) {
 			require.NoError(t, err, "failed to construct kube client for server")
 
 			testCase.work(ctx, t, runningServer{
-				orgClusterName:    orgClusterName,
 				RunningServer:     server,
 				kcpClusterClient:  kcpClusterClient,
 				kubeClusterClient: kubeClusterClient,
 			})
 		})
 	}
-}
-
-func shardClients(t *testing.T, kcpClusterClient clientset.ClusterInterface, defaultConfig *rest.Config, clusterName logicalcluster.Name) (clientset.Interface, kubernetesclientset.Interface) {
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	t.Cleanup(cancelFunc)
-
-	parent, workspaceName := clusterName.Split()
-	require.NotEmptyf(t, parent, "clusterName cannot be root", clusterName)
-
-	workspace, err := kcpClusterClient.Cluster(parent).TenancyV1alpha1().ClusterWorkspaces().Get(ctx, workspaceName, metav1.GetOptions{})
-	require.NoError(t, err, "failed to get workspace %s|%s", parent, workspaceName)
-
-	shardConfig := framework.ShardConfig(t, kcpClusterClient, workspace.Status.Location.Current, defaultConfig)
-
-	shardKcpClusterClient, err := clientset.NewClusterForConfig(shardConfig)
-	require.NoError(t, err, "failed to create kcp client for shard")
-
-	shardKubeClusterClient, err := kubernetesclientset.NewClusterForConfig(shardConfig)
-	require.NoError(t, err, "failed to create kube client for shard")
-
-	return shardKcpClusterClient.Cluster(clusterName), shardKubeClusterClient.Cluster(clusterName)
 }

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -55,7 +55,7 @@ func TestInitializingWorkspacesVirtualWorkspaceDiscovery(t *testing.T) {
 	t.Parallel()
 
 	source := framework.SharedKcpServer(t)
-	rootShardCfg := source.RootShardConfig(t)
+	rootShardCfg := source.RootShardSystemMasterBaseConfig(t)
 	rootShardCfg.Host = rootShardCfg.Host + "/services/initializingworkspaces/whatever"
 
 	virtualWorkspaceDiscoveryClient, err := clientgodiscovery.NewDiscoveryClientForConfig(rootShardCfg)

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -59,7 +59,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	t.Cleanup(cancel)
 	org := framework.NewOrganizationFixture(t, server)
 	cluster := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
-	rootShardConfig := server.RootShardConfig(t)
+	rootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 	cowBoysGR := metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"}
 
 	t.Log("Creating wildwest.dev CRD")
@@ -99,7 +99,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 		require.Equal(t, 1, len(res.Items), "expected to get exactly one cowboy")
 	}
 
-	totalCacheHits, cowboysCacheHit := collectCacheHitsFor(ctx, t, server.RootShardConfig(t), "/wildwest.dev/cowboys/customresources")
+	totalCacheHits, cowboysCacheHit := collectCacheHitsFor(ctx, t, server.RootShardSystemMasterBaseConfig(t), "/wildwest.dev/cowboys/customresources")
 	if totalCacheHits == 0 {
 		t.Fatalf("the watch cache is turned off, didn't find instances of %q metrics", "apiserver_cache_list_total")
 	}
@@ -115,7 +115,7 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 	server := framework.SharedKcpServer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	rootShardConfig := server.RootShardConfig(t)
+	rootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 	kcpClusterClient, err := kcpclientset.NewClusterForConfig(rootShardConfig)
 	require.NoError(t, err)
 	dynamicClusterClient, err := dynamic.NewClusterForConfig(rootShardConfig)
@@ -149,7 +149,7 @@ func TestWatchCacheEnabledForAPIBindings(t *testing.T) {
 		require.Equal(t, 1, len(res.Items), "expected to get exactly one sheriff")
 	}
 
-	totalCacheHits, sheriffsCacheHit := collectCacheHitsFor(ctx, t, server.RootShardConfig(t), "/newyork.io/sheriffs")
+	totalCacheHits, sheriffsCacheHit := collectCacheHitsFor(ctx, t, server.RootShardSystemMasterBaseConfig(t), "/newyork.io/sheriffs")
 	if totalCacheHits == 0 {
 		t.Fatalf("the watch cache is turned off, didn't find instances of %q metrics", "apiserver_cache_list_total")
 	}
@@ -165,7 +165,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 	server := framework.SharedKcpServer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	rootShardConfig := server.RootShardConfig(t)
+	rootShardConfig := server.RootShardSystemMasterBaseConfig(t)
 	kubeClusterClient, err := kubernetesclientset.NewClusterForConfig(rootShardConfig)
 	require.NoError(t, err)
 	secretsGR := metav1.GroupResource{Group: "", Resource: "secrets"}
@@ -208,7 +208,7 @@ func TestWatchCacheEnabledForBuiltinTypes(t *testing.T) {
 		}
 	}
 
-	totalCacheHits, secretsCacheHit := collectCacheHitsFor(ctx, t, server.RootShardConfig(t), "/core/secrets")
+	totalCacheHits, secretsCacheHit := collectCacheHitsFor(ctx, t, server.RootShardSystemMasterBaseConfig(t), "/core/secrets")
 	if totalCacheHits == 0 {
 		t.Fatalf("the watch cache is turned off, didn't find instances of %q metrics", "apiserver_cache_list_total")
 	}


### PR DESCRIPTION
The deletion checks have to skip authorization because authz would lead to 403 on deleted workspaces, i.e. you cannot look into the logical cluster then. Hence, we need a `system:master` client. We have that wired for the root shard.