### PR TITLE
logging: stop using formatted strings for object identifiers

### DIFF
--- a/pkg/logging/constants.go
+++ b/pkg/logging/constants.go
@@ -70,7 +70,9 @@ func From(obj Object) []interface{} {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	kind := gvk.Kind
 	if kind == "" {
-		kind = fmt.Sprintf("%T", obj)
+		// if there's no Kind present on the object, use the Go type name, without any package prefix
+		objType := fmt.Sprintf("%T", obj)
+		kind = objType[strings.Index(objType, ".")+1:]
 	}
 	prefix := strings.ToLower(kind)
 	return FromPrefix(prefix, obj)

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -269,8 +269,8 @@ func (c *controller) enqueueAPIExport(obj interface{}, logger logr.Logger, logSu
 		return
 	}
 
-	for _, obj := range bindingsForExport {
-		c.enqueueAPIBinding(obj, logger.WithValues("APIExport", key), fmt.Sprintf(" because of APIExport%s", logSuffix))
+	for _, binding := range bindingsForExport {
+		c.enqueueAPIBinding(binding, logging.WithObject(logger, obj.(*apisv1alpha1.APIExport)), fmt.Sprintf(" because of APIExport%s", logSuffix))
 	}
 }
 
@@ -326,8 +326,8 @@ func (c *controller) enqueueAPIResourceSchema(obj interface{}, logger logr.Logge
 		}
 	}
 
-	for _, obj := range apiExports {
-		c.enqueueAPIExport(obj, logger.WithValues("APIResourceSchema", key), fmt.Sprintf(" because of APIResourceSchema%s", logSuffix))
+	for _, export := range apiExports {
+		c.enqueueAPIExport(export, logging.WithObject(logger, obj.(*apisv1alpha1.APIResourceSchema)), fmt.Sprintf(" because of APIResourceSchema%s", logSuffix))
 	}
 }
 

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -25,6 +25,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kcp-dev/logicalcluster/v2"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog/v2"
 
 	virtualworkspacesoptions "github.com/kcp-dev/kcp/cmd/virtual-workspaces/options"
@@ -110,14 +109,16 @@ func (c *controller) reconcile(ctx context.Context, apiExport *apisv1alpha1.APIE
 }
 
 func (c *controller) ensureSecretNamespaceExists(ctx context.Context, clusterName logicalcluster.Name) {
-	logger := klog.FromContext(ctx).WithValues("Namespace", clusters.ToClusterAwareKey(clusterName, c.secretNamespace))
+	logger := klog.FromContext(ctx)
 	ctx = klog.NewContext(ctx, logger)
 	if _, err := c.getNamespace(clusterName, c.secretNamespace); errors.IsNotFound(err) {
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: c.secretNamespace,
+				Name:        c.secretNamespace,
+				Annotations: map[string]string{logicalcluster.AnnotationKey: clusterName.String()},
 			},
 		}
+		logger = logging.WithObject(logger, ns)
 		if err := c.createNamespace(ctx, clusterName, ns); err != nil && !errors.IsAlreadyExists(err) {
 			logger.Error(err, "error creating namespace for APIExport secret identities")
 			// Keep going - maybe things will work. If the secret creation fails, we'll make sure to set a condition.
@@ -130,6 +131,7 @@ func (c *controller) createIdentitySecret(ctx context.Context, clusterName logic
 	if err != nil {
 		return err
 	}
+	secret.Annotations[logicalcluster.AnnotationKey] = clusterName.String()
 
 	logger := logging.WithObject(klog.FromContext(ctx), secret)
 	ctx = klog.NewContext(ctx, logger)

--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -135,7 +135,7 @@ func (c *controller) createIdentitySecret(ctx context.Context, clusterName logic
 
 	logger := logging.WithObject(klog.FromContext(ctx), secret)
 	ctx = klog.NewContext(ctx, logger)
-	klog.V(2).Infof("creating identity secret")
+	logger.V(2).Info("creating identity secret")
 	if err := c.createSecret(ctx, clusterName, secret); err != nil {
 		return err
 	}

--- a/pkg/reconciler/apis/apiexport/crypto.go
+++ b/pkg/reconciler/apis/apiexport/crypto.go
@@ -40,8 +40,9 @@ func GenerateIdentitySecret(ctx context.Context, ns string, apiExportName string
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      apiExportName,
+			Namespace:   ns,
+			Name:        apiExportName,
+			Annotations: map[string]string{},
 		},
 		StringData: map[string]string{
 			apisv1alpha1.SecretKeyAPIExportIdentity: key,

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_controller.go
@@ -242,6 +242,7 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (c *Controller) patchIfNeeded(ctx context.Context, old, obj *tenancyv1alpha1.ClusterWorkspace) error {
+	logger := klog.FromContext(ctx)
 	specOrObjectMetaChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec) || !equality.Semantic.DeepEqual(old.ObjectMeta, obj.ObjectMeta)
 	statusChanged := !equality.Semantic.DeepEqual(old.Status, obj.Status)
 
@@ -293,7 +294,7 @@ func (c *Controller) patchIfNeeded(ctx context.Context, old, obj *tenancyv1alpha
 		subresources = []string{"status"}
 	}
 
-	klog.V(2).Infof("Patching clusterworkspace %s|%s: %s", clusterName, name, string(patchBytes))
+	logger.WithValues("patch", string(patchBytes)).V(2).Info("patching ClusterWorkspace")
 	_, err = c.kcpClusterClient.TenancyV1alpha1().ClusterWorkspaces().Patch(logicalcluster.WithCluster(ctx, clusterName), obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...)
 	if err != nil {
 		return fmt.Errorf("failed to patch ClusterWorkspace %s|%s: %w", clusterName, name, err)

--- a/pkg/reconciler/tenancy/clusterworkspacetype/clusterworkspacetype_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspacetype/clusterworkspacetype_controller.go
@@ -127,18 +127,13 @@ func (c *controller) enqueueClusterWorkspaceType(obj interface{}) {
 }
 
 func (c *controller) enqueueAllClusterWorkspaceTypes(clusterWorkspaceShard interface{}) {
-	clusterWorkspaceShardKey, err := cache.DeletionHandlingMetaNamespaceKeyFunc(clusterWorkspaceShard)
-	if err != nil {
-		runtime.HandleError(err)
-		return
-	}
-
 	list, err := c.clusterWorkspaceTypeLister.List(labels.Everything())
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
 
+	logger := logging.WithObject(logging.WithReconciler(klog.Background(), controllerName), clusterWorkspaceShard.(*tenancyv1alpha1.ClusterWorkspaceShard))
 	for i := range list {
 		key, err := cache.MetaNamespaceKeyFunc(list[i])
 		if err != nil {
@@ -146,8 +141,7 @@ func (c *controller) enqueueAllClusterWorkspaceTypes(clusterWorkspaceShard inter
 			continue
 		}
 
-		logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), controllerName), key)
-		logger.WithValues("clusterWorkspaceShardKey", clusterWorkspaceShardKey).V(2).Info("queuing ClusterWorkspaceType because ClusterWorkspaceShard changed")
+		logging.WithQueueKey(logger, key).V(2).Info("queuing ClusterWorkspaceType because ClusterWorkspaceShard changed")
 
 		c.queue.Add(key)
 	}

--- a/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_reconcile.go
+++ b/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_reconcile.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 )
 
@@ -39,7 +40,8 @@ const (
 )
 
 func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deployment) error {
-	klog.Infof("reconciling deployment %q", deployment.Name)
+	logger := klog.FromContext(ctx)
+	logger.Info("reconciling Deployment")
 
 	//nolint:staticcheck
 	if deployment.Labels == nil || shared.DeprecatedGetAssignedSyncTarget(deployment.Labels) == "" {
@@ -130,6 +132,7 @@ func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deploymen
 }
 
 func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) error {
+	logger := klog.FromContext(ctx)
 	cls, err := c.clusterLister.List(labels.Everything())
 	if err != nil {
 		return err
@@ -180,7 +183,7 @@ func (c *Controller) createLeafs(ctx context.Context, root *appsv1.Deployment) e
 		if _, err := c.kubeClient.AppsV1().Deployments(root.Namespace).Create(ctx, vd, metav1.CreateOptions{}); err != nil {
 			return err
 		}
-		klog.Infof("created child deployment %q", vd.Name)
+		logger.WithValues(logging.FromPrefix("child", vd)).Info("created child Deployment")
 	}
 
 	return nil

--- a/pkg/reconciler/workload/ingresssplitter/ingresssplitter_reconcile.go
+++ b/pkg/reconciler/workload/ingresssplitter/ingresssplitter_reconcile.go
@@ -92,7 +92,7 @@ func (c *Controller) reconcileLeaves(ctx context.Context, ingress *networkingv1.
 	// Create the new leaves
 	for _, leaf := range toCreate {
 		logger = logger.WithValues(logging.FromPrefix("leafIngress", leaf)...)
-		klog.InfoS("creating leaf")
+		logger.Info("creating leaf")
 
 		if _, err := c.client.NetworkingV1().Ingresses(leaf.Namespace).Create(logicalcluster.WithCluster(ctx, ingressClusterName), leaf, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 			// TODO(jmprusi): Surface as user-facing condition.

--- a/pkg/reconciler/workload/placement/placement_reconcile.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile.go
@@ -86,6 +86,7 @@ func (c *controller) getLocation(clusterName logicalcluster.Name, name string) (
 }
 
 func (c *controller) patchPlacement(ctx context.Context, clusterName logicalcluster.Name, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*schedulingv1alpha1.Placement, error) {
-	klog.V(2).Infof("Patching namespace %s|%s with patch %s", clusterName, name, string(data))
+	logger := klog.FromContext(ctx)
+	logger.WithValues("patch", string(data)).V(2).Info("patching Placement")
 	return c.kcpClusterClient.SchedulingV1alpha1().Placements().Patch(logicalcluster.WithCluster(ctx, clusterName), name, pt, data, opts, subresources...)
 }


### PR DESCRIPTION
logging: format Kind better when none is present

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

logging: stop using formatted strings for object identifiers

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Part of #1694 
/assign @sttts @ncdc  