### PR TITLE
Enable avoiding using podman

### DIFF
--- a/contrib/demos-unmaintained/demo/clusters/kind/createKindClusters.sh
+++ b/contrib/demos-unmaintained/demo/clusters/kind/createKindClusters.sh
@@ -70,7 +70,7 @@ detect_podman() {
 
     echo "Using Podman as container engine."
 
-    KIND_EXPERIMENTAL_PROVIDER=podman
+    KIND_EXPERIMENTAL_PROVIDER=${KIND_EXPERIMENTAL_PROVIDER:-podman}
 
     PODMAN_VERSION=$(podman version -f '{{.Server.Version}}')
     PODMAN_MAJOR=$(echo "${PODMAN_VERSION}" | cut -d. -f1)


### PR DESCRIPTION
## Summary

Allow using the `CreateKindClusters.sh` script without  `podman`, even though podman is installed on the system (for example on linux boxes where you have both `docker` and `podman`)