### PR TITLE
Update minimum Go version in CONTRIBUTING.md doc to 1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ coverage.*
 tools
 build
 .vscode
+
+# JetBrains IDE files
+.idea/
+*.iml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ contribution. See the [DCO](DCO) file for details.
 ### Prerequisites
 
 1. Clone this repository.
-2. [Install Go](https://golang.org/doc/install) (1.17+).
+2. [Install Go](https://golang.org/doc/install) (1.18+).
 3. Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl).
 
 ### Build & verify


### PR DESCRIPTION
## Summary

* Updates minimum Go version in CONTRIBUTING.md doc to 1.18
* Adds Jetbrains IDE files to gitignore

## Related issue(s)

Fixes #1650