### PR TITLE
✨ virtual/workspaces: add owner references to RBAC role and binding

### DIFF
--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -193,8 +193,8 @@ func newAuthorizer(cfg *clientrest.Config) func(ctx context.Context, a authorize
 		workspaceAttr := authorizer.AttributesRecord{
 			User:            a.GetUser(),
 			Verb:            a.GetVerb(),
-			APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
-			APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
+			APIGroup:        tenancyv1beta1.SchemeGroupVersion.Group,
+			APIVersion:      tenancyv1beta1.SchemeGroupVersion.Version,
 			Resource:        "workspaces",
 			Name:            a.GetName(),
 			ResourceRequest: true,

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/watch"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	rbacinformers "k8s.io/client-go/informers/rbac/v1"
@@ -146,6 +147,27 @@ func (s *REST) NamespaceScoped() bool {
 	return false
 }
 
+func (s *REST) canGetAll(ctx context.Context, cluster logicalcluster.Name, user kuser.Info) (bool, error) {
+	clusterAuthorizer, err := s.delegatedAuthz(cluster, s.kubeClusterClient)
+	if err != nil {
+		return false, err
+	}
+	adminWorkspaceAttr := authorizer.AttributesRecord{
+		User:            user,
+		Verb:            "get",
+		APIGroup:        tenancyv1beta1.SchemeGroupVersion.Group,
+		APIVersion:      tenancyv1beta1.SchemeGroupVersion.Version,
+		Resource:        "workspaces",
+		Name:            "", // all
+		ResourceRequest: true,
+	}
+	decision, _, err := clusterAuthorizer.Authorize(ctx, adminWorkspaceAttr)
+	if err != nil {
+		return false, err
+	}
+	return decision == authorizer.DecisionAllow, nil
+}
+
 // List retrieves a list of Workspaces that match label.
 func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (runtime.Object, error) {
 	userInfo, ok := apirequest.UserFrom(ctx)
@@ -155,7 +177,19 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 	orgClusterName := ctx.Value(WorkspacesOrgKey).(logicalcluster.Name)
 
 	clusterWorkspaceList := &tenancyv1alpha1.ClusterWorkspaceList{}
-	if clusterWorkspaces := s.getFilteredClusterWorkspaces(orgClusterName); clusterWorkspaces != nil {
+	if canGetAll, err := s.canGetAll(ctx, orgClusterName, userInfo); err != nil {
+		return nil, err
+	} else if canGetAll {
+		v1Opts := metav1.ListOptions{}
+		if err := metainternal.Convert_internalversion_ListOptions_To_v1_ListOptions(options, &v1Opts, nil); err != nil {
+			return nil, err
+		}
+		var err error
+		clusterWorkspaceList, err = s.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().List(ctx, v1Opts)
+		if err != nil {
+			return nil, err
+		}
+	} else if clusterWorkspaces := s.getFilteredClusterWorkspaces(orgClusterName); clusterWorkspaces != nil {
 		// TODO:
 		// The workspaceLister is informer driven, so it's important to note that the lister can be stale.
 		// It breaks the API guarantees of lists.
@@ -188,6 +222,21 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 	}
 
 	orgClusterName := ctx.Value(WorkspacesOrgKey).(logicalcluster.Name)
+
+	if canGetAll, err := s.canGetAll(ctx, orgClusterName, userInfo); err != nil {
+		return nil, err
+	} else if canGetAll {
+		v1Opts := metav1.ListOptions{}
+		if err := metainternal.Convert_internalversion_ListOptions_To_v1_ListOptions(options, &v1Opts, nil); err != nil {
+			return nil, err
+		}
+		w, err := s.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Watch(ctx, v1Opts)
+		if err != nil {
+			return nil, err
+		}
+		return withProjection{delegate: w, ch: make(chan watch.Event)}, nil
+	}
+
 	clusterWorkspaces := s.getFilteredClusterWorkspaces(orgClusterName)
 
 	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"
@@ -391,4 +440,35 @@ func (s *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 	}
 
 	return nil, false, errorToReturn
+}
+
+type withProjection struct {
+	delegate watch.Interface
+	ch       chan watch.Event
+}
+
+func (w withProjection) ResultChan() <-chan watch.Event {
+	ch := w.delegate.ResultChan()
+
+	go func() {
+		for ev := range ch {
+			if ev.Object == nil {
+				w.ch <- ev
+				continue
+			}
+			if cws, ok := ev.Object.(*tenancyv1alpha1.ClusterWorkspace); ok {
+				ws := &tenancyv1beta1.Workspace{}
+				projection.ProjectClusterWorkspaceToWorkspace(cws, ws)
+				ev.Object = ws
+			}
+			w.ch <- ev
+		}
+	}()
+
+	return w.ch
+}
+
+func (w withProjection) Stop() {
+	defer close(w.ch)
+	w.delegate.Stop()
 }

--- a/pkg/virtual/workspaces/registry/rest_test.go
+++ b/pkg/virtual/workspaces/registry/rest_test.go
@@ -44,6 +44,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/utils/pointer"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
@@ -578,6 +579,15 @@ func TestCreateWorkspace(t *testing.T) {
 						Labels: map[string]string{
 							WorkspaceNameLabel: "foo",
 						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "tenancy.kcp.dev/v1alpha1",
+								Kind:               "ClusterWorkspace",
+								Name:               "foo",
+								UID:                "",
+								BlockOwnerDeletion: pointer.BoolPtr(true),
+							},
+						},
 					},
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
@@ -601,6 +611,15 @@ func TestCreateWorkspace(t *testing.T) {
 						Name: "owner-workspace-foo-test-user",
 						Labels: map[string]string{
 							WorkspaceNameLabel: "foo",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "tenancy.kcp.dev/v1alpha1",
+								Kind:               "ClusterWorkspace",
+								Name:               "foo",
+								UID:                "",
+								BlockOwnerDeletion: pointer.BoolPtr(true),
+							},
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -665,6 +684,15 @@ func TestCreateWorkspaceWithCreateAnyPermission(t *testing.T) {
 						Labels: map[string]string{
 							WorkspaceNameLabel: "foo",
 						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "tenancy.kcp.dev/v1alpha1",
+								Kind:               "ClusterWorkspace",
+								Name:               "foo",
+								UID:                "",
+								BlockOwnerDeletion: pointer.BoolPtr(true),
+							},
+						},
 					},
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
@@ -688,6 +716,15 @@ func TestCreateWorkspaceWithCreateAnyPermission(t *testing.T) {
 						Name: "owner-workspace-foo-test-user",
 						Labels: map[string]string{
 							WorkspaceNameLabel: "foo",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "tenancy.kcp.dev/v1alpha1",
+								Kind:               "ClusterWorkspace",
+								Name:               "foo",
+								UID:                "",
+								BlockOwnerDeletion: pointer.BoolPtr(true),
+							},
 						},
 					},
 					Rules: []rbacv1.PolicyRule{
@@ -761,6 +798,15 @@ func TestCreateWorkspaceCustomLocalType(t *testing.T) {
 						Labels: map[string]string{
 							WorkspaceNameLabel: "foo",
 						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "tenancy.kcp.dev/v1alpha1",
+								Kind:               "ClusterWorkspace",
+								Name:               "foo",
+								UID:                "",
+								BlockOwnerDeletion: pointer.BoolPtr(true),
+							},
+						},
 					},
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: "rbac.authorization.k8s.io",
@@ -784,6 +830,15 @@ func TestCreateWorkspaceCustomLocalType(t *testing.T) {
 						Name: "owner-workspace-foo-test-user",
 						Labels: map[string]string{
 							WorkspaceNameLabel: "foo",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "tenancy.kcp.dev/v1alpha1",
+								Kind:               "ClusterWorkspace",
+								Name:               "foo",
+								UID:                "",
+								BlockOwnerDeletion: pointer.BoolPtr(true),
+							},
 						},
 					},
 					Rules: []rbacv1.PolicyRule{


### PR DESCRIPTION
When GC is implemented and the TODO is resolved, deletion of workspaces and their permission is more natural. But it's good to already add the owner refs now before we persist objects without.