### PR TITLE
api change: adds VirtualWorkspaceURL to ClusterWorkspaceShard

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspaceshards.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaceshards.yaml
@@ -61,7 +61,7 @@ spec:
                 minLength: 1
                 type: string
               externalURL:
-                description: "ExternalURL is the externally visible address presented
+                description: "externalURL is the externally visible address presented
                   to users in Workspace URLs. Changing this will break all existing
                   workspaces on that shard, i.e. existing kubeconfigs of clients will
                   be invalid. Hence, when changing this value, the old URL used by
@@ -71,6 +71,15 @@ spec:
                   front-proxy here. \n Note that movement of shards is only possible
                   (in the future) between shards that share a common external URL.
                   \n This will be defaulted to the value of the baseURL."
+                format: uri
+                minLength: 1
+                type: string
+              virtualWorkspaceURL:
+                description: "virtualWorkspaceURL is the address of the virtual workspace
+                  server associated with this shard. It can be a direct address, an
+                  address of a front-proxy or even an address of an LB. As of today
+                  this address is assigned to APIExports. \n This will be defaulted
+                  to the shard's base address if not specified."
                 format: uri
                 minLength: 1
                 type: string

--- a/config/root-phase0/apiexport-shards.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-shards.tenancy.kcp.dev.yaml
@@ -5,7 +5,7 @@ metadata:
   name: shards.tenancy.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220801-c65c674d4.clusterworkspaceshards.tenancy.kcp.dev
+  - v220803-e095b93c.clusterworkspaceshards.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-clusterworkspaceshards.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaceshards.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220801-c65c674d4.clusterworkspaceshards.tenancy.kcp.dev
+  name: v220803-e095b93c.clusterworkspaceshards.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -55,7 +55,7 @@ spec:
               minLength: 1
               type: string
             externalURL:
-              description: "ExternalURL is the externally visible address presented
+              description: "externalURL is the externally visible address presented
                 to users in Workspace URLs. Changing this will break all existing
                 workspaces on that shard, i.e. existing kubeconfigs of clients will
                 be invalid. Hence, when changing this value, the old URL used by clients
@@ -65,6 +65,15 @@ spec:
                 here. \n Note that movement of shards is only possible (in the future)
                 between shards that share a common external URL. \n This will be defaulted
                 to the value of the baseURL."
+              format: uri
+              minLength: 1
+              type: string
+            virtualWorkspaceURL:
+              description: "virtualWorkspaceURL is the address of the virtual workspace
+                server associated with this shard. It can be a direct address, an
+                address of a front-proxy or even an address of an LB. As of today
+                this address is assigned to APIExports. \n This will be defaulted
+                to the shard's base address if not specified."
               format: uri
               minLength: 1
               type: string

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -477,7 +477,7 @@ type ClusterWorkspaceShardSpec struct {
 	// +optional
 	BaseURL string `json:"baseURL,omitempty"`
 
-	// ExternalURL is the externally visible address presented to users in Workspace URLs.
+	// externalURL is the externally visible address presented to users in Workspace URLs.
 	// Changing this will break all existing workspaces on that shard, i.e. existing
 	// kubeconfigs of clients will be invalid. Hence, when changing this value, the old
 	// URL used by clients must keep working.
@@ -496,6 +496,17 @@ type ClusterWorkspaceShardSpec struct {
 	// +kubebuilder:Required
 	// +required
 	ExternalURL string `json:"externalURL"`
+
+	// virtualWorkspaceURL is the address of the virtual workspace server associated with this shard.
+	// It can be a direct address, an address of a front-proxy or even an address of an LB.
+	// As of today this address is assigned to APIExports.
+	//
+	// This will be defaulted to the shard's base address if not specified.
+	//
+	// +kubebuilder:validation:Format=uri
+	// +kubebuilder:validation:MinLength=1
+	// +optional
+	VirtualWorkspaceURL string `json:"virtualWorkspaceURL,omitempty"`
 }
 
 // ClusterWorkspaceShardStatus communicates the observed state of the ClusterWorkspaceShard.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2723,8 +2723,15 @@ func schema_pkg_apis_tenancy_v1alpha1_ClusterWorkspaceShardSpec(ref common.Refer
 					},
 					"externalURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExternalURL is the externally visible address presented to users in Workspace URLs. Changing this will break all existing workspaces on that shard, i.e. existing kubeconfigs of clients will be invalid. Hence, when changing this value, the old URL used by clients must keep working.\n\nThe external address will not be unique if a front-proxy does a fan-out to shards, but all workspace client will talk to the front-proxy. In that case, put the address of the front-proxy here.\n\nNote that movement of shards is only possible (in the future) between shards that share a common external URL.\n\nThis will be defaulted to the value of the baseURL.",
+							Description: "externalURL is the externally visible address presented to users in Workspace URLs. Changing this will break all existing workspaces on that shard, i.e. existing kubeconfigs of clients will be invalid. Hence, when changing this value, the old URL used by clients must keep working.\n\nThe external address will not be unique if a front-proxy does a fan-out to shards, but all workspace client will talk to the front-proxy. In that case, put the address of the front-proxy here.\n\nNote that movement of shards is only possible (in the future) between shards that share a common external URL.\n\nThis will be defaulted to the value of the baseURL.",
 							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"virtualWorkspaceURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "virtualWorkspaceURL is the address of the virtual workspace server associated with this shard. It can be a direct address, an address of a front-proxy or even an address of an LB. As of today this address is assigned to APIExports.\n\nThis will be defaulted to the shard's base address if not specified.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
VirtualWorkspaceURL is the address of the virtual workspace server associated with this shard.
It can be a direct address, an address of a front-proxy or even an address of an LB.
As of today this address is assigned to APIExports.

This will be defaulted to the shard's base address if not specified.


## Related issue(s)

Fixes #