### PR TITLE
Generate CRD defaults for known types

### DIFF
--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -455,6 +455,10 @@ func (sc *SchemaConverter) VisitPrimitive(p *proto.Primitive) {
 	sc.setupDescription(p)
 	sc.schemaProps.Type = p.Type
 	sc.schemaProps.Format = p.Format
+
+	if defaults, ok := knownDefaults[p.Path.String()]; ok {
+		sc.schemaProps.Default = defaults
+	}
 }
 
 func (sc *SchemaConverter) VisitKind(k *proto.Kind) {
@@ -626,4 +630,8 @@ func init() {
 			knownSchemas[schemaName] = schema
 		}
 	}
+}
+
+var knownDefaults map[string]*apiextensionsv1.JSON = map[string]*apiextensionsv1.JSON{
+	"io.k8s.api.core.v1.ContainerPort.protocol": {Raw: []byte(`"TCP"`)},
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

Hard-code defaults for known fields appearing in `x-kubernetes-list-map-keys`.

After auditing https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json, it seems that only one field needs to be patched. The other occurrences are required.



## Related issue(s)

This is a partial fix for #498