### PR TITLE
apiexport controller: assigns ClusterWorkspaceShard.VirtualWorkspaceURL

### DIFF
--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -167,18 +167,18 @@ func (c *controller) updateVirtualWorkspaceURLs(apiExport *apisv1alpha1.APIExpor
 
 	desiredURLs := sets.NewString()
 	for _, clusterWorkspaceShard := range clusterWorkspaceShards {
-		if clusterWorkspaceShard.Spec.ExternalURL == "" {
+		if clusterWorkspaceShard.Spec.VirtualWorkspaceURL == "" {
 			continue
 		}
 
-		u, err := url.Parse(clusterWorkspaceShard.Spec.ExternalURL)
+		u, err := url.Parse(clusterWorkspaceShard.Spec.VirtualWorkspaceURL)
 		if err != nil {
 			// Should never happen
 			klog.Errorf(
 				"Error parsing ClusterWorkspaceShard %s|%s spec.externalURL %q: %v",
 				logicalcluster.From(clusterWorkspaceShard),
 				clusterWorkspaceShard.Name,
-				clusterWorkspaceShard.Spec.ExternalURL,
+				clusterWorkspaceShard.Spec.VirtualWorkspaceURL,
 			)
 
 			continue


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
updates the apiexport controller to assign `ClusterWorkspaceShard.VirtualWorkspaceURL` to `APIExports`
## Related issue(s)

Fixes #