### PR TITLE
apibinding controller with root shard informers

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -593,6 +593,8 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		s.kcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 		s.kcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 		s.kcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
+		s.temporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
+		s.temporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.apiextensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 	)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
it enables non-root shards to read APIExports and APISchemas from the root shard so that they can create the root APIs for:
`"shards.tenancy.kcp.dev", "tenancy.kcp.dev", "scheduling.kcp.dev", "workload.kcp.dev", "apiresource.kcp.dev"`


## Related issue(s)

Fixes #