### PR TITLE
Generic helper for consistent post-reconcile spec and status updates

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -18,11 +18,9 @@ package apibinding
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-logr/logr"
 	"github.com/kcp-dev/logicalcluster/v2"
 
@@ -30,12 +28,10 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -50,6 +46,7 @@ import (
 	apislisters "github.com/kcp-dev/kcp/pkg/client/listers/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/reconciler/postreconcile"
 )
 
 const (
@@ -129,6 +126,7 @@ func NewController(
 		},
 		crdIndexer:        crdInformer.Informer().GetIndexer(),
 		deletedCRDTracker: newLockedStringSet(),
+		postReconcile:     postreconcile.NewPostReconcile[*APIBinding, *APIBindingSpec, *APIBindingStatus](kcpClusterClient.ApisV1alpha1().APIBindings()),
 	}
 
 	logger := logging.WithReconciler(klog.Background(), controllerName)
@@ -215,6 +213,12 @@ func NewController(
 	return c, nil
 }
 
+type APIBinding = apisv1alpha1.APIBinding
+type APIBindingSpec = apisv1alpha1.APIBindingSpec
+type APIBindingStatus = apisv1alpha1.APIBindingStatus
+type Resource = postreconcile.Resource[*APIBindingSpec, *APIBindingStatus]
+type PostReconcileFunc = func(context.Context, *Resource, *Resource) error
+
 // controller reconciles APIBindings. It creates and maintains CRDs associated with APIResourceSchemas that are
 // referenced from APIBindings. It also watches CRDs, APIResourceSchemas, and APIExports to ensure whenever
 // objects related to an APIBinding are updated, the APIBinding is reconciled.
@@ -241,6 +245,7 @@ type controller struct {
 	crdIndexer cache.Indexer
 
 	deletedCRDTracker *lockedStringSet
+	postReconcile     PostReconcileFunc
 }
 
 // enqueueAPIBinding enqueues an APIBinding .
@@ -380,12 +385,6 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 
 func (c *controller) process(ctx context.Context, key string) error {
 	logger := klog.FromContext(ctx)
-	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		logger.Error(err, "invalid key")
-		return nil
-	}
-	clusterName, name := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	obj, err := c.apiBindingsLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
 	if err != nil {
@@ -406,33 +405,10 @@ func (c *controller) process(ctx context.Context, key string) error {
 	// reconciliation error at the end.
 
 	// If the object being reconciled changed as a result, update it.
-	if !equality.Semantic.DeepEqual(old.Status, obj.Status) {
-		oldData, err := json.Marshal(apisv1alpha1.APIBinding{
-			Status: old.Status,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to Marshal old data for apibinding %s|%s: %w", clusterName, name, err)
-		}
-
-		newData, err := json.Marshal(apisv1alpha1.APIBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				UID:             old.UID,
-				ResourceVersion: old.ResourceVersion,
-			}, // to ensure they appear in the patch as preconditions
-			Status: obj.Status,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to Marshal new data for apibinding %s|%s: %w", clusterName, name, err)
-		}
-
-		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
-		if err != nil {
-			return fmt.Errorf("failed to create patch for apibinding %s|%s: %w", clusterName, name, err)
-		}
-
-		logger.V(2).Info("patching APIBinding", "patch", string(patchBytes))
-		_, uerr := c.kcpClusterClient.ApisV1alpha1().APIBindings().Patch(logicalcluster.WithCluster(ctx, clusterName), obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
-		return uerr
+	oldResource := &Resource{ObjectMeta: old.ObjectMeta, Spec: &old.Spec, Status: &old.Status}
+	newResource := &Resource{ObjectMeta: obj.ObjectMeta, Spec: &obj.Spec, Status: &obj.Status}
+	if postReconErr := c.postReconcile(ctx, oldResource, newResource); postReconErr != nil {
+		return postReconErr
 	}
 
 	return reconcileErr

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -18,20 +18,15 @@ package apiexport
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/google/go-cmp/cmp"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -51,6 +46,7 @@ import (
 	apislisters "github.com/kcp-dev/kcp/pkg/client/listers/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/reconciler/postreconcile"
 )
 
 const (
@@ -94,6 +90,7 @@ func NewController(
 		listClusterWorkspaceShards: func() ([]*tenancyv1alpha1.ClusterWorkspaceShard, error) {
 			return clusterWorkspaceShardInformer.Lister().List(labels.Everything())
 		},
+		postReconcile: postreconcile.NewPostReconcile[*APIExport, *APIExportSpec, *APIExportStatus](kcpClusterClient.ApisV1alpha1().APIExports()),
 	}
 
 	c.getSecret = c.readThroughGetSecret
@@ -169,6 +166,12 @@ func NewController(
 	return c, nil
 }
 
+type APIExport = apisv1alpha1.APIExport
+type APIExportSpec = apisv1alpha1.APIExportSpec
+type APIExportStatus = apisv1alpha1.APIExportStatus
+type Resource = postreconcile.Resource[*APIExportSpec, *APIExportStatus]
+type PostReconcileFunc = func(context.Context, *Resource, *Resource) error
+
 // controller reconciles APIExports. It ensures an export's identity secret exists and is valid.
 type controller struct {
 	queue workqueue.RateLimitingInterface
@@ -189,6 +192,7 @@ type controller struct {
 	createSecret func(ctx context.Context, clusterName logicalcluster.Name, secret *corev1.Secret) error
 
 	listClusterWorkspaceShards func() ([]*tenancyv1alpha1.ClusterWorkspaceShard, error)
+	postReconcile              PostReconcileFunc
 }
 
 // enqueueAPIBinding enqueues an APIExport .
@@ -315,81 +319,13 @@ func (c *controller) process(ctx context.Context, key string) error {
 	// reconciliation error at the end.
 
 	// If the object being reconciled changed as a result, update it.
-	if err := c.patchIfNeeded(ctx, old, obj); err != nil {
+	oldResource := &Resource{ObjectMeta: old.ObjectMeta, Spec: &old.Spec, Status: &old.Status}
+	newResource := &Resource{ObjectMeta: obj.ObjectMeta, Spec: &obj.Spec, Status: &obj.Status}
+	if err := c.postReconcile(ctx, oldResource, newResource); err != nil {
 		errs = append(errs, err)
 	}
 
 	return utilerrors.NewAggregate(errs)
-}
-
-func (c *controller) patchIfNeeded(ctx context.Context, old, obj *apisv1alpha1.APIExport) error {
-	logger := klog.FromContext(ctx)
-	specOrObjectMetaChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec) || !equality.Semantic.DeepEqual(old.ObjectMeta, obj.ObjectMeta)
-	statusChanged := !equality.Semantic.DeepEqual(old.Status, obj.Status)
-
-	if !specOrObjectMetaChanged && !statusChanged {
-		return nil
-	}
-
-	// apiExportForPatch ensures that only the spec/objectMeta fields will be changed
-	// or the status field but never both at the same time.
-	apiExportForPatch := func(apiExport *apisv1alpha1.APIExport) apisv1alpha1.APIExport {
-		var ret apisv1alpha1.APIExport
-		if specOrObjectMetaChanged {
-			ret.ObjectMeta = apiExport.ObjectMeta
-			ret.Spec = apiExport.Spec
-		} else {
-			ret.Status = apiExport.Status
-		}
-		return ret
-	}
-
-	clusterName := logicalcluster.From(old)
-	name := old.Name
-
-	oldForPatch := apiExportForPatch(old)
-	// to ensure they appear in the patch as preconditions
-	oldForPatch.UID = ""
-	oldForPatch.ResourceVersion = ""
-
-	oldData, err := json.Marshal(oldForPatch)
-	if err != nil {
-		return fmt.Errorf("failed to Marshal old data for APIExport %s|%s: %w", clusterName, name, err)
-	}
-
-	newForPatch := apiExportForPatch(obj)
-	// to ensure they appear in the patch as preconditions
-	newForPatch.UID = old.UID
-	newForPatch.ResourceVersion = old.ResourceVersion
-
-	newData, err := json.Marshal(newForPatch)
-	if err != nil {
-		return fmt.Errorf("failed to Marshal new data for APIExport %s|%s: %w", clusterName, name, err)
-	}
-
-	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
-	if err != nil {
-		return fmt.Errorf("failed to create patch for APIExport %s|%s: %w", clusterName, name, err)
-	}
-
-	var subresources []string
-	if statusChanged {
-		subresources = []string{"status"}
-	}
-
-	logger.V(2).Info("patching APIExport", "patch", string(patchBytes))
-	_, err = c.kcpClusterClient.ApisV1alpha1().APIExports().Patch(logicalcluster.WithCluster(ctx, clusterName), obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...)
-	if err != nil {
-		return fmt.Errorf("failed to patch APIExport %s|%s: %w", clusterName, name, err)
-	}
-
-	// Despite having patched either just spec/objectMeta or status we should log an error indicating a programming error.
-	if specOrObjectMetaChanged && statusChanged {
-		logger.Info("programmer error: spec and status changed in same reconcile iteration", "diff", cmp.Diff(old, obj))
-		c.enqueueAPIExport(obj) // enqueue again to take care of the spec change, assuming the patch did nothing
-	}
-
-	return nil
 }
 
 func (c *controller) readThroughGetSecret(ctx context.Context, clusterName logicalcluster.Name, ns, name string) (*corev1.Secret, error) {

--- a/pkg/reconciler/committer/committer.go
+++ b/pkg/reconciler/committer/committer.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package postreconcile
+package committer
 
 import (
 	"context"
@@ -43,14 +43,14 @@ type Patcher[R any] interface {
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (R, error)
 }
 
-// NewPostReconciler returns a function that can patch instances of R based on spec or status changes.
-func NewPostReconcile[R any, Sp any, St any](patcher Patcher[R]) func(context.Context, *Resource[Sp, St], *Resource[Sp, St]) error {
+// NewCommitter returns a function that can patch instances of R based on spec or status changes.
+func NewCommitter[R any, Sp any, St any](patcher Patcher[R]) func(context.Context, *Resource[Sp, St], *Resource[Sp, St]) error {
 	focusType := fmt.Sprintf("%T", *new(R))
 	return func(ctx context.Context, old, obj *Resource[Sp, St]) error {
 		logger := klog.FromContext(ctx)
 
-		specChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec)
 		objectMetaChanged := !equality.Semantic.DeepEqual(old.ObjectMeta, obj.ObjectMeta)
+		specChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec)
 		statusChanged := !equality.Semantic.DeepEqual(old.Status, obj.Status)
 
 		specOrObjectMetaChanged := specChanged || objectMetaChanged

--- a/pkg/reconciler/postreconcile/postreconcile.go
+++ b/pkg/reconciler/postreconcile/postreconcile.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package postreconcile
 
 import (
@@ -8,6 +24,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/google/go-cmp/cmp"
 	"github.com/kcp-dev/logicalcluster/v2"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/reconciler/postreconcile/postreconcile.go
+++ b/pkg/reconciler/postreconcile/postreconcile.go
@@ -1,0 +1,104 @@
+package postreconcile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster/v2"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+// Resource is a generic wrapper around resources so we can generate patches
+type Resource[Sp any, St any] struct {
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              Sp `json:"spec"`
+	Status            St `json:"status,omitempty"`
+}
+
+// Patcher is just the Patch API with a generic to keep use sites type safe
+type Patcher[R any] interface {
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (R, error)
+}
+
+// NewPostReconciler returns a function that can patch instances of R based on spec or status changes.
+func NewPostReconcile[R any, Sp any, St any](patcher Patcher[R]) func(context.Context, *Resource[Sp, St], *Resource[Sp, St]) error {
+	focusType := fmt.Sprintf("%T", *new(R))
+	return func(ctx context.Context, old, obj *Resource[Sp, St]) error {
+		logger := klog.FromContext(ctx)
+
+		specChanged := !equality.Semantic.DeepEqual(old.Spec, obj.Spec)
+		objectMetaChanged := !equality.Semantic.DeepEqual(old.ObjectMeta, obj.ObjectMeta)
+		statusChanged := !equality.Semantic.DeepEqual(old.Status, obj.Status)
+
+		specOrObjectMetaChanged := specChanged || objectMetaChanged
+
+		if !specOrObjectMetaChanged && !statusChanged {
+			return nil
+		}
+
+		// forPatch ensures that only the spec/objectMeta fields will be changed
+		// or the status field but never both at the same time.
+		forPatch := func(r *Resource[Sp, St]) *Resource[Sp, St] {
+			var ret Resource[Sp, St]
+			if specOrObjectMetaChanged {
+				ret.ObjectMeta = r.ObjectMeta
+				ret.Spec = r.Spec
+			} else {
+				ret.Status = r.Status
+			}
+			return &ret
+		}
+
+		clusterName := logicalcluster.From(old)
+		name := old.Name
+
+		oldForPatch := forPatch(old)
+		// to ensure they appear in the patch as preconditions
+		oldForPatch.UID = ""
+		oldForPatch.ResourceVersion = ""
+
+		oldData, err := json.Marshal(oldForPatch)
+		if err != nil {
+			return fmt.Errorf("failed to Marshal old data for %s %s|%s: %w", focusType, clusterName, name, err)
+		}
+
+		newForPatch := forPatch(obj)
+		// to ensure they appear in the patch as preconditions
+		newForPatch.UID = old.UID
+		newForPatch.ResourceVersion = old.ResourceVersion
+
+		newData, err := json.Marshal(newForPatch)
+		if err != nil {
+			return fmt.Errorf("failed to Marshal new data for %s %s|%s: %w", focusType, clusterName, name, err)
+		}
+
+		patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
+		if err != nil {
+			return fmt.Errorf("failed to create patch for %s %s|%s: %w", focusType, clusterName, name, err)
+		}
+
+		var subresources []string
+		if statusChanged {
+			subresources = []string{"status"}
+		}
+
+		logger.V(2).Info(fmt.Sprintf("patching %s", focusType), "patch", string(patchBytes))
+		_, err = patcher.Patch(logicalcluster.WithCluster(ctx, clusterName), obj.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...)
+		if err != nil {
+			return fmt.Errorf("failed to patch %s %s|%s: %w", focusType, clusterName, name, err)
+		}
+
+		// Simultaneous updates of spec and status are never allowed.
+		if specOrObjectMetaChanged && statusChanged {
+			panic(fmt.Sprintf("programmer error: spec and status changed in same reconcile iteration. diff=%s", cmp.Diff(old, obj)))
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
Unify post-reconcile spec and status updating logic in a type safe way. The `APIBinding` and `APIExport` controllers are updated as examples.