### PR TITLE
Fixes log line formatting

### DIFF
--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -100,7 +100,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		return err
 	}
 	if !exists {
-		klog.InfoS("Downstream GVR %q object %s|%s/%s does not exist. Removing finalizer upstream", gvr.String(), downstreamClusterName, upstreamNamespace, name)
+		klog.Infof("Downstream GVR %q object %s|%s/%s does not exist. Removing finalizer upstream", gvr.String(), downstreamClusterName, upstreamNamespace, name)
 		return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamInformers, c.upstreamClient, upstreamNamespace, c.syncTargetKey, upstreamWorkspace, name)
 	}
 


### PR DESCRIPTION
## Summary

Small fix to a log line: it looks like `klog.InfoS` was used instead of `klog.Infof` accidentally.

Currently it prints something like this:

```
"Downstream GVR %q object %s|%s/%s does not exist. Removing finalizer upstream" apps/v1, Resource=deployments="" default="test-deployment"
```
