### PR TITLE
Add goreleaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: v1.17
+          go-version: v1.18
       - run: make build
 
       # Install kind with a local registry
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: v1.17
+        go-version: v1.18
     - run: make build
 
     # Install kind with a local registry

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,38 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+    - 'release-*'
+    tags:
+    - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: v1.18
+    - name: Delete non-semver tags
+      run: 'git tag -d $(git tag -l | grep -v "^v")'
+    - name: Set LDFLAGS
+      run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: cytopia/upload-artifact-retry-action@v0.1.2
+      if: ${{ always() }}
+      with:
+        name: binaries
+        path: dist/*.tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,66 @@
+builds:
+- id: "kcp"
+  main: ./cmd/kcp
+  binary: bin/kcp
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  - darwin
+  goarch:
+  - amd64
+  - arm
+  - arm64
+- id: "kubectl-kcp"
+  main: ./cmd/kubectl-kcp
+  binary: bin/kubectl-kcp
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm
+  - arm64
+- id: "kubectl-ws"
+  main: ./cmd/kubectl-ws
+  binary: bin/kubectl-ws
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm
+  - arm64
+- id: "kubectl-workspaces"
+  main: ./cmd/kubectl-workspaces
+  binary: bin/kubectl-workspaces
+  ldflags:
+  - "{{ .Env.LDFLAGS }}"
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm
+  - arm64
+archives:
+- id: kcp
+  builds:
+  - kcp
+- id: kubectl-kcp-plugin
+  builds:
+  - kubectl-kcp
+  - kubectl-ws
+  - kubectl-workspaces
+  name_template: "kubectl-kcp-plugin_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+release:
+  draft: true
+  prerelease: auto
+  mode: keep-existing

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ LDFLAGS := \
 all: build
 .PHONY: all
 
+ldflags:
+	@echo $(LDFLAGS)
+
 .PHONY: require-%
 require-%:
 	@if ! command -v $* 1> /dev/null 2>&1; then echo "$* not found in \$$PATH"; exit 1; fi


### PR DESCRIPTION
This will upload tar.gzs for `kcp` and `kubectl-kcp-plugin` as artifacts, and in case of tags it will create a release if not pre-existing, but not publish it. If it is preexisting it will attach the tars.