### PR TITLE
Ignore .goreleaser.yaml in GH CI

### DIFF
--- a/.github/workflows/ci-docs-only.yaml
+++ b/.github/workflows/ci-docs-only.yaml
@@ -11,6 +11,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - ".github/ISSUE_TEMPLATE/*"
+      - ".goreleaser.yaml"
 
 jobs:
   e2e-shared-server:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - ".github/ISSUE_TEMPLATE/*"
+      - ".goreleaser.yaml"
 
 # NOTE!!!
 #


### PR DESCRIPTION
## Summary
No need to run e2e-shared-server or e2e-sharded if we change .goreleaser.yaml.

## Related issue(s)

Fixes #