### PR TITLE
authorization: add system:masters-only deep SAR via X-Kcp-Internal-Deep-SubjectAccessReview:true header

### DIFF
--- a/pkg/authorization/deep_sar.go
+++ b/pkg/authorization/deep_sar.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	authorization "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
+)
+
+type deepSARKeyType int
+
+const (
+	deepSARKey deepSARKeyType = iota
+)
+
+var (
+	deepSARHeader = "X-Kcp-Internal-Deep-SubjectAccessReview"
+)
+
+// WithDeepSARConfig returns a clone of the input rest.Config
+// with an additional header making SARs to be deep.
+func WithDeepSARConfig(config *rest.Config) *rest.Config {
+	clone := *config
+	clone.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &withHeaderRoundtripper{
+			RoundTripper: rt,
+			headers: map[string]string{
+				deepSARHeader: "true",
+			},
+		}
+	})
+	return &clone
+}
+
+type withHeaderRoundtripper struct {
+	http.RoundTripper
+
+	headers map[string]string
+}
+
+func (rt *withHeaderRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	for k, v := range rt.headers {
+		req.Header.Set(k, v)
+	}
+	return rt.RoundTripper.RoundTrip(req)
+}
+
+// WithDeepSubjectAccessReview attaches to the context that this request has set the DeepSubjectAccessReview
+// header. The header is ignore for non-system:master users and for non-SAR request.
+//
+// A deep SAR request does not check permission that the subject can access a workspace and the top-level workspace.
+func WithDeepSubjectAccessReview(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		val := r.Header.Get(deepSARHeader)
+		if val != "true" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// only for SAR
+		ri, ok := genericapirequest.RequestInfoFrom(r.Context())
+		if !ok {
+			responsewriters.InternalError(w, r, fmt.Errorf("cannot get request info"))
+			return
+		}
+		if !ri.IsResourceRequest || ri.APIGroup != authorization.GroupName || ri.Resource != "subjectaccessreviews" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// only for system:masters
+		user, ok := genericapirequest.UserFrom(r.Context())
+		if !ok {
+			responsewriters.InternalError(w, r, fmt.Errorf("cannot get user"))
+			return
+		}
+		if !sets.NewString(user.GetGroups()...).Has(kuser.SystemPrivilegedGroup) {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// attach whether that the header is set and all pre-conditions are fulfilled
+		r = r.WithContext(context.WithValue(r.Context(), deepSARKey, true))
+		handler.ServeHTTP(w, r)
+	})
+}
+
+// DeepSubjectAccessReviewFrom returns whether this is a deep SAR request.
+func DeepSubjectAccessReviewFrom(ctx context.Context) bool {
+	k := ctx.Value(deepSARKey)
+	return k != nil && k.(bool)
+}

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -69,6 +69,10 @@ type topLevelOrgAccessAuthorizer struct {
 }
 
 func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if DeepSubjectAccessReviewFrom(ctx) {
+		return authorizer.DecisionAllow, "", nil
+	}
+
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil || cluster == nil || cluster.Name.Empty() {
 		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, err

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -73,6 +73,10 @@ type workspaceContentAuthorizer struct {
 }
 
 func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	if DeepSubjectAccessReviewFrom(ctx) {
+		return authorizer.DecisionAllow, "", nil
+	}
+
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil {
 		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, err

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -48,6 +48,7 @@ import (
 	kcpadmissioninitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/embeddedetcd"
@@ -270,6 +271,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	c.GenericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, genericConfig *genericapiserver.Config) (secure http.Handler) {
 		apiHandler = WithWildcardListWatchGuard(apiHandler)
 		apiHandler = WithWildcardIdentity(apiHandler)
+		apiHandler = authorization.WithDeepSubjectAccessReview(apiHandler)
 
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, genericConfig)
 

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,13 +35,13 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
 
 	confighelpers "github.com/kcp-dev/kcp/config/helpers"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	kcp "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
@@ -59,8 +60,6 @@ func TestAuthorizer(t *testing.T) {
 
 	kubeClusterClient, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err)
-	kcpClusterClient, err := kcp.NewForConfig(cfg)
-	require.NoError(t, err)
 	dynamicClusterClient, err := kcpdynamic.NewClusterDynamicClientForConfig(cfg)
 	require.NoError(t, err)
 
@@ -70,10 +69,10 @@ func TestAuthorizer(t *testing.T) {
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org1, "org-resources.yaml")
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org2, "org-resources.yaml")
 
-	waitForReady(t, ctx, kcpClusterClient, org1, "workspace1")
-	waitForReady(t, ctx, kcpClusterClient, org1, "workspace2")
-	waitForReady(t, ctx, kcpClusterClient, org2, "workspace1")
-	waitForReady(t, ctx, kcpClusterClient, org2, "workspace2")
+	framework.NewWorkspaceFixture(t, server, org1, framework.WithName("workspace1"))
+	framework.NewWorkspaceFixture(t, server, org1, framework.WithName("workspace2"))
+	framework.NewWorkspaceFixture(t, server, org2, framework.WithName("workspace1"), framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: tenancyv1alpha1.RootShard})) // on root for deep SAR test
+	framework.NewWorkspaceFixture(t, server, org2, framework.WithName("workspace2"))
 
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org1.Join("workspace1"), "workspace1-resources.yaml")
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org2.Join("workspace1"), "workspace1-resources.yaml")
@@ -191,6 +190,36 @@ func TestAuthorizer(t *testing.T) {
 				return true
 			}, wait.ForeverTestTimeout, time.Millisecond*100, "User-3 should now be able to list Namespaces")
 		},
+		"without org access, a deep SAR with user-1 against org2 succeeds even with org access for user-1": func(t *testing.T) {
+			t.Log("try to list ConfigMap as user-1 in org without access, should fail")
+			_, err := user1KubeClusterClient.CoreV1().ConfigMaps("default").List(logicalcluster.WithCluster(ctx, org2.Join("workspace1")), metav1.ListOptions{})
+			require.Error(t, err, "user-1 should not be able to list configmaps in org2")
+
+			sar := &authorizationv1.SubjectAccessReview{
+				Spec: authorizationv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationv1.ResourceAttributes{Namespace: "default", Verb: "list", Version: "v1", Resource: "configmaps"},
+					User:               "user-1",
+					Groups:             []string{"team-1"},
+				},
+			}
+
+			t.Log("ask with normal SAR that user-1 cannot access org2 because it has no access")
+			resp, err := kubeClusterClient.AuthorizationV1().SubjectAccessReviews().Create(logicalcluster.WithCluster(ctx, org2.Join("workspace1")), sar, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.False(t, resp.Status.Allowed, "SAR should correctly answer that user-1 CANNOT list configmaps in org2 because it has no access to org2")
+
+			t.Log("ask with normal SAR that user-1 can access org1 because it has access")
+			resp, err = kubeClusterClient.AuthorizationV1().SubjectAccessReviews().Create(logicalcluster.WithCluster(ctx, org1.Join("workspace1")), sar, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.True(t, resp.Status.Allowed, "SAR should correctly answer that user-1 CAN list configmaps in org2 because it has access to org1")
+
+			t.Log("ask with deep SAR that user-1 hypothetically could list configmaps in org2 if it had access")
+			deepSARClient, err := kubernetes.NewForConfig(authorization.WithDeepSARConfig(rest.CopyConfig(server.RootShardSystemMasterBaseConfig(t))))
+			require.NoError(t, err)
+			resp, err = deepSARClient.AuthorizationV1().SubjectAccessReviews().Create(logicalcluster.WithCluster(ctx, org2.Join("workspace1")), sar, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.True(t, resp.Status.Allowed, "SAR should answer hypothetically that user-1 could list configmaps in org2 if it had access")
+		},
 	}
 
 	for tcName, tcFunc := range tests {
@@ -201,18 +230,6 @@ func TestAuthorizer(t *testing.T) {
 			tcFunc(t)
 		})
 	}
-}
-
-func waitForReady(t *testing.T, ctx context.Context, kcpClusterClient kcp.Interface, orgClusterName logicalcluster.Name, workspace string) {
-	t.Logf("Waiting for workspace %s|%s to be ready", orgClusterName, workspace)
-	require.Eventually(t, func() bool {
-		ws, err := kcpClusterClient.TenancyV1alpha1().ClusterWorkspaces().Get(logicalcluster.WithCluster(ctx, orgClusterName), workspace, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("failed to get workspace %s|%s: %v", orgClusterName, workspace, err)
-			return false
-		}
-		return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "workspace %s|%s didn't get ready", orgClusterName, workspace)
 }
 
 func createResources(t *testing.T, ctx context.Context, dynamicClusterClient *kcpdynamic.ClusterDynamicClient, discoveryClusterClient *discovery.DiscoveryClient, clusterName logicalcluster.Name, fileName string) {

--- a/test/e2e/authorizer/org-resources.yaml
+++ b/test/e2e/authorizer/org-resources.yaml
@@ -1,13 +1,3 @@
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspace
-metadata:
-  name: workspace1
----
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspace
-metadata:
-  name: workspace2
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
This will allow us
- to authorize APIBindings to bind without actual APIExport workspace access
- to authorize use of CWTs without actual CWT workspace access (fixes https://github.com/kcp-dev/kcp/issues/1518)
- to authorize permission claim access to fall under MaximalPermissionClaims of the APIExport owner.

TODO:
- [x] ~~clarify whether we want to map the users somehow with a prefix~~ only local (SA) users would need a prefix, see next point.
- [ ] clarify whether we want to keep restricting service accounts to their workspace, and/or wipe their usernames when not having workspace access