### PR TITLE
virtual/workspaces: do not filter if able to get all

### DIFF
--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
 	tenancylisters "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 	rbacwrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/rbac"
 )
@@ -186,14 +187,13 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 		return authorizer.DecisionNoOpinion, WorkspaceAcccessNotPermittedReason, nil
 	case isUser:
 		workspaceAttr := authorizer.AttributesRecord{
-			User:        attr.GetUser(),
-			Verb:        "access",
-			APIGroup:    tenancyv1alpha1.SchemeGroupVersion.Group,
-			APIVersion:  tenancyv1alpha1.SchemeGroupVersion.Version,
-			Resource:    "workspaces",
-			Subresource: "content",
-			Name:        requestTopLevelOrgName,
-
+			User:            attr.GetUser(),
+			Verb:            "access",
+			APIGroup:        tenancyv1beta1.SchemeGroupVersion.Group,
+			APIVersion:      tenancyv1beta1.SchemeGroupVersion.Version,
+			Resource:        "workspaces",
+			Subresource:     "content",
+			Name:            requestTopLevelOrgName,
 			ResourceRequest: true,
 		}
 

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	tenancyv1beta1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1"
 	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 	tenancylisters "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 	rbacwrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/rbac"
@@ -230,8 +231,8 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 			workspaceAttr := authorizer.AttributesRecord{
 				User:            attr.GetUser(),
 				Verb:            verb,
-				APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
-				APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
+				APIGroup:        tenancyv1beta1.SchemeGroupVersion.Group,
+				APIVersion:      tenancyv1beta1.SchemeGroupVersion.Version,
 				Resource:        "workspaces",
 				Subresource:     "content",
 				Name:            cluster.Name.Base(),

--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -193,8 +193,8 @@ func newAuthorizer(cfg *clientrest.Config) func(ctx context.Context, a authorize
 		workspaceAttr := authorizer.AttributesRecord{
 			User:            a.GetUser(),
 			Verb:            a.GetVerb(),
-			APIGroup:        tenancyv1alpha1.SchemeGroupVersion.Group,
-			APIVersion:      tenancyv1alpha1.SchemeGroupVersion.Version,
+			APIGroup:        tenancyv1beta1.SchemeGroupVersion.Group,
+			APIVersion:      tenancyv1beta1.SchemeGroupVersion.Version,
 			Resource:        "workspaces",
 			Name:            a.GetName(),
 			ResourceRequest: true,

--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/watch"
 	kuser "k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	rbacinformers "k8s.io/client-go/informers/rbac/v1"
@@ -145,6 +146,27 @@ func (s *REST) NamespaceScoped() bool {
 	return false
 }
 
+func (s *REST) canGetAll(ctx context.Context, cluster logicalcluster.Name, user kuser.Info) (bool, error) {
+	clusterAuthorizer, err := s.delegatedAuthz(cluster, s.kubeClusterClient)
+	if err != nil {
+		return false, err
+	}
+	adminWorkspaceAttr := authorizer.AttributesRecord{
+		User:            user,
+		Verb:            "get",
+		APIGroup:        tenancyv1beta1.SchemeGroupVersion.Group,
+		APIVersion:      tenancyv1beta1.SchemeGroupVersion.Version,
+		Resource:        "workspaces",
+		Name:            "", // all
+		ResourceRequest: true,
+	}
+	decision, _, err := clusterAuthorizer.Authorize(ctx, adminWorkspaceAttr)
+	if err != nil {
+		return false, err
+	}
+	return decision == authorizer.DecisionAllow, nil
+}
+
 // List retrieves a list of Workspaces that match label.
 func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (runtime.Object, error) {
 	userInfo, ok := apirequest.UserFrom(ctx)
@@ -154,7 +176,19 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 	orgClusterName := ctx.Value(WorkspacesOrgKey).(logicalcluster.Name)
 
 	clusterWorkspaceList := &tenancyv1alpha1.ClusterWorkspaceList{}
-	if clusterWorkspaces := s.getFilteredClusterWorkspaces(orgClusterName); clusterWorkspaces != nil {
+	if canGetAll, err := s.canGetAll(ctx, orgClusterName, userInfo); err != nil {
+		return nil, err
+	} else if canGetAll {
+		v1Opts := metav1.ListOptions{}
+		if err := metainternal.Convert_internalversion_ListOptions_To_v1_ListOptions(options, &v1Opts, nil); err != nil {
+			return nil, err
+		}
+		var err error
+		clusterWorkspaceList, err = s.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().List(ctx, v1Opts)
+		if err != nil {
+			return nil, err
+		}
+	} else if clusterWorkspaces := s.getFilteredClusterWorkspaces(orgClusterName); clusterWorkspaces != nil {
 		// TODO:
 		// The workspaceLister is informer driven, so it's important to note that the lister can be stale.
 		// It breaks the API guarantees of lists.
@@ -187,6 +221,21 @@ func (s *REST) Watch(ctx context.Context, options *metainternal.ListOptions) (wa
 	}
 
 	orgClusterName := ctx.Value(WorkspacesOrgKey).(logicalcluster.Name)
+
+	if canGetAll, err := s.canGetAll(ctx, orgClusterName, userInfo); err != nil {
+		return nil, err
+	} else if canGetAll {
+		v1Opts := metav1.ListOptions{}
+		if err := metainternal.Convert_internalversion_ListOptions_To_v1_ListOptions(options, &v1Opts, nil); err != nil {
+			return nil, err
+		}
+		w, err := s.kcpClusterClient.Cluster(orgClusterName).TenancyV1alpha1().ClusterWorkspaces().Watch(ctx, v1Opts)
+		if err != nil {
+			return nil, err
+		}
+		return withProjection{delegate: w, ch: make(chan watch.Event)}, nil
+	}
+
 	clusterWorkspaces := s.getFilteredClusterWorkspaces(orgClusterName)
 
 	includeAllExistingProjects := (options != nil) && options.ResourceVersion == "0"
@@ -369,4 +418,35 @@ func (s *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 	}
 
 	return nil, false, errorToReturn
+}
+
+type withProjection struct {
+	delegate watch.Interface
+	ch       chan watch.Event
+}
+
+func (w withProjection) ResultChan() <-chan watch.Event {
+	ch := w.delegate.ResultChan()
+
+	go func() {
+		for ev := range ch {
+			if ev.Object == nil {
+				w.ch <- ev
+				continue
+			}
+			if cws, ok := ev.Object.(*tenancyv1alpha1.ClusterWorkspace); ok {
+				ws := &tenancyv1beta1.Workspace{}
+				projection.ProjectClusterWorkspaceToWorkspace(cws, ws)
+				ev.Object = ws
+			}
+			w.ch <- ev
+		}
+	}()
+
+	return w.ch
+}
+
+func (w withProjection) Stop() {
+	defer close(w.ch)
+	w.delegate.Stop()
 }


### PR DESCRIPTION
Admins or users in their home workspace can see all workspaces. Filtering is not necessary, and until GC is implemented (see https://github.com/kcp-dev/kcp/pull/1774) even wrong.

Fixes https://github.com/kcp-dev/kcp/issues/1723.