### PR TITLE
Refactor ns scheduler for location workspace

### DIFF
--- a/pkg/apis/workload/v1alpha1/types.go
+++ b/pkg/apis/workload/v1alpha1/types.go
@@ -112,4 +112,8 @@ const (
 	// AnnotationSkipDefaultObjectCreation is the annotation key for an apiexport or apibinding indicating the other default resources
 	// has been created already. If the created default resource is deleted, it will not be recreated.
 	AnnotationSkipDefaultObjectCreation = "workload.kcp.dev/skip-default-object-creation"
+
+	// InternalSyncTargetPlacementAnnotationKey is a internal annotation key on placement API to mark the synctarget scheduled
+	// from this placement. The value is {location workspace}/{syncTarget name}
+	InternalSyncTargetPlacementAnnotationKey = "internal.workload.kcp.dev/synctarget"
 )

--- a/pkg/reconciler/workload/namespace/namespace_reconcile_scheduling.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile_scheduling.go
@@ -38,7 +38,9 @@ import (
 
 const removingGracePeriod = 5 * time.Second
 
-// placementSchedulingReconciler sync scheduled synctarget on placement to for this ns.
+// placementSchedulingReconciler reconciles the state.workload.kcp.dev/<syncTarget> labels according the
+// selected synctarget stored in the internal.workload.kcp.dev/synctarget annotation
+// on each placement.
 type placementSchedulingReconciler struct {
 	listPlacement func(clusterName logicalcluster.Name) ([]*schedulingv1alpha1.Placement, error)
 

--- a/pkg/reconciler/workload/placement/placement_controller.go
+++ b/pkg/reconciler/workload/placement/placement_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The KCP Authors.
+Copyright 2022 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/reconciler/workload/placement/placement_controller.go
+++ b/pkg/reconciler/workload/placement/placement_controller.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	schedulinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
+	workloadinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/workload/v1alpha1"
+	schedulinglisters "github.com/kcp-dev/kcp/pkg/client/listers/scheduling/v1alpha1"
+	workloadlisters "github.com/kcp-dev/kcp/pkg/client/listers/workload/v1alpha1"
+)
+
+const (
+	controllerName      = "kcp-workload-placement"
+	byWorkspace         = controllerName + "-byWorkspace" // will go away with scoping
+	byLocationWorkspace = controllerName + "-byLocationWorkspace"
+)
+
+// NewController returns a new controller starting the process of selecting synctarget for a placement
+func NewController(
+	kcpClusterClient kcpclient.Interface,
+	locationInformer schedulinginformers.LocationInformer,
+	syncTargetInformer workloadinformers.SyncTargetInformer,
+	placementInformer schedulinginformers.PlacementInformer,
+) (*controller, error) {
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName)
+
+	c := &controller{
+		queue: queue,
+
+		kcpClusterClient: kcpClusterClient,
+
+		locationLister:  locationInformer.Lister(),
+		locationIndexer: locationInformer.Informer().GetIndexer(),
+
+		syncTargetLister:  syncTargetInformer.Lister(),
+		syncTargetIndexer: syncTargetInformer.Informer().GetIndexer(),
+
+		placmentLister:   placementInformer.Lister(),
+		placementIndexer: placementInformer.Informer().GetIndexer(),
+	}
+
+	if err := locationInformer.Informer().AddIndexers(cache.Indexers{
+		byWorkspace: indexByWorksapce,
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := syncTargetInformer.Informer().AddIndexers(cache.Indexers{
+		byWorkspace: indexByWorksapce,
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := placementInformer.Informer().AddIndexers(cache.Indexers{
+		byWorkspace:         indexByWorksapce,
+		byLocationWorkspace: indexByLoactionWorkspace,
+	}); err != nil {
+		return nil, err
+	}
+
+	locationInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueLocation,
+			UpdateFunc: func(old, obj interface{}) {
+				oldLoc := old.(*schedulingv1alpha1.Location)
+				newLoc := obj.(*schedulingv1alpha1.Location)
+				if !reflect.DeepEqual(oldLoc.Spec, newLoc.Spec) || !reflect.DeepEqual(oldLoc.Labels, newLoc.Labels) {
+					c.enqueueLocation(obj)
+				}
+			},
+			DeleteFunc: c.enqueueLocation,
+		},
+	)
+
+	syncTargetInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueSyncTarget,
+			UpdateFunc: func(old, obj interface{}) {
+				oldCluster := old.(*workloadv1alpha1.SyncTarget)
+				oldClusterCopy := *oldCluster
+
+				// ignore fields that scheduler does not care
+				oldClusterCopy.ResourceVersion = "0"
+				oldClusterCopy.Status.LastSyncerHeartbeatTime = nil
+				oldClusterCopy.Status.VirtualWorkspaces = nil
+				oldClusterCopy.Status.Capacity = nil
+
+				newCluster := obj.(*workloadv1alpha1.SyncTarget)
+				newClusterCopy := *newCluster
+				newClusterCopy.ResourceVersion = "0"
+				newClusterCopy.Status.LastSyncerHeartbeatTime = nil
+				newClusterCopy.Status.VirtualWorkspaces = nil
+				newClusterCopy.Status.Capacity = nil
+
+				// compare ignoring heart-beat
+				if !reflect.DeepEqual(oldClusterCopy, newClusterCopy) {
+					c.enqueueSyncTarget(obj)
+				}
+			},
+			DeleteFunc: c.enqueueSyncTarget,
+		},
+	)
+
+	placementInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.enqueuePlacement(obj, "") },
+		UpdateFunc: func(_, obj interface{}) { c.enqueuePlacement(obj, "") },
+		DeleteFunc: func(obj interface{}) { c.enqueuePlacement(obj, "") },
+	})
+
+	return c, nil
+}
+
+// controller
+type controller struct {
+	queue workqueue.RateLimitingInterface
+
+	kcpClusterClient kcpclient.Interface
+
+	locationLister  schedulinglisters.LocationLister
+	locationIndexer cache.Indexer
+
+	syncTargetLister  workloadlisters.SyncTargetLister
+	syncTargetIndexer cache.Indexer
+
+	placmentLister   schedulinglisters.PlacementLister
+	placementIndexer cache.Indexer
+}
+
+// enqueueLocation finds placement ref to this location at first, and then namespaces bound to this placement.
+func (c *controller) enqueueLocation(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(key)
+
+	placements, err := c.placementIndexer.ByIndex(byLocationWorkspace, clusterName.String())
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	for _, obj := range placements {
+		c.enqueuePlacement(obj, fmt.Sprintf(" because of Location %s", key))
+	}
+}
+
+func (c *controller) enqueuePlacement(obj interface{}, logSuffix string) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, name := clusters.SplitClusterAwareKey(key)
+
+	klog.V(2).Infof("Queueing Namespace %s|%s", clusterName.String(), name)
+	c.queue.Add(key)
+}
+
+func (c *controller) enqueueSyncTarget(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(key)
+
+	placements, err := c.placementIndexer.ByIndex(byLocationWorkspace, clusterName.String())
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	for _, obj := range placements {
+		c.enqueuePlacement(obj, fmt.Sprintf(" because of SyncTarget %s", key))
+	}
+}
+
+// Start starts the controller, which stops when ctx.Done() is closed.
+func (c *controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting %s controller", controllerName)
+	defer klog.Infof("Shutting down %s controller", controllerName)
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) process(ctx context.Context, key string) error {
+	obj, err := c.placmentLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil // object deleted before we handled it
+		}
+		return err
+	}
+	obj = obj.DeepCopy()
+
+	reconcileErr := c.reconcile(ctx, obj)
+
+	return reconcileErr
+}

--- a/pkg/reconciler/workload/placement/placement_indexes.go
+++ b/pkg/reconciler/workload/placement/placement_indexes.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"fmt"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+)
+
+func indexByWorksapce(obj interface{}) ([]string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
+	}
+
+	lcluster := logicalcluster.From(metaObj)
+	return []string{lcluster.String()}, nil
+}
+
+func indexByLoactionWorkspace(obj interface{}) ([]string, error) {
+	placement, ok := obj.(*schedulingv1alpha1.Placement)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a Placement, but is %T", obj)
+	}
+
+	if placement.Status.SelectedLocation == nil {
+		return []string{}, nil
+	}
+
+	return []string{placement.Status.SelectedLocation.Path}, nil
+}

--- a/pkg/reconciler/workload/placement/placement_reconcile.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	utilserrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/klog/v2"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+)
+
+type reconcileStatus int
+
+const (
+	reconcileStatusStop reconcileStatus = iota
+	reconcileStatusContinue
+)
+
+type reconciler interface {
+	reconcile(ctx context.Context, placement *schedulingv1alpha1.Placement) (reconcileStatus, *schedulingv1alpha1.Placement, error)
+}
+
+func (c *controller) reconcile(ctx context.Context, placement *schedulingv1alpha1.Placement) error {
+	reconcilers := []reconciler{
+		&placementSchedulingReconciler{
+			listSyncTarget: c.listSyncTarget,
+			getLocation:    c.getLocation,
+			patchPlacement: c.patchPlacement,
+		},
+	}
+
+	var errs []error
+
+	for _, r := range reconcilers {
+		var err error
+		var status reconcileStatus
+		status, placement, err = r.reconcile(ctx, placement)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if status == reconcileStatusStop {
+			break
+		}
+	}
+
+	return utilserrors.NewAggregate(errs)
+}
+
+func (c *controller) listSyncTarget(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
+	items, err := c.syncTargetIndexer.ByIndex(byWorkspace, clusterName.String())
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]*workloadv1alpha1.SyncTarget, 0, len(items))
+	for _, item := range items {
+		ret = append(ret, item.(*workloadv1alpha1.SyncTarget))
+	}
+	return ret, nil
+}
+
+func (c *controller) getLocation(clusterName logicalcluster.Name, name string) (*schedulingv1alpha1.Location, error) {
+	key := clusters.ToClusterAwareKey(clusterName, name)
+	return c.locationLister.Get(key)
+}
+
+func (c *controller) patchPlacement(ctx context.Context, clusterName logicalcluster.Name, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*schedulingv1alpha1.Placement, error) {
+	klog.V(2).Infof("Patching namespace %s|%s with patch %s", clusterName, name, string(data))
+	return c.kcpClusterClient.SchedulingV1alpha1().Placements().Patch(logicalcluster.WithCluster(ctx, clusterName), name, pt, data, opts, subresources...)
+}

--- a/pkg/reconciler/workload/placement/placement_reconcile_scheduling.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile_scheduling.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	locationreconciler "github.com/kcp-dev/kcp/pkg/reconciler/scheduling/location"
+)
+
+// placementSchedulingReconciler schedules a workload for this ns. It checks the current placement annotation on the ns,
+// and find all valid synctargets.
+type placementSchedulingReconciler struct {
+	listSyncTarget func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error)
+	getLocation    func(clusterName logicalcluster.Name, name string) (*schedulingv1alpha1.Location, error)
+	patchPlacement func(ctx context.Context, clusterName logicalcluster.Name, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*schedulingv1alpha1.Placement, error)
+}
+
+func (r *placementSchedulingReconciler) reconcile(ctx context.Context, placement *schedulingv1alpha1.Placement) (reconcileStatus, *schedulingv1alpha1.Placement, error) {
+	clusterName := logicalcluster.From(placement)
+
+	// 1. get current scheduled
+	expectedAnnotations := map[string]interface{}{} // nil means to remove the key
+	currentScheduled, foundScheduled := placement.Annotations[workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey]
+
+	// 2. pick all valid synctargets in this placements
+	syncTargetClusterName, syncTargets, err := r.getAllValidSyncTargetsForPlacement(clusterName, placement)
+	if err != nil {
+		return reconcileStatusStop, placement, err
+	}
+
+	// no valid synctarget, clean the annotationt.
+	if foundScheduled && len(syncTargets) == 0 {
+		expectedAnnotations[workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey] = nil
+		updated, err := r.patchPlacementAnnotation(ctx, clusterName, placement, expectedAnnotations)
+		return reconcileStatusContinue, updated, err
+	}
+
+	// 2. do nothing if scheduled cluster is in the valid clusters
+	if foundScheduled && len(syncTargets) > 0 {
+		scheduledSyncTargeClusterName, scheduledSyncTargeName := ParseCurrentScheduled(currentScheduled)
+		for _, syncTarget := range syncTargets {
+			if syncTargetClusterName != scheduledSyncTargeClusterName {
+				continue
+			}
+			if scheduledSyncTargeName != syncTarget.Name {
+				continue
+			}
+
+			return reconcileStatusContinue, placement, nil
+		}
+	}
+
+	// 3. randomly select one as the scheduled cluster
+	// TODO(qiujian16): we currently schedule each in each location independently. It cannot guarantee 1 cluster is scheduled per location
+	// when the same synctargets are in multiple locations, we need to rethink whether we need a better algorithm or we need location
+	// to be exclusive.
+	if len(syncTargets) > 0 {
+		scheduledSyncTarget := syncTargets[rand.Intn(len(syncTargets))]
+		expectedAnnotations[workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey] = fmt.Sprintf("%s/%s", syncTargetClusterName.String(), scheduledSyncTarget.Name)
+		updated, err := r.patchPlacementAnnotation(ctx, clusterName, placement, expectedAnnotations)
+		return reconcileStatusContinue, updated, err
+	}
+
+	return reconcileStatusContinue, placement, nil
+}
+
+func (r *placementSchedulingReconciler) getAllValidSyncTargetsForPlacement(clusterName logicalcluster.Name, placement *schedulingv1alpha1.Placement) (logicalcluster.Name, []*workloadv1alpha1.SyncTarget, error) {
+	if placement.Status.Phase == schedulingv1alpha1.PlacementPending || placement.Status.SelectedLocation == nil {
+		return logicalcluster.Name{}, nil, nil
+	}
+
+	locationWorkspace := logicalcluster.New(placement.Status.SelectedLocation.Path)
+	location, err := r.getLocation(
+		locationWorkspace,
+		placement.Status.SelectedLocation.LocationName)
+	switch {
+	case errors.IsNotFound(err):
+		return locationWorkspace, nil, nil
+	case err != nil:
+		return locationWorkspace, nil, err
+	}
+
+	// find all synctargets in the location workspace
+	syncTargets, err := r.listSyncTarget(locationWorkspace)
+	if err != nil {
+		return locationWorkspace, nil, err
+	}
+
+	// filter the sync targets by location
+	locationClusters, err := locationreconciler.LocationSyncTargets(syncTargets, location)
+	if err != nil {
+		return locationWorkspace, nil, err
+	}
+
+	// find all the valid sync targets.
+	validClusters := locationreconciler.FilterNonEvicting(locationreconciler.FilterReady(locationClusters))
+
+	return locationWorkspace, validClusters, nil
+}
+
+func (r *placementSchedulingReconciler) patchPlacementAnnotation(ctx context.Context, clusterName logicalcluster.Name, placement *schedulingv1alpha1.Placement, annotations map[string]interface{}) (*schedulingv1alpha1.Placement, error) {
+	patch := map[string]interface{}{}
+	if len(annotations) > 0 {
+		if err := unstructured.SetNestedField(patch, annotations, "metadata", "annotations"); err != nil {
+			return placement, err
+		}
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return placement, err
+	}
+	klog.V(3).Infof("Patching to update sync target information on placement %s|%s: %s",
+		clusterName, placement.Name, string(patchBytes))
+	updated, err := r.patchPlacement(ctx, clusterName, placement.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return placement, err
+	}
+	return updated, nil
+}
+
+func ParseCurrentScheduled(value string) (logicalcluster.Name, string) {
+	if len(value) == 0 {
+		return logicalcluster.Name{}, ""
+	}
+	comps := strings.SplitN(value, "/", 2)
+	return logicalcluster.New(comps[0]), comps[1]
+}

--- a/pkg/reconciler/workload/placement/placement_reconcile_scheduling.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile_scheduling.go
@@ -36,8 +36,9 @@ import (
 	locationreconciler "github.com/kcp-dev/kcp/pkg/reconciler/scheduling/location"
 )
 
-// placementSchedulingReconciler schedules a workload for this ns. It checks the current placement annotation on the ns,
-// and find all valid synctargets.
+// placementSchedulingReconciler schedules placments according to the selected locations.
+// It considers only valid SyncTargets and updates the internal.workload.kcp.dev/synctarget
+// annotation with the selected one on the placement object.
 type placementSchedulingReconciler struct {
 	listSyncTarget func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error)
 	getLocation    func(clusterName logicalcluster.Name, name string) (*schedulingv1alpha1.Location, error)
@@ -57,7 +58,7 @@ func (r *placementSchedulingReconciler) reconcile(ctx context.Context, placement
 		return reconcileStatusStop, placement, err
 	}
 
-	// no valid synctarget, clean the annotationt.
+	// no valid synctarget, clean the annotation.
 	if foundScheduled && len(syncTargets) == 0 {
 		expectedAnnotations[workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey] = nil
 		updated, err := r.patchPlacementAnnotation(ctx, clusterName, placement, expectedAnnotations)

--- a/pkg/reconciler/workload/placement/placement_reconcile_scheduling_test.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile_scheduling_test.go
@@ -23,16 +23,18 @@ import (
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
-	conditionsapi "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
-	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 )
 
 func TestSchedulingReconcile(t *testing.T) {

--- a/pkg/reconciler/workload/placement/placement_reconcile_scheduling_test.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile_scheduling_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
+	conditionsapi "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestSchedulingReconcile(t *testing.T) {
+	testCases := []struct {
+		name string
+
+		placement   *schedulingv1alpha1.Placement
+		location    *schedulingv1alpha1.Location
+		syncTargets []*workloadv1alpha1.SyncTarget
+
+		wantPatch           bool
+		expectedAnnotations map[string]string
+	}{
+		{
+			name:      "no location",
+			placement: newPlacement("test", "test-location", ""),
+		},
+		{
+			name:      "no synctarget",
+			placement: newPlacement("test", "test-location", ""),
+			location:  newLocation("test-location"),
+		},
+		{
+			name:        "schedule one synctarget",
+			placement:   newPlacement("test", "test-location", ""),
+			location:    newLocation("test-location"),
+			syncTargets: []*workloadv1alpha1.SyncTarget{newSyncTarget("c1", true)},
+			wantPatch:   true,
+			expectedAnnotations: map[string]string{
+				workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey: "/c1",
+			},
+		},
+		{
+			name:        "synctarget scheduled",
+			placement:   newPlacement("test", "test-location", "c1"),
+			location:    newLocation("test-location"),
+			syncTargets: []*workloadv1alpha1.SyncTarget{newSyncTarget("c1", true)},
+			expectedAnnotations: map[string]string{
+				workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey: "/c1",
+			},
+		},
+		{
+			name:                "unschedule synctarget",
+			placement:           newPlacement("test", "test-location", "c1"),
+			location:            newLocation("test-location"),
+			syncTargets:         []*workloadv1alpha1.SyncTarget{newSyncTarget("c1", false)},
+			wantPatch:           true,
+			expectedAnnotations: map[string]string{},
+		},
+		{
+			name:        "reschedule synctarget",
+			placement:   newPlacement("test", "test-location", "c1"),
+			location:    newLocation("test-location"),
+			syncTargets: []*workloadv1alpha1.SyncTarget{newSyncTarget("c1", false), newSyncTarget("c2", true)},
+			wantPatch:   true,
+			expectedAnnotations: map[string]string{
+				workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey: "/c2",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			listSyncTarget := func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
+				return testCase.syncTargets, nil
+			}
+			getLocation := func(clusterName logicalcluster.Name, name string) (*schedulingv1alpha1.Location, error) {
+				if testCase.location == nil {
+					return nil, errors.NewNotFound(schema.GroupResource{}, name)
+				}
+				return testCase.location, nil
+			}
+			var patched bool
+			patchPlacement := func(ctx context.Context, clusterName logicalcluster.Name, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*schedulingv1alpha1.Placement, error) {
+				patched = true
+				nsData, _ := json.Marshal(testCase.placement)
+				updatedData, err := jsonpatch.MergePatch(nsData, data)
+				if err != nil {
+					return nil, err
+				}
+
+				var patchedPlacement schedulingv1alpha1.Placement
+				err = json.Unmarshal(updatedData, &patchedPlacement)
+				if err != nil {
+					return testCase.placement, err
+				}
+				return &patchedPlacement, err
+			}
+			reconciler := &placementSchedulingReconciler{
+				listSyncTarget: listSyncTarget,
+				getLocation:    getLocation,
+				patchPlacement: patchPlacement,
+			}
+
+			_, updated, err := reconciler.reconcile(context.TODO(), testCase.placement)
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantPatch, patched)
+			require.Equal(t, testCase.expectedAnnotations, updated.Annotations)
+		})
+	}
+}
+
+func newPlacement(name, location, synctarget string) *schedulingv1alpha1.Placement {
+	placement := &schedulingv1alpha1.Placement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: schedulingv1alpha1.PlacementSpec{
+			NamespaceSelector: &metav1.LabelSelector{},
+		},
+		Status: schedulingv1alpha1.PlacementStatus{
+			SelectedLocation: &schedulingv1alpha1.LocationReference{
+				LocationName: location,
+			},
+		},
+	}
+
+	if len(synctarget) > 0 {
+		placement.Annotations = map[string]string{
+			workloadv1alpha1.InternalSyncTargetPlacementAnnotationKey: fmt.Sprintf("/%s", synctarget),
+		}
+	}
+
+	return placement
+}
+
+func newLocation(name string) *schedulingv1alpha1.Location {
+	return &schedulingv1alpha1.Location{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: schedulingv1alpha1.LocationSpec{
+			InstanceSelector: &metav1.LabelSelector{},
+		},
+	}
+}
+
+func newSyncTarget(name string, ready bool) *workloadv1alpha1.SyncTarget {
+	syncTarget := &workloadv1alpha1.SyncTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if ready {
+		conditions.MarkTrue(syncTarget, conditionsapi.ReadyCondition)
+	}
+
+	return syncTarget
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -623,6 +623,9 @@ func (s *Server) Run(ctx context.Context) error {
 			if err := s.installWorkloadNamespaceScheduler(ctx, controllerConfig, delegationChainHead); err != nil {
 				return err
 			}
+			if err := s.installWorkloadPlacementScheduler(ctx, controllerConfig, delegationChainHead); err != nil {
+				return err
+			}
 			if err := s.installSchedulingLocationStatusController(ctx, controllerConfig, delegationChainHead); err != nil {
 				return err
 			}


### PR DESCRIPTION
1. add a internal annotation for placement to
schedule synctarget
2. ns controller only update sync label by collecting
the annotation result from the placements

Signed-off-by: Jian Qiu <jqiu@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

## Related issue(s)

Fixes #