### PR TITLE
apiexport: report 0 VW URLs correctly

### DIFF
--- a/pkg/apis/apis/v1alpha1/types_apiexport.go
+++ b/pkg/apis/apis/v1alpha1/types_apiexport.go
@@ -35,6 +35,7 @@ const (
 	APIExportVirtualWorkspaceURLsReady conditionsv1alpha1.ConditionType = "VirtualWorkspaceURLsReady"
 
 	ErrorGeneratingURLsReason = "ErrorGeneratingURLs"
+	NoViableShardsReason      = "NoViableShards"
 )
 
 // These are for APIExport identity.

--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -203,7 +203,17 @@ func (c *controller) updateVirtualWorkspaceURLs(apiExport *apisv1alpha1.APIExpor
 		})
 	}
 
-	conditions.MarkTrue(apiExport, apisv1alpha1.APIExportVirtualWorkspaceURLsReady)
+	if len(apiExport.Status.VirtualWorkspaces) == 0 {
+		conditions.MarkFalse(
+			apiExport,
+			apisv1alpha1.APIExportVirtualWorkspaceURLsReady,
+			apisv1alpha1.NoViableShardsReason,
+			conditionsv1alpha1.ConditionSeverityError,
+			"Unable to find any shards with virtual workspace URLs",
+		)
+	} else {
+		conditions.MarkTrue(apiExport, apisv1alpha1.APIExportVirtualWorkspaceURLsReady)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
If there are no shards with their virtual workspace URL set, do not
report that an APIExport's virtual workspace URLs are ready.

## Related issue(s)

Fixes #