### PR TITLE
introduce system:shard logical cluster

### DIFF
--- a/config/shard/bootstrap.go
+++ b/config/shard/bootstrap.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shard
+
+import (
+	"context"
+
+	confighelpers "github.com/kcp-dev/kcp/config/helpers"
+	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+)
+
+// Bootstrap creates resources required for a shard.
+// As of today creating API bindings for the root APIs is enough.
+func Bootstrap(ctx context.Context, kcpClient kcpclientset.Interface) error {
+	// note: shards are not really needed. But to avoid breaking the kcp shared informer factory, we also add them.
+	return confighelpers.BindRootAPIs(ctx, kcpClient, "shards.tenancy.kcp.dev", "tenancy.kcp.dev", "scheduling.kcp.dev", "workload.kcp.dev", "apiresource.kcp.dev")
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
This PR creates `system:shard` logical cluster on every shard (including the root shard).
The new cluster is meant to host bindings for the root APIs.

It paves the way for supporting multiple shards.


## Related issue(s)

Fixes #