### PR TITLE
pkg/authorization: add audit logging

### DIFF
--- a/pkg/authorization/apibinding_authorizer.go
+++ b/pkg/authorization/apibinding_authorizer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kaudit "k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -37,6 +38,12 @@ import (
 
 const (
 	byWorkspaceIndex = "apiBindingAuthorizer-byWorkspace"
+)
+
+const (
+	APIBindingContentAuditPrefix   = "apibinding.authorization.kcp.dev/"
+	APIBindingContentAuditDecision = APIBindingContentAuditPrefix + "decision"
+	APIBindingContentAuditReason   = APIBindingContentAuditPrefix + "reason"
 )
 
 // NewAPIBindingAccessAuthorizer returns an authorizer that checks if the the request is for a
@@ -98,33 +105,75 @@ func (a *apiBindingAccessAuthorizer) Authorize(ctx context.Context, attr authori
 	// get the cluster from the ctx.
 	lcluster, err := genericapirequest.ClusterNameFrom(ctx)
 	if err != nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionNoOpinion,
+			APIBindingContentAuditReason, fmt.Sprintf("error getting cluster from request: %v", err),
+		)
 		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
 	}
 
 	bindingLogicalCluster, bound, err := a.getAPIBindingReference(attr, lcluster)
 	if err != nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionNoOpinion,
+			APIBindingContentAuditReason, fmt.Sprintf("error getting API binding reference: %v", err),
+		)
 		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
 	}
 
 	if !bound {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionAllowed,
+			APIBindingContentAuditReason, "no API binding bound",
+		)
 		return a.delegate.Authorize(ctx, attr)
 	}
 
 	apiExport, found, err := a.getAPIExport(bindingLogicalCluster)
 	if err != nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionNoOpinion,
+			APIBindingContentAuditReason, fmt.Sprintf("error getting API export: %v", err),
+		)
 		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
+	}
+
+	path := "unknown"
+	exportName := "unknown"
+	if bindingLogicalCluster.Workspace != nil {
+		exportName = bindingLogicalCluster.Workspace.ExportName
+		path = bindingLogicalCluster.Workspace.Path
 	}
 
 	// If we can't find the export default to close
 	if !found {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionNoOpinion,
+			APIBindingContentAuditReason, fmt.Sprintf("API export %q not found, path: %q", exportName, path),
+		)
 		return authorizer.DecisionNoOpinion, apiBindingAccessDenied, err
 	}
 
 	if apiExport.Spec.MaximalPermissionPolicy == nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionAllowed,
+			APIBindingContentAuditReason, fmt.Sprintf("no maximal permission policy present in API export %q, path: %q, owning cluster: %q", exportName, path, logicalcluster.From(apiExport)),
+		)
 		return a.delegate.Authorize(ctx, attr)
 	}
 
 	if apiExport.Spec.MaximalPermissionPolicy.Local == nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionAllowed,
+			APIBindingContentAuditReason, fmt.Sprintf("no maximal local permission policy present in API export %q, path: %q, owning cluster: %q", apiExport.Name, path, logicalcluster.From(apiExport)),
+		)
 		return a.delegate.Authorize(ctx, attr)
 	}
 
@@ -145,8 +194,19 @@ func (a *apiBindingAccessAuthorizer) Authorize(ctx context.Context, attr authori
 	}
 	dec, reason, err := clusterAuthorizer.Authorize(ctx, prefixedAttr)
 	if err != nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			APIBindingContentAuditDecision, DecisionNoOpinion,
+			APIBindingContentAuditReason, fmt.Sprintf("error authorizing RBAC in API export cluster %q: %v", logicalcluster.From(apiExport), err),
+		)
 		return authorizer.DecisionNoOpinion, reason, err
 	}
+
+	kaudit.AddAuditAnnotations(
+		ctx,
+		APIBindingContentAuditDecision, decisionString(dec),
+		APIBindingContentAuditReason, fmt.Sprintf("API export cluster %q reason: %v", logicalcluster.From(apiExport), reason),
+	)
 
 	if dec == authorizer.DecisionAllow {
 		return a.delegate.Authorize(ctx, attr)

--- a/pkg/authorization/decision.go
+++ b/pkg/authorization/decision.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import "k8s.io/apiserver/pkg/authorization/authorizer"
+
+const (
+	DecisionNoOpinion = "NoOpinion"
+	DecisionAllowed   = "Allowed"
+	DecisionDenied    = "Denied"
+)
+
+func decisionString(dec authorizer.Decision) string {
+	switch dec {
+	case authorizer.DecisionNoOpinion:
+		return DecisionNoOpinion
+	case authorizer.DecisionAllow:
+		return DecisionAllowed
+	case authorizer.DecisionDeny:
+		return DecisionDenied
+	}
+	return ""
+}

--- a/pkg/authorization/system_crd_authorizer.go
+++ b/pkg/authorization/system_crd_authorizer.go
@@ -18,11 +18,19 @@ package authorization
 
 import (
 	"context"
+	"fmt"
 
+	kaudit "k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+const (
+	SystemCRDAuditPrefix   = "systemcrd.authorization.kcp.dev/"
+	SystemCRDAuditDecision = SystemCRDAuditPrefix + "decision"
+	SystemCRDAuditReason   = SystemCRDAuditPrefix + "reason"
 )
 
 // SystemCRDAuthorizer protects the system CRDs from users who are admins in their workspaces.
@@ -39,9 +47,19 @@ func NewSystemCRDAuthorizer(delegate authorizer.Authorizer) authorizer.Authorize
 func (a *SystemCRDAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	cluster, err := genericapirequest.ValidClusterFrom(ctx)
 	if err != nil {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			SystemCRDAuditDecision, DecisionNoOpinion,
+			SystemCRDAuditReason, fmt.Sprintf("error getting cluster from request: %v", err),
+		)
 		return authorizer.DecisionNoOpinion, "", err
 	}
 	if cluster == nil || cluster.Name.Empty() {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			SystemCRDAuditDecision, DecisionNoOpinion,
+			SystemCRDAuditReason, "empty cluster name",
+		)
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 
@@ -49,8 +67,18 @@ func (a *SystemCRDAuthorizer) Authorize(ctx context.Context, attr authorizer.Att
 	case attr.GetAPIGroup() == apisv1alpha1.SchemeGroupVersion.Group:
 		switch {
 		case attr.GetResource() == "apibindings" && attr.GetSubresource() == "status":
+			kaudit.AddAuditAnnotations(
+				ctx,
+				SystemCRDAuditDecision, DecisionDenied,
+				SystemCRDAuditReason, "apibinding status updates not permitted",
+			)
 			return authorizer.DecisionDeny, "status update not permitted", nil
 		case attr.GetResource() == "apiexports" && attr.GetSubresource() == "status":
+			kaudit.AddAuditAnnotations(
+				ctx,
+				SystemCRDAuditDecision, DecisionDenied,
+				SystemCRDAuditReason, "apiexport status updates not permitted",
+			)
 			return authorizer.DecisionDeny, "status update not permitted", nil
 		}
 	}

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -76,6 +76,11 @@ type topLevelOrgAccessAuthorizer struct {
 
 func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	if IsDeepSubjectAccessReviewFrom(ctx, attr) {
+		kaudit.AddAuditAnnotations(
+			ctx,
+			TopLevelContentAuditDecision, DecisionAllowed,
+			TopLevelContentAuditReason, "deep SAR request",
+		)
 		// this is a deep SAR request, we have to skip the checks here and delegate to the subsequent authorizer.
 		return a.delegate.Authorize(ctx, attr)
 	}
@@ -231,16 +236,4 @@ func topLevelOrg(clusterName logicalcluster.Name) (string, bool) {
 		}
 		clusterName = parent
 	}
-}
-
-func decisionString(dec authorizer.Decision) string {
-	switch dec {
-	case authorizer.DecisionNoOpinion:
-		return DecisionNoOpinion
-	case authorizer.DecisionAllow:
-		return DecisionAllowed
-	case authorizer.DecisionDeny:
-		return DecisionDenied
-	}
-	return ""
 }

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -47,10 +47,6 @@ import (
 const (
 	WorkspaceAcccessNotPermittedReason = "workspace access not permitted"
 
-	DecisionNoOpinion = "NoOpinion"
-	DecisionAllowed   = "Allowed"
-	DecisionDenied    = "Denied"
-
 	WorkspaceContentAuditPrefix   = "content.authorization.kcp.dev/"
 	WorkspaceContentAuditDecision = WorkspaceContentAuditPrefix + "decision"
 	WorkspaceContentAuditReason   = WorkspaceContentAuditPrefix + "reason"
@@ -126,6 +122,11 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 				Groups: []string{"system:authenticated"},
 			}
 		}
+		kaudit.AddAuditAnnotations(
+			ctx,
+			WorkspaceContentAuditDecision, DecisionAllowed,
+			WorkspaceContentAuditReason, "deep SAR request",
+		)
 		return a.delegate.Authorize(ctx, attr)
 	}
 


### PR DESCRIPTION
## Summary

This adds audit logs for remaining authorizers.

## Related issue(s)

Fixes #1307