### PR TITLE
exclude authn/authz apis from claimable list

### DIFF
--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
@@ -24,8 +24,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	authenticationv1 "k8s.io/api/authentication/v1"
-	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -394,56 +392,6 @@ var InternalAPIs = []internalapis.InternalAPI{
 		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
 		Instance:      &rbacv1.RoleBinding{},
 		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "tokenreviews",
-			Singular: "tokenreview",
-			Kind:     "TokenReview",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "authentication.k8s.io", Version: "v1"},
-		Instance:      &authenticationv1.TokenReview{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "localsubjectaccessreviews",
-			Singular: "localsubjectaccessreview",
-			Kind:     "LocalSubjectAccessReview",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "authorization.k8s.io", Version: "v1"},
-		Instance:      &authorizationv1.LocalSubjectAccessReview{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "selfsubjectaccessreviews",
-			Singular: "selfsubjectaccessreview",
-			Kind:     "SelfSubjectAccessReview",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "authorization.k8s.io", Version: "v1"},
-		Instance:      &authorizationv1.SelfSubjectAccessReview{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "selfsubjectrulesreviews",
-			Singular: "selfsubjectrulesreview",
-			Kind:     "SelfSubjectRulesReview",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "authorization.k8s.io", Version: "v1"},
-		Instance:      &authorizationv1.SelfSubjectRulesReview{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "subjectaccessreviews",
-			Singular: "subjectaccessreview",
-			Kind:     "SubjectAccessReview",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "authorization.k8s.io", Version: "v1"},
-		Instance:      &authorizationv1.SubjectAccessReview{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
 	},
 	{
 		Names: apiextensionsv1.CustomResourceDefinitionNames{

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -430,6 +430,10 @@ func gatherInternalAPIs(discoveryClient discovery.DiscoveryInterface, t *testing
 		if strings.HasSuffix(gv.Group, ".kcp.dev") {
 			continue
 		}
+		// ignore authn/authz non-crud apis
+		if gv.Group == "authentication.k8s.io" || gv.Group == "authorization.k8s.io" {
+			continue
+		}
 		for _, apiResource := range apiResourcesList.APIResources {
 			gvk := schema.GroupVersionKind{Kind: apiResource.Kind, Version: gv.Version, Group: gv.Group}
 


### PR DESCRIPTION
Signed-off-by: Robin Y Bobbitt <rbobbitt@redhat.com>

## Summary
Exclude authentication.k8s.io and authorization.k8s.io from list of claimable APIs.

## Related issue(s)

Fixes #1697