### PR TITLE
the identity provider gets data from a local cm too

### DIFF
--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -108,7 +108,7 @@ routed based on paths.`,
 			if err != nil {
 				return fmt.Errorf("failed to create root client: %w", err)
 			}
-			rootShardConfig, resolveIdentities := bootstrap.NewConfigWithWildcardIdentities(nonIdentityRootConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nonIdentityRootKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
+			rootShardConfig, resolveIdentities := bootstrap.NewConfigWithWildcardIdentities(nonIdentityRootConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nonIdentityRootKcpClusterClient, nil)
 			if err := wait.PollImmediateInfiniteWithContext(ctx, time.Millisecond*500, func(ctx context.Context) (bool, error) {
 				if err := resolveIdentities(ctx); err != nil {
 					klog.V(3).Infof("failed to resolve identities, keeping trying: %v", err)

--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
-	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
@@ -100,7 +99,7 @@ func Run(ctx context.Context, o *options.Options) error {
 	if err != nil {
 		return err
 	}
-	identityConfig, resolveIdentities := boostrap.NewConfigWithWildcardIdentities(nonIdentityConfig, boostrap.KcpRootGroupExportNames, boostrap.KcpRootGroupResourceExportNames, nonIdentityKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster))
+	identityConfig, resolveIdentities := boostrap.NewConfigWithWildcardIdentities(nonIdentityConfig, boostrap.KcpRootGroupExportNames, boostrap.KcpRootGroupResourceExportNames, nonIdentityKcpClusterClient, nil)
 	if err := wait.PollImmediateInfiniteWithContext(ctx, time.Millisecond*500, func(ctx context.Context) (bool, error) {
 		if err := resolveIdentities(ctx); err != nil {
 			klog.V(3).Infof("failed to resolve identities, keeping trying: %v", err)

--- a/config/shard/bootstrap.go
+++ b/config/shard/bootstrap.go
@@ -19,9 +19,14 @@ package shard
 import (
 	"context"
 
+	"github.com/kcp-dev/logicalcluster/v2"
+
 	confighelpers "github.com/kcp-dev/kcp/config/helpers"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 )
+
+// SystemShardCluster is the name of a logical cluster on every shard (including the root shard) that holds essential system resources (like the root APIs).
+var SystemShardCluster = logicalcluster.New("system:shard")
 
 // Bootstrap creates resources required for a shard.
 // As of today creating API bindings for the root APIs is enough.

--- a/pkg/server/bootstrap/api-export-identity_controller.go
+++ b/pkg/server/bootstrap/api-export-identity_controller.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package boostrap
+
+const (
+	configMapName = "api-exports-identities"
+)
+
+// TODO(p0lyn0mial): implement a controller, see: https://github.com/kcp-dev/kcp/pull/1725

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,9 +49,6 @@ import (
 
 const resyncPeriod = 10 * time.Hour
 
-// systemShardCluster is the name of a logical cluster on every shard (including the root shard) that holds essential system resources (like the root APIs).
-var systemShardCluster = logicalcluster.New("system:shard")
-
 type Server struct {
 	CompletedConfig
 
@@ -143,7 +140,7 @@ func (s *Server) Run(ctx context.Context) error {
 		klog.Infof("Finished bootstrapping system CRDs")
 
 		if err := wait.PollInfiniteWithContext(goContext(ctx), time.Second, func(ctx context.Context) (bool, error) {
-			if err := configshard.Bootstrap(ctx, s.KcpClusterClient.Cluster(systemShardCluster)); err != nil {
+			if err := configshard.Bootstrap(ctx, s.KcpClusterClient.Cluster(configshard.SystemShardCluster)); err != nil {
 				klog.Errorf("Failed to bootstrap the shard workspace: %v", err)
 				return false, nil // keep trying
 			}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
the config map is maintained by a controller and contains identities for the root API Exports.
the config map is used by non-root shards and provides higher fault tolerance than reading directly from the root shard.

if the config map doesn't exist or there were some errors during getting it we always fall back to the previous behavior of getting identities from exports directly.
## Related issue(s)

xref: see item `1. add identities configmap in system:shard` from  https://github.com/kcp-dev/kcp/issues/1225 