### PR TITLE
Add --batteries-included

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/term"
 	"k8s.io/component-base/version"
+	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/cmd/help"
 	"github.com/kcp-dev/kcp/pkg/embeddedetcd"
@@ -112,6 +113,8 @@ func main() {
 				return errors.NewAggregate(errs)
 			}
 
+			klog.Infof("Batteries included: %s", strings.Join(completed.Extra.BatteriesIncluded, ","))
+
 			config, err := server.NewConfig(completed)
 			if err != nil {
 				return err
@@ -172,7 +175,7 @@ func main() {
 
 	setPartialUsageAndHelpFunc(startCmd, namedStartFlagSets, cols, []string{
 		"etcd-servers",
-		"run-controllers",
+		"batteries-included",
 		"run-virtual-workspaces",
 	})
 

--- a/config/homebucket/bootstrap.go
+++ b/config/homebucket/bootstrap.go
@@ -19,6 +19,7 @@ package organization
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
@@ -29,6 +30,6 @@ import (
 // Bootstrap creates CRDs and the resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, kcpClient kcpclient.Interface) error {
+func Bootstrap(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, kcpClient kcpclient.Interface, batteriesIncluded sets.String) error {
 	return confighelpers.BindRootAPIs(ctx, kcpClient, "tenancy.kcp.dev")
 }

--- a/config/homeroot/bootstrap.go
+++ b/config/homeroot/bootstrap.go
@@ -19,6 +19,7 @@ package organization
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
@@ -29,6 +30,6 @@ import (
 // Bootstrap creates CRDs and the resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, kcpClient kcpclient.Interface) error {
+func Bootstrap(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, kcpClient kcpclient.Interface, batteriesIncluded sets.String) error {
 	return confighelpers.BindRootAPIs(ctx, kcpClient, "tenancy.kcp.dev")
 }

--- a/config/root-phase0/bootstrap.go
+++ b/config/root-phase0/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/yaml"
@@ -34,11 +35,11 @@ var fs embed.FS
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, kcpClient kcpclientset.Interface, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface) error {
+func Bootstrap(ctx context.Context, kcpClient kcpclientset.Interface, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, batteriesIncluded sets.String) error {
 	if err := confighelpers.BindRootAPIs(ctx, kcpClient, "shards.tenancy.kcp.dev", "tenancy.kcp.dev", "scheduling.kcp.dev", "workload.kcp.dev", "apiresource.kcp.dev"); err != nil {
 		return err
 	}
-	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, fs)
+	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, batteriesIncluded, fs)
 }
 
 // Unmarshal YAML-decodes the give embedded file name into the target.

--- a/config/root/bootstrap.go
+++ b/config/root/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"embed"
 	"encoding/base64"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
@@ -35,7 +36,7 @@ var fs embed.FS
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, shardVirtualWorkspaceURL string, kubeconfig clientcmdapi.Config, homePrefix string, homeWorkspaceCreatorGroups []string) error {
+func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, shardVirtualWorkspaceURL string, kubeconfig clientcmdapi.Config, homePrefix string, homeWorkspaceCreatorGroups []string, batteriesIncluded sets.String) error {
 	kubeconfigRaw, err := clientcmd.Write(kubeconfig)
 	if err != nil {
 		return err
@@ -52,7 +53,7 @@ func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInter
 		homeWorkspaceCreatorGroupReplacement = "[]"
 	}
 
-	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, fs, confighelpers.ReplaceOption(
+	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, batteriesIncluded, fs, confighelpers.ReplaceOption(
 		"SHARD_NAME", shardName,
 		"SHARD_VIRTUAL_WORKSPACE_URL", shardVirtualWorkspaceURL,
 		"SHARD_KUBECONFIG", base64.StdEncoding.EncodeToString(kubeconfigRaw),

--- a/config/root/clusterworkspacetype-organization.yaml
+++ b/config/root/clusterworkspacetype-organization.yaml
@@ -2,6 +2,8 @@ apiVersion: tenancy.kcp.dev/v1alpha1
 kind: ClusterWorkspaceType
 metadata:
   name: organization
+  annotations:
+    bootstrap.kcp.dev/battery: cluster-workspace-types
 spec:
   extend:
     with:

--- a/config/root/clusterworkspacetype-root.yaml
+++ b/config/root/clusterworkspacetype-root.yaml
@@ -2,11 +2,16 @@ apiVersion: tenancy.kcp.dev/v1alpha1
 kind: ClusterWorkspaceType
 metadata:
   name: root
+  annotations:
+    bootstrap.kcp.dev/create-only: "true"
 spec:
+{{- $bat := index .Batteries "cluster-workspace-types" -}}
+{{ if eq $bat true }}
   defaultChildWorkspaceType:
     name: organization
     path: root
-  parentConstraints:
+{{ end }}
+  limitAllowedParents:
     none: true
   extend:
     with:

--- a/config/root/clusterworkspacetype-team.yaml
+++ b/config/root/clusterworkspacetype-team.yaml
@@ -2,6 +2,8 @@ apiVersion: tenancy.kcp.dev/v1alpha1
 kind: ClusterWorkspaceType
 metadata:
   name: team
+  annotations:
+    bootstrap.kcp.dev/battery: cluster-workspace-types
 spec:
   extend:
     with:

--- a/config/system-crds/bootstrap.go
+++ b/config/system-crds/bootstrap.go
@@ -24,6 +24,7 @@ import (
 
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -40,7 +41,7 @@ var fs embed.FS
 // Bootstrap creates CRDs and the resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, crdClient apiextensionsclient.Interface, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface) error {
+func Bootstrap(ctx context.Context, crdClient apiextensionsclient.Interface, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, batteriesIncluded sets.String) error {
 	// This is the full list of CRDs that kcp owns and manages in the system:system-crds logical cluster. Our custom CRD
 	// lister currently has a hard-coded list of which system CRDs are made available to which workspaces. See
 	// pkg/server/apiextensions.go newSystemCRDProvider for the list. These CRDs should never be installed in any other
@@ -62,5 +63,5 @@ func Bootstrap(ctx context.Context, crdClient apiextensionsclient.Interface, dis
 		return fmt.Errorf("failed to bootstrap system CRDs: %w", err)
 	}
 
-	return confighelpers.Bootstrap(ctx, discoveryClient, dynamicClient, fs)
+	return confighelpers.Bootstrap(ctx, discoveryClient, dynamicClient, batteriesIncluded, fs)
 }

--- a/config/universal/bootstrap.go
+++ b/config/universal/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"embed"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
@@ -33,10 +34,10 @@ var fs embed.FS
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, kcpClient kcpclient.Interface) error {
+func Bootstrap(ctx context.Context, discoveryClient discovery.DiscoveryInterface, dynamicClient dynamic.Interface, kcpClient kcpclient.Interface, batteriesIncluded sets.String) error {
 	if err := confighelpers.BindRootAPIs(ctx, kcpClient, "tenancy.kcp.dev", "scheduling.kcp.dev", "workload.kcp.dev", "apiresource.kcp.dev"); err != nil {
 		return err
 	}
 
-	return confighelpers.Bootstrap(ctx, discoveryClient, dynamicClient, fs)
+	return confighelpers.Bootstrap(ctx, discoveryClient, dynamicClient, batteriesIncluded, fs)
 }

--- a/pkg/authorization/bootstrap/policy.go
+++ b/pkg/authorization/bootstrap/policy.go
@@ -27,20 +27,21 @@ import (
 )
 
 const (
+	// SystemKcpClusterWorkspaceAccessGroup is a group that gives a user basic access to a workspace.
+	// It does not give them any permissions in the workspace.
 	SystemKcpClusterWorkspaceAccessGroup = "system:kcp:clusterworkspace:access"
-	// An admin group per cluster workspace.
-	// Members of this group have all permissions in the referenced cluster workspace (capped by maximal permission policy).
+	// SystemKcpClusterWorkspaceAdminGroup is an admin group per cluster workspace. Members of this group have all permissions
+	// in the referenced cluster workspace (capped by maximal permission policy).
 	SystemKcpClusterWorkspaceAdminGroup = "system:kcp:clusterworkspace:admin"
-	// A global admin group.
-	// Members of this group have all permissions across all cluster workspaces.
+	// SystemKcpAdminGroup is global admin group. Members of this group have all permissions across all cluster workspaces.
 	SystemKcpAdminGroup = "system:kcp:admin"
 )
 
 // ClusterRoleBindings return default rolebindings to the default roles
 func clusterRoleBindings() []rbacv1.ClusterRoleBinding {
 	return []rbacv1.ClusterRoleBinding{
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups(SystemKcpClusterWorkspaceAdminGroup, SystemKcpAdminGroup).BindingOrDie(), "system:kcp:clusterworkspace:admin"),
-		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("system:kcp:tenancy:reader").Groups(SystemKcpClusterWorkspaceAccessGroup).BindingOrDie(), "system:kcp:clusterworkspace:access"),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("cluster-admin").Groups(SystemKcpClusterWorkspaceAdminGroup, SystemKcpAdminGroup).BindingOrDie(), SystemKcpClusterWorkspaceAdminGroup),
+		clusterRoleBindingCustomName(rbacv1helpers.NewClusterBinding("system:kcp:tenancy:reader").Groups(SystemKcpClusterWorkspaceAccessGroup).BindingOrDie(), SystemKcpClusterWorkspaceAccessGroup),
 	}
 }
 

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
@@ -53,7 +53,7 @@ func (c *controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.C
 	if err != nil {
 		return err
 	}
-	if err := c.bootstrap(logicalcluster.WithCluster(bootstrapCtx, wsClusterName), crdWsClient.Discovery(), c.dynamicClusterClient, c.kcpClusterClient); err != nil {
+	if err := c.bootstrap(logicalcluster.WithCluster(bootstrapCtx, wsClusterName), crdWsClient.Discovery(), c.dynamicClusterClient, c.kcpClusterClient, c.batteriesIncluded); err != nil {
 		return err // requeue
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -27,6 +27,7 @@ import (
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/quota/v1/generic"
@@ -55,6 +56,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/informer"
 	boostrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
 	kcpserveroptions "github.com/kcp-dev/kcp/pkg/server/options"
+	"github.com/kcp-dev/kcp/pkg/server/options/batteries"
 	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
 )
 
@@ -79,8 +81,8 @@ type ExtraConfig struct {
 	identityConfig    *rest.Config
 
 	// authentication
-	kcpAdminToken, shardAdminToken string
-	shardAdminTokenHash            []byte
+	kcpAdminToken, shardAdminToken, userToken string
+	shardAdminTokenHash                       []byte
 
 	// clients
 	DynamicClusterClient       dynamic.ClusterInterface
@@ -254,9 +256,13 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	if err := opts.Authorization.ApplyTo(c.GenericConfig, c.KubeSharedInformerFactory, c.KcpSharedInformerFactory); err != nil {
 		return nil, err
 	}
-	c.kcpAdminToken, c.shardAdminToken, c.shardAdminTokenHash, err = opts.AdminAuthentication.ApplyTo(c.GenericConfig)
+	var userToken string
+	c.kcpAdminToken, c.shardAdminToken, userToken, c.shardAdminTokenHash, err = opts.AdminAuthentication.ApplyTo(c.GenericConfig)
 	if err != nil {
 		return nil, err
+	}
+	if sets.NewString(opts.Extra.BatteriesIncluded...).Has(batteries.User) {
+		c.userToken = userToken
 	}
 
 	if err := opts.GenericControlPlane.Audit.ApplyTo(c.GenericConfig); err != nil {

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/discovery"
@@ -401,6 +402,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 		s.KcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
 		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "universal"},
 		configuniversal.Bootstrap,
+		sets.NewString(s.Options.Extra.BatteriesIncluded...),
 	)
 	if err != nil {
 		return err
@@ -450,6 +452,7 @@ func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config)
 		s.KcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
 		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "homeroot"},
 		confighomeroot.Bootstrap,
+		sets.NewString(s.Options.Extra.BatteriesIncluded...),
 	)
 	if err != nil {
 		return err
@@ -463,6 +466,7 @@ func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config)
 		s.KcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaces(),
 		tenancyv1alpha1.ClusterWorkspaceTypeReference{Path: "root", Name: "homebucket"},
 		confighomebucket.Bootstrap,
+		sets.NewString(s.Options.Extra.BatteriesIncluded...),
 	)
 	if err != nil {
 		return err

--- a/pkg/server/options/batteries/batteries.go
+++ b/pkg/server/options/batteries/batteries.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batteries
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	_ "github.com/kcp-dev/kcp/pkg/features"
+)
+
+const (
+	// ClusterWorkspaceTypes leads to creation of a number of default types beyond the universal type.
+	ClusterWorkspaceTypes = "cluster-workspace-types"
+)
+
+var All = sets.NewString(
+	ClusterWorkspaceTypes,
+)
+
+var Defaults = sets.NewString(
+	ClusterWorkspaceTypes,
+)

--- a/pkg/server/options/batteries/batteries.go
+++ b/pkg/server/options/batteries/batteries.go
@@ -25,10 +25,14 @@ import (
 const (
 	// ClusterWorkspaceTypes leads to creation of a number of default types beyond the universal type.
 	ClusterWorkspaceTypes = "cluster-workspace-types"
+
+	// User leads to an additional user named "user" in the admin.kubeconfig that is not admin.
+	User = "user"
 )
 
 var All = sets.NewString(
 	ClusterWorkspaceTypes,
+	User,
 )
 
 var Defaults = sets.NewString(

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -137,6 +137,7 @@ var (
 		"shard-kubeconfig-file",       // Kubeconfig holding admin(!) credentials to peer kcp shards.
 		"root-shard-kubeconfig-file",  // Kubeconfig holding admin(!) credentials to the root kcp shard.
 		"experimental-bind-free-port", // Bind to a free port. --secure-bind-port must be 0. Use the admin.kubeconfig to extract the chosen port.
+		"batteries-included",          // A list of batteries included (= default objects that might be unwanted in production, but very helpful in trying out kcp or development).
 
 		// secure serving flags
 		"bind-address",                     // The IP address on which to listen for the --secure-port port. The associated interface(s) must be reachable by the rest of the cluster, and by CLI/web clients. If blank or an unspecified address (0.0.0.0 or ::), all interfaces will be used.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -38,6 +38,7 @@ import (
 	etcdoptions "github.com/kcp-dev/kcp/pkg/embeddedetcd/options"
 	_ "github.com/kcp-dev/kcp/pkg/features"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
+	"github.com/kcp-dev/kcp/pkg/server/options/batteries"
 )
 
 type Options struct {
@@ -63,6 +64,8 @@ type ExtraOptions struct {
 	ShardVirtualWorkspaceURL string
 	DiscoveryPollInterval    time.Duration
 	ExperimentalBindFreePort bool
+
+	BatteriesIncluded []string
 }
 
 type completedOptions struct {
@@ -103,6 +106,7 @@ func NewOptions(rootDir string) *Options {
 			ShardName:                "root",
 			DiscoveryPollInterval:    60 * time.Second,
 			ExperimentalBindFreePort: false,
+			BatteriesIncluded:        batteries.Defaults.List(),
 		},
 	}
 
@@ -171,6 +175,15 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 	fs.BoolVar(&o.Extra.ExperimentalBindFreePort, "experimental-bind-free-port", o.Extra.ExperimentalBindFreePort, "Bind to a free port. --secure-port must be 0. Use the admin.kubeconfig to extract the chosen port.")
 	fs.MarkHidden("experimental-bind-free-port") // nolint:errcheck
 
+	fs.StringSliceVar(&o.Extra.BatteriesIncluded, "batteries-included", o.Extra.BatteriesIncluded, fmt.Sprintf(
+		`A list of batteries included (= default objects that might be unwanted in production, but are very helpful in trying out kcp or for development). These are the possible values: %s.
+
+- cluster-workspace-types: creates "organization" and "team" ClusterWorkspaceTypes in the root workspace.
+
+Prefixing with - or + means to remove from the default set or add to the default set.`,
+		strings.Join(batteries.All.Difference(batteries.Defaults).List(), ","),
+	))
+
 	return fss
 }
 
@@ -190,6 +203,24 @@ func (o *CompletedOptions) Validate() []error {
 	errs = append(errs, o.AdminAuthentication.Validate()...)
 	errs = append(errs, o.Virtual.Validate()...)
 	errs = append(errs, o.HomeWorkspaces.Validate()...)
+
+	differential := false
+	for i, b := range o.Extra.BatteriesIncluded {
+		if strings.HasPrefix(b, "+") || strings.HasPrefix(b, "-") {
+			if !differential && i > 0 {
+				errs = append(errs, fmt.Errorf("--batteries-included must all be prefixed with + or - or none"))
+				break
+			}
+			differential = true
+			b = b[1:]
+		} else if differential {
+			errs = append(errs, fmt.Errorf("--batteries-included must all be prefixed with + or - or none"))
+			break
+		}
+		if !batteries.All.Has(b) {
+			errs = append(errs, fmt.Errorf("unknown battery: %s", b))
+		}
+	}
 
 	return errs
 }
@@ -272,6 +303,25 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 		// but other than that only has cosmetic effects e.g. on the flag description. Hence, we do it here
 		// in Complete and not in NewOptions.
 		o.GenericControlPlane.SecureServing.Required = false
+	}
+
+	differential := false
+	for _, b := range o.Extra.BatteriesIncluded {
+		if strings.HasPrefix(b, "+") || strings.HasPrefix(b, "-") {
+			differential = true
+			break
+		}
+	}
+	if differential {
+		bats := sets.NewString(batteries.Defaults.List()...)
+		for _, b := range o.Extra.BatteriesIncluded {
+			if strings.HasPrefix(b, "+") {
+				bats.Insert(b[1:])
+			} else if strings.HasPrefix(b, "-") {
+				bats.Delete(b[1:])
+			}
+		}
+		o.Extra.BatteriesIncluded = bats.List()
 	}
 
 	return &CompletedOptions{

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -179,6 +179,7 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 		`A list of batteries included (= default objects that might be unwanted in production, but are very helpful in trying out kcp or for development). These are the possible values: %s.
 
 - cluster-workspace-types: creates "organization" and "team" ClusterWorkspaceTypes in the root workspace.
+- user:                  creates an additional non-admin user and context named "user" in the admin.kubeconfig
 
 Prefixing with - or + means to remove from the default set or add to the default set.`,
 		strings.Join(batteries.All.Difference(batteries.Defaults).List(), ","),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -424,7 +424,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
-	if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.shardAdminTokenHash); err != nil {
+	if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.userToken, s.shardAdminTokenHash); err != nil {
 		return err
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -128,6 +128,7 @@ func (s *Server) Run(ctx context.Context) error {
 				s.ApiExtensionsClusterClient.Cluster(SystemCRDLogicalCluster),
 				s.ApiExtensionsClusterClient.Cluster(SystemCRDLogicalCluster).Discovery(),
 				s.DynamicClusterClient.Cluster(SystemCRDLogicalCluster),
+				sets.NewString(s.Options.Extra.BatteriesIncluded...),
 			); err != nil {
 				klog.Errorf("failed to bootstrap system CRDs: %v", err)
 				return false, nil // keep trying
@@ -173,6 +174,7 @@ func (s *Server) Run(ctx context.Context) error {
 				s.KcpClusterClient.Cluster(tenancyv1alpha1.RootCluster),
 				s.ApiExtensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
 				s.DynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
+				sets.NewString(s.Options.Extra.BatteriesIncluded...),
 			); err != nil {
 				// nolint:nilerr
 				klog.Errorf("failed to bootstrap root workspace phase 0: %w", err)
@@ -291,6 +293,7 @@ func (s *Server) Run(ctx context.Context) error {
 				},
 				logicalcluster.New(s.Options.HomeWorkspaces.HomeRootPrefix).Base(),
 				s.Options.HomeWorkspaces.HomeCreatorGroups,
+				sets.NewString(s.Options.Extra.BatteriesIncluded...),
 			); err != nil {
 				// nolint:nilerr
 				klog.Errorf("failed to bootstrap root workspace phase 1: %w", err)

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -318,7 +318,7 @@ func setUpServiceProvider(ctx context.Context, dynamicClusterClient *kcpdynamic.
 	require.NoError(t, err)
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -70,7 +70,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 
 	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")

--- a/test/e2e/apibinding/apibinding_permissionclaims_test.go
+++ b/test/e2e/apibinding/apibinding_permissionclaims_test.go
@@ -154,7 +154,7 @@ func setUpServiceProviderWithPermissionClaims(ctx context.Context, dynamicCluste
 	require.NoError(t, err)
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -64,7 +64,7 @@ func TestProtectedAPI(t *testing.T) {
 
 	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", providerWorkspace)
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(providerWorkspaceClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(providerWorkspace), mapper, "apiresourceschema_tlsroutes.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(providerWorkspace), mapper, nil, "apiresourceschema_tlsroutes.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -92,7 +92,7 @@ func TestAPIBinding(t *testing.T) {
 		serviceProviderClient, err := clientset.NewForConfig(serviceProviderClusterCfg)
 		require.NoError(t, err)
 		mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Discovery()))
-		err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+		err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(serviceProviderWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 		require.NoError(t, err)
 
 		t.Logf("Create an APIExport today-cowboys in %q", serviceProviderWorkspace)

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -80,7 +80,7 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 
 	t.Logf("Install a cowboys APIResourceSchema into workspace %q", sourceWorkspace)
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(sourceWorkspaceClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(sourceWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(sourceWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")
@@ -224,7 +224,7 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 
 	t.Logf("Install a cowboys APIResourceSchema into workspace %q", sourceWorkspace)
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(sourceWorkspaceClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(sourceWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(sourceWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -219,7 +219,7 @@ func createResources(t *testing.T, ctx context.Context, dynamicClusterClient *kc
 	t.Logf("Create resources in %s", clusterName)
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClusterClient.WithCluster(clusterName)))
 	require.Eventually(t, func() bool {
-		if err := confighelpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(clusterName), mapper, fileName, embeddedResources); err != nil {
+		if err := confighelpers.CreateResourceFromFS(ctx, dynamicClusterClient.Cluster(clusterName), mapper, nil, fileName, embeddedResources); err != nil {
 			t.Logf("failed to create resources: %v", err)
 			return false
 		}

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -55,12 +55,12 @@ func TestCustomResourceCreation(t *testing.T) {
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(sourceWorkspace).Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(sourceWorkspace), mapper, "wildwest.dev_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(sourceWorkspace), mapper, nil, "wildwest.dev_cowboys.yaml", testFiles)
 	if err == nil {
 		t.Errorf("Expected an error due to reserved annotation")
 	}
 
-	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(sourceWorkspace), mapper, "apis.kcp.dev_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(sourceWorkspace), mapper, nil, "apis.kcp.dev_cowboys.yaml", testFiles)
 	if err == nil {
 		t.Errorf("Expected an error due to reserved group")
 	}

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -523,7 +523,7 @@ func setUpServiceProvider(ctx context.Context, dynamicClients *dynamic.Cluster, 
 	require.NoError(t, err)
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(serviceProviderWorkspace), mapper, "apiresourceschema_cowboys.yaml", testFiles)
+	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(serviceProviderWorkspace), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
 	t.Logf("Create an APIExport for it")


### PR DESCRIPTION
This adds a mechanism that allows to have certain defaults when running `kcp start`, but gives system integrators a way to disable the "integrated batteries". Canonical example: organization and team cluster workspace types. These were always just meant as examples, nothing set in stone for a service offering.

```
Start the control plane process

The server process listens on port 6443 and will act like a Kubernetes API server. It will initialize any necessary data to the provided start location or as a '.kcp' directory in the current directory. An admin kubeconfig file will be generated at initialization time that may be used to access the control plane.


Usage:
  kcp start [flags]

Most important flags:

      --batteries-included strings
                A list of batteries included (= default objects that might be unwanted in production, but are very helpful in trying out kcp or for development). These are the possible
                values: user.

                - cluster-workspace-types: creates "organization" and "team" ClusterWorkspaceTypes in the root workspace.
                - user:                  creates an additional non-admin user and context named "user" in the admin.kubeconfig

                Prefixing with - or + means to remove from the default set or add to the default set. (default [cluster-workspace-types])
      --etcd-servers strings
                List of etcd servers to connect with (scheme://ip:port), comma separated. By default an embedded etcd server is started. (default [embedded])
      --run-virtual-workspaces
                Run the virtual workspace apiservers in-process (default true)

Use "kcp start options" for a list of all flags available.
```

Based on https://github.com/kcp-dev/kcp/pull/1686.