### PR TITLE
use ClusterWorkspaceShard.VirtualWorkspaceURL

### DIFF
--- a/config/root/bootstrap.go
+++ b/config/root/bootstrap.go
@@ -35,7 +35,7 @@ var fs embed.FS
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, kubeconfig clientcmdapi.Config, homePrefix string, homeWorkspaceCreatorGroups []string) error {
+func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, shardVirtualWorkspaceURL string, kubeconfig clientcmdapi.Config, homePrefix string, homeWorkspaceCreatorGroups []string) error {
 	kubeconfigRaw, err := clientcmd.Write(kubeconfig)
 	if err != nil {
 		return err
@@ -54,6 +54,7 @@ func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInter
 
 	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, fs, confighelpers.ReplaceOption(
 		"SHARD_NAME", shardName,
+		"SHARD_VIRTUAL_WORKSPACE_URL", shardVirtualWorkspaceURL,
 		"SHARD_KUBECONFIG", base64.StdEncoding.EncodeToString(kubeconfigRaw),
 		"HOME_CREATOR_GROUPS", homeWorkspaceCreatorGroupReplacement,
 		"HOMEPREFIX", homePrefix,

--- a/config/root/clusterworkspaceshard.yaml
+++ b/config/root/clusterworkspaceshard.yaml
@@ -3,6 +3,7 @@ kind: ClusterWorkspaceShard
 metadata:
   name: SHARD_NAME
 spec:
+  virtualWorkspaceURL: SHARD_VIRTUAL_WORKSPACE_URL
   credentials:
     namespace: default
     name: shard-root-kubeconfig

--- a/pkg/admission/clusterworkspaceshard/admission.go
+++ b/pkg/admission/clusterworkspaceshard/admission.go
@@ -133,6 +133,10 @@ func (o *clusterWorkspaceShard) Admit(_ context.Context, a admission.Attributes,
 		}
 	}
 
+	if cws.Spec.VirtualWorkspaceURL == "" {
+		cws.Spec.VirtualWorkspaceURL = cws.Spec.BaseURL
+	}
+
 	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cws)
 	if err != nil {
 		return err

--- a/pkg/admission/clusterworkspaceshard/admission_test.go
+++ b/pkg/admission/clusterworkspaceshard/admission_test.go
@@ -90,6 +90,11 @@ func (b *shardBuilder) externalURL(u string) *shardBuilder {
 	return b
 }
 
+func (b *shardBuilder) virtualWorkspaceURL(u string) *shardBuilder {
+	b.Spec.VirtualWorkspaceURL = u
+	return b
+}
+
 func TestAdmitIgnoresOtherResources(t *testing.T) {
 	o := &clusterWorkspaceShard{
 		Handler: admission.NewHandler(admission.Create, admission.Update),
@@ -117,7 +122,7 @@ func TestAdmitIgnoresOtherResources(t *testing.T) {
 }
 
 func TestNoOp(t *testing.T) {
-	shard := newTestShard().baseURL("https://boston2.kcp.dev").externalURL("https://kcp2.dev")
+	shard := newTestShard().baseURL("https://boston2.kcp.dev").externalURL("https://kcp2.dev").virtualWorkspaceURL("https://boston2.kcp.dev")
 	attrs := map[string]admission.Attributes{
 		"create": createAttr(shard),
 		"update": updateAttr(shard, shard),
@@ -155,21 +160,21 @@ func TestAdmit(t *testing.T) {
 	}{
 		{
 			name:        "default baseURL to shardBaseURL when both shardBaseURL and externalAddress are set",
-			expectedObj: newTestShard().baseURL("https://shard.base").externalURL("https://shard.external"),
+			expectedObj: newTestShard().baseURL("https://shard.base").externalURL("https://shard.external").virtualWorkspaceURL("https://shard.base"),
 		},
 		{
 			name:              "default baseURL to externalAddress when only externalAddress is set",
 			emptyShardBaseURL: true,
-			expectedObj:       newTestShard().baseURL("https://external.kcp.dev").externalURL("https://shard.external"),
+			expectedObj:       newTestShard().baseURL("https://external.kcp.dev").externalURL("https://shard.external").virtualWorkspaceURL("https://external.kcp.dev"),
 		},
 		{
 			name:        "default externalURL to shardExternalURL when both shardExternalURL and externalAddress are set",
-			expectedObj: newTestShard().baseURL("https://shard.base").externalURL("https://shard.external"),
+			expectedObj: newTestShard().baseURL("https://shard.base").externalURL("https://shard.external").virtualWorkspaceURL("https://shard.base"),
 		},
 		{
 			name:                  "default externalURL to externalAddress when only externalAddress is set",
 			emptyShardExternalURL: true,
-			expectedObj:           newTestShard().baseURL("https://shard.base").externalURL("https://external.kcp.dev"),
+			expectedObj:           newTestShard().baseURL("https://shard.base").externalURL("https://external.kcp.dev").virtualWorkspaceURL("https://shard.base"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -132,6 +132,7 @@ var (
 		"root-directory",              // Root directory.
 		"shard-base-url",              // Base URL to this kcp shard. Defaults to external address.
 		"shard-external-url",          // URL used by outside clients to talk to this kcp shard. Defaults to external address.
+		"shard-virtual-workspace-url", // An external URL address of a virtual workspace server associated with this shard. Defaults to shard's base address.
 		"shard-name",                  // A name of this kcp shard.
 		"shard-kubeconfig-file",       // Kubeconfig holding admin(!) credentials to peer kcp shards.
 		"root-shard-kubeconfig-file",  // Kubeconfig holding admin(!) credentials to the root kcp shard.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -60,6 +60,7 @@ type ExtraOptions struct {
 	ShardBaseURL             string
 	ShardExternalURL         string
 	ShardName                string
+	ShardVirtualWorkspaceURL string
 	DiscoveryPollInterval    time.Duration
 	ExperimentalBindFreePort bool
 }
@@ -164,6 +165,7 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs.StringVar(&o.Extra.ShardBaseURL, "shard-base-url", o.Extra.ShardBaseURL, "Base URL to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardExternalURL, "shard-external-url", o.Extra.ShardExternalURL, "URL used by outside clients to talk to this kcp shard. Defaults to external address.")
 	fs.StringVar(&o.Extra.ShardName, "shard-name", o.Extra.ShardName, "A name of this kcp shard. Defaults to the \"root\" name.")
+	fs.StringVar(&o.Extra.ShardVirtualWorkspaceURL, "shard-virtual-workspace-url", o.Extra.ShardVirtualWorkspaceURL, "An external URL address of a virtual workspace server associated with this shard. Defaults to shard's base address.")
 	fs.StringVar(&o.Extra.RootDirectory, "root-directory", o.Extra.RootDirectory, "Root directory.")
 
 	fs.BoolVar(&o.Extra.ExperimentalBindFreePort, "experimental-bind-free-port", o.Extra.ExperimentalBindFreePort, "Bind to a free port. --secure-port must be 0. Use the admin.kubeconfig to extract the chosen port.")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -239,8 +239,9 @@ func (s *Server) Run(ctx context.Context) error {
 			shard := &tenancyv1alpha1.ClusterWorkspaceShard{
 				ObjectMeta: metav1.ObjectMeta{Name: s.Options.Extra.ShardName},
 				Spec: tenancyv1alpha1.ClusterWorkspaceShardSpec{
-					BaseURL:     fmt.Sprintf("https://%v", s.GenericConfig.ExternalAddress),
-					ExternalURL: fmt.Sprintf("https://%v", s.Options.Extra.ShardExternalURL),
+					BaseURL:             fmt.Sprintf("https://%v", s.GenericConfig.ExternalAddress),
+					ExternalURL:         fmt.Sprintf("https://%v", s.Options.Extra.ShardExternalURL),
+					VirtualWorkspaceURL: s.Options.Extra.ShardVirtualWorkspaceURL,
 				},
 			}
 			if _, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Create(goContext(ctx), shard, metav1.CreateOptions{}); err != nil {
@@ -274,6 +275,7 @@ func (s *Server) Run(ctx context.Context) error {
 				s.ApiExtensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
 				s.DynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
 				s.Options.Extra.ShardName,
+				s.Options.Extra.ShardVirtualWorkspaceURL,
 				clientcmdapi.Config{
 					Clusters: map[string]*clientcmdapi.Cluster{
 						// cross-cluster is the virtual cluster running by default


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
this PR:
- exposes the new field as `shard-virtual-workspace-url` flag.
   when set points to an external URL address of a virtual workspace server
   associated with as shard.
- updates the admission plugin so that it defaults the new field to the shard's base address.

## Related issue(s)

Fixes #