### PR TITLE
🌱 Part 20: Scope clients in cmd/

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -29,8 +29,10 @@ import (
 
 	"github.com/abiosoft/lineprefix"
 	"github.com/fatih/color"
+	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
@@ -164,7 +166,8 @@ func startFrontProxy(ctx context.Context, args []string, servingCA *crypto.CA, h
 		if err != nil {
 			continue
 		}
-		kcpClient, err := kcpclient.NewClusterForConfig(config)
+		clusterConfig := kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(config))
+		kcpClient, err := kcpclient.NewForConfig(clusterConfig)
 		if err != nil {
 			klog.Errorf("Failed to create kcp client: %v", err)
 			continue

--- a/cmd/test-server/kcp/shard.go
+++ b/cmd/test-server/kcp/shard.go
@@ -29,7 +29,9 @@ import (
 
 	"github.com/abiosoft/lineprefix"
 	"github.com/fatih/color"
+	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
 
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
@@ -162,7 +164,8 @@ func Start(ctx context.Context, name, runtimeDir, logFilePath string, args []str
 		if err != nil {
 			continue
 		}
-		kcpClient, err := kcpclient.NewClusterForConfig(config)
+		clusterConfig := kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(config))
+		kcpClient, err := kcpclient.NewForConfig(clusterConfig)
 		if err != nil {
 			klog.Errorf("Failed to create kcp client: %v", err)
 			continue


### PR DESCRIPTION
Scope client calls in cmd/ pkg. This removes the use `ClusterInterface` and instead passes of either scoped rest config or scoped context.

Fix one of the issue in #1490 
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

## Related issue(s)

Fixes #