### PR TITLE
goreleaser: add write permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,6 +8,10 @@ on:
     - 'release-*'
     tags:
     - 'v*'
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our token is restricted. So we have to ask for content write.