### PR TITLE
Syncer: refuse to work on sync target UID discrepancy.

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -110,6 +110,7 @@ func Run(options *synceroptions.Options, ctx context.Context) error {
 			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
 			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),
 			SyncTargetName:      options.SyncTargetName,
+			SyncTargetUID:       options.SyncTargetUID,
 		},
 		numThreads,
 		options.APIImportPollInterval,

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	ToKubeconfig        string
 	ToContext           string
 	SyncTargetName      string
+	SyncTargetUID       string
 	Logs                *logs.Options
 	SyncedResourceTypes []string
 
@@ -68,6 +69,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&options.ToContext, "to-context", options.ToContext, "Context to use in the Kubeconfig file for -to cluster, instead of the current context.")
 	fs.StringVar(&options.SyncTargetName, "sync-target-name", options.SyncTargetName,
 		fmt.Sprintf("ID of the -to cluster. Resources with this ID set in the '%s' label will be synced.", workloadv1alpha1.ClusterResourceStateLabelPrefix+"<ClusterID>"))
+	fs.StringVar(&options.SyncTargetUID, "sync-target-uid", options.SyncTargetUID, "The UID from the SyncTarget resource in KCP.")
 	fs.StringArrayVarP(&options.SyncedResourceTypes, "resources", "r", options.SyncedResourceTypes, "Resources to be synchronized in kcp.")
 	fs.DurationVar(&options.APIImportPollInterval, "api-import-poll-interval", options.APIImportPollInterval, "Polling interval for API import.")
 

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -140,6 +140,7 @@ spec:
         args:
         - --from-kubeconfig=/kcp/kubeconfig
         - --sync-target-name=sync-target-name
+        - --sync-target-uid=sync-target-uid
         - --from-cluster=root:default:foo
         - --resources=resource1
         - --resources=resource2
@@ -167,6 +168,7 @@ spec:
 		Namespace:       "kcp-syncer-sync-target-name-34b23c4k",
 		LogicalCluster:  "root:default:foo",
 		SyncTarget:      "sync-target-name",
+		SyncTargetUID:   "sync-target-uid",
 		Image:           "image",
 		Replicas:        1,
 		ResourcesToSync: []string{"resource1", "resource2"},

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -117,6 +117,7 @@ spec:
         args:
         - --from-kubeconfig=/kcp/{{.SecretConfigKey}}
         - --sync-target-name={{.SyncTarget}}
+        - --sync-target-uid={{.SyncTargetUID}}
         - --from-cluster={{.LogicalCluster}}
 {{- range $resourceToSync := .ResourcesToSync}}
         - --resources={{$resourceToSync}}

--- a/pkg/reconciler/workload/synctarget/synctarget_reconcile.go
+++ b/pkg/reconciler/workload/synctarget/synctarget_reconcile.go
@@ -55,6 +55,7 @@ func (c *Controller) reconcile(syncTarget *workloadv1alpha1.SyncTarget, workspac
 				syncerbuilder.SyncerVirtualWorkspaceName,
 				logicalcluster.From(syncTargetCopy).String(),
 				syncTargetCopy.Name,
+				string(syncTargetCopy.UID),
 			)
 			desiredURLs.Insert(syncerVirtualWorkspaceURL.String())
 		}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -66,6 +67,7 @@ type SyncerConfig struct {
 	ResourcesToSync     sets.String
 	SyncTargetWorkspace logicalcluster.Name
 	SyncTargetName      string
+	SyncTargetUID       string
 }
 
 func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, importPollInterval time.Duration) error {
@@ -93,6 +95,12 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		syncTarget, err = kcpClusterClient.Cluster(cfg.SyncTargetWorkspace).WorkloadV1alpha1().SyncTargets().Get(ctx, cfg.SyncTargetName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
+		}
+
+		// If the SyncTargetUID flag is set, we compare the provided value with the kcp synctarget uid, if the values don't match
+		// the syncer will refuse to work.
+		if cfg.SyncTargetUID != "" && cfg.SyncTargetUID != string(syncTarget.UID) {
+			return false, fmt.Errorf("unexpected SyncTarget UID %s, expected %s, refusing to sync", syncTarget.UID, cfg.SyncTargetUID)
 		}
 
 		if len(syncTarget.Status.VirtualWorkspaces) == 0 {
@@ -221,12 +229,28 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		// Attempt to heartbeat every second until successful. Errors are logged instead of being returned so the
 		// poll error can be safely ignored.
 		_ = wait.PollImmediateInfiniteWithContext(ctx, 1*time.Second, func(ctx context.Context) (bool, error) {
+			syncTarget, err = kcpClusterClient.Cluster(cfg.SyncTargetWorkspace).WorkloadV1alpha1().SyncTargets().Get(ctx, cfg.SyncTargetName, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("Failed to retrieve SyncTarget %s|%s: %v", cfg.SyncTargetWorkspace, cfg.SyncTargetName, err)
+				return false, nil
+			}
+
+			// If the SyncTargetUID flag is set, we compare the provided value with the kcp synctarget uid, if the values don't match
+			// the syncer will refuse to work.
+			if cfg.SyncTargetUID != "" {
+				if cfg.SyncTargetUID != string(syncTarget.UID) {
+					klog.Errorf("SyncTargetUID %s does not match the UID of the synctarget %s", cfg.SyncTargetUID, string(syncTarget.UID))
+					os.Exit(1)
+				}
+			}
+
 			patchBytes := []byte(fmt.Sprintf(`[{"op":"replace","path":"/status/lastSyncerHeartbeatTime","value":%q}]`, time.Now().Format(time.RFC3339)))
-			syncTarget, err := kcpClusterClient.Cluster(cfg.SyncTargetWorkspace).WorkloadV1alpha1().SyncTargets().Patch(ctx, cfg.SyncTargetName, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status")
+			syncTarget, err = kcpClusterClient.Cluster(cfg.SyncTargetWorkspace).WorkloadV1alpha1().SyncTargets().Patch(ctx, cfg.SyncTargetName, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status")
 			if err != nil {
 				klog.Errorf("failed to set status.lastSyncerHeartbeatTime for SyncTarget %s|%s: %v", cfg.SyncTargetWorkspace, cfg.SyncTargetName, err)
 				return false, nil
 			}
+
 			heartbeatTime = syncTarget.Status.LastSyncerHeartbeatTime.Time
 			return true, nil
 		})

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -386,6 +386,8 @@ func syncerConfigFromCluster(t *testing.T, downstreamConfig *rest.Config, namesp
 	resourcesToSync := argMap["--resources"]
 	require.NotEmpty(t, fromCluster, "--resources is required")
 
+	syncTargetUID := argMap["--sync-target-uid"][0]
+
 	// Read the downstream token from the deployment's service account secret
 	var tokenSecret corev1.Secret
 	Eventually(t, func() (bool, string) {
@@ -414,6 +416,7 @@ func syncerConfigFromCluster(t *testing.T, downstreamConfig *rest.Config, namesp
 		ResourcesToSync:     sets.NewString(resourcesToSync...),
 		SyncTargetWorkspace: kcpClusterName,
 		SyncTargetName:      syncTargetName,
+		SyncTargetUID:       syncTargetUID,
 	}
 }
 

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -567,7 +567,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			kubelikeWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 			t.Logf("Deploying syncer into workspace %s", kubelikeWorkspace)
-			_ = framework.NewSyncerFixture(t, server, kubelikeWorkspace,
+			kubelikeSyncer := framework.NewSyncerFixture(t, server, kubelikeWorkspace,
 				framework.WithSyncTarget(kubelikeWorkspace, "kubelike"),
 				framework.WithExtraResources("ingresses.networking.k8s.io", "services"),
 				framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
@@ -641,7 +641,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			wildwestSyncTargetName := fmt.Sprintf("wildwest-%d", +rand.Intn(1000000))
 
 			t.Logf("Deploying syncer into workspace %s", wildwestWorkspace)
-			_ = framework.NewSyncerFixture(t, server, wildwestWorkspace,
+			wildwestSyncer := framework.NewSyncerFixture(t, server, wildwestWorkspace,
 				framework.WithExtraResources("cowboys.wildwest.dev"),
 				framework.WithSyncTarget(wildwestWorkspace, wildwestSyncTargetName),
 				framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
@@ -669,11 +669,11 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			require.NoError(t, err)
 			virtualWorkspaceRawConfig := rawConfig.DeepCopy()
 			virtualWorkspaceRawConfig.Clusters["kubelike"] = rawConfig.Clusters["base"].DeepCopy()
-			virtualWorkspaceRawConfig.Clusters["kubelike"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + kubelikeWorkspace.String() + "/kubelike"
+			virtualWorkspaceRawConfig.Clusters["kubelike"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + kubelikeWorkspace.String() + "/kubelike/" + kubelikeSyncer.SyncerConfig.SyncTargetUID
 			virtualWorkspaceRawConfig.Contexts["kubelike"] = rawConfig.Contexts["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["kubelike"].Cluster = "kubelike"
 			virtualWorkspaceRawConfig.Clusters["wildwest"] = rawConfig.Clusters["base"].DeepCopy()
-			virtualWorkspaceRawConfig.Clusters["wildwest"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + wildwestWorkspace.String() + "/" + wildwestSyncTargetName
+			virtualWorkspaceRawConfig.Clusters["wildwest"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + wildwestWorkspace.String() + "/" + wildwestSyncTargetName + "/" + wildwestSyncer.SyncerConfig.SyncTargetUID
 			virtualWorkspaceRawConfig.Contexts["wildwest"] = rawConfig.Contexts["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["wildwest"].Cluster = "wildwest"
 			kubelikeVWConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "kubelike", nil, nil).ClientConfig()


### PR DESCRIPTION
The changes in this PR are focused on avoiding a Syncer running with an old SyncTarget, this is accomplished by:

- Syncer: 
   - New flag for providing the expected sync target UID: `--sync-target-uid`
   - When starting will check that the provided UID matches the existing sync target UID, if not, fail to start
   - When patching a sync target status for setting the heartbeat, tries to match the expected sync target UID, if not, refuses to patch 
- KCP Kubectl plugin: The generated manifests include the sync target UID flag.
- SyncTarget controller: Appends the desired sync target UID to the VirtualWorkspace URLs.
- Syncer VirtualWorkspace: validates that the sync target name and UID in the request 
match.
  
related to: https://github.com/kcp-dev/kcp/issues/1679