### PR TITLE
Cleanup Syncer to prepare for Syncer Virtual Workspace transformations

### DIFF
--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -372,7 +372,7 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 			if apierrors.IsNotFound(err) {
 				// That's not an error.
 				// Just think about removing the finalizer from the KCP location-specific resource:
-				if err := shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamClient, upstreamObj.GetNamespace(), c.syncTargetName, upstreamObjLogicalCluster, upstreamObj.GetName()); err != nil {
+				if err := shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamInformers, c.upstreamClient, upstreamObj.GetNamespace(), c.syncTargetName, upstreamObjLogicalCluster, upstreamObj.GetName()); err != nil {
 					return err
 				}
 				return nil

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -262,7 +262,15 @@ func (c *Controller) ensureSyncerFinalizer(ctx context.Context, gvr schema.Group
 			hasFinalizer = true
 		}
 	}
-	if !hasFinalizer {
+
+	// TODO(davidfestal): When using syncer virtual workspace we would check the DeletionTimestamp on the upstream object, instead of the DeletionTimestamp annotation,
+	//                as the virtual workspace will set the the deletionTimestamp() on the location view by a transformation.
+	intendedToBeRemovedFromLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+c.syncTargetName] != ""
+
+	// TODO(davidfestal): When using syncer virtual workspace this condition would not be necessary anymore, since directly tested on the virtual workspace side.
+	stillOwnedByExternalActorForLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.ClusterFinalizerAnnotationPrefix+c.syncTargetName] != ""
+
+	if !hasFinalizer && (!intendedToBeRemovedFromLocation || stillOwnedByExternalActorForLocation) {
 		upstreamObjCopy := upstreamObj.DeepCopy()
 		name := upstreamObjCopy.GetName()
 		namespace := upstreamObjCopy.GetNamespace()

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/client-go/tools/clusters"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 )
 
 var scheme *runtime.Scheme
@@ -479,7 +478,7 @@ func TestSyncerProcess(t *testing.T) {
 		expectActionsOnFrom []clienttesting.Action
 		expectActionsOnTo   []clienttesting.Action
 	}{
-		"SpecSyncer sync deployment to downstream, upstream gets patched with the finalizer and the object is created downstream": {
+		"SpecSyncer sync deployment to downstream, upstream gets patched with the finalizer and the object is not created downstream (will be in the next reconciliation)": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
 				"internal.workload.kcp.dev/cluster": "us-west1",
@@ -521,20 +520,6 @@ func TestSyncerProcess(t *testing.T) {
 								"kcp.dev/namespace-locator": `{"syncTarget":{"workspace":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"test"}`,
 							})),
 						removeNilOrEmptyFields,
-					),
-				),
-				patchDeploymentAction(
-					"theDeployment",
-					"kcp-hcbsa8z6c2er",
-					types.ApplyPatchType,
-					toJson(t,
-						changeUnstructured(
-							toUnstructured(t, deployment("theDeployment", "kcp-hcbsa8z6c2er", "", map[string]string{
-								"internal.workload.kcp.dev/cluster": "us-west1",
-							}, nil, nil)),
-							setNestedField(map[string]interface{}{}, "status"),
-							setPodSpecServiceAccount("spec", "template", "spec"),
-						),
 					),
 				),
 			},
@@ -800,23 +785,19 @@ func TestSyncerProcess(t *testing.T) {
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
-				deployment("theDeployment", "test", "root:org:ws", map[string]string{
-					"state.workload.kcp.dev/us-west1": "Sync",
-				}, map[string]string{"experimental.spec-diff.workload.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, nil),
+				deployment("theDeployment", "test", "root:org:ws",
+					map[string]string{
+						"state.workload.kcp.dev/us-west1": "Sync",
+					},
+					map[string]string{"experimental.spec-diff.workload.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"},
+					[]string{"workload.kcp.dev/syncer-us-west1"}),
 			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
 			syncTargetName:                      "us-west1",
 			advancedSchedulingEnabled:           true,
 
-			expectActionsOnFrom: []clienttesting.Action{
-				updateDeploymentAction("test",
-					toUnstructured(t, changeDeployment(
-						deployment("theDeployment", "test", "root:org:ws", map[string]string{
-							"state.workload.kcp.dev/us-west1": "Sync",
-						}, map[string]string{"experimental.spec-diff.workload.kcp.dev/us-west1": "[{\"op\":\"replace\",\"path\":\"/replicas\",\"value\":3}]"}, []string{shared.SyncerFinalizerNamePrefix + "us-west1"}),
-					))),
-			},
+			expectActionsOnFrom: []clienttesting.Action{},
 			expectActionsOnTo: []clienttesting.Action{
 				createNamespaceAction(
 					"",

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -679,7 +679,6 @@ func TestSyncerProcess(t *testing.T) {
 			resourceToProcessName:               "theDeployment",
 			syncTargetName:                      "us-west1",
 			expectActionsOnFrom: []clienttesting.Action{
-				getDeploymentAction("theDeployment", "test"),
 				updateDeploymentAction("test",
 					changeUnstructured(
 						toUnstructured(t, changeDeployment(
@@ -1182,13 +1181,6 @@ func namespaceAction(verb string, subresources ...string) clienttesting.ActionIm
 		Verb:        verb,
 		Resource:    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
 		Subresource: strings.Join(subresources, "/"),
-	}
-}
-
-func getDeploymentAction(name, namespace string) clienttesting.GetActionImpl {
-	return clienttesting.GetActionImpl{
-		ActionImpl: deploymentAction("get", namespace),
-		Name:       name,
 	}
 }
 

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -113,37 +113,31 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 }
 
 func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamNamespace string, upstreamLogicalCluster logicalcluster.Name, downstreamObj *unstructured.Unstructured) error {
-	upstreamObj := downstreamObj.DeepCopy()
-	upstreamObj.SetUID("")
-	upstreamObj.SetResourceVersion("")
-	upstreamObj.SetNamespace(upstreamNamespace)
+	upstreamName := getUpstreamResourceName(downstreamObj)
 
-	// Run name transformations on upstreamObj
-	transformName(upstreamObj)
-
-	name := upstreamObj.GetName()
-	downstreamStatus, statusExists, err := unstructured.NestedFieldCopy(upstreamObj.UnstructuredContent(), "status")
+	downstreamStatus, statusExists, err := unstructured.NestedFieldCopy(downstreamObj.UnstructuredContent(), "status")
 	if err != nil {
 		return err
 	} else if !statusExists {
-		klog.V(5).Infof("Resource doesn't contain a status. Skipping updating status of resource %s|%s/%s from syncTargetName namespace %s", upstreamLogicalCluster, upstreamNamespace, name, downstreamObj.GetNamespace())
+		klog.V(5).Infof("Resource doesn't contain a status. Skipping updating status of resource %s|%s/%s from syncTargetName namespace %s", upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace())
 		return nil
 	}
 
-	existingObj, err := c.upstreamInformers.ForResource(gvr).Lister().ByNamespace(upstreamNamespace).Get(clusters.ToClusterAwareKey(upstreamLogicalCluster, name))
+	existingObj, err := c.upstreamInformers.ForResource(gvr).Lister().ByNamespace(upstreamNamespace).Get(clusters.ToClusterAwareKey(upstreamLogicalCluster, upstreamName))
 	if err != nil {
-		klog.Errorf("Getting resource %s/%s: %v", upstreamNamespace, name, err)
+		klog.Errorf("Getting resource %s/%s: %v", upstreamNamespace, upstreamName, err)
 		return err
 	}
 
 	existing, ok := existingObj.(*unstructured.Unstructured)
 	if !ok {
-		klog.Errorf("Resource %s|%s/%s expected to be *unstructured.Unstructured, got %T", upstreamLogicalCluster.String(), upstreamNamespace, name, existing)
+		klog.Errorf("Resource %s|%s/%s expected to be *unstructured.Unstructured, got %T", upstreamLogicalCluster.String(), upstreamNamespace, upstreamName, existing)
 		return nil
 	}
 
+	newUpstream := existing.DeepCopy()
+
 	if c.advancedSchedulingEnabled {
-		newUpstream := existing.DeepCopy()
 		statusAnnotationValue, err := json.Marshal(downstreamStatus)
 		if err != nil {
 			return err
@@ -156,31 +150,40 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 		newUpstream.SetAnnotations(newUpstreamAnnotations)
 
 		if reflect.DeepEqual(existing, newUpstream) {
-			klog.V(2).Infof("No need to update the status of resource %s|%s/%s from syncTargetName namespace %s", upstreamLogicalCluster, upstreamNamespace, name, downstreamObj.GetNamespace())
+			klog.V(2).Infof("No need to update the status of resource %s|%s/%s from syncTargetName namespace %s", upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace())
 			return nil
 		}
 
 		if _, err := c.upstreamClient.Cluster(upstreamLogicalCluster).Resource(gvr).Namespace(upstreamNamespace).Update(ctx, newUpstream, metav1.UpdateOptions{}); err != nil {
-			klog.Errorf("Failed updating location status annotation of resource %s|%s/%s from syncTargetName namespace %s: %v", upstreamLogicalCluster, upstreamNamespace, upstreamObj.GetName(), downstreamObj.GetNamespace(), err)
+			klog.Errorf("Failed updating location status annotation of resource %s|%s/%s from syncTargetName namespace %s: %v", upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace(), err)
 			return err
 		}
-		klog.Infof("Updated status of resource %s|%s/%s from syncTargetName namespace %s", upstreamLogicalCluster, upstreamNamespace, upstreamObj.GetName(), downstreamObj.GetNamespace())
+		klog.Infof("Updated status of resource %s|%s/%s from syncTargetName namespace %s", upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace())
 		return nil
 	}
 
-	if _, err := c.upstreamClient.Cluster(upstreamLogicalCluster).Resource(gvr).Namespace(upstreamNamespace).UpdateStatus(ctx, upstreamObj, metav1.UpdateOptions{}); err != nil {
-		klog.Errorf("Failed updating status of resource %q %s|%s/%s from pcluster namespace %s: %v", gvr.String(), upstreamLogicalCluster, upstreamNamespace, upstreamObj.GetName(), downstreamObj.GetNamespace(), err)
+	if err := unstructured.SetNestedField(newUpstream.UnstructuredContent(), downstreamStatus, "status"); err != nil {
 		return err
 	}
-	klog.Infof("Updated status of resource %q %s|%s/%s from pcluster namespace %s", gvr.String(), upstreamLogicalCluster, upstreamNamespace, upstreamObj.GetName(), downstreamObj.GetNamespace())
+
+	// TODO (davidfestal): Here in the future we might want to also set some fields of the Spec, per resource type, for example:
+	// clusterIP for service, or other field values set by SyncTarget cluster admission.
+	// But for now let's only update the status.
+
+	if _, err := c.upstreamClient.Cluster(upstreamLogicalCluster).Resource(gvr).Namespace(upstreamNamespace).UpdateStatus(ctx, newUpstream, metav1.UpdateOptions{}); err != nil {
+		klog.Errorf("Failed updating status of resource %q %s|%s/%s from pcluster namespace %s: %v", gvr.String(), upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace(), err)
+		return err
+	}
+	klog.Infof("Updated status of resource %q %s|%s/%s from pcluster namespace %s", gvr.String(), upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace())
 	return nil
 }
 
-// TransformName changes the object name into the desired one upstream.
-func transformName(syncedObject *unstructured.Unstructured) {
+// getUpstreamResourceName returns the name with which the resource is known upstream.
+func getUpstreamResourceName(downstreamResource *unstructured.Unstructured) string {
 	configMapGVR := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 
-	if syncedObject.GroupVersionKind() == configMapGVR && syncedObject.GetName() == "kcp-root-ca.crt" {
-		syncedObject.SetName("kube-root-ca.crt")
+	if downstreamResource.GroupVersionKind() == configMapGVR && downstreamResource.GetName() == "kcp-root-ca.crt" {
+		return "kube-root-ca.crt"
 	}
+	return downstreamResource.GetName()
 }

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -350,7 +350,7 @@ func TestSyncerProcess(t *testing.T) {
 			expectActionsOnTo: []clienttesting.Action{
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
-						deployment("theDeployment", "test", "", map[string]string{
+						deployment("theDeployment", "test", "root:org:ws", map[string]string{
 							"state.workload.kcp.dev/us-west1": "Sync",
 						}, nil, nil),
 						addDeploymentStatus(appsv1.DeploymentStatus{

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clusters"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
@@ -347,7 +348,6 @@ func TestSyncerProcess(t *testing.T) {
 
 			expectActionsOnFrom: []clienttesting.Action{},
 			expectActionsOnTo: []clienttesting.Action{
-				getDeploymentAction("theDeployment", "test"),
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
 						deployment("theDeployment", "test", "", map[string]string{
@@ -384,9 +384,7 @@ func TestSyncerProcess(t *testing.T) {
 			syncTargetName:                      "us-west1",
 
 			expectActionsOnFrom: []clienttesting.Action{},
-			expectActionsOnTo: []clienttesting.Action{
-				getDeploymentAction("theDeployment", "test"),
-			},
+			expectActionsOnTo:   []clienttesting.Action{},
 		},
 		"StatusSyncer with AdvancedScheduling, update status upstream": {
 			upstreamLogicalCluster: "root:org:ws",
@@ -417,7 +415,6 @@ func TestSyncerProcess(t *testing.T) {
 
 			expectActionsOnFrom: []clienttesting.Action{},
 			expectActionsOnTo: []clienttesting.Action{
-				getDeploymentAction("theDeployment", "test"),
 				updateDeploymentAction("test",
 					toUnstructured(t, changeDeployment(
 						deployment("theDeployment", "test", "root:org:ws", map[string]string{
@@ -458,9 +455,7 @@ func TestSyncerProcess(t *testing.T) {
 			advancedSchedulingEnabled:           true,
 
 			expectActionsOnFrom: []clienttesting.Action{},
-			expectActionsOnTo: []clienttesting.Action{
-				getDeploymentAction("theDeployment", "test"),
-			},
+			expectActionsOnTo:   []clienttesting.Action{},
 		},
 		"StatusSyncer with AdvancedScheduling, deletion: object does not exists upstream": {
 			upstreamLogicalCluster: "root:org:ws",
@@ -489,7 +484,6 @@ func TestSyncerProcess(t *testing.T) {
 
 			expectActionsOnFrom: []clienttesting.Action{},
 			expectActionsOnTo: []clienttesting.Action{
-				getDeploymentAction("theDeployment", "test"),
 				updateDeploymentAction("test",
 					changeUnstructured(
 						toUnstructured(t, changeDeployment(
@@ -536,8 +530,9 @@ func TestSyncerProcess(t *testing.T) {
 			})
 
 			setupServersideApplyPatchReactor(toClient)
-			namespaceWatcherStarted := setupWatchReactor("namespaces", fromClient)
-			resourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClient)
+			fromClientNamespaceWatcherStarted := setupWatchReactor("namespaces", fromClient)
+			fromClientResourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClient)
+			toClientResourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, toClient)
 
 			gvrs := []schema.GroupVersionResource{
 				{Group: "", Version: "v1", Resource: "namespaces"},
@@ -546,14 +541,17 @@ func TestSyncerProcess(t *testing.T) {
 			controller, err := NewStatusSyncer(gvrs, kcpLogicalCluster, tc.syncTargetName, tc.advancedSchedulingEnabled, toClusterClient, fromClient, toInformers, fromInformers, syncTargetUID)
 			require.NoError(t, err)
 
+			toInformers.ForResource(tc.gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
 			fromInformers.Start(ctx.Done())
 			toInformers.Start(ctx.Done())
 
 			fromInformers.WaitForCacheSync(ctx.Done())
 			toInformers.WaitForCacheSync(ctx.Done())
 
-			<-resourceWatcherStarted
-			<-namespaceWatcherStarted
+			<-fromClientResourceWatcherStarted
+			<-fromClientNamespaceWatcherStarted
+			<-toClientResourceWatcherStarted
 
 			fromClient.ClearActions()
 			toClient.ClearActions()
@@ -588,12 +586,12 @@ func setupServersideApplyPatchReactor(toClient *dynamicfake.FakeDynamicClient) {
 	})
 }
 
-func setupWatchReactor(resource string, fromClient *dynamicfake.FakeDynamicClient) chan struct{} {
+func setupWatchReactor(resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
 	watcherStarted := make(chan struct{})
-	fromClient.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
-		watch, err := fromClient.Tracker().Watch(gvr, ns)
+		watch, err := client.Tracker().Watch(gvr, ns)
 		if err != nil {
 			return false, nil, err
 		}
@@ -671,13 +669,6 @@ func deploymentAction(verb, namespace string, subresources ...string) clienttest
 		Verb:        verb,
 		Resource:    schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 		Subresource: strings.Join(subresources, "/"),
-	}
-}
-
-func getDeploymentAction(name, namespace string) clienttesting.GetActionImpl {
-	return clienttesting.GetActionImpl{
-		ActionImpl: deploymentAction("get", namespace),
-		Name:       name,
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR fixes some corner cases or behaviors in the Syncer that would not be compatible with the Syncer Virtual Workspace transformations. More precisely:
- We now [stop reconciling just after adding the Syncer Finalizer](https://github.com/kcp-dev/kcp/pull/1629/commits/af19673c45f1c7e668162919791620d025843f14). The Update of the upstream resource with the syncer finalizer will trigger a new reconcile round anyway. We should avoid updating both the upstream resource and the downstream resource, and thus combine distinct purposes in the same reconciliation round.
- [Don't add the syncer finalizer to a resource already marked for deletion](https://github.com/kcp-dev/kcp/pull/1629/commits/14c391941f063640f48a0350d5b338d905092b93). This will lead to some sort of hot-looping with the VW logic when the deletion process is already started
- [Use upstream informer listers instead the upstream kube client](https://github.com/kcp-dev/kcp/pull/1629/commits/cc96852c4180b913aaacac5d8d310206f98b613d) to get the upstream resource during the reconcile.
- [Fix how upstream status is updated](https://github.com/kcp-dev/kcp/pull/1629/commits/d5adc7a9c5f9c6439cbefd4b4f7d7ebafdfccab2) : we should not update the upstream status based on the downstream resource: this leaks many downstream-related fields to the Syncer virtual workspace, which we don't want.