### PR TITLE
authorization: add system:masters-only deep SAR via X-Kcp-Internal-Deep-SubjectAccessReview header

### DIFF
--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -86,6 +86,26 @@ func (i *kcpClusterClientInitializer) Initialize(plugin admission.Interface) {
 	}
 }
 
+// NewDeepSARClientInitializer returns an admission plugin initializer that injects
+// a deep SAR client into admission plugins.
+func NewDeepSARClientInitializer(
+	deepSARClient kubernetes.ClusterInterface,
+) *clientConfigInitializer {
+	return &clientConfigInitializer{
+		deepSARClient: deepSARClient,
+	}
+}
+
+type clientConfigInitializer struct {
+	deepSARClient kubernetes.ClusterInterface
+}
+
+func (i *clientConfigInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsDeepSARClient); ok {
+		wants.SetDeepSARClient(i.deepSARClient)
+	}
+}
+
 // NewExternalAddressInitializer returns an admission plugin initializer that injects
 // an external address provider into the admission plugin.
 func NewExternalAddressInitializer(

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -26,19 +26,26 @@ import (
 // WantsKcpInformers interface should be implemented by admission plugins
 // that want to have a kcp informer factory injected.
 type WantsKcpInformers interface {
-	SetKcpInformers(informers kcpinformers.SharedInformerFactory)
+	SetKcpInformers(kcpinformers.SharedInformerFactory)
 }
 
 // WantsKubeClusterClient interface should be implemented by admission plugins
 // that want to have a kube cluster client injected.
 type WantsKubeClusterClient interface {
-	SetKubeClusterClient(kubeClusterClient kubernetes.ClusterInterface)
+	SetKubeClusterClient(kubernetes.ClusterInterface)
 }
 
 // WantsKcpClusterClient interface should be implemented by admission plugins
 // that want to have a kcp cluster client injected.
 type WantsKcpClusterClient interface {
-	SetKcpClusterClient(kubeClusterClient kcpclientset.ClusterInterface)
+	SetKcpClusterClient(kcpclientset.ClusterInterface)
+}
+
+// WantsDeepSARClient interface should be implemented by admission plugins
+// that want to have a client capable of deep SAR handling.
+// See pkg/authorization.WithDeepSARConfig for details.
+type WantsDeepSARClient interface {
+	SetDeepSARClient(kubernetes.ClusterInterface)
 }
 
 // WantsExternalAddressProvider interface should be implemented by admission plugins
@@ -50,13 +57,13 @@ type WantsExternalAddressProvider interface {
 // WantsShardBaseURL interface should be implemented by admission plugins
 // that want to have the default shard base url injected.
 type WantsShardBaseURL interface {
-	SetShardBaseURL(shardBaseURL string)
+	SetShardBaseURL(string)
 }
 
 // WantsShardExternalURL interface should be implemented by admission plugins
 // that want to have the shard external url injected.
 type WantsShardExternalURL interface {
-	SetShardExternalURL(shardExternalURL string)
+	SetShardExternalURL(string)
 }
 
 // WantsServerShutdownChannel interface should be implemented by admission plugins that want to perform cleanup

--- a/pkg/authorization/deep_sar.go
+++ b/pkg/authorization/deep_sar.go
@@ -40,11 +40,10 @@ var (
 	deepSARHeader = "X-Kcp-Internal-Deep-SubjectAccessReview"
 )
 
-// WithDeepSARConfig returns a clone of the input rest.Config
+// WithDeepSARConfig modifies and returns the input rest.Config
 // with an additional header making SARs to be deep.
 func WithDeepSARConfig(config *rest.Config) *rest.Config {
-	clone := *config
-	clone.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+	config.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 		return &withHeaderRoundtripper{
 			RoundTripper: rt,
 			headers: map[string]string{
@@ -52,7 +51,7 @@ func WithDeepSARConfig(config *rest.Config) *rest.Config {
 			},
 		}
 	})
-	return &clone
+	return config
 }
 
 type withHeaderRoundtripper struct {

--- a/pkg/authorization/deep_sar.go
+++ b/pkg/authorization/deep_sar.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/rest"
+)
+
+type deepSARKeyType int
+
+const (
+	deepSARKey deepSARKeyType = iota
+)
+
+var (
+	deepSARHeader = "X-Kcp-Internal-Deep-SubjectAccessReview"
+)
+
+// WithDeepSARConfig returns a clone of the input rest.Config
+// with an additional header making SARs to be deep.
+func WithDeepSARConfig(config *rest.Config) *rest.Config {
+	clone := *config
+	clone.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		return &withHeaderRoundtripper{
+			RoundTripper: rt,
+			headers: map[string]string{
+				deepSARHeader: "true",
+			},
+		}
+	})
+	return &clone
+}
+
+type withHeaderRoundtripper struct {
+	http.RoundTripper
+
+	headers map[string]string
+}
+
+func (rt *withHeaderRoundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	for k, v := range rt.headers {
+		req.Header.Set(k, v)
+	}
+	return rt.RoundTripper.RoundTrip(req)
+}
+
+// WithDeepSubjectAccessReview attaches to the context that this request has set the DeepSubjectAccessReview
+// header. The header is ignored for non-system:master users and for non-SAR request.
+//
+// A deep SAR request skips top-level workspace and workspace content authorization checks.
+func WithDeepSubjectAccessReview(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		val := r.Header.Get(deepSARHeader)
+		if val != "true" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// only for SAR
+		ri, ok := genericapirequest.RequestInfoFrom(r.Context())
+		if !ok {
+			responsewriters.InternalError(w, r, fmt.Errorf("cannot get request info"))
+			return
+		}
+		if !ri.IsResourceRequest || ri.APIGroup != authorizationv1.GroupName || ri.Resource != "subjectaccessreviews" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// only for system:masters
+		user, ok := genericapirequest.UserFrom(r.Context())
+		if !ok {
+			responsewriters.InternalError(w, r, fmt.Errorf("cannot get user"))
+			return
+		}
+		if !sets.NewString(user.GetGroups()...).Has(kuser.SystemPrivilegedGroup) {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// attach whether that the header is set and all pre-conditions are fulfilled
+		r = r.WithContext(context.WithValue(r.Context(), deepSARKey, true))
+		handler.ServeHTTP(w, r)
+	})
+}
+
+// IsDeepSubjectAccessReviewFrom returns whether this is a deep SAR request.
+// If true, top-level workspace and workspace content authorization checks have to be skipped.
+func IsDeepSubjectAccessReviewFrom(ctx context.Context, attr authorizer.Attributes) bool {
+	k := ctx.Value(deepSARKey)
+	return k != nil && k.(bool) && attr.GetAPIGroup() != authorizationv1.GroupName && attr.GetResource() != "subjectaccessreview"
+}

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -75,6 +75,11 @@ type topLevelOrgAccessAuthorizer struct {
 }
 
 func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if IsDeepSubjectAccessReviewFrom(ctx, attr) {
+		// this is a deep SAR request, we have to skip the checks here and delegate to the subsequent authorizer.
+		return a.delegate.Authorize(ctx, attr)
+	}
+
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil || cluster == nil || cluster.Name.Empty() {
 		kaudit.AddAuditAnnotations(

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -118,7 +118,9 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 		attr := deepCopyAttributes(attr)
 		// this is a deep SAR request, we have to skip the checks here and delegate to the subsequent authorizer.
 		if isAuthenticated && !isUser && !isServiceAccountFromCluster {
-			// anonymize service accounts from other workspaces
+			// service accounts from other workspaces might conflict with local service accounts by name.
+			// This could lead to unwanted side effects of unwanted applied permissions.
+			// Hence, these requests have to be anonymized.
 			attr.User = &user.DefaultInfo{
 				Name:   "system:anonymous",
 				Groups: []string{"system:authenticated"},

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -88,6 +88,7 @@ type ExtraConfig struct {
 	// clients
 	DynamicClusterClient       dynamic.ClusterInterface
 	KubeClusterClient          kubernetes.ClusterInterface
+	DeepSARClient              kubernetes.ClusterInterface
 	ApiExtensionsClusterClient apiextensionsclient.ClusterInterface
 	KcpClusterClient           kcpclient.ClusterInterface
 	RootShardKcpClusterClient  kcpclient.ClusterInterface
@@ -235,6 +236,10 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		kcpexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
 		kcpexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
 	)
+	c.DeepSARClient, err = kubernetes.NewClusterForConfig(authorization.WithDeepSARConfig(rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)))
+	if err != nil {
+		return nil, err
+	}
 
 	// Setup apiextensions * informers
 	c.ApiExtensionsClusterClient, err = apiextensionsclient.NewClusterForConfig(c.GenericConfig.LoopbackClientConfig)
@@ -339,6 +344,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		kcpadmissioninitializers.NewKcpInformersInitializer(c.KcpSharedInformerFactory),
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(c.KubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(c.KcpClusterClient),
+		kcpadmissioninitializers.NewDeepSARClientInitializer(c.DeepSARClient),
 		kcpadmissioninitializers.NewShardBaseURLInitializer(opts.Extra.ShardBaseURL),
 		kcpadmissioninitializers.NewShardExternalURLInitializer(opts.Extra.ShardExternalURL),
 		// The external address is provided as a function, as its value may be updated

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -49,6 +49,7 @@ import (
 
 	kcpadmissioninitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpexternalversions "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/embeddedetcd"
@@ -284,6 +285,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	c.GenericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, genericConfig *genericapiserver.Config) (secure http.Handler) {
 		apiHandler = WithWildcardListWatchGuard(apiHandler)
 		apiHandler = WithWildcardIdentity(apiHandler)
+		apiHandler = authorization.WithDeepSubjectAccessReview(apiHandler)
 
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, genericConfig)
 

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -34,13 +35,13 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
 
 	confighelpers "github.com/kcp-dev/kcp/config/helpers"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	kcp "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
@@ -59,8 +60,6 @@ func TestAuthorizer(t *testing.T) {
 
 	kubeClusterClient, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err)
-	kcpClusterClient, err := kcp.NewForConfig(cfg)
-	require.NoError(t, err)
 	dynamicClusterClient, err := kcpdynamic.NewClusterDynamicClientForConfig(cfg)
 	require.NoError(t, err)
 
@@ -70,10 +69,10 @@ func TestAuthorizer(t *testing.T) {
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org1, "org-resources.yaml")
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org2, "org-resources.yaml")
 
-	waitForReady(t, ctx, kcpClusterClient, org1, "workspace1")
-	waitForReady(t, ctx, kcpClusterClient, org1, "workspace2")
-	waitForReady(t, ctx, kcpClusterClient, org2, "workspace1")
-	waitForReady(t, ctx, kcpClusterClient, org2, "workspace2")
+	framework.NewWorkspaceFixture(t, server, org1, framework.WithName("workspace1"))
+	framework.NewWorkspaceFixture(t, server, org1, framework.WithName("workspace2"))
+	framework.NewWorkspaceFixture(t, server, org2, framework.WithName("workspace1"), framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: tenancyv1alpha1.RootShard})) // on root for deep SAR test
+	framework.NewWorkspaceFixture(t, server, org2, framework.WithName("workspace2"))
 
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org1.Join("workspace1"), "workspace1-resources.yaml")
 	createResources(t, ctx, dynamicClusterClient, kubeClusterClient.DiscoveryClient, org2.Join("workspace1"), "workspace1-resources.yaml")
@@ -190,6 +189,36 @@ func TestAuthorizer(t *testing.T) {
 				return true
 			}, wait.ForeverTestTimeout, time.Millisecond*100, "User-3 should now be able to list Namespaces")
 		},
+		"without org access, a deep SAR with user-1 against org2 succeeds even with org access for user-1": func(t *testing.T) {
+			t.Log("try to list ConfigMap as user-1 in org without access, should fail")
+			_, err := user1KubeClusterClient.CoreV1().ConfigMaps("default").List(logicalcluster.WithCluster(ctx, org2.Join("workspace1")), metav1.ListOptions{})
+			require.Error(t, err, "user-1 should not be able to list configmaps in org2")
+
+			sar := &authorizationv1.SubjectAccessReview{
+				Spec: authorizationv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &authorizationv1.ResourceAttributes{Namespace: "default", Verb: "list", Version: "v1", Resource: "configmaps"},
+					User:               "user-1",
+					Groups:             []string{"team-1"},
+				},
+			}
+
+			t.Log("ask with normal SAR that user-1 cannot access org2 because it has no access")
+			resp, err := kubeClusterClient.AuthorizationV1().SubjectAccessReviews().Create(logicalcluster.WithCluster(ctx, org2.Join("workspace1")), sar, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.False(t, resp.Status.Allowed, "SAR should correctly answer that user-1 CANNOT list configmaps in org2 because it has no access to org2")
+
+			t.Log("ask with normal SAR that user-1 can access org1 because it has access")
+			resp, err = kubeClusterClient.AuthorizationV1().SubjectAccessReviews().Create(logicalcluster.WithCluster(ctx, org1.Join("workspace1")), sar, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.True(t, resp.Status.Allowed, "SAR should correctly answer that user-1 CAN list configmaps in org2 because it has access to org1")
+
+			t.Log("ask with deep SAR that user-1 hypothetically could list configmaps in org2 if it had access")
+			deepSARClient, err := kubernetes.NewForConfig(authorization.WithDeepSARConfig(rest.CopyConfig(server.RootShardSystemMasterBaseConfig(t))))
+			require.NoError(t, err)
+			resp, err = deepSARClient.AuthorizationV1().SubjectAccessReviews().Create(logicalcluster.WithCluster(ctx, org2.Join("workspace1")), sar, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.True(t, resp.Status.Allowed, "SAR should answer hypothetically that user-1 could list configmaps in org2 if it had access")
+		},
 	}
 
 	for tcName, tcFunc := range tests {
@@ -200,18 +229,6 @@ func TestAuthorizer(t *testing.T) {
 			tcFunc(t)
 		})
 	}
-}
-
-func waitForReady(t *testing.T, ctx context.Context, kcpClusterClient kcp.Interface, orgClusterName logicalcluster.Name, workspace string) {
-	t.Logf("Waiting for workspace %s|%s to be ready", orgClusterName, workspace)
-	require.Eventually(t, func() bool {
-		ws, err := kcpClusterClient.TenancyV1alpha1().ClusterWorkspaces().Get(logicalcluster.WithCluster(ctx, orgClusterName), workspace, metav1.GetOptions{})
-		if err != nil {
-			klog.Errorf("failed to get workspace %s|%s: %v", orgClusterName, workspace, err)
-			return false
-		}
-		return ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseReady
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "workspace %s|%s didn't get ready", orgClusterName, workspace)
 }
 
 func createResources(t *testing.T, ctx context.Context, dynamicClusterClient *kcpdynamic.ClusterDynamicClient, discoveryClusterClient *discovery.DiscoveryClient, clusterName logicalcluster.Name, fileName string) {

--- a/test/e2e/authorizer/org-resources.yaml
+++ b/test/e2e/authorizer/org-resources.yaml
@@ -1,13 +1,3 @@
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspace
-metadata:
-  name: workspace1
----
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspace
-metadata:
-  name: workspace2
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/test/e2e/authorizer/workspace1-resources.yaml
+++ b/test/e2e/authorizer/workspace1-resources.yaml
@@ -20,3 +20,25 @@ rules:
     verbs: ["get", "list", "watch"]
     apiGroups: [""]
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: user-1-configmap-reader
+subjects:
+  - kind: User
+    name: user-1
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: configmap-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: configmap-reader
+rules:
+  - resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+    apiGroups: [""]
+---


### PR DESCRIPTION
This is a follow-up for #1680

TODOs:
- [x] wire in api export binding logic
- [x] wire in CWT acess, fixing https://github.com/kcp-dev/kcp/issues/1518

/cc @sttts