### PR TITLE
Remove the redirect from shard to virtual workspaces

### DIFF
--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -219,9 +219,6 @@ var (
 		"max-connection-bytes-per-sec",          // If non-zero, throttle each user connection to this number of bytes/sec. Currently only applies to long-running requests.
 		"proxy-client-cert-file",                // Client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins. It is expected that this cert includes a signature from the CA in the --requestheader-client-ca-file flag. That CA is published in the 'extension-apiserver-authentication' configmap in the kube-system namespace. Components receiving calls from kube-aggregator should use that CA to perform their half of the mutual TLS verification.
 		"proxy-client-key-file",                 // Private key for the client certificate used to prove the identity of the aggregator or kube-apiserver when it must call out during a request. This includes proxying requests to a user api-server and calling out to webhook admission plugins.
-
-		// KCP Virtual Workspaces flags
-		"virtual-workspace-address", // Address of a stand-alone virtual workspace apiserver.
 	)
 
 	disallowedFlags = sets.NewString(

--- a/pkg/server/options/virtual.go
+++ b/pkg/server/options/virtual.go
@@ -17,9 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"fmt"
-	"net/url"
-
 	"github.com/spf13/pflag"
 
 	virtualworkspacesoptions "github.com/kcp-dev/kcp/pkg/virtual/options"
@@ -28,9 +25,6 @@ import (
 type Virtual struct {
 	VirtualWorkspaces virtualworkspacesoptions.Options
 	Enabled           bool
-
-	// ExternalVirtualWorkspaceAddress holds a URL to redirect to for stand-alone virtual workspaces.
-	ExternalVirtualWorkspaceAddress string
 }
 
 func NewVirtual() *Virtual {
@@ -46,18 +40,6 @@ func (v *Virtual) Validate() []error {
 
 	if v.Enabled {
 		errs = append(errs, v.VirtualWorkspaces.Validate()...)
-
-		if v.ExternalVirtualWorkspaceAddress != "" {
-			errs = append(errs, fmt.Errorf("--virtual-workspace-address must be empty if virtual workspaces run in-process"))
-		}
-	} else {
-		if v.ExternalVirtualWorkspaceAddress == "" {
-			errs = append(errs, fmt.Errorf("--virtual-workspace-address is required if virtual workspaces run out-of-process"))
-		} else if u, err := url.Parse(v.ExternalVirtualWorkspaceAddress); err != nil {
-			errs = append(errs, fmt.Errorf("--virtual-workspace-address must be a valid URL: %w", err))
-		} else if u.Scheme != "http" && u.Scheme != "https" {
-			errs = append(errs, fmt.Errorf("--virtual-workspace-address must be a valid  https URL"))
-		}
 	}
 
 	return errs
@@ -67,5 +49,4 @@ func (v *Virtual) AddFlags(fs *pflag.FlagSet) {
 	v.VirtualWorkspaces.AddFlags(fs)
 
 	fs.BoolVar(&v.Enabled, "run-virtual-workspaces", v.Enabled, "Run the virtual workspace apiservers in-process")
-	fs.StringVar(&v.ExternalVirtualWorkspaceAddress, "virtual-workspace-address", v.ExternalVirtualWorkspaceAddress, "Address of a stand-alone virtual workspace apiserver (without the /services path)")
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -417,8 +417,6 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.installVirtualWorkspaces(ctx, controllerConfig, delegationChainHead, s.GenericConfig.Authentication, s.GenericConfig.ExternalAddress, s.preHandlerChainMux); err != nil {
 			return err
 		}
-	} else if err := s.installVirtualWorkspacesRedirect(ctx, s.preHandlerChainMux); err != nil {
-		return err
 	}
 
 	if err := s.Options.AdminAuthentication.WriteKubeConfig(s.GenericConfig, s.kcpAdminToken, s.shardAdminToken, s.shardAdminTokenHash); err != nil {

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -170,6 +171,7 @@ type runningServer struct {
 	kubeClusterClient     kubernetes.ClusterInterface
 	kcpClusterClient      kcpclientset.ClusterInterface
 	virtualUserKcpClients []kcpclientset.ClusterInterface
+	UserKcpClients        []kcpclientset.ClusterInterface
 }
 
 var testCases = []struct {
@@ -182,6 +184,8 @@ var testCases = []struct {
 		userTokens: []string{"user-1-token", "user-2-token"},
 		work: func(ctx context.Context, t *testing.T, server runningServer) {
 			testData := newTestData()
+
+			user1Client := server.UserKcpClients[0]
 
 			vwUser1Client := server.virtualUserKcpClients[0]
 			vwUser2Client := server.virtualUserKcpClients[1]
@@ -217,8 +221,13 @@ var testCases = []struct {
 				return len(list.Items) == 1 && list.Items[0].Name == workspace1.Name
 			}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to list workspace1")
 
+			t.Logf("Workspace will also show up when user1 submits a list to KCP itself (through projection)")
+			list, err := user1Client.Cluster(server.orgClusterName).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
+			require.NoError(t, err, "expected to list workspaces from KCP through projection")
+			require.True(t, len(list.Items) == 1 && list.Items[0].Name == workspace1.Name, "expected to get workspace1 from KCP through projection")
+
 			t.Logf("Workspace will not show up in list of user2")
-			list, err := vwUser2Client.Cluster(server.orgClusterName).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
+			list, err = vwUser2Client.Cluster(server.orgClusterName).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
 			if err != nil {
 				t.Logf("failed to get workspaces: %v", err)
 			}
@@ -551,6 +560,7 @@ var testCases = []struct {
 
 func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 	var server framework.RunningServer
+	var virtualWorkspaceServerHost string
 	if standalone {
 		// create port early. We have to hope it is still free when we are ready to start the virtual workspace apiserver.
 		portStr, err := framework.GetFreePort(t)
@@ -560,7 +570,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		server = framework.PrivateKcpServer(t,
 			append(framework.TestServerArgsWithTokenAuthFile(tokenAuthFile),
 				"--run-virtual-workspaces=false",
-				fmt.Sprintf("--virtual-workspace-address=https://localhost:%s", portStr),
+				fmt.Sprintf("--shard-virtual-workspace-url=https://localhost:%s", portStr),
 			)...,
 		)
 
@@ -607,8 +617,12 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 
 		// wait for readiness
 		client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+		baseClusterServerURL, err := url.Parse(baseCluster.Server)
+		require.NoError(t, err)
+		virtualWorkspaceServerHost = fmt.Sprintf("https://%s:%s", baseClusterServerURL.Hostname(), portStr)
+
 		require.Eventually(t, func() bool {
-			resp, err := client.Get(fmt.Sprintf("https://localhost:%s/readyz", portStr))
+			resp, err := client.Get(fmt.Sprintf("%s/readyz", virtualWorkspaceServerHost))
 			if err != nil {
 				klog.Warningf("error checking virtual workspace readiness: %v", err)
 				return false
@@ -622,6 +636,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		}, wait.ForeverTestTimeout, time.Millisecond*100, "virtual workspace apiserver not ready")
 	} else {
 		server = framework.SharedKcpServer(t)
+		virtualWorkspaceServerHost = server.BaseConfig(t).Host
 	}
 
 	for i := range testCases {
@@ -641,12 +656,19 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 			kcpClusterClient, err := kcpclientset.NewClusterForConfig(kcpConfig)
 			require.NoError(t, err, "failed to construct client for server")
 
+			vwConfig := rest.CopyConfig(kcpConfig)
+			vwConfig.Host = virtualWorkspaceServerHost
+
 			// create virtual clients for all paths and users requested
 			var virtualUserlKcpClients []kcpclientset.ClusterInterface
+			var userKcpClients []kcpclientset.ClusterInterface
 			for _, token := range testCase.userTokens {
-				userConfig := framework.ConfigWithToken(token, rest.CopyConfig(kcpConfig))
-				userClient := &virtualClusterClient{config: userConfig}
-				virtualUserlKcpClients = append(virtualUserlKcpClients, userClient)
+				userKcpClient, err := kcpclientset.NewClusterForConfig(framework.ConfigWithToken(token, rest.CopyConfig(kcpConfig)))
+				require.NoError(t, err, "failed to construct client for server")
+				userKcpClients = append(userKcpClients, userKcpClient)
+				virtualUserlKcpClients = append(virtualUserlKcpClients, &virtualClusterClient{
+					config: framework.ConfigWithToken(token, rest.CopyConfig(vwConfig)),
+				})
 			}
 
 			testCase.work(ctx, t, runningServer{
@@ -654,6 +676,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 				orgClusterName:        orgClusterName,
 				kubeClusterClient:     kubeClusterClient,
 				kcpClusterClient:      kcpClusterClient,
+				UserKcpClients:        userKcpClients,
 				virtualUserKcpClients: virtualUserlKcpClients,
 			})
 		})


### PR DESCRIPTION
## Summary

Remove the redirect from shard to virtual workspaces in case of standalone virtual workspace deployment.
Npw that the old "personal workspaces" feature has been removed from both the `workspaces` virtual workspace and the CLI, there's no need to point to virtual workspaces through the KCP server host.
In the future explicit virtual workspace Base URL (carried by the Shard resource) should be used.

So when a virtual workspace is started in standalone mode, there's no need anymore to setup a redirection from the KCP shard host to the virtual workspace host.

## Related issue(s)

This is a followup of PR https://github.com/kcp-dev/kcp/pull/1685