### PR TITLE
cache-server: adds WithShardScope HTTP filter

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -133,6 +133,7 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 		apiHandler = kcpserver.WithClusterScope(apiHandler)
 		apiHandler = kcpserver.WithAcceptHeader(apiHandler)
 		apiHandler = kcpserver.WithUserAgent(apiHandler)
+		apiHandler = WithShardScope(apiHandler)
 		return apiHandler
 	}
 
@@ -153,6 +154,9 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 	serverConfig.LoopbackClientConfig.DisableCompression = true
 	clientutils.EnableMultiCluster(serverConfig.LoopbackClientConfig, &serverConfig.Config, "namespaces", "apiservices", "customresourcedefinitions", "clusterroles", "clusterrolebindings", "roles", "rolebindings", "serviceaccounts", "secrets")
 
+	// TODO: the extension client could be shard-aware
+	//      for now the shard name is implicit and assigned
+	//      by the WithShardScope to "cache"
 	var err error
 	c.ApiExtensionsClusterClient, err = apiextensionsclient.NewClusterForConfig(serverConfig.LoopbackClientConfig)
 	if err != nil {

--- a/pkg/cache/server/handler.go
+++ b/pkg/cache/server/handler.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+var (
+	shardNameRegExp = regexp.MustCompile(`^[a-z0-9-:]{0,61}$`)
+
+	errorScheme = runtime.NewScheme()
+	errorCodecs = serializer.NewCodecFactory(errorScheme)
+)
+
+func init() {
+	errorScheme.AddUnversionedTypes(metav1.Unversioned,
+		&metav1.Status{},
+	)
+}
+
+// WithShardScope reads a shard name from the URL path and puts it into the context.
+// It also trims "/shards/" prefix from the URL.
+// If the path doesn't contain the shard name then a default "system:cache:server" name is assigned.
+//
+// For example:
+//
+// /shards/*/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports
+//
+// /shards/amber/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports
+//
+// /shards/sapphire/clusters/system:sapphire/apis/apis.kcp.dev/v1alpha1/apiexports
+//
+// /shards/amber/clusters/system:amber/apis/apis.kcp.dev/v1alpha1/apiexports
+func WithShardScope(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var shardName string
+		if path := req.URL.Path; strings.HasPrefix(path, "/shards/") {
+			path = strings.TrimPrefix(path, "/shards/")
+
+			i := strings.Index(path, "/")
+			if i == -1 {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewBadRequest(fmt.Sprintf("unable to parse shard: no `/` found in path %s", path)),
+					errorCodecs, schema.GroupVersion{},
+					w, req)
+				return
+			}
+			shardName, path = path[:i], path[i:]
+			req.URL.Path = path
+			newURL, err := url.Parse(req.URL.String())
+			if err != nil {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewInternalError(fmt.Errorf("unable to resolve %s, err %w", req.URL.Path, err)),
+					errorCodecs, schema.GroupVersion{},
+					w, req)
+				return
+			}
+			req.URL = newURL
+		}
+
+		var shard request.Shard
+		switch {
+		case shardName == "*":
+			shard = "*"
+		case len(shardName) == 0:
+			// because we don't store a shard name in an object.
+			// requests without a shard name won't be able to find associated data and will fail.
+			// as of today we don't instruct controllers used by the apiextention server
+			// how to assign/extract a shard name to/from an object.
+			// so we need to set a default name here, otherwise these controllers will fail.
+			shard = "system:cache:server"
+		default:
+			if !shardNameRegExp.MatchString(shardName) {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewBadRequest(fmt.Sprintf("invalid shard: %q does not match the regex", shardName)),
+					errorCodecs, schema.GroupVersion{},
+					w, req)
+				return
+			}
+			shard = request.Shard(shardName)
+		}
+
+		ctx := request.WithShard(req.Context(), shard)
+		handler.ServeHTTP(w, req.WithContext(ctx))
+	})
+}

--- a/pkg/cache/server/options/options.go
+++ b/pkg/cache/server/options/options.go
@@ -78,6 +78,11 @@ func NewOptions(rootDir string) *Options {
 	o.SecureServing.ServerCert.CertDirectory = rootDir
 	o.SecureServing.BindPort = 6443
 	o.Etcd.StorageConfig.Transport.ServerList = []string{"embedded"}
+	// TODO: enable the watch cache, it was disabled because
+	//  - we need to pass a shard name so that the watch cache can calculate the key
+	//    we already do that for cluster names (stored in the obj)
+	//  - we need to modify wildcardClusterNameRegex and crdWildcardPartialMetadataClusterNameRegex
+	o.Etcd.EnableWatchCache = false
 	return o
 }
 


### PR DESCRIPTION
The filter reads a shard name from the URL path and puts it into the context.
It also trims `/shards/` prefix from the URL. 
So that the next filter in the chain doesn't have to deal with `/shards/` prefix.
If the path doesn't contain the shard name then a default "cache" name is assigned.

For example:
`/shards/amber/apis/apis.kcp.dev/v1alpha1/apiexports` assigns `amber`
`/shards/*/apis/apis.kcp.dev/v1alpha1/apiexports` assigns `*`
`/shards/amber/clusters/system:admin/apis/apis.kcp.dev/v1alpha1/apiexports` also assigns `amber`

Tested manually with

PUT:
```
curl -k -X POST 'https://localhost:6443/shards/amber/clusters/system:amber/apis/apis.kcp.dev/v1alpha1/apiexports' -H 'Content-Type: application/json' -d '{"apiVersion":"apis.kcp.dev/v1alpha1","kind":"APIExport","metadata":{"name":"ab"},"foo":"amber"}'

curl -k -X POST 'https://localhost:6443/shards/sapphire/clusters/system:sapphire/apis/apis.kcp.dev/v1alpha1/apiexports' -H 'Content-Type: application/json' -d '{"apiVersion":"apis.kcp.dev/v1alpha1","kind":"APIExport","metadata":{"name":"ab"},"foo":"sapphire"}'
```

GET:
```
curl -k 'https://localhost:6443/shards/*/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports'

curl -k 'https://localhost:6443/shards/sapphire/clusters/system:sapphire/apis/apis.kcp.dev/v1alpha1/apiexports'

curl -k 'https://localhost:6443/shards/amber/clusters/system:amber/apis/apis.kcp.dev/v1alpha1/apiexports'
```

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary

## Related issue(s)

requires https://github.com/kcp-dev/kubernetes/pull/96