### PR TITLE
cache-server: expose apiresourceschemas and apiexports

### DIFF
--- a/config/crds/bootstrap.go
+++ b/config/crds/bootstrap.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
 )
 
 //go:embed *.yaml
@@ -174,6 +175,16 @@ func CreateSingle(ctx context.Context, client apiextensionsv1client.CustomResour
 
 		return crdhelpers.IsCRDConditionTrue(crd, apiextensionsv1.Established), nil
 	})
+}
+
+// Unmarshal YAML-decodes the give embedded file name into the target.
+func Unmarshal(fileName string, crd *apiextensionsv1.CustomResourceDefinition) error {
+	bs, err := raw.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+
+	return yaml.Unmarshal(bs, crd)
 }
 
 func retryRetryableErrors(f func() error) error {

--- a/pkg/cache/server/bootstrap/bootstrap.go
+++ b/pkg/cache/server/bootstrap/bootstrap.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
+
+	configcrds "github.com/kcp-dev/kcp/config/crds"
+)
+
+// SystemCRDLogicalCluster holds a logical cluster name under which we store system-related CRDs.
+// We use the same name as the KCP for symmetry.
+var SystemCRDLogicalCluster = logicalcluster.New("system:system-crds")
+
+func Bootstrap(ctx context.Context, apiExtensionsClusterClient apiextensionsclient.ClusterInterface) error {
+	crds := []*apiextensionsv1.CustomResourceDefinition{}
+	for _, resource := range []string{"apiresourceschemas", "apiexports"} {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := configcrds.Unmarshal(fmt.Sprintf("apis.kcp.dev_%s.yaml", resource), crd); err != nil {
+			panic(fmt.Errorf("failed to unmarshal %v resource: %w", resource, err))
+		}
+		for i := range crd.Spec.Versions {
+			v := &crd.Spec.Versions[i]
+			v.Schema = &apiextensionsv1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:                   "object",
+					XPreserveUnknownFields: pointer.BoolPtr(true),
+				},
+			} // wipe the schema, we don't need validation
+		}
+		crds = append(crds, crd)
+	}
+
+	logger := klog.FromContext(ctx)
+	return wait.PollInfiniteWithContext(ctx, time.Second, func(ctx context.Context) (bool, error) {
+		for _, crd := range crds {
+			err := configcrds.CreateSingle(ctx, apiExtensionsClusterClient.Cluster(SystemCRDLogicalCluster).ApiextensionsV1().CustomResourceDefinitions(), crd)
+			if err != nil {
+				logger.Error(err, "failed to create CustomResourceDefinition", crd.Name)
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}

--- a/pkg/cache/server/crd_lister.go
+++ b/pkg/cache/server/crd_lister.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/kcp"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/clusters"
+
+	"github.com/kcp-dev/kcp/pkg/cache/server/bootstrap"
+)
+
+// crdLister is a CRD lister
+type crdLister struct {
+	lister apiextensionslisters.CustomResourceDefinitionLister
+}
+
+var _ kcp.ClusterAwareCRDLister = &crdLister{}
+
+// List lists all CustomResourceDefinitions
+func (c *crdLister) List(ctx context.Context, selector labels.Selector) ([]*apiextensionsv1.CustomResourceDefinition, error) {
+	// TODO: make it shard and cluster aware, for now just return what we have in the system ws
+	return c.lister.List(selector)
+}
+
+func (c *crdLister) Refresh(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
+	return crd, nil
+}
+
+// Get gets a CustomResourceDefinition
+func (c *crdLister) Get(ctx context.Context, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	// TODO: make it shard and cluster aware, for now just return what we have in the system ws
+	return c.lister.Get(clusters.ToClusterAwareKey(bootstrap.SystemCRDLogicalCluster, name))
+}

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -77,6 +77,7 @@ import (
 	workloadresource "github.com/kcp-dev/kcp/pkg/reconciler/workload/resource"
 	synctargetcontroller "github.com/kcp-dev/kcp/pkg/reconciler/workload/synctarget"
 	"github.com/kcp-dev/kcp/pkg/reconciler/workload/synctargetexports"
+	"github.com/kcp-dev/kcp/pkg/util"
 )
 
 func postStartHookName(controllerName string) string {
@@ -652,7 +653,7 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		// do custom wait logic here because APIExports+APIBindings are special as system CRDs,
 		// and the controllers must run as soon as these two informers are up in order to bootstrap
 		// the rest of the system. Everything else in the kcp clientset is APIBinding based.
-		if err := wait.PollImmediateInfiniteWithContext(goContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
+		if err := wait.PollImmediateInfiniteWithContext(util.GoContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
 			crdsSynced := s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced()
 			exportsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
 			bindingsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
@@ -663,9 +664,9 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
-		go permissionClaimLabelController.Start(goContext(hookContext), 5)
-		go permissionClaimLabelResourceController.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
+		go permissionClaimLabelController.Start(util.GoContext(hookContext), 5)
+		go permissionClaimLabelResourceController.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	}); err != nil {
@@ -687,7 +688,7 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go apibindingDeletionController.Start(goContext(hookContext), 10)
+		go apibindingDeletionController.Start(util.GoContext(hookContext), 10)
 
 		return nil
 	})
@@ -725,7 +726,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 		// do custom wait logic here because APIExports+APIBindings are special as system CRDs,
 		// and the controllers must run as soon as these two informers are up in order to bootstrap
 		// the rest of the system. Everything else in the kcp clientset is APIBinding based.
-		if err := wait.PollImmediateInfiniteWithContext(goContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
+		if err := wait.PollImmediateInfiniteWithContext(util.GoContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
 			crdsSynced := s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced()
 			exportsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
 			bindingsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
@@ -736,7 +737,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -769,7 +770,7 @@ func (s *Server) installSchedulingLocationStatusController(ctx context.Context, 
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -801,7 +802,7 @@ func (s *Server) installDefaultPlacementController(ctx context.Context, config *
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -833,7 +834,7 @@ func (s *Server) installWorkloadNamespaceScheduler(ctx context.Context, config *
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	}); err != nil {
@@ -870,7 +871,7 @@ func (s *Server) installWorkloadPlacementScheduler(ctx context.Context, config *
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -903,7 +904,7 @@ func (s *Server) installSchedulingPlacementController(ctx context.Context, confi
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -936,7 +937,7 @@ func (s *Server) installWorkloadsAPIExportController(ctx context.Context, config
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -970,7 +971,7 @@ func (s *Server) installWorkloadsAPIExportCreateController(ctx context.Context, 
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -1003,7 +1004,7 @@ func (s *Server) installWorkloadsSyncTargetExportController(ctx context.Context,
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -1035,7 +1036,7 @@ func (s *Server) installSyncTargetController(ctx context.Context, config *rest.C
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	})
@@ -1085,7 +1086,7 @@ func (s *Server) installKubeQuotaController(
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 2)
+		go c.Start(util.GoContext(hookContext), 2)
 
 		return nil
 	}); err != nil {
@@ -1124,7 +1125,7 @@ func (s *Server) installApiExportIdentityController(ctx context.Context, config 
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
 
-		go c.Start(goContext(hookContext), 1)
+		go c.Start(util.GoContext(hookContext), 1)
 		return nil
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/util"
 )
 
 const resyncPeriod = 10 * time.Hour
@@ -126,7 +127,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		logger.Info("finished starting kube informers")
 
-		if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
+		if err := wait.PollInfiniteWithContext(util.GoContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
 			if err := systemcrds.Bootstrap(ctx,
 				s.ApiExtensionsClusterClient.Cluster(SystemCRDLogicalCluster),
 				s.ApiExtensionsClusterClient.Cluster(SystemCRDLogicalCluster).Discovery(),
@@ -144,7 +145,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		logger.Info("finished bootstrapping system CRDs")
 
-		if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
+		if err := wait.PollInfiniteWithContext(util.GoContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
 			if err := configshard.Bootstrap(ctx,
 				s.ApiExtensionsClusterClient.Cluster(configshard.SystemShardCluster).Discovery(),
 				s.DynamicClusterClient.Cluster(configshard.SystemShardCluster),
@@ -164,7 +165,7 @@ func (s *Server) Run(ctx context.Context) error {
 		go s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().Run(hookContext.StopCh)
 		go s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().Run(hookContext.StopCh)
 
-		if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
+		if err := wait.PollInfiniteWithContext(util.GoContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
 			exportsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
 			bindingsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
 			return exportsSynced && bindingsSynced, nil
@@ -177,7 +178,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		if s.Options.Extra.ShardName == tenancyv1alpha1.RootShard {
 			// bootstrap root workspace phase 0 only if we are on the root shard, no APIBinding resources yet
-			if err := configrootphase0.Bootstrap(goContext(hookContext),
+			if err := configrootphase0.Bootstrap(util.GoContext(hookContext),
 				s.KcpClusterClient.Cluster(tenancyv1alpha1.RootCluster),
 				s.ApiExtensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
 				s.DynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
@@ -190,7 +191,7 @@ func (s *Server) Run(ctx context.Context) error {
 			logger.Info("bootstrapped root workspace phase 0")
 
 			logger.Info("getting kcp APIExport identities")
-			if err := wait.PollImmediateInfiniteWithContext(goContext(hookContext), time.Millisecond*500, func(ctx context.Context) (bool, error) {
+			if err := wait.PollImmediateInfiniteWithContext(util.GoContext(hookContext), time.Millisecond*500, func(ctx context.Context) (bool, error) {
 				if err := s.resolveIdentities(ctx); err != nil {
 					logger.V(3).Info("failed to resolve identities, keeping trying", "err", err)
 					return false, nil
@@ -208,7 +209,7 @@ func (s *Server) Run(ctx context.Context) error {
 			go s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().Run(hookContext.StopCh)
 			go s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().Run(hookContext.StopCh)
 
-			if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
+			if err := wait.PollInfiniteWithContext(util.GoContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
 				exportsSynced := s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
 				bindingsSynced := s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
 				return exportsSynced && bindingsSynced, nil
@@ -220,7 +221,7 @@ func (s *Server) Run(ctx context.Context) error {
 			logger.Info("finished starting APIExport and APIBinding informers for the root shard")
 
 			logger.Info("getting kcp APIExport identities for the root shard")
-			if err := wait.PollImmediateInfiniteWithContext(goContext(hookContext), time.Millisecond*500, func(ctx context.Context) (bool, error) {
+			if err := wait.PollImmediateInfiniteWithContext(util.GoContext(hookContext), time.Millisecond*500, func(ctx context.Context) (bool, error) {
 				if err := s.resolveIdentities(ctx); err != nil {
 					logger.V(3).Info("failed to resolve identities for the root shard, keeping trying", "err", err)
 					return false, nil
@@ -257,7 +258,7 @@ func (s *Server) Run(ctx context.Context) error {
 			}
 			logger := logging.WithObject(logger, shard)
 
-			if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
+			if err := wait.PollInfiniteWithContext(util.GoContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
 				logger.Info("getting ClusterWorkspaceShard from the root shard")
 				existingShard, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Get(ctx, shard.Name, metav1.GetOptions{})
 				if err != nil && !errors.IsNotFound(err) {
@@ -301,7 +302,7 @@ func (s *Server) Run(ctx context.Context) error {
 		logger.Info("finished starting (remaining) kcp informers")
 
 		logger.Info("starting dynamic metadata informer worker")
-		go s.DynamicDiscoverySharedInformerFactory.StartWorker(goContext(hookContext))
+		go s.DynamicDiscoverySharedInformerFactory.StartWorker(util.GoContext(hookContext))
 
 		logger.Info("synced all informers, ready to start controllers")
 		close(s.syncedCh)
@@ -310,7 +311,7 @@ func (s *Server) Run(ctx context.Context) error {
 			// the root ws is only present on the root shard
 			logger.Info("starting bootstrapping root workspace phase 1")
 			servingCert, _ := delegationChainHead.SecureServingInfo.Cert.CurrentCertKeyContent()
-			if err := configroot.Bootstrap(goContext(hookContext),
+			if err := configroot.Bootstrap(util.GoContext(hookContext),
 				s.ApiExtensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
 				s.DynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
 				s.Options.Extra.ShardName,
@@ -471,18 +472,6 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	return delegationChainHead.PrepareRun().Run(ctx.Done())
-}
-
-// goContext turns the PostStartHookContext into a context.Context for use in routines that may or may not
-// run inside of a post-start-hook. The k8s APIServer wrote the post-start-hook context code before contexts
-// were part of the Go stdlib.
-func goContext(parent genericapiserver.PostStartHookContext) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func(done <-chan struct{}) {
-		<-done
-		cancel()
-	}(parent.StopCh)
-	return ctx
 }
 
 type handlerChainMuxes []*http.ServeMux

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+
+	genericapiserver "k8s.io/apiserver/pkg/server"
+)
+
+// GoContext turns the PostStartHookContext into a context.Context for use in routines that may or may not
+// run inside of a post-start-hook. The k8s APIServer wrote the post-start-hook context code before contexts
+// were part of the Go stdlib.
+func GoContext(parent genericapiserver.PostStartHookContext) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func(done <-chan struct{}) {
+		<-done
+		cancel()
+	}(parent.StopCh)
+	return ctx
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
exposes schema-less `apiresourceschemas` and `apiexports` resources. It allows us to store any fields we need. Since this server will be used by the shards, schemas will be implicit.

I did the following manual test which indicates storing `"foo": "bar"` with an `apiexport` obj works. 

POST:
```
curl -k -X POST 'https://localhost:6443/apis/apis.kcp.dev/v1alpha1/apiexports' -H 'Content-Type: application/json' -d '{"apiVersion":"apis.kcp.dev/v1alpha1","kind":"APIExport","metadata":{"name":"ab"},"foo":"bar"}'
```

GET:
```
curl -k 'https://localhost:6443/apis/apis.kcp.dev/v1alpha1/apiexports/ab'
{
  "apiVersion": "apis.kcp.dev/v1alpha1",
  "foo": "bar",
  "kind": "APIExport",
  "metadata": {
    "annotations": {
      "kcp.dev/cluster": "system:admin"
    },
    "creationTimestamp": "2022-08-24T08:50:09Z",
    "generation": 1,
    "managedFields": [
      {
        "apiVersion": "apis.kcp.dev/v1alpha1",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:foo": {}
        },
        "manager": "curl",
        "operation": "Update",
        "time": "2022-08-24T08:50:09Z"
      }
    ],
    "name": "ab",
    "resourceVersion": "11",
    "uid": "b4b9447e-5ea8-4b73-a996-eb4a98eae3e0"
  }
}
```


note for now passing a logical cluster name is not required in the future it might be required along with a shard name.

## Related issue(s)

requires https://github.com/kcp-dev/kubernetes/pull/93