### PR TITLE
controllers: avoid double copy of the rest config

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -28,6 +28,7 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
@@ -84,7 +85,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	clusterConfig := kcpclienthelper.NewClusterConfig(config)
+	clusterConfig := kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(config))
 
 	crdClusterClient, err := apiextensionsclient.NewForConfig(clusterConfig)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
-	github.com/kcp-dev/apimachinery v0.0.0-20220803185518-868856d14e8a
+	github.com/kcp-dev/apimachinery v0.0.0-20220819164220-dbb759406933
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -431,8 +431,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-github.com/kcp-dev/apimachinery v0.0.0-20220803185518-868856d14e8a h1:lJyVMNywLln1x5A3WVELeDpftc5FktP3asI1Prx0lOU=
-github.com/kcp-dev/apimachinery v0.0.0-20220803185518-868856d14e8a/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
+github.com/kcp-dev/apimachinery v0.0.0-20220819164220-dbb759406933 h1:32by2A7rpm3Vmu9sQwSZjOdCGRmG+PQOLuusgcRdF0k=
+github.com/kcp-dev/apimachinery v0.0.0-20220819164220-dbb759406933/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
 github.com/kcp-dev/kubernetes v0.0.0-20220819235229-1629b4678518 h1:wy3gVsgO1bioXnJLRJF1MK1k0qkw2HEvNUxw78FeY6g=
 github.com/kcp-dev/kubernetes v0.0.0-20220819235229-1629b4678518/go.mod h1:x3RxHGS2ZEGxxiakIQx3KJJJ9T5Q0DqFKWjIjIRSGCY=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20220819235229-1629b4678518 h1:+8+yyZX7Xf/hprDcs2Kvn6cvqkCWB6Dqj5KtoqhEpt8=

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	crdclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/apis/tenancy/initialization"
@@ -48,7 +49,7 @@ func (c *controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.C
 	bootstrapCtx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second*30)) // to not block the controller
 	defer cancel()
 
-	clusterWsConfig := kcpclienthelper.ConfigWithCluster(c.baseConfig, wsClusterName)
+	clusterWsConfig := kcpclienthelper.SetCluster(rest.CopyConfig(c.baseConfig), wsClusterName)
 	crdWsClient, err := crdclientset.NewForConfig(clusterWsConfig)
 	if err != nil {
 		return err

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -282,7 +282,8 @@ func readCA(file string) ([]byte, error) {
 }
 
 func (s *Server) installWorkspaceDeletionController(ctx context.Context, config *rest.Config) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-workspace-deletion-controller"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-workspace-deletion-controller")
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -321,7 +322,8 @@ func (s *Server) installWorkspaceDeletionController(ctx context.Context, config 
 }
 
 func (s *Server) installWorkloadResourceScheduler(ctx context.Context, config *rest.Config, ddsif *informer.DynamicDiscoverySharedInformerFactory) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-workload-resource-scheduler"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-workload-resource-scheduler")
 	dynamicClusterClient, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return err
@@ -350,7 +352,8 @@ func (s *Server) installWorkloadResourceScheduler(ctx context.Context, config *r
 }
 
 func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Config) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-workspace-scheduler"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-workspace-scheduler")
 
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
@@ -430,7 +433,8 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 }
 
 func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-home-workspaces"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-home-workspaces")
 
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
@@ -490,7 +494,8 @@ func (s *Server) installHomeWorkspaces(ctx context.Context, config *rest.Config)
 }
 
 func (s *Server) installApiResourceController(ctx context.Context, config *rest.Config) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-api-resource-controller"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-api-resource-controller")
 
 	crdClusterClient, err := apiextensionsclient.NewForConfig(config)
 	if err != nil {
@@ -527,7 +532,8 @@ func (s *Server) installApiResourceController(ctx context.Context, config *rest.
 }
 
 func (s *Server) installSyncTargetHeartbeatController(ctx context.Context, config *rest.Config) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-synctarget-heartbeat-controller"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-synctarget-heartbeat-controller")
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -557,7 +563,8 @@ func (s *Server) installSyncTargetHeartbeatController(ctx context.Context, confi
 }
 
 func (s *Server) installAPIBindingController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer, ddsif *informer.DynamicDiscoverySharedInformerFactory) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-apibinding-controller"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-apibinding-controller")
 
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
@@ -660,7 +667,8 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 }
 
 func (s *Server) installAPIExportController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), "kcp-apiexport-controller"))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), "kcp-apiexport-controller")
 
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
@@ -707,7 +715,8 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 
 func (s *Server) installSchedulingLocationStatusController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-scheduling-location-status-controller"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
@@ -738,7 +747,8 @@ func (s *Server) installSchedulingLocationStatusController(ctx context.Context, 
 
 func (s *Server) installDefaultPlacementController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-workload-default-placement"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -768,7 +778,8 @@ func (s *Server) installDefaultPlacementController(ctx context.Context, config *
 
 func (s *Server) installWorkloadNamespaceScheduler(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-workload-namespace-scheduler"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kubeClusterClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return err
@@ -802,7 +813,8 @@ func (s *Server) installWorkloadNamespaceScheduler(ctx context.Context, config *
 
 func (s *Server) installWorkloadPlacementScheduler(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-workload-placement-scheduler"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -833,7 +845,8 @@ func (s *Server) installWorkloadPlacementScheduler(ctx context.Context, config *
 
 func (s *Server) installSchedulingPlacementController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-scheduling-placement-controller"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -864,7 +877,8 @@ func (s *Server) installSchedulingPlacementController(ctx context.Context, confi
 
 func (s *Server) installWorkloadsAPIExportController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-workloads-apiexport-controller"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -895,7 +909,8 @@ func (s *Server) installWorkloadsAPIExportController(ctx context.Context, config
 
 func (s *Server) installWorkloadsAPIExportCreateController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-workloads-apiexport-create-controller"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -927,7 +942,8 @@ func (s *Server) installWorkloadsAPIExportCreateController(ctx context.Context, 
 
 func (s *Server) installWorkloadsSyncTargetExportController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-workloads-synctarget-exports-controller"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -959,7 +975,8 @@ func (s *Server) installWorkloadsSyncTargetExportController(ctx context.Context,
 
 func (s *Server) installSyncTargetController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
 	controllerName := "kcp-synctarget-controller"
-	config = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(config), controllerName))
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), controllerName)
 	kcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err
@@ -988,13 +1005,14 @@ func (s *Server) installSyncTargetController(ctx context.Context, config *rest.C
 }
 
 func (s *Server) installKubeQuotaController(
-	ctx context.Context,
+	_ context.Context,
 	config *rest.Config,
 	server *genericapiserver.GenericAPIServer,
 ) error {
 	controllerName := "kcp-kube-quota-controller"
+	config = rest.CopyConfig(config)
+	// TODO(ncdc): figure out if we need kcpclienthelper.SetMultiClusterRoundTripper(config)
 	config = rest.AddUserAgent(config, controllerName)
-
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(config)
 	if err != nil {
 		return err
@@ -1050,7 +1068,8 @@ func (s *Server) installApiExportIdentityController(config *rest.Config, server 
 	if s.Options.Extra.ShardName == tenancyv1alpha1.RootShard {
 		return nil
 	}
-	config = rest.AddUserAgent(kcpclienthelper.NewClusterConfig(config), identitycache.ControllerName)
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), identitycache.ControllerName)
 	kubeClusterClient, err := kubernetes.NewClusterForConfig(config)
 	if err != nil {
 		return err

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -195,7 +195,7 @@ func TestAPIBindingAuthorizer(t *testing.T) {
 		_, err = kcpClusterClient.ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		consumerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, consumerWorkspace)
+		consumerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), consumerWorkspace)
 		consumerWorkspaceClient, err := clientset.NewForConfig(consumerWorkspaceConfig)
 		require.NoError(t, err)
 
@@ -312,7 +312,7 @@ func createClusterRoleAndBindings(name, subjectName, subjectKind string, verbs [
 func setUpServiceProvider(ctx context.Context, dynamicClusterClient *kcpdynamic.ClusterDynamicClient, kcpClients clientset.Interface, kubeClusterClient kubernetes.Interface, serviceProviderWorkspace, rbacServiceProvider logicalcluster.Name, cfg *rest.Config, t *testing.T) {
 	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
 
-	clusterCfg := kcpclienthelper.ConfigWithCluster(cfg, serviceProviderWorkspace)
+	clusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), serviceProviderWorkspace)
 	serviceProviderClient, err := clientset.NewForConfig(clusterCfg)
 	require.NoError(t, err)
 

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/util/retry"
 
@@ -64,7 +65,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 	dynamicClusterClient, err := kcpdynamic.NewClusterDynamicClientForConfig(cfg)
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
-	serviceProviderClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, serviceProviderWorkspace)
+	serviceProviderClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), serviceProviderWorkspace)
 	serviceProviderClient, err := clientset.NewForConfig(serviceProviderClusterCfg)
 	require.NoError(t, err)
 
@@ -117,7 +118,7 @@ func TestAPIBindingDeletion(t *testing.T) {
 		return true
 	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
-	consumerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, consumerWorkspace)
+	consumerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), consumerWorkspace)
 	consumerWorkspaceClient, err := clientset.NewForConfig(consumerWorkspaceConfig)
 	require.NoError(t, err)
 

--- a/test/e2e/apibinding/apibinding_permissionclaims_test.go
+++ b/test/e2e/apibinding/apibinding_permissionclaims_test.go
@@ -167,7 +167,7 @@ func TestAPIBindingPermissionClaimsConditions(t *testing.T) {
 
 func setUpServiceProviderWithPermissionClaims(ctx context.Context, dynamicClusterClient *kcpdynamic.ClusterDynamicClient, kcpClusterClients clientset.Interface, serviceProviderWorkspace logicalcluster.Name, cfg *rest.Config, t *testing.T, identityHash string) {
 	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
-	serviceProviderClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, serviceProviderWorkspace)
+	serviceProviderClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), serviceProviderWorkspace)
 	serviceProviderClient, err := clientset.NewForConfig(serviceProviderClusterCfg)
 	require.NoError(t, err)
 
@@ -253,7 +253,7 @@ func bindConsumerToProvider(ctx context.Context, consumerWorkspace, providerWork
 	_, err := kcpClusterClients.ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	consumerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, consumerWorkspace)
+	consumerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), consumerWorkspace)
 	consumerWorkspaceClient, err := clientset.NewForConfig(consumerWorkspaceConfig)
 	require.NoError(t, err)
 

--- a/test/e2e/apibinding/apibinding_protected_test.go
+++ b/test/e2e/apibinding/apibinding_protected_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 
 	"github.com/kcp-dev/kcp/config/helpers"
@@ -58,7 +59,7 @@ func TestProtectedAPI(t *testing.T) {
 	dynamicClusterClient, err := kcpdynamic.NewClusterDynamicClientForConfig(cfg)
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
-	providerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, providerWorkspace)
+	providerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), providerWorkspace)
 	providerWorkspaceClient, err := clientset.NewForConfig(providerWorkspaceConfig)
 	require.NoError(t, err)
 
@@ -107,7 +108,7 @@ func TestProtectedAPI(t *testing.T) {
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "APIBinding %q in workspace %q did not complete", apiBinding.Name, consumerWorkspace)
 
 	t.Logf("Make sure gateway API resource shows up in workspace %q group version discovery", consumerWorkspace)
-	consumerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, consumerWorkspace)
+	consumerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), consumerWorkspace)
 	consumerWorkspaceClient, err := clientset.NewForConfig(consumerWorkspaceConfig)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -98,7 +98,7 @@ func TestAPIBinding(t *testing.T) {
 	for _, serviceProviderWorkspace := range serviceProviderWorkspaces {
 		t.Logf("Install today cowboys APIResourceSchema into %q", serviceProviderWorkspace)
 
-		serviceProviderClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, serviceProviderWorkspace)
+		serviceProviderClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), serviceProviderWorkspace)
 		serviceProviderClient, err := clientset.NewForConfig(serviceProviderClusterCfg)
 		require.NoError(t, err)
 		mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(serviceProviderClient.Discovery()))
@@ -166,7 +166,7 @@ func TestAPIBinding(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Logf("Make sure %s API group does NOT show up in workspace %q group discovery", wildwest.GroupName, providerWorkspace)
-		providerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, providerWorkspace)
+		providerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), providerWorkspace)
 		providerWorkspaceClient, err := clientset.NewForConfig(providerWorkspaceConfig)
 		require.NoError(t, err)
 
@@ -175,7 +175,7 @@ func TestAPIBinding(t *testing.T) {
 		require.False(t, groupExists(groups, wildwest.GroupName),
 			"should not have seen %s API group in %q group discovery", wildwest.GroupName, providerWorkspace)
 
-		consumerWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, consumerWorkspace)
+		consumerWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), consumerWorkspace)
 		consumerWorkspaceClient, err := clientset.NewForConfig(consumerWorkspaceConfig)
 		require.NoError(t, err)
 

--- a/test/e2e/apibinding/apibinding_webhook_test.go
+++ b/test/e2e/apibinding/apibinding_webhook_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 
 	"github.com/kcp-dev/kcp/config/helpers"
@@ -74,7 +75,7 @@ func TestAPIBindingMutatingWebhook(t *testing.T) {
 	kubeClusterClient, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct client for server")
 
-	sourceWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, sourceWorkspace)
+	sourceWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), sourceWorkspace)
 	sourceWorkspaceClient, err := clientset.NewForConfig(sourceWorkspaceConfig)
 	require.NoError(t, err)
 
@@ -218,7 +219,7 @@ func TestAPIBindingValidatingWebhook(t *testing.T) {
 	kubeClusterClient, err := kubernetes.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct client for server")
 
-	sourceWorkspaceConfig := kcpclienthelper.ConfigWithCluster(cfg, sourceWorkspace)
+	sourceWorkspaceConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), sourceWorkspace)
 	sourceWorkspaceClient, err := clientset.NewForConfig(sourceWorkspaceConfig)
 	require.NoError(t, err)
 

--- a/test/e2e/conformance/metadata_test.go
+++ b/test/e2e/conformance/metadata_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/kube"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
@@ -54,13 +55,13 @@ func TestMetadataMutations(t *testing.T) {
 
 	workspaceName := framework.NewOrganizationFixture(t, server)
 
-	workspaceCfg := kcpclienthelper.ConfigWithCluster(cfg, workspaceName)
+	workspaceCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), workspaceName)
 	workspaceCRDClient, err := apiextensionclientset.NewForConfig(workspaceCfg)
 	require.NoError(t, err, "error creating crd cluster client")
 
 	kube.Create(t, workspaceCRDClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: "apps.k8s.io", Resource: "deployments"})
 
-	kubeClusterClient, err := kubernetes.NewForConfig(kcpclienthelper.NewClusterConfig(cfg))
+	kubeClusterClient, err := kubernetes.NewForConfig(kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(cfg)))
 	require.NoError(t, err, "error creating kube cluster client")
 
 	d := &appsv1.Deployment{

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -555,16 +555,18 @@ func (c *kcpServer) config(context string) (*rest.Config, error) {
 func (c *kcpServer) BaseConfig(t *testing.T) *rest.Config {
 	cfg, err := c.config("base")
 	require.NoError(t, err)
-	cfg = kcpclienthelper.NewClusterConfig(cfg)
-	return rest.AddUserAgent(rest.CopyConfig(cfg), t.Name())
+	cfg = rest.CopyConfig(cfg)
+	cfg = kcpclienthelper.SetMultiClusterRoundTripper(cfg)
+	return rest.AddUserAgent(cfg, t.Name())
 }
 
 // RootShardSystemMasterBaseConfig returns a rest.Config for the "system:admin" context. Client-side throttling is disabled (QPS=-1).
 func (c *kcpServer) RootShardSystemMasterBaseConfig(t *testing.T) *rest.Config {
 	cfg, err := c.config("system:admin")
 	require.NoError(t, err)
-	cfg = kcpclienthelper.NewClusterConfig(cfg)
-	return rest.AddUserAgent(rest.CopyConfig(cfg), t.Name())
+	cfg = rest.CopyConfig(cfg)
+	cfg = kcpclienthelper.SetMultiClusterRoundTripper(cfg)
+	return rest.AddUserAgent(cfg, t.Name())
 }
 
 // RawConfig exposes a copy of the client config for this server.
@@ -830,7 +832,7 @@ func (s *unmanagedKCPServer) BaseConfig(t *testing.T) *rest.Config {
 	defaultConfig, err := config.ClientConfig()
 	require.NoError(t, err)
 
-	wrappedCfg := kcpclienthelper.NewClusterConfig(defaultConfig)
+	wrappedCfg := kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(defaultConfig))
 	wrappedCfg.QPS = -1
 
 	return wrappedCfg
@@ -846,7 +848,7 @@ func (s *unmanagedKCPServer) RootShardSystemMasterBaseConfig(t *testing.T) *rest
 	defaultConfig, err := config.ClientConfig()
 	require.NoError(t, err)
 
-	wrappedCfg := kcpclienthelper.NewClusterConfig(defaultConfig)
+	wrappedCfg := kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(defaultConfig))
 	wrappedCfg.QPS = -1
 
 	return wrappedCfg

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -169,7 +169,7 @@ func TestClusterController(t *testing.T) {
 
 			// clients
 			sourceConfig := source.BaseConfig(t)
-			sourceWsClusterConfig := kcpclienthelper.ConfigWithCluster(sourceConfig, wsClusterName)
+			sourceWsClusterConfig := kcpclienthelper.SetCluster(rest.CopyConfig(sourceConfig), wsClusterName)
 
 			sourceKubeClient, err := kubernetesclient.NewForConfig(sourceWsClusterConfig)
 			require.NoError(t, err)

--- a/test/e2e/reconciler/clusterworkspace/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspace/controller_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
@@ -194,11 +195,11 @@ func TestWorkspaceController(t *testing.T) {
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
 			// create clients
-			orgClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, orgClusterName)
+			orgClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), orgClusterName)
 			orgClusterKcpClient, err := kcpclientset.NewForConfig(orgClusterCfg)
 			require.NoError(t, err)
 
-			rootClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, tenancyv1alpha1.RootCluster)
+			rootClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), tenancyv1alpha1.RootCluster)
 			rootClusterKcpClient, err := kcpclientset.NewForConfig(rootClusterCfg)
 			require.NoError(t, err)
 

--- a/test/e2e/reconciler/clusterworkspaceshard/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspaceshard/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	kubernetesclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
@@ -70,11 +71,11 @@ func TestWorkspaceShardController(t *testing.T) {
 
 			orgClusterName := framework.NewOrganizationFixture(t, server)
 
-			orgClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, orgClusterName)
+			orgClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), orgClusterName)
 			orgClusterKcpClient, err := kubernetesclientset.NewForConfig(orgClusterCfg)
 			require.NoError(t, err)
 
-			rootClusterCfg := kcpclienthelper.ConfigWithCluster(cfg, tenancyv1alpha1.RootCluster)
+			rootClusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), tenancyv1alpha1.RootCluster)
 			rootClusterKcpClient, err := kcpclientset.NewForConfig(rootClusterCfg)
 			require.NoError(t, err)
 

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -243,7 +244,7 @@ func TestNamespaceScheduler(t *testing.T) {
 
 			clusterName := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-			clusterConfig := kcpclienthelper.ConfigWithCluster(cfg, clusterName)
+			clusterConfig := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), clusterName)
 			kubeClusterClient, err := kubernetes.NewForConfig(clusterConfig)
 			require.NoError(t, err)
 

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -537,7 +537,7 @@ func setUpServiceProvider(ctx context.Context, dynamicClusterClient *kcpdynamic.
 
 	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProviderWorkspace)
 
-	clusterCfg := kcpclienthelper.ConfigWithCluster(cfg, serviceProviderWorkspace)
+	clusterCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), serviceProviderWorkspace)
 	serviceProviderClient, err := clientset.NewForConfig(clusterCfg)
 	require.NoError(t, err)
 
@@ -620,7 +620,7 @@ func bindConsumerToProvider(ctx context.Context, consumerWorkspace, providerWork
 		},
 	}
 
-	consumerWorkspaceCfg := kcpclienthelper.ConfigWithCluster(cfg, consumerWorkspace)
+	consumerWorkspaceCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), consumerWorkspace)
 	consumerWsClient, err := clientset.NewForConfig(consumerWorkspaceCfg)
 	require.NoError(t, err)
 

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -678,10 +678,10 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			virtualWorkspaceRawConfig.Contexts["wildwest"] = rawConfig.Contexts["base"].DeepCopy()
 			virtualWorkspaceRawConfig.Contexts["wildwest"].Cluster = "wildwest"
 			kubelikeVWConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "kubelike", nil, nil).ClientConfig()
-			kubelikeVWConfig = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(kubelikeVWConfig), t.Name()))
+			kubelikeVWConfig = kcpclienthelper.SetMultiClusterRoundTripper(rest.AddUserAgent(rest.CopyConfig(kubelikeVWConfig), t.Name()))
 			require.NoError(t, err)
 			wildwestVWConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "wildwest", nil, nil).ClientConfig()
-			wildwestVWConfig = kcpclienthelper.NewClusterConfig(rest.AddUserAgent(rest.CopyConfig(wildwestVWConfig), t.Name()))
+			wildwestVWConfig = kcpclienthelper.SetMultiClusterRoundTripper(rest.AddUserAgent(rest.CopyConfig(wildwestVWConfig), t.Name()))
 			require.NoError(t, err)
 
 			t.Log("Starting test...")

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -249,7 +249,7 @@ func collectCacheHitsFor(ctx context.Context, t *testing.T, rootCfg *rest.Config
 const byWorkspace = "byWorkspace"
 
 func testDynamicDiscoverySharedInformerFactory(ctx context.Context, t *testing.T, rootShardConfig *rest.Config, expectedGVR schema.GroupVersionResource, expectedResName string, expectedClusterName logicalcluster.Name) {
-	rootShardWildcardConfig := kcpclienthelper.ConfigWithCluster(rootShardConfig, logicalcluster.Wildcard)
+	rootShardWildcardConfig := kcpclienthelper.SetCluster(rest.CopyConfig(rootShardConfig), logicalcluster.Wildcard)
 	rootShardCRDWildcardClient, err := apiextensionsclient.NewForConfig(rootShardWildcardConfig)
 	require.NoError(t, err, "failed to construct apiextensions client")
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
adding a user agent changes the original config, which might be used by other clients.
## Related issue(s)

Fixes #