### PR TITLE
bootstrap the root workspace only on the root shard

### DIFF
--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -31,6 +31,9 @@ import (
 // RootCluster is the root of ClusterWorkspace based logical clusters.
 var RootCluster = logicalcluster.New("root")
 
+// RootShard holds a name of the root shard.
+var RootShard = "root"
+
 // ClusterWorkspace defines a Kubernetes-cluster-like endpoint that holds a default set
 // of resources and exhibits standard Kubernetes API semantics of CRUD operations. It represents
 // the full life-cycle of the persisted data in this workspace in a KCP installation.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
the root workspace is only available on the root shard, this pr makes sure it will be only created on it.

## Related issue(s)

Fixes #