### PR TITLE
Add owners files and notes on review/approver role to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,12 @@ All of the built-in types for `kcp` are `CustomResourceDefinitions`, and we gene
 
 When adding a field that requires validation, custom annotations are used to translate this logic into the generated OpenAPI spec. [This doc](https://book.kubebuilder.io/reference/markers/crd-validation.html) gives an overview of possible validations. These annotations map directly to concepts in the [OpenAPI Spec](https://swagger.io/specification/#data-type-format) so, for instance, the `format` of strings is defined there, not in kubebuilder. Furthermore, Kubernetes has forked the OpenAPI project [here](https://github.com/kubernetes/kube-openapi/tree/master/pkg/validation) and extends more formats in the extensions-apiserver [here](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go#L27).
 
+### Getting your PR Merged
+
+The `kcp` project uses `OWNERS` files to denote the collaborators who can assist you in getting your PR merged.  There
+are two roles: reviewer and approver.  Merging a PR requires sign off from both a reviewer and an approver.
+
+
 ## Continuous Integration
 
 kcp uses a combination of [GitHub Actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions) and
@@ -214,3 +220,25 @@ Then, to have your test use that shared kcp server, you add `-args --use-default
 ```shell
 go test ./test/e2e/apibinding -count 20 -failfast -args --use-default-kcp-server
 ```
+## Community Roles
+
+### Reviewers
+
+Reviewers are responsible for reviewing code for correctness and adherence to standards. Oftentimes reviewers will
+be able to advise on code efficiency and style as it relates to golang or project conventions as well as other considerations
+that might not be obvious to the contributor.
+
+### Approvers
+
+Approvers are responsible for sign-off on the acceptance of the contribution. In essence, approval indicates that the
+change is desired and good for the project, aligns with code, api, and system conventions, and appears to follow all required
+process including adequate testing, documentation, follow ups, or notifications to other areas who might be interested
+or affected by the change.
+
+Approvers are also reviewers.
+
+### Management of `OWNERS` files
+
+If a reviewer or approver no longer wishes to be in their current role it is requested that a PR
+be opened to update the `OWNERS` file. `OWNERS` files may be periodically reviewed and updated based on project activity
+or feedback to ensure an acceptable contributor experience is maintained.

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,6 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+    api-approvers:
+    - ncdc
+    - sttts

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- ncdc
+- sttts
+reviewers:
+- stevekuznetsov
+- davidfestal
+- s-urbaniak

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal
+- stevekuznetsov
+reviewers:
+- s-urbaniak
+- shawn-hurley
+- qiujian16

--- a/config/crds/OWNERS
+++ b/config/crds/OWNERS
@@ -1,0 +1,10 @@
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+filters:
+  ".*":
+    approvers:
+      - api-approvers
+  ".*\\.yaml":
+      labels:
+        - kind/api-change

--- a/contrib/OWNERS
+++ b/contrib/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+- stevekuznetsov
+- davidfestal
+- jmprusi

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+- stevekuznetsov
+reviewers:
+- csams

--- a/manifest/OWNERS
+++ b/manifest/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+- kylape
+reviewers:
+- csams

--- a/pkg/admission/OWNERS
+++ b/pkg/admission/OWNERS
@@ -1,0 +1,7 @@
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+approvers:
+- api-approvers
+labels:
+- kind/api-change

--- a/pkg/admission/crdnooverlappinggvr/OWNERS
+++ b/pkg/admission/crdnooverlappinggvr/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- p0lyn0mial

--- a/pkg/admission/mutatingwebhook/OWNERS
+++ b/pkg/admission/mutatingwebhook/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- shawn-hurley

--- a/pkg/admission/namespacelifecycle/OWNERS
+++ b/pkg/admission/namespacelifecycle/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- qiujian16

--- a/pkg/admission/permissionclaims/OWNERS
+++ b/pkg/admission/permissionclaims/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- shawn-hurley

--- a/pkg/admission/reservedcrdannotations/OWNERS
+++ b/pkg/admission/reservedcrdannotations/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- shawn-hurley

--- a/pkg/admission/validatingwebhook/OWNERS
+++ b/pkg/admission/validatingwebhook/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- shawn-hurley

--- a/pkg/admission/webhook/OWNERS
+++ b/pkg/admission/webhook/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- shawn-hurley
+- stevekuznetsov

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -1,0 +1,13 @@
+# Disable inheritance as this is an api owners file
+options:
+  no_parent_owners: true
+filters:
+  ".*":
+    approvers:
+      - api-approvers
+  # examples:
+  #   pkg/apis/*/types.go
+  #   pkg/apis/*/*/types.go
+  "[^/]+/([^/]+/)?(register|types)\\.go$":
+    labels:
+      - kind/api-change

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -8,6 +8,6 @@ filters:
   # examples:
   #   pkg/apis/*/types.go
   #   pkg/apis/*/*/types.go
-  "[^/]+/([^/]+/)?(register|types)\\.go$":
+  "[^/]+/([^/]+/)?(register|types)(_.*)?\\.go$":
     labels:
       - kind/api-change

--- a/pkg/apis/scheduling/OWNERS
+++ b/pkg/apis/scheduling/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- qiujian16

--- a/pkg/apis/tenancy/OWNERS
+++ b/pkg/apis/tenancy/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- stevekuznetsov

--- a/pkg/authorization/OWNERS
+++ b/pkg/authorization/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- ncdc
+- sttts
+- s-urbaniak

--- a/pkg/cliplugins/OWNERS
+++ b/pkg/cliplugins/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+reviewers:
+- stevekuznetsov
+- davidfestal

--- a/pkg/cmd/OWNERS
+++ b/pkg/cmd/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+reviewers:
+- stevekuznetsov
+- davidfestal

--- a/pkg/crdpuller/OWNERS
+++ b/pkg/crdpuller/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal

--- a/pkg/features/OWNERS
+++ b/pkg/features/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+reviewers:
+- shawn-hurley
+- qiujian16

--- a/pkg/indexers/OWNERS
+++ b/pkg/indexers/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- ncdc
+- sttts
+- shawn-hurley

--- a/pkg/indexers/OWNERS
+++ b/pkg/indexers/OWNERS
@@ -1,4 +1,3 @@
 approvers:
 - ncdc
 - sttts
-- shawn-hurley

--- a/pkg/localenvoy/OWNERS
+++ b/pkg/localenvoy/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- ncdc
+- sttts
+reviewers:
+- jmprusi

--- a/pkg/proxy/OWNERS
+++ b/pkg/proxy/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- ncdc
+- sttts
+reviewers:
+- csams

--- a/pkg/schemacompat/OWNERS
+++ b/pkg/schemacompat/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal

--- a/pkg/syncer/OWNERS
+++ b/pkg/syncer/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal
+reviewers:
+- jmprusi

--- a/pkg/virtual/OWNERS
+++ b/pkg/virtual/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal
+reviewers:
+- shawn-hurley

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,13 @@
+approvers:
+- ncdc
+- sttts
+- davidfestal
+- stevekuznetsov
+- jmprusi
+reviewers:
+- s-urbaniak
+- davidfestal
+- shawn-hurley
+- qiujian16
+- csams
+- kylape


### PR DESCRIPTION
Fixes #1557 

Figured this might be easier with something to actually apply red pen to.  Note, this is not a judgement of any contributor's capabilities.  I simply looked at history and picked what I thought looked like names that were frequently contributing to areas.  Comment and change suggestions encouraged.

