### PR TITLE
remove deprecated command from use description

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -90,7 +90,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	}
 	cmd := &cobra.Command{
 		Aliases:          []string{"ws", "workspaces"},
-		Use:              "workspace [list|create|create-context|<workspace>|..|.|-|~|<root:absolute:workspace>]",
+		Use:              "workspace [create|create-context|<workspace>|..|.|-|~|<root:absolute:workspace>]",
 		Short:            "Manages KCP workspaces",
 		Example:          fmt.Sprintf(workspaceExample, "kubectl kcp"),
 		SilenceUsage:     true,


### PR DESCRIPTION
## Summary
Removes the deprecated 'list' command from the kubectl kcp ws help.

## Related issue(s)

Fixes #1580