### PR TITLE
home workspaces: handle slow bootstrapping

### DIFF
--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -550,11 +550,11 @@ func tryToCreate(h *homeWorkspaceHandler, ctx context.Context, user kuser.Info, 
 		return retryAfterCreateSeconds, nil
 	}
 
-	if !kerrors.IsForbidden(err) {
+	if !kerrors.IsForbidden(err) && !kerrors.IsNotFound(err) {
 		return 0, err
 	}
 
-	// The error returned by the creation attempt is a Forbidden error.
+	// The error returned by the creation attempt is either Forbidden or NotFound (due to APIBindings not being ready).
 	// We have to detect whether it is because:
 	//
 	// - the parent workspace doesn't exist (in which case we'd try to create it),


### PR DESCRIPTION
## Summary
When a user tries to create content in the home workspace hierarchy, if
the ancestor clusterworkspaces are slow to bootstrap and/or the
apibindings are slow to become ready, there is a chance that the logic
that tries to create intermediate home buckets might get a 404 because
the apibinding for tenancy.kcp.dev isn't ready yet.

Handle a 404 and instruct the client to retry.

## Related issue(s)

Fixes #1626