### PR TITLE
Syncer:  Refactors KCPClusterName to SyncTargetWorkspace.

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -104,11 +104,11 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 	if err := syncer.StartSyncer(
 		ctx,
 		&syncer.SyncerConfig{
-			UpstreamConfig:   kcpConfig,
-			DownstreamConfig: toConfig,
-			ResourcesToSync:  sets.NewString(options.SyncedResourceTypes...),
-			KCPClusterName:   logicalcluster.New(options.FromClusterName),
-			SyncTargetName:   options.PclusterID,
+			UpstreamConfig:      kcpConfig,
+			DownstreamConfig:    toConfig,
+			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
+			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),
+			SyncTargetName:      options.PclusterID,
 		},
 		numThreads,
 		options.APIImportPollInterval,

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -89,7 +89,7 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 	upstreamConfig.QPS = options.QPS
 	upstreamConfig.Burst = options.Burst
 
-	toConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+	downstreamConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
 		&clientcmd.ConfigOverrides{
 			CurrentContext: options.ToContext,
@@ -98,14 +98,14 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 		return err
 	}
 
-	toConfig.QPS = options.QPS
-	toConfig.Burst = options.Burst
+	downstreamConfig.QPS = options.QPS
+	downstreamConfig.Burst = options.Burst
 
 	if err := syncer.StartSyncer(
 		ctx,
 		&syncer.SyncerConfig{
 			UpstreamConfig:      upstreamConfig,
-			DownstreamConfig:    toConfig,
+			DownstreamConfig:    downstreamConfig,
 			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
 			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),
 			SyncTargetName:      options.PclusterID,

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -79,15 +79,15 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 	kcpConfigOverrides := &clientcmd.ConfigOverrides{
 		CurrentContext: options.FromContext,
 	}
-	kcpConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+	upstreamConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.FromKubeconfig},
 		kcpConfigOverrides).ClientConfig()
 	if err != nil {
 		return err
 	}
 
-	kcpConfig.QPS = options.QPS
-	kcpConfig.Burst = options.Burst
+	upstreamConfig.QPS = options.QPS
+	upstreamConfig.Burst = options.Burst
 
 	toConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: options.ToKubeconfig},
@@ -104,7 +104,7 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 	if err := syncer.StartSyncer(
 		ctx,
 		&syncer.SyncerConfig{
-			UpstreamConfig:      kcpConfig,
+			UpstreamConfig:      upstreamConfig,
 			DownstreamConfig:    toConfig,
 			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
 			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -108,7 +108,7 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 			DownstreamConfig:    downstreamConfig,
 			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
 			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),
-			SyncTargetName:      options.PclusterID,
+			SyncTargetName:      options.SyncTargetName,
 		},
 		numThreads,
 		options.APIImportPollInterval,

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -37,7 +37,7 @@ type Options struct {
 	FromClusterName     string
 	ToKubeconfig        string
 	ToContext           string
-	PclusterID          string
+	SyncTargetName      string
 	Logs                *logs.Options
 	SyncedResourceTypes []string
 
@@ -66,7 +66,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.FromClusterName, "from-cluster", options.FromClusterName, "Name of the -from logical cluster.")
 	fs.StringVar(&options.ToKubeconfig, "to-kubeconfig", options.ToKubeconfig, "Kubeconfig file for -to cluster. If not set, the InCluster configuration will be used.")
 	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
-	fs.StringVar(&options.PclusterID, "sync-target-name", options.PclusterID,
+	fs.StringVar(&options.SyncTargetName, "sync-target-name", options.SyncTargetName,
 		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", workloadv1alpha1.ClusterResourceStateLabelPrefix+"<ClusterID>"))
 	fs.StringArrayVarP(&options.SyncedResourceTypes, "resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
 	fs.DurationVar(&options.APIImportPollInterval, "api-import-poll-interval", options.APIImportPollInterval, "Polling interval for API import.")

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -111,7 +111,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName log
 				c.AddToQueue(gvr, obj)
 			},
 		})
-		klog.V(2).InfoS("Set up upstream informer", "clusterName", syncTargetClusterName, "pcluster", syncTargetName, "gvr", gvr.String())
+		klog.V(2).InfoS("Set up upstream informer", "syncTarget_workspace", syncTargetWorkspace, "synctarget_name", syncTargetName, "gvr", gvr.String())
 
 		downstreamInformers.ForResource(gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			DeleteFunc: func(obj interface{}) {
@@ -157,7 +157,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName log
 				c.AddToQueue(gvr, m)
 			},
 		})
-		klog.V(2).InfoS("Set up downstream informer", "clusterName", syncTargetClusterName, "pcluster", syncTargetName, "gvr", gvr.String())
+		klog.V(2).InfoS("Set up downstream informer", "SyncTarget Workspace", syncTargetClusterName, "SyncTarget Name", syncTargetName, "gvr", gvr.String())
 	}
 
 	secretMutator := specmutators.NewSecretMutator()

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -58,12 +58,12 @@ type Controller struct {
 	upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory
 
 	syncTargetName            string
-	syncTargetClusterName     logicalcluster.Name
+	syncTargetWorkspace       logicalcluster.Name
 	syncTargetUID             types.UID
 	advancedSchedulingEnabled bool
 }
 
-func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName logicalcluster.Name, syncTargetName string, upstreamURL *url.URL, advancedSchedulingEnabled bool,
+func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetWorkspace logicalcluster.Name, syncTargetName string, upstreamURL *url.URL, advancedSchedulingEnabled bool,
 	upstreamClient dynamic.ClusterInterface, downstreamClient dynamic.Interface, upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory, syncTargetUID types.UID) (*Controller, error) {
 
 	c := Controller{
@@ -75,7 +75,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName log
 		downstreamInformers: downstreamInformers,
 
 		syncTargetName:            syncTargetName,
-		syncTargetClusterName:     syncTargetClusterName,
+		syncTargetWorkspace:       syncTargetWorkspace,
 		syncTargetUID:             syncTargetUID,
 		advancedSchedulingEnabled: advancedSchedulingEnabled,
 	}
@@ -157,7 +157,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName log
 				c.AddToQueue(gvr, m)
 			},
 		})
-		klog.V(2).InfoS("Set up downstream informer", "SyncTarget Workspace", syncTargetClusterName, "SyncTarget Name", syncTargetName, "gvr", gvr.String())
+		klog.V(2).InfoS("Set up downstream informer", "SyncTarget Workspace", syncTargetWorkspace, "SyncTarget Name", syncTargetName, "gvr", gvr.String())
 	}
 
 	secretMutator := specmutators.NewSecretMutator()

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -115,8 +115,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	clusterName, name := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	namespaceGvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
-
-	desiredNSLocator := shared.NewNamespaceLocator(clusterName, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
+	desiredNSLocator := shared.NewNamespaceLocator(clusterName, c.syncTargetWorkspace, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
 	jsonNSLocator, err := json.Marshal(desiredNSLocator)
 	if err != nil {
 		return err
@@ -127,7 +126,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	}
 	if len(downstreamNamespaces) == 0 {
 		// case for up to v0.6.0 where we used syncTarget.path in namespace locators
-		desiredNSLocator := shared.NewNamespaceLocatorV060(clusterName, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
+		desiredNSLocator := shared.NewNamespaceLocatorV060(clusterName, c.syncTargetWorkspace, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
 		jsonNSLocator, err := json.Marshal(desiredNSLocator)
 		if err != nil {
 			return err
@@ -199,7 +198,7 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 	// TODO: if the downstream namespace loses these annotations/labels after creation,
 	// we don't have anything in place currently that will put them back.
 	upstreamLogicalCluster := logicalcluster.From(upstreamObj)
-	desiredNSLocator := shared.NewNamespaceLocator(upstreamLogicalCluster, c.syncTargetClusterName, c.syncTargetUID, c.syncTargetName, upstreamObj.GetNamespace())
+	desiredNSLocator := shared.NewNamespaceLocator(upstreamLogicalCluster, c.syncTargetWorkspace, c.syncTargetUID, c.syncTargetName, upstreamObj.GetNamespace())
 	b, err := json.Marshal(desiredNSLocator)
 	if err != nil {
 		return err

--- a/pkg/syncer/status/status_controller.go
+++ b/pkg/syncer/status/status_controller.go
@@ -50,12 +50,12 @@ type Controller struct {
 	downstreamNamespaceLister              cache.GenericLister
 
 	syncTargetName            string
-	syncTargetClusterName     logicalcluster.Name
+	syncTargetWorkspace       logicalcluster.Name
 	syncTargetUID             types.UID
 	advancedSchedulingEnabled bool
 }
 
-func NewStatusSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName logicalcluster.Name, syncTargetName string, advancedSchedulingEnabled bool,
+func NewStatusSyncer(gvrs []schema.GroupVersionResource, syncTargetWorkspace logicalcluster.Name, syncTargetName string, advancedSchedulingEnabled bool,
 	upstreamClient dynamic.ClusterInterface, downstreamClient dynamic.Interface, upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory, syncTargetUID types.UID) (*Controller, error) {
 
 	c := &Controller{
@@ -68,7 +68,7 @@ func NewStatusSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName l
 		downstreamNamespaceLister: downstreamInformers.ForResource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}).Lister(),
 
 		syncTargetName:            syncTargetName,
-		syncTargetClusterName:     syncTargetClusterName,
+		syncTargetWorkspace:       syncTargetWorkspace,
 		syncTargetUID:             syncTargetUID,
 		advancedSchedulingEnabled: advancedSchedulingEnabled,
 	}
@@ -92,7 +92,7 @@ func NewStatusSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName l
 				c.AddToQueue(gvr, obj)
 			},
 		})
-		klog.InfoS("Set up informer", "SyncTarget Workspace", syncTargetClusterName, "SyncTarget Name", syncTargetName, "gvr", gvr.String())
+		klog.InfoS("Set up informer", "SyncTarget Workspace", syncTargetWorkspace, "SyncTarget Name", syncTargetName, "gvr", gvr.String())
 	}
 
 	return c, nil

--- a/pkg/syncer/status/status_controller.go
+++ b/pkg/syncer/status/status_controller.go
@@ -92,7 +92,7 @@ func NewStatusSyncer(gvrs []schema.GroupVersionResource, syncTargetClusterName l
 				c.AddToQueue(gvr, obj)
 			},
 		})
-		klog.InfoS("Set up informer", "clusterName", syncTargetClusterName, "pcluster", syncTargetName, "gvr", gvr.String())
+		klog.InfoS("Set up informer", "SyncTarget Workspace", syncTargetClusterName, "SyncTarget Name", syncTargetName, "gvr", gvr.String())
 	}
 
 	return c, nil

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -69,7 +69,7 @@ type SyncerConfig struct {
 }
 
 func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, importPollInterval time.Duration) error {
-	klog.Infof("Starting syncer for logical-cluster: %s, sync-target: %s", cfg.SyncTargetWorkspace, cfg.SyncTargetName)
+	klog.Infof("Starting syncer for SyncTarget: %s|%s", cfg.SyncTargetWorkspace, cfg.SyncTargetName)
 
 	kcpVersion := version.Get().GitVersion
 
@@ -159,7 +159,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	// syncers depend on the types being present to start their informers.
 	var gvrs []schema.GroupVersionResource
 	err = wait.PollImmediateInfinite(gvrQueryInterval, func() (bool, error) {
-		klog.Infof("Attempting to retrieve GVRs from upstream clusterName %s (for pcluster %s)", cfg.SyncTargetWorkspace, cfg.SyncTargetName)
+		klog.Infof("Attempting to retrieve GVRs from upstream...")
 
 		var err error
 		// Get all types the upstream API server knows about.
@@ -184,7 +184,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		advancedSchedulingEnabled = true
 	}
 
-	klog.Infof("Creating spec syncer for clusterName %s to pcluster %s, resources %v", cfg.SyncTargetWorkspace, cfg.SyncTargetName, resources)
+	klog.Infof("Creating spec syncer for SyncTarget %s|%s, resources %v", cfg.SyncTargetWorkspace, cfg.SyncTargetName, resources)
 	upstreamURL, err := url.Parse(cfg.UpstreamConfig.Host)
 	if err != nil {
 		return err
@@ -195,7 +195,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		return err
 	}
 
-	klog.Infof("Creating status syncer for clusterName %s from pcluster %s, resources %v", cfg.SyncTargetWorkspace, cfg.SyncTargetName, resources)
+	klog.Infof("Creating status syncer for SyncTarget %s|%s, resources %v", cfg.SyncTargetWorkspace, cfg.SyncTargetName, resources)
 	statusSyncer, err := status.NewStatusSyncer(gvrs, cfg.SyncTargetWorkspace, cfg.SyncTargetName, advancedSchedulingEnabled,
 		upstreamDynamicClusterClient, downstreamDynamicClient, upstreamInformers, downstreamInformers, syncTarget.GetUID())
 	if err != nil {

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -569,7 +569,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 				return
 			}
 
-			t.Logf("Deleting syncer resources for logical cluster %q, sync target %q", syncerConfig.SyncTargetWorkspace, syncerConfig.SyncTargetName)
+			t.Logf("Deleting syncer resources for logical cluster %q, sync target %q", sf.WorkspaceClusterName, syncerConfig.SyncTargetName)
 			err = downstreamKubeClient.CoreV1().Namespaces().Delete(ctx, syncerID, metav1.DeleteOptions{})
 			if err != nil {
 				t.Errorf("failed to delete Namespace %q: %v", syncerID, err)
@@ -583,7 +583,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 				t.Errorf("failed to delete ClusterRole %q: %v", syncerID, err)
 			}
 
-			t.Logf("Deleting synced resources for logical cluster %q, sync target %q", syncerConfig.SyncTargetWorkspace, syncerConfig.SyncTargetName)
+			t.Logf("Deleting synced resources for logical cluster %q, sync target %q", sf.WorkspaceClusterName, syncerConfig.SyncTargetName)
 			namespaces, err := downstreamKubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				t.Errorf("failed to list namespaces: %v", err)

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -569,7 +569,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 				return
 			}
 
-			t.Logf("Deleting syncer resources for logical cluster %q, sync target %q", syncerConfig.KCPClusterName, syncerConfig.SyncTargetName)
+			t.Logf("Deleting syncer resources for logical cluster %q, sync target %q", syncerConfig.SyncTargetWorkspace, syncerConfig.SyncTargetName)
 			err = downstreamKubeClient.CoreV1().Namespaces().Delete(ctx, syncerID, metav1.DeleteOptions{})
 			if err != nil {
 				t.Errorf("failed to delete Namespace %q: %v", syncerID, err)
@@ -583,7 +583,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 				t.Errorf("failed to delete ClusterRole %q: %v", syncerID, err)
 			}
 
-			t.Logf("Deleting synced resources for logical cluster %q, sync target %q", syncerConfig.KCPClusterName, syncerConfig.SyncTargetName)
+			t.Logf("Deleting synced resources for logical cluster %q, sync target %q", syncerConfig.SyncTargetWorkspace, syncerConfig.SyncTargetName)
 			namespaces, err := downstreamKubeClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				t.Errorf("failed to list namespaces: %v", err)
@@ -598,7 +598,7 @@ func (sf SyncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 					// Not a kcp-synced namespace
 					continue
 				}
-				if locator.Workspace.String() != syncerConfig.KCPClusterName.String() {
+				if locator.Workspace.String() != syncerConfig.SyncTargetWorkspace.String() {
 					// Not a namespace synced by this syncer
 					continue
 				}
@@ -645,7 +645,7 @@ func (sf *StartedSyncerFixture) WaitForClusterReadyReason(t *testing.T, ctx cont
 	t.Logf("Waiting for cluster %q condition %q to have reason %q", cfg.SyncTargetName, conditionsapi.ReadyCondition, reason)
 	kcpClusterClient, err := kcpclient.NewClusterForConfig(cfg.UpstreamConfig)
 	require.NoError(t, err)
-	kcpClient := kcpClusterClient.Cluster(cfg.KCPClusterName)
+	kcpClient := kcpClusterClient.Cluster(cfg.SyncTargetWorkspace)
 	Eventually(t, func() (bool, string) {
 		cluster, err := kcpClient.WorkloadV1alpha1().SyncTargets().Get(ctx, cfg.SyncTargetName, metav1.GetOptions{})
 		require.NoError(t, err)
@@ -741,11 +741,11 @@ func syncerConfigFromCluster(t *testing.T, config *rest.Config, namespace, synce
 	// Compose a new downstream config that uses the token
 	downstreamConfig := ConfigWithToken(string(token), rest.CopyConfig(config))
 	return &syncer.SyncerConfig{
-		UpstreamConfig:   upstreamConfig,
-		DownstreamConfig: downstreamConfig,
-		ResourcesToSync:  sets.NewString(resourcesToSync...),
-		KCPClusterName:   kcpClusterName,
-		SyncTargetName:   syncTargetName,
+		UpstreamConfig:      upstreamConfig,
+		DownstreamConfig:    downstreamConfig,
+		ResourcesToSync:     sets.NewString(resourcesToSync...),
+		SyncTargetWorkspace: kcpClusterName,
+		SyncTargetName:      syncTargetName,
 	}
 }
 

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -88,7 +88,7 @@ func TestClusterController(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				nsLocator := shared.NewNamespaceLocator(syncerFixture.SyncerConfig.KCPClusterName, logicalcluster.From(syncTarget), syncTarget.GetUID(), syncTarget.GetName(), cowboy.Namespace)
+				nsLocator := shared.NewNamespaceLocator(syncerFixture.SyncerConfig.SyncTargetWorkspace, logicalcluster.From(syncTarget), syncTarget.GetUID(), syncTarget.GetName(), cowboy.Namespace)
 				targetNamespace, err := shared.PhysicalClusterNamespaceName(nsLocator)
 				require.NoError(t, err, "Error determining namespace mapping for %v", nsLocator)
 

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -81,7 +81,7 @@ func TestIngressController(t *testing.T) {
 				require.NoError(t, err, "failed to create ingress")
 
 				rootIngressLogicalCluster := logicalcluster.From(rootIngress)
-				nsLocator := shared.NewNamespaceLocator(rootIngressLogicalCluster, syncerFixture.SyncerConfig.KCPClusterName, types.UID("syncTargetUID"), syncerFixture.SyncerConfig.SyncTargetName, rootIngress.Namespace)
+				nsLocator := shared.NewNamespaceLocator(rootIngressLogicalCluster, syncerFixture.SyncerConfig.SyncTargetWorkspace, types.UID("syncTargetUID"), syncerFixture.SyncerConfig.SyncTargetName, rootIngress.Namespace)
 				targetNamespace, err := shared.PhysicalClusterNamespaceName(nsLocator) // nolint: staticcheck
 				require.NoError(t, err, "error determining namespace mapping for %v", nsLocator)
 


### PR DESCRIPTION
Various refactors and improvements to logging messages