### PR TITLE
wire TemporaryRootShardKcpSharedInformerFactory

### DIFF
--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -60,7 +60,8 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 	}
 
 	if n > 0 {
-		// args = append(args, "--root-kubeconfig=.kcp-0/root.kubeconfig")
+		args = append(args, fmt.Sprintf("--shard-name=shard-%d", n))
+		args = append(args, "--root-shard-kubeconfig-file=.kcp-0/admin.kubeconfig")
 		args = append(args, fmt.Sprintf("--embedded-etcd-client-port=%d", 2379+n+1))
 		args = append(args, fmt.Sprintf("--embedded-etcd-peer-port=%d", (2379+n+1)+1)) // prev value +1
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

wires TemporaryRootShardKcpSharedInformerFactory, essentially when c.Options.Extra.RootShardKubeconfigFile is set then:
- we start a new SharedInformerFactory for the root shard
- we create a KcpClusterClient to the root shard
- we registerer a new shard in the root namespace

   
## Related issue(s)

Fixes #