### PR TITLE
pkg/virtual/syncer/builder: fix incorrect comment

### DIFF
--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -113,7 +113,7 @@ func BuildVirtualWorkspace(
 				realPath += parts[3]
 			}
 
-			//  /services/syncer/root:org:ws/<sync-target-uid>/<sync-target-name>/clusters/*/api/v1/configmaps
+			//  /services/syncer/root:org:ws/<sync-target-name>/<sync-target-uid>/clusters/*/api/v1/configmaps
 			//                  ┌───────────────────────────────────────────────┘
 			// We are now here: ┘
 			// Now, we parse out the logical cluster.


### PR DESCRIPTION
Fixes wrong order in a comment.

follow-up: https://github.com/kcp-dev/kcp/pull/1687