### PR TITLE
logging: use kind-prefixed fields instead of string-formatting

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -281,9 +281,8 @@ func (c *controller) enqueueCRD(obj interface{}, logger logr.Logger) {
 		runtime.HandleError(fmt.Errorf("obj is supposed to be a CustomResourceDefinition, but is %T", obj))
 		return
 	}
-	logger = logger.WithValues(
-		"CustomResource", fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group),
-		"CustomResourceDefinition", logging.Key(crd),
+	logger = logging.WithObject(logger, crd).WithValues(
+		"groupResource", fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group),
 		"established", apihelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established),
 	)
 

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -143,7 +143,7 @@ func (c *controller) reconcileBinding(ctx context.Context, apiBinding *apisv1alp
 		)
 		return err
 	}
-	logger = logger.WithValues("APIExport", logging.Key(apiExport))
+	logger = logging.WithObject(logger, apiExport)
 
 	if apiExport.Status.IdentityHash == "" {
 		conditions.MarkFalse(
@@ -180,7 +180,7 @@ func (c *controller) reconcileBinding(ctx context.Context, apiBinding *apisv1alp
 
 			return err
 		}
-		logger = logger.WithValues("APIResourceSchema", logging.Key(schema))
+		logger = logging.WithObject(logger, schema)
 
 		crd, err := generateCRD(schema)
 		if err != nil {
@@ -196,9 +196,8 @@ func (c *controller) reconcileBinding(ctx context.Context, apiBinding *apisv1alp
 
 			return nil
 		}
-		logger = logger.WithValues(
-			"CustomResourceDefinition", logging.Key(crd),
-			"CustomResource", fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group),
+		logger = logging.WithObject(logger, crd).WithValues(
+			"groupResource", fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group),
 		)
 
 		// Check for conflicts

--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -131,7 +131,7 @@ func (c *controller) createIdentitySecret(ctx context.Context, clusterName logic
 		return err
 	}
 
-	logger := klog.FromContext(ctx).WithValues("Secret", logging.Key(secret))
+	logger := logging.WithObject(klog.FromContext(ctx), secret)
 	ctx = klog.NewContext(ctx, logger)
 	klog.V(2).Infof("creating identity secret")
 	if err := c.createSecret(ctx, clusterName, secret); err != nil {
@@ -174,7 +174,7 @@ func (c *controller) updateVirtualWorkspaceURLs(ctx context.Context, apiExport *
 
 	desiredURLs := sets.NewString()
 	for _, clusterWorkspaceShard := range clusterWorkspaceShards {
-		logger = logger.WithValues("ClusterWorkspaceShard", logging.Key(clusterWorkspaceShard))
+		logger = logging.WithObject(logger, clusterWorkspaceShard)
 		if clusterWorkspaceShard.Spec.VirtualWorkspaceURL == "" {
 			continue
 		}

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_scheduling.go
@@ -151,7 +151,7 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 				workspace.Status.Location.Current = targetShard.Name
 
 				conditions.MarkTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
-				logger.Info("scheduled workspace to shard", "ClusterWorkspaceShard", logging.Key(targetShard))
+				logging.WithObject(logger, targetShard).Info("scheduled workspace to shard")
 			} else {
 				conditions.MarkFalse(workspace, tenancyv1alpha1.WorkspaceScheduled, tenancyv1alpha1.WorkspaceReasonUnschedulable, conditionsv1alpha1.ConditionSeverityError, "No available shards to schedule the workspace.")
 				failures := make([]error, 0, len(invalidShards))


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part of #1694 
/assign @sttts 

Using the resource instead of the kind would be cool but I don't know that there's any lightweight way to figure that out.