### PR TITLE
kcp server: introduce root-shard-kubeconfig-file flag

### DIFF
--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -134,6 +134,7 @@ var (
 		"shard-external-url",          // URL used by outside clients to talk to this kcp shard. Defaults to external address.
 		"shard-name",                  // A name of this kcp shard.
 		"shard-kubeconfig-file",       // Kubeconfig holding admin(!) credentials to peer kcp shards.
+		"root-shard-kubeconfig-file",  // Kubeconfig holding admin(!) credentials to the root kcp shard.
 		"experimental-bind-free-port", // Bind to a free port. --secure-bind-port must be 0. Use the admin.kubeconfig to extract the chosen port.
 
 		// secure serving flags

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -55,6 +55,7 @@ type ExtraOptions struct {
 	RootDirectory            string
 	ProfilerAddress          string
 	ShardKubeconfigFile      string
+	RootShardKubeconfigFile  string
 	ShardBaseURL             string
 	ShardExternalURL         string
 	ShardName                string
@@ -158,6 +159,7 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs := fss.FlagSet("KCP")
 	fs.StringVar(&o.Extra.ProfilerAddress, "profiler-address", o.Extra.ProfilerAddress, "[Address]:port to bind the profiler to")
 	fs.StringVar(&o.Extra.ShardKubeconfigFile, "shard-kubeconfig-file", o.Extra.ShardKubeconfigFile, "Kubeconfig holding admin(!) credentials to peer kcp shards.")
+	fs.StringVar(&o.Extra.RootShardKubeconfigFile, "root-shard-kubeconfig-file", o.Extra.RootShardKubeconfigFile, "Kubeconfig holding admin(!) credentials to the root kcp shard.")
 	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardExternalURL, "shard-external-url", o.Extra.ShardExternalURL, "URL used by outside clients to talk to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
the new flag holds a path to the Kubeconfig for the root kcp shard. It will be used by the other shards to communicate with the root shard. 

It paves the way for supporting multiple shards.

## Related issue(s)

Fixes #