### PR TITLE
0.6: ddsif: replace discovery polling

### DIFF
--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -28,80 +28,182 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
-	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
-	tenancylisters "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
+	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
 )
 
 const (
 	resyncPeriod = 10 * time.Hour
-)
 
-type clusterDiscovery interface {
-	WithCluster(name logicalcluster.Name) discovery.DiscoveryInterface
-}
+	byGroupFirstFoundVersionResourceIndex = "byGroup-firstFoundVersion-resource"
+)
 
 // DynamicDiscoverySharedInformerFactory is a SharedInformerFactory that
 // dynamically discovers new types and begins informing on them.
 type DynamicDiscoverySharedInformerFactory struct {
-	workspaceLister tenancylisters.ClusterWorkspaceLister
-	disco           clusterDiscovery
-	dynamicClient   dynamic.Interface
-	filterFunc      func(interface{}) bool
-	pollInterval    time.Duration
-	indexers        cache.Indexers
+	dynamicClient     dynamic.Interface
+	filterFunc        func(interface{}) bool
+	indexers          cache.Indexers
+	crdIndexer        cache.Indexer
+	crdInformerSynced cache.InformerSynced
 
 	// handlersLock protects multiple writers racing to update handlers.
 	handlersLock sync.Mutex
 	handlers     atomic.Value
 
-	mu               sync.RWMutex
+	// updateCh receives notifications for all CRD add/update/delete events, so we can start new informers and stop
+	// informers no longer needed.
+	updateCh chan struct{}
+
+	informersLock    sync.RWMutex
 	informers        map[schema.GroupVersionResource]informers.GenericInformer
 	startedInformers map[schema.GroupVersionResource]bool
 	informerStops    map[schema.GroupVersionResource]chan struct{}
-	terminating      bool
+}
+
+// NewDynamicDiscoverySharedInformerFactory returns a factory for shared
+// informers that discovers new types and informs on updates to resources of
+// those types.
+func NewDynamicDiscoverySharedInformerFactory(
+	cfg *rest.Config,
+	filterFunc func(obj interface{}) bool,
+	crdInformer apiextensionsinformers.CustomResourceDefinitionInformer,
+	indexers cache.Indexers,
+) (*DynamicDiscoverySharedInformerFactory, error) {
+	cfg = rest.AddUserAgent(rest.CopyConfig(cfg), "kcp-partial-metadata-informers")
+
+	metadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &DynamicDiscoverySharedInformerFactory{
+		dynamicClient:     metadataClusterClient.Cluster(logicalcluster.Wildcard),
+		filterFunc:        filterFunc,
+		indexers:          indexers,
+		crdIndexer:        crdInformer.Informer().GetIndexer(),
+		crdInformerSynced: crdInformer.Informer().HasSynced,
+
+		// Use a buffered channel of size 1 to allow enqueuing 1 update notification
+		updateCh: make(chan struct{}, 1),
+
+		informers:        make(map[schema.GroupVersionResource]informers.GenericInformer),
+		startedInformers: make(map[schema.GroupVersionResource]bool),
+		informerStops:    make(map[schema.GroupVersionResource]chan struct{}),
+	}
+
+	f.handlers.Store([]GVREventHandler{})
+
+	// Add an index function that indexes a CRD by its group/firstServedVersion/resource. We only need the first
+	// served version because this shared informer factory is expected to be using a wildcard client for partial
+	// metadata only. In this instance, version does not matter, because a wildcard partial metadata list request
+	// for CRs always serves all CRs for the group-resource, regardless of storage version.
+	if err := crdInformer.Informer().AddIndexers(cache.Indexers{
+		byGroupFirstFoundVersionResourceIndex: func(obj interface{}) ([]string, error) {
+			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				return nil, fmt.Errorf("%T is not a CustomResourceDefinition", obj)
+			}
+
+			firstServedVersion := ""
+			for _, version := range crd.Spec.Versions {
+				if !version.Served {
+					continue
+				}
+				firstServedVersion = version.Name
+				break
+			}
+
+			if firstServedVersion == "" {
+				return []string{}, nil
+			}
+
+			group := crd.Spec.Group
+			resource := crd.Spec.Names.Plural
+
+			indexValue := fmt.Sprintf("%s/%s/%s", group, firstServedVersion, resource)
+			return []string{indexValue}, nil
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	// Any time a CRD event comes in, let StartWorker() know about it
+	notifyUpdateNeeded := func() {
+		select {
+		case f.updateCh <- struct{}{}:
+			klog.V(4).InfoS("Enqueued update notification for dynamic informer recalculation")
+		default:
+			klog.V(5).InfoS("Dropping update notification for dynamic informer recalculation because a notification is already pending")
+		}
+	}
+
+	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			notifyUpdateNeeded()
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			notifyUpdateNeeded()
+		},
+		DeleteFunc: func(obj interface{}) {
+			notifyUpdateNeeded()
+		},
+	})
+
+	return f, nil
 }
 
 // InformerForResource returns the GenericInformer for gvr, creating it if needed. The GenericInformer must be started
 // by calling Start on the DynamicDiscoverySharedInformerFactory before the GenericInformer can be used.
 func (d *DynamicDiscoverySharedInformerFactory) InformerForResource(gvr schema.GroupVersionResource) (informers.GenericInformer, error) {
 	// See if we already have it
-	d.mu.RLock()
+	d.informersLock.RLock()
 	inf := d.informers[gvr]
-	d.mu.RUnlock()
+	d.informersLock.RUnlock()
 
 	if inf != nil {
 		return inf, nil
 	}
 
 	// Grab the write lock, then find-or-create
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.informersLock.Lock()
+	defer d.informersLock.Unlock()
 
-	return d.informerForResourceLockHeld(gvr)
+	return d.informerForResourceLockHeld(gvr), nil
 }
 
 // informerForResourceLockHeld returns the GenericInformer for gvr, creating it if needed. The caller must have the write
 // lock before calling this method.
-func (d *DynamicDiscoverySharedInformerFactory) informerForResourceLockHeld(gvr schema.GroupVersionResource) (informers.GenericInformer, error) {
+func (d *DynamicDiscoverySharedInformerFactory) informerForResourceLockHeld(gvr schema.GroupVersionResource) informers.GenericInformer {
 	// In case it was created in between the initial check while the rlock was held and when the write lock was
 	// acquired, return it instead of creating a 2nd copy and overwriting.
 	inf := d.informers[gvr]
 	if inf != nil {
-		return inf, nil
+		return inf
 	}
 
-	klog.Infof("Adding dynamic informer for %q", gvr)
+	klog.V(2).Infof("Adding dynamic informer for %q", gvr)
+
+	// TODO(ncdc) remove NamespaceIndex when scoping is fully integrated
+	indexers := cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}
+
+	for k, v := range d.indexers {
+		if k == cache.NamespaceIndex {
+			// Don't allow overriding NamespaceIndex
+			continue
+		}
+
+		indexers[k] = v
+	}
 
 	// Definitely need to create it
 	inf = dynamicinformer.NewFilteredDynamicInformer(
@@ -109,7 +211,7 @@ func (d *DynamicDiscoverySharedInformerFactory) informerForResourceLockHeld(gvr 
 		gvr,
 		corev1.NamespaceAll,
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 		nil,
 	)
 
@@ -134,14 +236,10 @@ func (d *DynamicDiscoverySharedInformerFactory) informerForResourceLockHeld(gvr 
 		},
 	})
 
-	if err := inf.Informer().AddIndexers(d.indexers); err != nil {
-		return nil, err
-	}
-
 	// Store in cache
 	d.informers[gvr] = inf
 
-	return inf, nil
+	return inf
 }
 
 // Listers returns a map of per-resource-type listers for all types that are
@@ -152,12 +250,8 @@ func (d *DynamicDiscoverySharedInformerFactory) informerForResourceLockHeld(gvr 
 func (d *DynamicDiscoverySharedInformerFactory) Listers() (listers map[schema.GroupVersionResource]cache.GenericLister, notSynced []schema.GroupVersionResource) {
 	listers = map[schema.GroupVersionResource]cache.GenericLister{}
 
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	if d.terminating {
-		return
-	}
+	d.informersLock.RLock()
+	defer d.informersLock.RUnlock()
 
 	for gvr, informer := range d.informers {
 		// We have the read lock so d.informers is fully populated for all the gvrs in d.gvrs. We use d.informers
@@ -171,32 +265,6 @@ func (d *DynamicDiscoverySharedInformerFactory) Listers() (listers map[schema.Gr
 	}
 
 	return listers, notSynced
-}
-
-// NewDynamicDiscoverySharedInformerFactory returns a factory for shared
-// informers that discovers new types and informs on updates to resources of
-// those types.
-func NewDynamicDiscoverySharedInformerFactory(
-	workspaceLister tenancylisters.ClusterWorkspaceLister,
-	disco clusterDiscovery,
-	dynClient dynamic.Interface,
-	filterFunc func(obj interface{}) bool,
-	pollInterval time.Duration,
-) *DynamicDiscoverySharedInformerFactory {
-	f := &DynamicDiscoverySharedInformerFactory{
-		workspaceLister:  workspaceLister,
-		disco:            disco,
-		dynamicClient:    dynClient,
-		filterFunc:       filterFunc,
-		pollInterval:     pollInterval,
-		informers:        make(map[schema.GroupVersionResource]informers.GenericInformer),
-		informerStops:    make(map[schema.GroupVersionResource]chan struct{}),
-		startedInformers: make(map[schema.GroupVersionResource]bool),
-	}
-
-	f.handlers.Store([]GVREventHandler{})
-
-	return f
 }
 
 // GVREventHandler is an event handler that includes the GroupVersionResource
@@ -244,129 +312,114 @@ func (d *DynamicDiscoverySharedInformerFactory) AddEventHandler(handler GVREvent
 	d.handlersLock.Unlock()
 }
 
-func (d *DynamicDiscoverySharedInformerFactory) AddIndexers(indexers cache.Indexers) error {
-	if d.indexers == nil {
-		d.indexers = map[string]cache.IndexFunc{}
-	}
-	for name, indexer := range indexers {
-		if _, found := d.indexers[name]; found {
-			return fmt.Errorf("indexer %q already exists", name)
-		}
-		d.indexers[name] = indexer
-	}
+// StartWorker starts the worker that waits for notifications that informer updates are needed. This call is blocking,
+// stopping when ctx.Done() is closed.
+func (d *DynamicDiscoverySharedInformerFactory) StartWorker(ctx context.Context) {
+	defer func() {
+		d.informersLock.Lock()
 
-	return nil
-}
-
-// StartPolling starts the polling process that periodically discovers new resources and starts informers for them.
-// This call is non-blocking.
-func (d *DynamicDiscoverySharedInformerFactory) StartPolling(ctx context.Context) {
-	// Immediately discover types and start informing.
-	if err := wait.PollImmediateInfiniteWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
-		if err := d.discoverTypes(ctx); err != nil {
-			klog.Errorf("Error discovering initial types: %v", err)
-			return false, nil
+		for _, stopCh := range d.informerStops {
+			close(stopCh)
 		}
-		return true, nil
-	}); err != nil {
-		klog.Errorf("Error discovering initial types: %v", err)
+
+		d.informersLock.Unlock()
+	}()
+
+	if !cache.WaitForNamedCacheSync("kcp-ddsif-crd", ctx.Done(), d.crdInformerSynced) {
+		klog.Errorf("CRD informer never synced")
 		return
 	}
 
-	// Poll for new types in the background.
-	ticker := time.NewTicker(d.pollInterval)
-	go func() {
-		defer func() {
-			d.mu.Lock()
-			defer d.mu.Unlock()
+	// Now that the CRD informer has synced, do an initial update
+	d.updateInformers()
 
-			// tear down all informers when done.
-			for _, stopCh := range d.informerStops {
-				close(stopCh)
-			}
-
-			// Note: it does not matter if after this another informer is added. It won't be started without
-			// calling discoverTypes.
-		}()
-
-		for {
-			select {
-			case <-ctx.Done():
-				ticker.Stop()
-				return
-			case <-ticker.C:
-				if err := d.discoverTypes(ctx); err != nil {
-					klog.Errorf("Error discovering types: %v", err)
-				}
-			}
+	// Use UntilWithContext here so that we only check updateCh at most once every second. Because a flurry of several
+	// watch events for CRDs can come in quickly, this effectively "batches" them, so we aren't recalculating the
+	// informers for each watch event in a tightly grouped set of events.
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		klog.V(5).InfoS("Waiting for notification")
+		select {
+		case <-ctx.Done():
+			return
+		case <-d.updateCh:
 		}
-	}()
+
+		klog.V(5).InfoS("Notification received")
+		d.updateInformers()
+	}, time.Second)
 }
 
-func (d *DynamicDiscoverySharedInformerFactory) discoverTypes(ctx context.Context) error {
-	latest := map[schema.GroupVersionResource]struct{}{}
-
-	// Get a list of all the logical cluster names. We'll get discovery from all of them, union all the GVRs, and use
-	// that union for the informer.
-
-	// TODO(ncdc): this may not scale well. Watchable discovery or something like that
-	// is a better long term solution.
-	workspaces, err := d.workspaceLister.List(labels.Everything())
-	if err != nil {
-		return err
+func gvrFor(group, version, resource string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    group,
+		Version:  version,
+		Resource: resource,
 	}
-	for i := range workspaces {
-		logicalClusterName := logicalcluster.From(workspaces[i]).Join(workspaces[i].Name).String()
+}
 
-		klog.Infof("Discovering types for logical cluster %q", logicalClusterName)
-		rs, err := d.disco.WithCluster(logicalcluster.New(logicalClusterName)).ServerPreferredResources()
-		if err != nil {
-			return err
-		}
-		for _, r := range rs {
-			gv, err := schema.ParseGroupVersion(r.GroupVersion)
-			if err != nil {
-				return err
-			}
-			for _, ai := range r.APIResources {
-				gvr := gv.WithResource(ai.Name)
+func builtInInformableTypes() map[schema.GroupVersionResource]struct{} {
+	// Hard-code built in types that support list+watch
+	latest := map[schema.GroupVersionResource]struct{}{
+		gvrFor("", "v1", "configmaps"):                                                   {},
+		gvrFor("", "v1", "events"):                                                       {},
+		gvrFor("", "v1", "limitranges"):                                                  {},
+		gvrFor("", "v1", "namespaces"):                                                   {},
+		gvrFor("", "v1", "resourcequotas"):                                               {},
+		gvrFor("", "v1", "secrets"):                                                      {},
+		gvrFor("", "v1", "serviceaccounts"):                                              {},
+		gvrFor("certificates.k8s.io", "v1", "certificatesigningrequests"):                {},
+		gvrFor("coordination.k8s.io", "v1", "leases"):                                    {},
+		gvrFor("rbac.authorization.k8s.io", "v1", "clusterroles"):                        {},
+		gvrFor("rbac.authorization.k8s.io", "v1", "clusterrolebindings"):                 {},
+		gvrFor("rbac.authorization.k8s.io", "v1", "roles"):                               {},
+		gvrFor("rbac.authorization.k8s.io", "v1", "rolebindings"):                        {},
+		gvrFor("flowcontrol.apiserver.k8s.io", "v1beta2", "flowschemas"):                 {},
+		gvrFor("flowcontrol.apiserver.k8s.io", "v1beta2", "prioritylevelconfigurations"): {},
+		gvrFor("events.k8s.io", "v1", "events"):                                          {},
+		gvrFor("admissionregistration.k8s.io", "v1", "mutatingwebhookconfigurations"):    {},
+		gvrFor("admissionregistration.k8s.io", "v1", "validatingwebhookconfigurations"):  {},
+		gvrFor("apiextensions.k8s.io", "v1", "customresourcedefinitions"):                {},
+	}
 
-				if strings.Contains(ai.Name, "/") {
-					// foo/status, pods/exec, namespace/finalize, etc.
-					continue
-				}
-				if !ai.Namespaced {
-					// Ignore cluster-scoped things.
-					continue
-				}
-				if !sets.NewString([]string(ai.Verbs)...).HasAll("list", "watch") {
-					klog.V(4).InfoS("resource is not list+watchable", "logical-cluster", logicalClusterName, "group", gv.Group, "version", gv.Version, "resource", ai.Name, "verbs", ai.Verbs)
-					continue
-				}
+	return latest
+}
 
-				latest[gvr] = struct{}{}
-			}
-		}
+func (d *DynamicDiscoverySharedInformerFactory) updateInformers() {
+	klog.V(5).InfoS("Determining dynamic informer additions and removals")
+
+	latest := builtInInformableTypes()
+
+	// Get the unique set of Group(Version)Resources (version doesn't matter because we're expecting a wildcard
+	// partial metadata client, but we need a version in the request, so we need it here) and add them to latest.
+	crdGVRs := d.crdIndexer.ListIndexFuncValues(byGroupFirstFoundVersionResourceIndex)
+	for _, s := range crdGVRs {
+		parts := strings.Split(s, "/")
+		group := parts[0]
+		version := parts[1]
+		resource := parts[2]
+		latest[gvrFor(group, version, resource)] = struct{}{}
 	}
 
 	// Grab a read lock to compare against d.informers to see if we need to start or stop any informers
-	d.mu.RLock()
+	d.informersLock.RLock()
 	informersToAdd, informersToRemove := d.calculateInformersLockHeld(latest)
-	d.mu.RUnlock()
+	d.informersLock.RUnlock()
 
 	if len(informersToAdd) == 0 && len(informersToRemove) == 0 {
-		return nil
+		klog.V(5).InfoS("No changes")
+		return
 	}
 
 	// We have to add/remove, so we need the write lock
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.informersLock.Lock()
+	defer d.informersLock.Unlock()
 
 	// Recalculate in case another goroutine did this work in between when we had the read lock and when we acquired
 	// the write lock
 	informersToAdd, informersToRemove = d.calculateInformersLockHeld(latest)
 	if len(informersToAdd) == 0 && len(informersToRemove) == 0 {
-		return nil
+		klog.V(5).InfoS("No changes")
+		return
 	}
 
 	// Now we definitely need to do this work
@@ -374,10 +427,7 @@ func (d *DynamicDiscoverySharedInformerFactory) discoverTypes(ctx context.Contex
 		gvr := informersToAdd[i]
 
 		// We have the write lock, so call the LH variant
-		inf, err := d.informerForResourceLockHeld(gvr)
-		if err != nil {
-			return err
-		}
+		inf := d.informerForResourceLockHeld(gvr)
 
 		// Set up a stop channel for this specific informer
 		stop := make(chan struct{})
@@ -391,7 +441,7 @@ func (d *DynamicDiscoverySharedInformerFactory) discoverTypes(ctx context.Contex
 	for i := range informersToRemove {
 		gvr := informersToRemove[i]
 
-		klog.Infof("Removing dynamic informer for %q", gvr)
+		klog.V(2).Infof("Removing dynamic informer for %q", gvr)
 
 		stop, ok := d.informerStops[gvr]
 		if ok {
@@ -404,16 +454,14 @@ func (d *DynamicDiscoverySharedInformerFactory) discoverTypes(ctx context.Contex
 		delete(d.informerStops, gvr)
 		delete(d.startedInformers, gvr)
 	}
-
-	return nil
 }
 
 // Start starts any informers that have been created but not yet started. The passed in stop channel is ignored;
 // instead, a new stop channel is created, so the factory can properly stop the informer if/when the API is removed.
 // Like other shared informer factories, this call is non-blocking.
 func (d *DynamicDiscoverySharedInformerFactory) Start(_ <-chan struct{}) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	d.informersLock.Lock()
+	defer d.informersLock.Unlock()
 
 	for gvr, informer := range d.informers {
 		if !d.startedInformers[gvr] {
@@ -428,11 +476,6 @@ func (d *DynamicDiscoverySharedInformerFactory) Start(_ <-chan struct{}) {
 	}
 }
 
-var (
-	crdGVR         = apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions")
-	apibindingsGVR = apisv1alpha1.SchemeGroupVersion.WithResource("apibindings")
-)
-
 func (d *DynamicDiscoverySharedInformerFactory) calculateInformersLockHeld(latest map[schema.GroupVersionResource]struct{}) (toAdd, toRemove []schema.GroupVersionResource) {
 	for gvr := range latest {
 		if _, found := d.informers[gvr]; !found {
@@ -441,11 +484,6 @@ func (d *DynamicDiscoverySharedInformerFactory) calculateInformersLockHeld(lates
 	}
 
 	for gvr := range d.informers {
-		// HACK(ncdc): these are needed by our kubeQuota controller - don't delete them
-		if gvr == crdGVR || gvr == apibindingsGVR {
-			continue
-		}
-
 		if _, found := latest[gvr]; !found {
 			toRemove = append(toRemove, gvr)
 		}

--- a/pkg/informer/informer_test.go
+++ b/pkg/informer/informer_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/api/genericcontrolplanescheme"
+	_ "k8s.io/kubernetes/pkg/genericcontrolplane/apis/install"
+)
+
+// TestBuiltInInformableTypes tests that there is no drift between actual built-in types and the list that is hard-coded
+// in builtInInformableTypes.
+func TestBuiltInInformableTypes(t *testing.T) {
+	builtInGVRs := map[schema.GroupVersionResource]struct{}{}
+
+	// In the scheme, but not actual resources
+	kindsToIgnore := sets.NewString(
+		"List",
+		"CreateOptions",
+		"DeleteOptions",
+		"GetOptions",
+		"ListOptions",
+		"PatchOptions",
+		"UpdateOptions",
+		"WatchEvent",
+	)
+
+	// Internal types and/or things that are not list/watchable
+	gvksToIgnore := map[schema.GroupVersionKind]struct{}{
+		{Version: "v1", Kind: "APIGroup"}:                                                {},
+		{Version: "v1", Kind: "APIVersions"}:                                             {},
+		{Version: "v1", Kind: "RangeAllocation"}:                                         {},
+		{Version: "v1", Kind: "SerializedReference"}:                                     {},
+		{Version: "v1", Kind: "Status"}:                                                  {},
+		{Group: "authentication.k8s.io", Version: "v1", Kind: "TokenRequest"}:            {},
+		{Group: "authentication.k8s.io", Version: "v1", Kind: "TokenReview"}:             {},
+		{Group: "authorization.k8s.io", Version: "v1", Kind: "LocalSubjectAccessReview"}: {},
+		{Group: "authorization.k8s.io", Version: "v1", Kind: "SelfSubjectAccessReview"}:  {},
+		{Group: "authorization.k8s.io", Version: "v1", Kind: "SelfSubjectRulesReview"}:   {},
+		{Group: "authorization.k8s.io", Version: "v1", Kind: "SubjectAccessReview"}:      {},
+	}
+
+	gvsToIgnore := map[schema.GroupVersion]struct{}{
+		// Covered by Group=""
+		{Group: "core", Version: "v1"}: {},
+
+		// These are alpha/beta versions that are not preferred (they all have v1)
+		{Group: "admissionregistration.k8s.io", Version: "v1beta1"}:  {},
+		{Group: "authentication.k8s.io", Version: "v1beta1"}:         {},
+		{Group: "authorization.k8s.io", Version: "v1beta1"}:          {},
+		{Group: "certificates.k8s.io", Version: "v1beta1"}:           {},
+		{Group: "coordination.k8s.io", Version: "v1beta1"}:           {},
+		{Group: "events.k8s.io", Version: "v1beta1"}:                 {},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1alpha1"}: {},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"}:  {},
+		{Group: "rbac.authorization.k8s.io", Version: "v1alpha1"}:    {},
+		{Group: "rbac.authorization.k8s.io", Version: "v1beta1"}:     {},
+	}
+
+	allKnownTypes := genericcontrolplanescheme.Scheme.AllKnownTypes()
+
+	// CRDs are not included in the genericcontrolplane scheme (because they're part of the apiextensions apiserver),
+	// so we have to manually add them
+	allKnownTypes[schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}] = reflect.TypeOf(struct{}{})
+
+	for gvk := range allKnownTypes {
+		if kindsToIgnore.Has(gvk.Kind) {
+			continue
+		}
+
+		if _, found := gvsToIgnore[gvk.GroupVersion()]; found {
+			continue
+		}
+
+		if _, found := gvksToIgnore[gvk]; found {
+			continue
+		}
+
+		if strings.HasSuffix(gvk.Kind, "List") {
+			continue
+		}
+		if gvk.Version == "__internal" {
+			continue
+		}
+
+		resourceName := strings.ToLower(gvk.Kind) + "s"
+		gvr := gvk.GroupVersion().WithResource(resourceName)
+
+		builtInGVRs[gvr] = struct{}{}
+	}
+
+	require.Empty(t, cmp.Diff(builtInGVRs, builtInInformableTypes()))
+}

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -127,7 +127,6 @@ var (
 		"tracing-config-file", // File with apiserver tracing configuration.
 
 		// KCP flags
-		"discovery-poll-interval",     // Polling interval for dynamic discovery informers.
 		"profiler-address",            // [Address]:port to bind the profiler to
 		"root-directory",              // Root directory.
 		"shard-base-url",              // Base URL to this kcp shard. Defaults to external address.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -158,7 +158,6 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.Extra.ShardExternalURL, "shard-external-url", o.Extra.ShardExternalURL, "URL used by outside clients to talk to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")
 	fs.StringVar(&o.Extra.RootDirectory, "root-directory", o.Extra.RootDirectory, "Root directory.")
-	fs.DurationVar(&o.Extra.DiscoveryPollInterval, "discovery-poll-interval", o.Extra.DiscoveryPollInterval, "Polling interval for dynamic discovery informers.")
 
 	fs.BoolVar(&o.Extra.ExperimentalBindFreePort, "experimental-bind-free-port", o.Extra.ExperimentalBindFreePort, "Bind to a free port. --secure-port must be 0. Use the admin.kubeconfig to extract the chosen port.")
 	fs.MarkHidden("experimental-bind-free-port") // nolint:errcheck
@@ -181,10 +180,6 @@ func (o *CompletedOptions) Validate() []error {
 	errs = append(errs, o.Authorization.Validate()...)
 	errs = append(errs, o.AdminAuthentication.Validate()...)
 	errs = append(errs, o.Virtual.Validate()...)
-
-	if o.Extra.DiscoveryPollInterval == 0 {
-		errs = append(errs, fmt.Errorf("--discovery-poll-interval not set"))
-	}
 
 	return errs
 }

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -30,6 +30,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,10 +44,9 @@ import (
 	tenancyapi "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
-	bootstrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
@@ -160,8 +160,7 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 
 	// Make sure the informers aren't throttled because dynamic informers do lots of discovery which slows down tests
 	cfg := server.DefaultConfig(t)
-	cfg.QPS = 500
-	cfg.Burst = 1000
+	cfg.QPS = -1
 
 	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct apiextensions client for server")
@@ -218,26 +217,32 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	_, err = rootShardMetadataClusterClient.Cluster(logicalcluster.Wildcard).Resource(sheriffsGVR).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "expected wildcard list to work with metadata client even though schemas are different")
 
-	t.Log("Start dynamic metadata informers")
-	identityRootCfg, resolve := bootstrap.NewConfigWithWildcardIdentities(rootCfg, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, kcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
-	require.Eventually(t, func() bool {
-		return resolve(ctx) == nil
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-	identityRootKcpClusterClient, err := kcpclientset.NewClusterForConfig(identityRootCfg)
-	require.NoError(t, err, "failed to construct kcp cluster client for server with identitis")
-	rootShardKcpInformer := kcpinformers.NewSharedInformerFactoryWithOptions(identityRootKcpClusterClient.Cluster(logicalcluster.Wildcard), 0)
-	rootShardKcpInformer.Tenancy().V1alpha1().ClusterWorkspaces().Lister()
-	rootShardKcpInformer.Start(ctx.Done())
-	rootShardKcpInformer.WaitForCacheSync(ctx.Done())
+	rootShardCRDClusterClient, err := apiextensionsclient.NewClusterForConfig(rootCfg)
+	require.NoError(t, err, "error creating root shard crd client")
 
-	informerFactory := informer.NewDynamicDiscoverySharedInformerFactory(
-		rootShardKcpInformer.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
-		identityRootKcpClusterClient.DiscoveryClient,
-		rootShardMetadataClusterClient.Cluster(logicalcluster.Wildcard),
-		func(obj interface{}) bool { return true },
-		time.Second*2,
+	apiExtensionsInformerFactory := apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
+		rootShardCRDClusterClient.Cluster(logicalcluster.Wildcard),
+		0,
 	)
-	informerFactory.StartPolling(ctx)
+
+	informerFactory, err := informer.NewDynamicDiscoverySharedInformerFactory(
+		rootCfg,
+		func(obj interface{}) bool { return true },
+		apiExtensionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		indexers.NamespaceScoped(),
+	)
+	require.NoError(t, err, "error creating DynamicDiscoverySharedInformerFactory")
+
+	// Have to start this after informer.NewDynamicDiscoverySharedInformerFactory() is invoked, as that adds an
+	// index to the crd informer that is required for the dynamic factory to work correctly.
+	t.Log("Start apiextensions informers")
+	apiExtensionsInformerFactory.Start(ctx.Done())
+	cacheSyncCtx, cacheSyncCancel := context.WithTimeout(ctx, wait.ForeverTestTimeout)
+	t.Cleanup(cacheSyncCancel)
+	apiExtensionsInformerFactory.WaitForCacheSync(cacheSyncCtx.Done())
+
+	t.Log("Start dynamic metadata informers")
+	go informerFactory.StartWorker(ctx)
 
 	t.Logf("Wait for the sheriff to show up in the informer")
 	// key := "default/" + clusters.ToClusterAwareKey(wsNormalCRD1a, "john-hicks-adams")

--- a/test/e2e/framework/fixture.go
+++ b/test/e2e/framework/fixture.go
@@ -81,7 +81,6 @@ func TestServerArgs() []string {
 // start a test server with the given token auth file.
 func TestServerArgsWithTokenAuthFile(tokenAuthFile string) []string {
 	return []string{
-		"--discovery-poll-interval=5s",
 		"-v=4",
 		"--token-auth-file", tokenAuthFile,
 	}

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,14 +41,9 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 
-	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/informer"
-	metadataclient "github.com/kcp-dev/kcp/pkg/metadata"
-	boostrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest"
 	wildwestv1alpha1 "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest/v1alpha1"
@@ -252,12 +248,11 @@ func collectCacheHitsFor(ctx context.Context, t *testing.T, config *rest.Config,
 	return totalCacheHits, prefixCacheHit
 }
 
-const resyncPeriod = 10 * time.Hour
 const byWorkspace = "byWorkspace"
 
 func testDynamicDiscoverySharedInformerFactory(ctx context.Context, t *testing.T, config *rest.Config, expectedGVR schema.GroupVersionResource, expectedResName string, expectedClusterName logicalcluster.Name) {
 	nonIdentityKcpClusterClient, err := kcpclientset.NewClusterForConfig(config) // can only used for wildcard requests of apis.kcp.dev
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to construct apiextensions client")
 
 	// since wildcard request are only allowed against a shard
 	// create a cfg that points to the root shard and use it to create ddsif
@@ -265,36 +260,27 @@ func testDynamicDiscoverySharedInformerFactory(ctx context.Context, t *testing.T
 	rootConfig.QPS = 100
 	rootConfig.Burst = 200
 
-	// resolve identities for system APIBindings
-	identityRootConfig, resolveIdentities := boostrap.NewConfigWithWildcardIdentities(rootConfig, boostrap.KcpRootGroupExportNames, boostrap.KcpRootGroupResourceExportNames, nonIdentityKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
-	require.Eventually(t, func() bool {
-		if err := resolveIdentities(ctx); err != nil {
-			klog.Errorf("failed to resolve identities, keeping trying: %v", err)
-			return false
-		}
-		return true
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
+	crdClusterClient, err := apiextensionsclient.NewClusterForConfig(rootConfig)
+	require.NoError(t, err, "failed to construct apiextensions client")
 
-	rootKcpClusterClient, err := kcpclientset.NewClusterForConfig(identityRootConfig)
-	require.NoError(t, err)
-	rootKcpSharedInformerFactory := kcpexternalversions.NewSharedInformerFactoryWithOptions(rootKcpClusterClient.Cluster(logicalcluster.Wildcard), resyncPeriod)
-	rootMetadataClusterClient, err := metadataclient.NewDynamicMetadataClusterClientForConfig(rootConfig) // no identites necessary for partial metadata
-	require.NoError(t, err)
-	ddsif := informer.NewDynamicDiscoverySharedInformerFactory(
-		rootKcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces().Lister(),
-		rootKcpClusterClient.DiscoveryClient,
-		rootMetadataClusterClient.Cluster(logicalcluster.Wildcard),
-		func(obj interface{}) bool { return true }, 5*time.Second,
+	apiExtensionsInformerFactory := apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
+		crdClusterClient.Cluster(logicalcluster.Wildcard),
+		0,
 	)
-	err = ddsif.AddIndexers(cache.Indexers{byWorkspace: indexByWorkspace})
-	require.NoError(t, err)
 
-	t.Log("Starting KCP Shared Informer Factory")
-	rootKcpSharedInformerFactory.Start(ctx.Done())
-	t.Log("Waiting for KCP Shared Informer Factory to sync caches")
-	rootKcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
+	ddsif, err := informer.NewDynamicDiscoverySharedInformerFactory(
+		rootConfig,
+		func(obj interface{}) bool { return true },
+		apiExtensionsInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		cache.Indexers{byWorkspace: indexByWorkspace},
+	)
+	require.NoError(t, err, "error creating DynamicDiscoverySharedInformerFactory")
+
+	t.Log("Starting apiextensions shared informer factory")
+	apiExtensionsInformerFactory.Start(ctx.Done())
+
 	t.Log("Starting DynamicDiscoverySharedInformerFactory")
-	ddsif.StartPolling(context.Background())
+	go ddsif.StartWorker(ctx)
 
 	t.Logf("Checking if DynamicDiscoverySharedInformerFactory has %v with name %v in cluster %v", expectedGVR.String(), expectedResName, expectedClusterName)
 	framework.Eventually(t, func() (success bool, reason string) {


### PR DESCRIPTION
Backport of #1473.

Replace the polling mechanism that wouldn't scale as the number of
ClusterWorkspaces increased with one that is based on a fixed-set of
built-in types + a dynamic set of informers driven by all the unique
group-resources across all the CRDs in the system.