### PR TITLE
syncer: move namespace locator normalization to indexer

### DIFF
--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -276,9 +276,15 @@ func indexByNamespaceLocator(obj interface{}) ([]string, error) {
 	if !ok {
 		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
 	}
-	locator, ok := metaObj.GetAnnotations()[shared.NamespaceLocatorAnnotation]
-	if !ok {
+	if loc, found, err := shared.LocatorFromAnnotations(metaObj.GetAnnotations()); err != nil {
+		return []string{}, fmt.Errorf("failed to get locator from annotations: %w", err)
+	} else if !found {
 		return []string{}, nil
+	} else {
+		bs, err := json.Marshal(loc)
+		if err != nil {
+			return []string{}, fmt.Errorf("failed to marshal locator %#v: %w", loc, err)
+		}
+		return []string{string(bs)}, nil
 	}
-	return []string{locator}, nil
 }

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -124,21 +124,8 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	if err != nil {
 		return err
 	}
-	if len(downstreamNamespaces) == 0 {
-		// case for up to v0.6.0 where we used syncTarget.path in namespace locators
-		desiredNSLocator := shared.NewNamespaceLocatorV060(clusterName, c.syncTargetWorkspace, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
-		jsonNSLocator, err := json.Marshal(desiredNSLocator)
-		if err != nil {
-			return err
-		}
-		downstreamNamespaces, err = c.downstreamInformers.ForResource(namespaceGvr).Informer().GetIndexer().ByIndex(byNamespaceLocatorIndexName, string(jsonNSLocator))
-		if err != nil {
-			return err
-		}
-	}
 
 	var downstreamNamespace string
-
 	if len(downstreamNamespaces) == 1 {
 		namespace := downstreamNamespaces[0].(*unstructured.Unstructured)
 		klog.V(4).Infof("Found downstream namespace %s for upstream namespace %s", namespace.GetName(), upstreamNamespace)


### PR DESCRIPTION
Simpler to normalize in the decoding flow rather than in the logic.