### PR TITLE
*: remove member verb

### DIFF
--- a/contrib/demos-unmaintained/demo/prototype2-script/user-rbac.yaml
+++ b/contrib/demos-unmaintained/demo/prototype2-script/user-rbac.yaml
@@ -7,7 +7,7 @@ rules:
 - apiGroups: ["tenancy.kcp.dev"]
   resources: ["clusterworkspaces/content"]
   resourceNames: ["demo"]
-  verbs: ["access","member"]
+  verbs: ["access"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -21,13 +21,13 @@ The details are outlined below.
 
 The following authorizers are configured in kcp:
 
-| Authorizer                             | Description                                                                    |
-|----------------------------------------|--------------------------------------------------------------------------------|
-| Top-Level organization authorizer      | checks that the user is allowed to access the organization (access and member) |
-| Workspace content authorizer           | determines additional groups a user gets inside of a workspace                 |
-| API binding authorizer                 | validates the RBAC policy in the api exporters workspace                       |
-| Local Policy authorizer                | validates the RBAC policy in the workspace that is accessed                    |
-| Kubernetes Bootstrap Policy authorizer | validates the RBAC Kubernetes standard policy                                  |
+| Authorizer                             | Description                                                    |
+|----------------------------------------|----------------------------------------------------------------|
+| Top-Level organization authorizer      | checks that the user is allowed to access the organization     |
+| Workspace content authorizer           | determines additional groups a user gets inside of a workspace |
+| API binding authorizer                 | validates the RBAC policy in the api exporters workspace       |
+| Local Policy authorizer                | validates the RBAC policy in the workspace that is accessed    |
+| Kubernetes Bootstrap Policy authorizer | validates the RBAC Kubernetes standard policy                  |
 
 They are related in the following way:
 
@@ -62,7 +62,6 @@ to the top-level org workspace represented by the `ClusterWorkspace` named `org`
 | Verb     | Resource                   | Semantics                                                  |
 |----------|----------------------------|------------------------------------------------------------|
 | `access` | `clusterworkspace/content` | the user can access the organization `root:org`            |
-| `member` | `clusterworkspace/content` | like access, but the user can additional create workspaces |
 
 E.g. the user is bound via a `ClusterRoleBinding` in `root` to a `ClusterRole` of the following shape:
 
@@ -80,7 +79,6 @@ rules:
   - org
   verbs:
   - access
-  - member
 ```
 
 ## Workspace Content authorizer

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -133,9 +133,7 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 			reasonList []string
 		)
 
-		//TODO(sur): member is going to be removed with the advent of user workspaces, member won't be needed,
-		//rather this has to be solved using classic RBAC with "create workspace" permissions.
-		for _, verb := range []string{"access", "member"} {
+		for _, verb := range []string{"access"} {
 			workspaceAttr := authorizer.AttributesRecord{
 				User:        attr.GetUser(),
 				Verb:        verb,

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -169,8 +169,7 @@ func TestAPIBindingAuthorizer(t *testing.T) {
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
 	serviceProviderWorkspaces := []logicalcluster.Name{rbacServiceProviderWorkspace, serviceProvider2Workspace}
-	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1"}, nil, []string{"member"})
-	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-2"}, nil, []string{"access"})
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1", "user-2"}, nil, []string{"access"})
 
 	// Set up service provider workspace.
 	for _, serviceProviderWorkspace := range serviceProviderWorkspaces {

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -78,8 +78,7 @@ func TestAuthorizer(t *testing.T) {
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org1.Join("workspace1"), "workspace1-resources.yaml")
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org2.Join("workspace1"), "workspace1-resources.yaml")
 
-	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, org1, []string{"user-1"}, nil, []string{"member"})
-	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, org1, []string{"user-2", "user-3"}, nil, []string{"access"})
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, org1, []string{"user-1", "user-2", "user-3"}, nil, []string{"access"})
 
 	user1KubeClusterClient, err := kubernetes.NewForConfig(framework.UserConfig("user-1", cfg))
 	require.NoError(t, err)

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -86,8 +86,8 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	wildwestClusterClient, err := wildwestclientset.NewClusterForConfig(cfg)
 	require.NoError(t, err, "failed to construct wildwest cluster client for server")
 
-	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1", "user-2"}, nil, []string{"member"})
-	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, serviceProviderWorkspace, []string{"user-1", "user-2"}, nil, []string{"member", "access"})
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, orgClusterName, []string{"user-1", "user-2"}, nil, []string{"access"})
+	framework.AdmitWorkspaceAccess(t, ctx, kubeClusterClient, serviceProviderWorkspace, []string{"user-1", "user-2"}, nil, []string{"access"})
 
 	setUpServiceProvider(ctx, dynamicClients, kcpClients, serviceProviderWorkspace, cfg, t)
 


### PR DESCRIPTION
## Summary

It was being removed from virtual workspace handling hence unused.

## Related issue(s)

https://github.com/kcp-dev/kcp/pull/1685