### PR TITLE
Fix image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ COPY cmd/ cmd/
 COPY third_party/ third_party/
 COPY hack/ hack/
 COPY .git/ .git/
+# To make sure hack/verify-go-versions.sh succeeds
+COPY .ci-operator.yaml .
+COPY Dockerfile .
+COPY .github/ .github/
 
 RUN apt-get update && apt-get install -y jq && mkdir bin
 RUN CGO_ENABLED=0 make

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ verify-k8s-deps:
 verify-imports:
 	hack/verify-imports.sh
 
-.PHONY: verify-go-imports
+.PHONY: verify-go-versions
 verify-go-versions:
 	hack/verify-go-versions.sh
 


### PR DESCRIPTION
## Summary
Fix image builds due to verify-go-versions failing to find all the files it needed

## Related issue(s)

Fixes #1770