### PR TITLE
cache-server: starts empty apiextentions-server

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -17,15 +17,38 @@ limitations under the License.
 package server
 
 import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	apiextentionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextentionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	apiextensionsoptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/features"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/kubernetes/pkg/genericcontrolplane/clientutils"
+
 	cacheserveroptions "github.com/kcp-dev/kcp/pkg/cache/server/options"
+	"github.com/kcp-dev/kcp/pkg/embeddedetcd"
+	kcpserver "github.com/kcp-dev/kcp/pkg/server"
 )
 
 type Config struct {
-	Options *cacheserveroptions.CompletedOptions
+	Options       *cacheserveroptions.CompletedOptions
+	ApiExtensions *apiextensionsapiserver.Config
+	EmbeddedEtcd  *embeddedetcd.Config
 }
 
 type completedConfig struct {
-	Options *cacheserveroptions.CompletedOptions
+	Options       *cacheserveroptions.CompletedOptions
+	ApiExtensions apiextensionsapiserver.CompletedConfig
+	EmbeddedEtcd  embeddedetcd.CompletedConfig
 }
 
 type CompletedConfig struct {
@@ -36,7 +59,9 @@ type CompletedConfig struct {
 // Complete fills in any fields not set that are required to have valid data. It's mutating the receiver.
 func (c *Config) Complete() (CompletedConfig, error) {
 	return CompletedConfig{&completedConfig{
-		Options: c.Options,
+		Options:       c.Options,
+		ApiExtensions: c.ApiExtensions.Complete(),
+		EmbeddedEtcd:  c.EmbeddedEtcd.Complete(),
 	}}, nil
 }
 
@@ -44,5 +69,82 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 	c := &Config{
 		Options: opts,
 	}
+	if opts.EmbeddedEtcd.Enabled {
+		var err error
+		c.EmbeddedEtcd, err = embeddedetcd.NewConfig(opts.EmbeddedEtcd, opts.Etcd.EnableWatchCache)
+		if err != nil {
+			return nil, err
+		}
+	}
+	serverConfig := genericapiserver.NewRecommendedConfig(apiextensionsapiserver.Codecs)
+
+	if err := opts.ServerRunOptions.ApplyTo(&serverConfig.Config); err != nil {
+		return nil, err
+	}
+	if err := opts.Etcd.ApplyTo(&serverConfig.Config); err != nil {
+		return nil, err
+	}
+	if err := opts.SecureServing.ApplyTo(&serverConfig.Config.SecureServing, &serverConfig.Config.LoopbackClientConfig); err != nil {
+		return nil, err
+	}
+	if err := opts.Authentication.ApplyTo(&serverConfig.Config.Authentication, serverConfig.SecureServing, serverConfig.OpenAPIConfig); err != nil {
+		return nil, err
+	}
+	if err := opts.Authorization.ApplyTo(&serverConfig.Config.Authorization); err != nil {
+		return nil, err
+	}
+
+	if err := opts.APIEnablement.ApplyTo(&serverConfig.Config, apiextensionsapiserver.DefaultAPIResourceConfigSource(), apiextensionsapiserver.Scheme); err != nil {
+		return nil, err
+	}
+
+	serverConfig.Config.BuildHandlerChainFunc = func(apiHandler http.Handler, genericConfig *genericapiserver.Config) (secure http.Handler) {
+		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, genericConfig)
+		apiHandler = genericapiserver.DefaultBuildHandlerChainBeforeAuthz(apiHandler, genericConfig)
+		apiHandler = kcpserver.WithClusterAnnotation(apiHandler)
+		apiHandler = kcpserver.WithClusterScope(apiHandler)
+		apiHandler = kcpserver.WithAcceptHeader(apiHandler)
+		apiHandler = kcpserver.WithUserAgent(apiHandler)
+		return apiHandler
+	}
+
+	opts.Etcd.StorageConfig.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
+	// this is where the true decodable levels come from.
+	opts.Etcd.StorageConfig.Codec = apiextensionsapiserver.Codecs.LegacyCodec(apiextentionsv1beta1.SchemeGroupVersion, apiextentionsv1.SchemeGroupVersion)
+	// prefer the more compact serialization (v1beta1) for storage until http://issue.k8s.io/82292 is resolved for objects whose v1 serialization is too big but whose v1beta1 serialization can be stored
+	opts.Etcd.StorageConfig.EncodeVersioner = runtime.NewMultiGroupVersioner(apiextentionsv1beta1.SchemeGroupVersion, schema.GroupKind{Group: apiextentionsv1beta1.GroupName})
+	serverConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: *opts.Etcd}
+
+	// use protobufs for self-communication.
+	// Since not every generic apiserver has to support protobufs, we
+	// cannot default to it in generic apiserver and need to explicitly
+	// set it in kube-apiserver.
+	serverConfig.LoopbackClientConfig.ContentConfig.ContentType = "application/vnd.kubernetes.protobuf"
+	// disable compression for self-communication, since we are going to be
+	// on a fast local network
+	serverConfig.LoopbackClientConfig.DisableCompression = true
+	clientutils.EnableMultiCluster(serverConfig.LoopbackClientConfig, &serverConfig.Config, "namespaces", "apiservices", "customresourcedefinitions", "clusterroles", "clusterrolebindings", "roles", "rolebindings", "serviceaccounts", "secrets")
+
+	c.ApiExtensions = &apiextensionsapiserver.Config{
+		GenericConfig: serverConfig,
+		ExtraConfig: apiextensionsapiserver.ExtraConfig{
+			CRDRESTOptionsGetter: apiextensionsoptions.NewCRDRESTOptionsGetter(*opts.Etcd),
+			// Wire in a ServiceResolver that always returns an error that ResolveEndpoint is not yet
+			// supported. The effect is that CRD webhook conversions are not supported and will always get an
+			// error.
+			ServiceResolver:     &unimplementedServiceResolver{},
+			AuthResolverWrapper: webhook.NewDefaultAuthenticationInfoResolverWrapper(nil, nil, serverConfig.LoopbackClientConfig, nil),
+		},
+	}
 	return c, nil
+}
+
+// unimplementedServiceResolver is a webhook.ServiceResolver that always returns an error, because
+// we have not implemented support for this yet. As a result, CRD webhook conversions are not
+// supported.
+type unimplementedServiceResolver struct{}
+
+// ResolveEndpoint always returns an error that this is not yet supported.
+func (r *unimplementedServiceResolver) ResolveEndpoint(namespace string, name string, port int32) (*url.URL, error) {
+	return nil, errors.New("CRD webhook conversions are not supported")
 }

--- a/pkg/cache/server/server.go
+++ b/pkg/cache/server/server.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package server
 
-import "context"
+import (
+	"context"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+)
 
 type Server struct {
 	CompletedConfig
@@ -30,5 +34,9 @@ func NewServer(c CompletedConfig) (*Server, error) {
 }
 
 func (s *Server) Run(ctx context.Context) error {
-	return nil
+	server, err := s.ApiExtensions.New(genericapiserver.NewEmptyDelegate())
+	if err != nil {
+		return err
+	}
+	return server.GenericAPIServer.PrepareRun().Run(ctx.Done())
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
Allows for starting empty `apiextentions server` on port 6443. It runs with the embedded etcd. 

As of today, it has disabled `authN/Z` stack which needs to be restored in the future.

The server can be started with `go run ./cmd/cache-server/main.go` which produces:
```
I0822 12:03:17.366752   76028 server.go:44] Starting embedded etcd server
{"level":"warn","ts":"2022-08-22T12:03:17.580+0200","caller":"etcdserver/metrics.go:224","msg":"failed to get file descriptor usage","error":"cannot get FDUsage on darwin"}
W0822 12:03:17.642213   76028 authentication.go:47] Authentication is disabled
W0822 12:03:17.744823   76028 genericapiserver.go:590] Skipping API apiextensions.k8s.io/v1beta1 because it has no resources.
I0822 12:03:17.749135   76028 dynamic_serving_content.go:132] "Starting controller" name="serving-cert::.kcp-cache/apiserver.crt::.kcp-cache/apiserver.key"
I0822 12:03:17.749282   76028 secure_serving.go:210] Serving securely on [::]:6443
I0822 12:03:17.749312   76028 tlsconfig.go:240] "Starting DynamicServingCertificateController"
I0822 12:03:17.749350   76028 crd_finalizer.go:270] Starting CRDFinalizer
I0822 12:03:17.749376   76028 establishing_controller.go:79] Starting EstablishingController
I0822 12:03:17.749383   76028 nonstructuralschema_controller.go:192] Starting NonStructuralSchemaConditionController
I0822 12:03:17.749389   76028 naming_controller.go:307] Starting NamingConditionController
I0822 12:03:17.749391   76028 apiapproval_controller.go:186] Starting KubernetesAPIApprovalPolicyConformantConditionController
```

The empty server exposes the following paths:

```
curl -k 'https://localhost:6443/api'
{
  "paths": [
    "/apis",
    "/apis/",
    "/apis/apiextensions.k8s.io",
    "/apis/apiextensions.k8s.io/v1",
    "/healthz",
    "/healthz/etcd",
    "/healthz/log",
    "/healthz/ping",
    "/healthz/poststarthook/crd-informer-synced",
    "/healthz/poststarthook/max-in-flight-filter",
    "/healthz/poststarthook/start-apiextensions-controllers",
    "/healthz/poststarthook/start-apiextensions-informers",
    "/livez",
    "/livez/etcd",
    "/livez/log",
    "/livez/ping",
    "/livez/poststarthook/crd-informer-synced",
    "/livez/poststarthook/max-in-flight-filter",
    "/livez/poststarthook/start-apiextensions-controllers",
    "/livez/poststarthook/start-apiextensions-informers",
    "/metrics",
    "/readyz",
    "/readyz/etcd",
    "/readyz/log",
    "/readyz/ping",
    "/readyz/poststarthook/crd-informer-synced",
    "/readyz/poststarthook/max-in-flight-filter",
    "/readyz/poststarthook/start-apiextensions-controllers",
    "/readyz/poststarthook/start-apiextensions-informers",
    "/readyz/shutdown",
    "/version"
  ]
}%
```

In the next PR I'm going to `wire CRD lister similar to today's pkg/server/apiextensions.go with at least APIExports and APIResourceSchemas`

## Related issue(s)

part of `instantiate apiextensions-apiserver` in https://github.com/kcp-dev/kcp/issues/1225