### PR TITLE
Don't add /clusters/ prefix to /services/ requests

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -280,6 +280,11 @@ func WithInClusterServiceAccountRequestRewrite(handler http.Handler) http.Handle
 			return
 		}
 
+		if strings.HasPrefix(req.RequestURI, "/services/") {
+			handler.ServeHTTP(w, req)
+			return
+		}
+
 		prefix := "Bearer "
 		token := req.Header.Get("Authorization")
 		if !strings.HasPrefix(token, prefix) {


### PR DESCRIPTION
Currently all requests from bound service accounts get `/clusters/`
prepended to the path in the front proxy with a few exeptions.  None of
those exceptions are for `/services/` requests.

With `/services/` requests prepended with `/clusters/`, the front proxy will
then route them to the KCP container instead of the virtual workspace
server.  KCP will remove the `/clusters/` prefix, create the logical
cluster context, and then try to redirect the `/services/` request to the
virtual workspace server.

Rinse and repeat until the client gives up.

This fix is to stop prepending `/clusters/` on requests to the virtual
workspace server.