### PR TITLE
hack: verify-go-version.sh in all the repo

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: v1.17
+          go-version: v1.18
 
       - name: Get the short sha
         id: vars

--- a/.github/workflows/kcp-test-image.yaml
+++ b/.github/workflows/kcp-test-image.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: v1.17
+          go-version: v1.18
 
       # Build and push the kcp test image, tagged with the commit SHA and the branch name.
       - uses: imjasonh/setup-ko@v0.5

--- a/.github/workflows/syncer-image.yaml
+++ b/.github/workflows/syncer-image.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: v1.17
+          go-version: v1.18
 
       # Build and push multi-arch supported syncer image, tagged with the commit SHA and the branch name.
       - uses: imjasonh/setup-ko@v0.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM golang:1.17 AS builder
+FROM golang:1.18 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -33,6 +33,7 @@ COPY config/ config/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
 COPY third_party/ third_party/
+COPY hack/ hack/
 COPY .git/ .git/
 
 RUN apt-get update && apt-get install -y jq && mkdir bin

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ require-%:
 	@if ! command -v $* 1> /dev/null 2>&1; then echo "$* not found in \$$PATH"; exit 1; fi
 
 build: WHAT ?= ./cmd/...
-build: require-jq require-go require-git ## Build the project
+build: require-jq require-go require-git verify-go-versions ## Build the project
 	go build $(BUILDFLAGS) -ldflags="$(LDFLAGS)" -o bin $(WHAT)
 .PHONY: build
 
@@ -248,6 +248,10 @@ verify-k8s-deps:
 .PHONY: verify-imports
 verify-imports:
 	hack/verify-imports.sh
+
+.PHONY: verify-go-imports
+verify-go-versions:
+	hack/verify-go-versions.sh
 
 .PHONY: help
 help: ## Show this help.

--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+
+VERSION=$(grep "go 1." go.mod | sed 's/go //')
+
+grep "tag: \"" .ci-operator.yaml | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in .ci-operator.yaml, expected ${VERSION}"; exit 1; }
+grep "FROM golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
+grep "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
+if [ -z "${IGNORE_GO_VERSION}" ]; then
+  go version | { ! grep -v go${VERSION}; } || { echo "Unexpected go version installed, expected ${VERSION}. Use IGNORE_GO_VERSION=1 to skip this check."; exit 1; }
+fi


### PR DESCRIPTION
So many places where we reference a go version.

Check that the build go version matches.