### PR TITLE
Update gitops repo org

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Check out shared-resources (gitops repo)
         uses: actions/checkout@v3
         with:
-          repository: kcp-dev/shared-resources
+          repository: redhat-cps/shared-resources
           token: ${{ secrets.KCP_BOT_TOKEN }}
 
       - name: Update sha and commit


### PR DESCRIPTION
The Red Hat gitops repo is updated with the latest upon for every push
to main.  The repo is moving to a different org, so we need to update
the github action accordingly.