### PR TITLE
enable ExperimentalWatchProgressNotifyInterval for etcd

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,7 +143,7 @@ func (s *Server) Run(ctx context.Context) error {
 				return err
 			}
 		}
-		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, listenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.QuotaBackendBytes, s.options.EmbeddedEtcd.ForceNewCluster)
+		embeddedClientInfo, err := es.Run(ctx, s.options.EmbeddedEtcd.PeerPort, s.options.EmbeddedEtcd.ClientPort, listenMetricsURLs, s.options.EmbeddedEtcd.WalSizeBytes, s.options.EmbeddedEtcd.QuotaBackendBytes, s.options.EmbeddedEtcd.ForceNewCluster, s.options.GenericControlPlane.Etcd.EnableWatchCache)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
it defines the interval for etcd watch progress notify events.

note:
- gcp, ocp and upstream k8s set it to 5s, so we simply follow suit
- in practice this value never changes so we are not exposing it as a flag/option
- we enable it only when the watch cache is on, otherwise it might not scale,
   sending an event every 5s to thousands of clients
## Related issue(s)

Fixes #