### PR TITLE
logging: move clusterworkspaceshard reconciler to structured logging

### DIFF
--- a/pkg/logging/constants.go
+++ b/pkg/logging/constants.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logging supplies common constants to ensure consistent use of structured logs.
+package logging
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ReconcilerKey is used to identify a reconciler.
+	ReconcilerKey = "reconciler"
+
+	// QueueKeyKey is used to expose the workqueue key being processed.
+	QueueKeyKey = "key"
+
+	// WorkspaceKey is used to specify a workspace when a log is related to an object.
+	WorkspaceKey = "workspace"
+	// NamespaceKey is used to specify a namespace when a log is related to an object.
+	NamespaceKey = "namespace"
+	// NameKey is used to specify a name when a log is related to an object.
+	NameKey = "name"
+)
+
+// WithReconciler adds the reconciler name to the logger.
+func WithReconciler(logger logr.Logger, reconciler string) logr.Logger {
+	return logger.WithValues(ReconcilerKey, reconciler)
+}
+
+// WithQueueKey adds the queue key to the logger.
+func WithQueueKey(logger logr.Logger, key string) logr.Logger {
+	return logger.WithValues(QueueKeyKey, key)
+}
+
+// WithObject adds object identifiers to the logger.
+func WithObject(logger logr.Logger, obj metav1.Object) logr.Logger {
+	return logger.WithValues(From(obj)...)
+}
+
+// From provides the structured logging fields that identify an object.
+func From(obj metav1.Object) []interface{} {
+	return []interface{}{
+		WorkspaceKey,
+		logicalcluster.From(obj).String(),
+		NamespaceKey,
+		obj.GetNamespace(),
+		NameKey,
+		obj.GetName(),
+	}
+}

--- a/pkg/reconciler/tenancy/clusterworkspaceshard/clusterworkspaceshard_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspaceshard/clusterworkspaceshard_controller.go
@@ -19,6 +19,7 @@ package clusterworkspaceshard
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -26,7 +27,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -39,6 +40,7 @@ import (
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	tenancyinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/tenancy/v1alpha1"
 	tenancylister "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/logging"
 )
 
 const (
@@ -83,7 +85,8 @@ func (c *Controller) enqueue(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	klog.Infof("queueing workspace shard %q", key)
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), controllerName), key)
+	logger.Info("queueing workspace shard")
 	c.queue.Add(key)
 }
 
@@ -91,8 +94,10 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	defer runtime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	klog.Info("Starting ClusterWorkspaceShard controller")
-	defer klog.Info("Shutting down ClusterWorkspaceShard controller")
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
 
 	for i := 0; i < numThreads; i++ {
 		go wait.Until(func() { c.startWorker(ctx) }, time.Second, ctx.Done())
@@ -114,7 +119,9 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	}
 	key := k.(string)
 
-	klog.Infof("processing key %q", key)
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("processing key")
 
 	// No matter what, tell the queue we're done with this key, to unblock
 	// other workers.
@@ -130,25 +137,29 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (c *Controller) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		klog.Errorf("invalid key: %q: %v", key, err)
+		logger.Error(err, "invalid key")
 		return nil
 	}
 	if namespace != "" {
-		klog.Errorf("namespace %q found in key for cluster-wide ClusterWorkspaceShard object", namespace)
+		logger.Error(errors.New("namespace found in key for cluster-wide ClusterWorkspaceShard object"), "invalid key")
 		return nil
 	}
 
 	obj, err := c.rootWorkspaceShardLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			return nil // object deleted before we handled it
 		}
 		return err
 	}
 	previous := obj
 	obj = obj.DeepCopy()
+
+	logger = logging.WithObject(logger, obj)
+	ctx = klog.NewContext(ctx, logger)
 
 	if err := c.reconcile(ctx, obj); err != nil {
 		return err
@@ -182,6 +193,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		return uerr
 	}
 
+	logger.V(6).Info("processed ClusterWorkspaceShard")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Example output:

```
clusterworkspaceshard_controller.go:99] "Starting controller" reconciler="clusterworkspaceshard"
clusterworkspaceshard_controller.go:88] "queueing workspace shard" reconciler="clusterworkspaceshard" key="root|root"
clusterworkspaceshard_controller.go:125] "processing key" reconciler="clusterworkspaceshard" key="root|root"
clusterworkspaceshard_controller.go:197] "processed ClusterWorkspaceShard" reconciler="clusterworkspaceshard" key="root|root" workspace="root" namespace="" name="root"
clusterworkspaceshard_controller.go:88] "queueing workspace shard" reconciler="clusterworkspaceshard" key="root|root"
clusterworkspaceshard_controller.go:125] "processing key" reconciler="clusterworkspaceshard" key="root|root"
clusterworkspaceshard_controller.go:197] "processed ClusterWorkspaceShard" reconciler="clusterworkspaceshard" key="root|root" workspace="root" namespace="" name="root"
clusterworkspaceshard_controller.go:107] "Shutting down controller" reconciler="clusterworkspaceshard"

```

/cc @ncdc @sttts 