### PR TITLE
modified cmd.Use for kubectl-workspaces

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -90,7 +90,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	}
 	cmd := &cobra.Command{
 		Aliases:          []string{"ws", "workspaces"},
-		Use:              "workspace [create|create-context|<workspace>|..|.|-|~|<root:absolute:workspace>]",
+		Use:              "workspace [command]",
 		Short:            "Manages KCP workspaces",
 		Example:          fmt.Sprintf(workspaceExample, "kubectl kcp"),
 		SilenceUsage:     true,

--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -90,7 +90,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	}
 	cmd := &cobra.Command{
 		Aliases:          []string{"ws", "workspaces"},
-		Use:              "workspace [command]",
+		Use:              "workspace [create|create-context|use|current|<workspace>|..|.|-|~|<root:absolute:workspace>]",
 		Short:            "Manages KCP workspaces",
 		Example:          fmt.Sprintf(workspaceExample, "kubectl kcp"),
 		SilenceUsage:     true,


### PR DESCRIPTION
## Summary: 
As sub-commands like create/create-context required additional details about workspace, whereas rest of the commands did not. So, the usage section `workspace [create|create-context|<workspace>|..|.|-|~|<root:absolute:workspace>] [flags]` might lead to a confusion as some sub-commands aren't specified. Modified the usage section as below, using the generic keywords:
`Usage:
  workspace [command] [flags]
  workspace [command]
` 
Considered keeping (workspace [command]) for commands like `use`.
Let me know, if we should only keep `workspace [command] [flags]` instead of both the statements.

Fixes #1579 