### PR TITLE
virtual: give VWs an order in order to control precedence

### DIFF
--- a/pkg/virtual/apiexport/options/options.go
+++ b/pkg/virtual/apiexport/options/options.go
@@ -27,8 +27,8 @@ import (
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/builder"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/client/dynamic"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 )
 
 type APIExport struct{}
@@ -56,7 +56,7 @@ func (o *APIExport) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (workspaces map[string]framework.VirtualWorkspace, err error) {
+) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "apiexport-virtual-workspace")
 	kcpClusterClient, err := kcpclientset.NewClusterForConfig(config)
 	if err != nil {
@@ -71,8 +71,5 @@ func (o *APIExport) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	virtualWorkspaces := map[string]framework.VirtualWorkspace{
-		builder.VirtualWorkspaceName: builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
-	}
-	return virtualWorkspaces, nil
+	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
 }

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -55,6 +55,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apiserver"
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/handler"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces"
 )
 
@@ -64,7 +65,7 @@ func BuildVirtualWorkspace(
 	dynamicClusterClient dynamic.ClusterInterface,
 	kubeClusterClient kubernetes.ClusterInterface,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (map[string]framework.VirtualWorkspace, error) {
+) ([]rootapiserver.NamedVirtualWorkspace, error) {
 	if !strings.HasSuffix(rootPathPrefix, "/") {
 		rootPathPrefix += "/"
 	}
@@ -295,10 +296,10 @@ func BuildVirtualWorkspace(
 		}),
 	}
 
-	return map[string]framework.VirtualWorkspace{
-		wildcardWorkspacesName: wildcardWorkspaces,
-		workspacesName:         workspaces,
-		workspaceContentName:   workspaceContent,
+	return []rootapiserver.NamedVirtualWorkspace{
+		{Name: wildcardWorkspacesName, VirtualWorkspace: wildcardWorkspaces},
+		{Name: workspacesName, VirtualWorkspace: workspaces},
+		{Name: workspaceContentName, VirtualWorkspace: workspaceContent},
 	}, nil
 }
 

--- a/pkg/virtual/initializingworkspaces/options/options.go
+++ b/pkg/virtual/initializingworkspaces/options/options.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces"
 	"github.com/kcp-dev/kcp/pkg/virtual/initializingworkspaces/builder"
 )
@@ -56,7 +56,7 @@ func (o *InitializingWorkspaces) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (workspaces map[string]framework.VirtualWorkspace, err error) {
+) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "initializingworkspaces-virtual-workspace")
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(config)
 	if err != nil {

--- a/pkg/virtual/options/authorization.go
+++ b/pkg/virtual/options/authorization.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apiserver/pkg/authorization/union"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	"github.com/kcp-dev/kcp/pkg/virtual/framework"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/authorization"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 )
 
 type Authorization struct {
@@ -80,7 +80,7 @@ func (s *Authorization) AddFlags(fs *pflag.FlagSet) {
 			"contacting the 'core' kubernetes server.")
 }
 
-func (s *Authorization) ApplyTo(config *genericapiserver.Config, virtualWorkspaces map[string]framework.VirtualWorkspace) error {
+func (s *Authorization) ApplyTo(config *genericapiserver.Config, virtualWorkspaces []rootapiserver.NamedVirtualWorkspace) error {
 	var authorizers []authorizer.Authorizer
 
 	// group authorizer

--- a/pkg/virtual/syncer/options/options.go
+++ b/pkg/virtual/syncer/options/options.go
@@ -27,7 +27,7 @@ import (
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/syncer/builder"
 )
 
@@ -56,7 +56,7 @@ func (o *Syncer) NewVirtualWorkspaces(
 	rootPathPrefix string,
 	config *rest.Config,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (workspaces map[string]framework.VirtualWorkspace, err error) {
+) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "syncer-virtual-workspace")
 	kcpClusterClient, err := kcpclient.NewClusterForConfig(config)
 	if err != nil {
@@ -71,8 +71,7 @@ func (o *Syncer) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	virtualWorkspaces := map[string]framework.VirtualWorkspace{
-		builder.SyncerVirtualWorkspaceName: builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.SyncerVirtualWorkspaceName), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers),
-	}
-	return virtualWorkspaces, nil
+	return []rootapiserver.NamedVirtualWorkspace{
+		{Name: builder.SyncerVirtualWorkspaceName, VirtualWorkspace: builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.SyncerVirtualWorkspaceName), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)},
+	}, nil
 }

--- a/pkg/virtual/workspaces/options/options.go
+++ b/pkg/virtual/workspaces/options/options.go
@@ -27,7 +27,7 @@ import (
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/rootapiserver"
 	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/builder"
 )
 
@@ -57,7 +57,7 @@ func (o *Workspaces) NewVirtualWorkspaces(
 	config *rest.Config,
 	wildcardKubeInformers informers.SharedInformerFactory,
 	wildcardKcpInformers kcpinformer.SharedInformerFactory,
-) (workspaces map[string]framework.VirtualWorkspace, err error) {
+) (workspaces []rootapiserver.NamedVirtualWorkspace, err error) {
 	config = rest.AddUserAgent(rest.CopyConfig(config), "workspaces-virtual-workspace")
 	kcpClusterClient, err := kcpclient.NewClusterForConfig(config)
 	if err != nil {
@@ -68,8 +68,7 @@ func (o *Workspaces) NewVirtualWorkspaces(
 		return nil, err
 	}
 
-	virtualWorkspaces := map[string]framework.VirtualWorkspace{
-		"workspaces": builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient),
-	}
-	return virtualWorkspaces, nil
+	return []rootapiserver.NamedVirtualWorkspace{
+		{Name: "workspaces", VirtualWorkspace: builder.BuildVirtualWorkspace(config, path.Join(rootPathPrefix, "workspaces"), wildcardKcpInformers.Tenancy().V1alpha1().ClusterWorkspaces(), wildcardKubeInformers.Rbac().V1(), kubeClusterClient, kcpClusterClient)},
+	}, nil
 }


### PR DESCRIPTION
To allow shadowing one VW another, e.g. a by-default APIBinding VW shadowed by a PermissionClaim VW: if the user does not claim APIBindings, just the bindings for their own exports are visible. But through a claim all bindings in those workspaces become visible. This needs an order of VW layers.