### PR TITLE
virtual: Support SSA patch requests for non-existent objects

### DIFF
--- a/pkg/virtual/framework/forwardingregistry/rest_test.go
+++ b/pkg/virtual/framework/forwardingregistry/rest_test.go
@@ -433,6 +433,9 @@ func TestPatch(t *testing.T) {
 	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
 
 	patcher := func(ctx context.Context, newObj, oldObj runtime.Object) (runtime.Object, error) {
+		if oldObj == nil {
+			return nil, errors.NewNotFound(schema.ParseGroupResource("noxus.mygroup.example.com"), "foo")
+		}
 		updated := oldObj.DeepCopyObject().(*unstructured.Unstructured)
 		newReplicas, _, err := unstructured.NestedInt64(updated.UnstructuredContent(), "spec", "replicas")
 		if err != nil {

--- a/pkg/virtual/framework/forwardingregistry/rest_test.go
+++ b/pkg/virtual/framework/forwardingregistry/rest_test.go
@@ -391,6 +391,48 @@ func TestUpdate(t *testing.T) {
 	require.Equalf(t, 1, updates, "Should not have retried calling client.Update in case of conflict: it's an Update call.")
 }
 
+func TestUpdateWithForceAllowCreate(t *testing.T) {
+	resource := createResource("default", "foo")
+	resource.SetGeneration(1)
+	resource.SetResourceVersion("100")
+	fakeClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	fakeClient.PrependReactor("update", "noxus", updateReactor(fakeClient))
+
+	storage, _ := newStorage(t, &mockedClusterClient{fakeClient}, "", nil)
+	ctx := request.WithNamespace(context.Background(), "default")
+	ctx = request.WithCluster(ctx, request.Cluster{Name: logicalcluster.New("foo")})
+	updated := resource.DeepCopy()
+
+	newReplicas, _, err := unstructured.NestedInt64(updated.UnstructuredContent(), "spec", "replicas")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	newReplicas++
+	_ = unstructured.SetNestedField(updated.UnstructuredContent(), newReplicas, "spec", "replicas")
+
+	updater := storage.(rest.Updater)
+	result, _, err := updater.Update(ctx, updated.GetName(), rest.DefaultUpdatedObjectInfo(updated), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, true, &metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Now we can check that the object has been updated
+	require.True(t, apiequality.Semantic.DeepEqual(updated, result), "expected:\n%V\nactual:\n%V", updated, result)
+
+	fakeClient.ClearActions()
+	updated.SetResourceVersion("101")
+	newReplicas++
+	_ = unstructured.SetNestedField(updated.UnstructuredContent(), newReplicas, "spec", "replicas")
+	_, _, err = updater.Update(ctx, updated.GetName(), rest.DefaultUpdatedObjectInfo(updated), rest.ValidateAllObjectFunc, rest.ValidateAllObjectUpdateFunc, true, &metav1.UpdateOptions{})
+	require.EqualError(t, err, "Operation cannot be fulfilled on noxus.mygroup.example.com \"foo\": the object has been modified; please apply your changes to the latest version and try again")
+
+	updates := 0
+	for _, action := range fakeClient.Actions() {
+		if action.GetVerb() == "update" {
+			updates++
+		}
+	}
+	require.Equalf(t, 1, updates, "Should not have retried calling client.Update in case of conflict: it's an Update call.")
+}
+
 func TestStatusUpdate(t *testing.T) {
 	resource := createResource("default", "foo")
 	resource.SetGeneration(1)

--- a/pkg/virtual/framework/forwardingregistry/store.go
+++ b/pkg/virtual/framework/forwardingregistry/store.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -176,10 +178,17 @@ func DefaultDynamicDelegatedStoreFuncs(
 			return nil, false, err
 		}
 
+		requestInfo, _ := genericapirequest.RequestInfoFrom(ctx)
+
 		doUpdate := func() (*unstructured.Unstructured, error) {
 			oldObj, err := s.Get(ctx, name, &metav1.GetOptions{})
 			if err != nil {
-				return nil, err
+				// Continue on 404 for PATCH requests, so server-side apply requests
+				// for non-existent objects can still be processed.
+				if !(requestInfo != nil && requestInfo.Verb == "patch" && apierrors.IsNotFound(err)) {
+					return nil, err
+				}
+				oldObj = nil
 			}
 
 			obj, err := objInfo.UpdatedObject(ctx, oldObj)
@@ -192,10 +201,17 @@ func DefaultDynamicDelegatedStoreFuncs(
 				return nil, fmt.Errorf("not an Unstructured: %T", obj)
 			}
 
+			// If the updated object does not have a CreationTimestamp, it means it doesn't currently exist.
+			// In that case, we switch to calling a create operation on the forwarding registry.
+			// This enables support for server-side apply requests, to create non-existent objects.
+			if exists, err := hasCreationTimestamp(unstructuredObj); err != nil {
+				return nil, err
+			} else if !exists {
+				return delegate.Create(ctx, unstructuredObj, updateToCreateOptions(options), subResources...)
+			}
 			return delegate.Update(ctx, unstructuredObj, *options, subResources...)
 		}
 
-		requestInfo, _ := genericapirequest.RequestInfoFrom(ctx)
 		if requestInfo != nil && requestInfo.Verb == "patch" {
 			var result *unstructured.Unstructured
 			err := retry.RetryOnConflict(patchConflictRetryBackoff, func() error {
@@ -272,4 +288,32 @@ func clientGetter(dynamicClusterClient dynamic.ClusterInterface, namespaceScoped
 			return dynamicClusterClient.Cluster(clusterName).Resource(gvr), nil
 		}
 	}
+}
+
+// updateToCreateOptions creates a CreateOptions with the same field values as the provided PatchOptions.
+func updateToCreateOptions(uo *metav1.UpdateOptions) metav1.CreateOptions {
+	co := metav1.CreateOptions{
+		DryRun:          uo.DryRun,
+		FieldManager:    uo.FieldManager,
+		FieldValidation: uo.FieldValidation,
+	}
+	co.TypeMeta.SetGroupVersionKind(metav1.SchemeGroupVersion.WithKind("CreateOptions"))
+	return co
+}
+
+// hasCreationTimestamp return whether the provided object has a CreationTimestamp.
+func hasCreationTimestamp(obj runtime.Object) (bool, error) {
+	if obj == nil {
+		return false, nil
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+
+	if t := accessor.GetCreationTimestamp(); !t.IsZero() {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/virtual/framework/forwardingregistry/store.go
+++ b/pkg/virtual/framework/forwardingregistry/store.go
@@ -193,6 +193,12 @@ func DefaultDynamicDelegatedStoreFuncs(
 				oldObj = nil
 			}
 
+			// The following call returns a 404 error for non server-side apply
+			// requests, i.e., for json, merge and strategic-merge PATCH requests,
+			// as it's not possible to construct the updated object out of the patch
+			// alone, when the object does not already exist.
+			// For server-side apply, the computed object is used as the body of the
+			// PUT request below, to create the object from the apply patch.
 			obj, err := objInfo.UpdatedObject(ctx, oldObj)
 			if err != nil {
 				return nil, err

--- a/pkg/virtual/framework/forwardingregistry/store_test.go
+++ b/pkg/virtual/framework/forwardingregistry/store_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/virtual/framework/forwardingregistry/store_test.go
+++ b/pkg/virtual/framework/forwardingregistry/store_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package forwardingregistry
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUpdateToCreateOptions(t *testing.T) {
+	updateOptions := reflect.TypeOf(metav1.UpdateOptions{})
+	numField := updateOptions.NumField()
+	require.Equalf(t, 4, numField, "UpdateOptions is expected to have 4 fields")
+
+	var fields []string
+	for i := 0; i < numField; i++ {
+		fields = append(fields, updateOptions.Field(i).Name)
+	}
+
+	// Assert the UpdateOptions struct fields set has not changed
+	expectedFields := []string{
+		"TypeMeta",
+		"DryRun",
+		"FieldManager",
+		"FieldValidation",
+	}
+	require.ElementsMatchf(t, expectedFields, fields, "UpdateOptions struct fields have changed")
+
+	// Assert the CreateOptions fields match that of the UpdateOptions
+	uo := &metav1.UpdateOptions{
+		DryRun: []string{
+			"All",
+		},
+		FieldManager:    "manager",
+		FieldValidation: "Strict",
+	}
+	co := updateToCreateOptions(uo)
+
+	expectedCreateOptions := metav1.CreateOptions{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CreateOptions",
+			APIVersion: "meta.k8s.io/v1",
+		},
+		DryRun: []string{
+			"All",
+		},
+		FieldManager:    "manager",
+		FieldValidation: "Strict",
+	}
+	require.Equalf(t, expectedCreateOptions, co, "CreateOptions should have the same fields as the UpdateOptions")
+}

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -247,10 +247,8 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	t.Logf("patch (application/merge-patch+json) a cowboy with user-1 via APIExport virtual workspace server")
 	patchedCowboy := cowboy.DeepCopy()
 	patchedCowboy.Spec.Intent = "3"
-	source, err := json.Marshal(cowboy)
-	require.NoError(t, err)
-	target, err := json.Marshal(patchedCowboy)
-	require.NoError(t, err)
+	source := encodeJSON(t, cowboy)
+	target := encodeJSON(t, patchedCowboy)
 	mergePatch, err := jsonpatch.CreateMergePatch(source, target)
 	require.NoError(t, err)
 	cowboy, err = wwUser1VC.WildwestV1alpha1().Cowboys("default").
@@ -260,8 +258,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	t.Logf("patch (application/apply-patch+yaml) a cowboy with user-1 via APIExport virtual workspace server")
 	applyCowboy := newCowboy("default", "cowboy-via-vw")
 	applyCowboy.Spec.Intent = "4"
-	applyPatch, err := json.Marshal(applyCowboy)
-	require.NoError(t, err)
+	applyPatch := encodeJSON(t, applyCowboy)
 	cowboy, err = wwUser1VC.WildwestV1alpha1().Cowboys("default").
 		Patch(logicalcluster.WithCluster(ctx, consumerWorkspace), "cowboy-via-vw", types.ApplyPatchType, applyPatch, metav1.PatchOptions{FieldManager: "e2e-test-runner", Force: pointer.Bool(true)})
 	require.NoError(t, err)
@@ -269,8 +266,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	t.Logf("create a cowboy with user-1 via APIExport virtual workspace server using Server-Side Apply")
 	cowboySSA := newCowboy("default", "cowboy-via-vw-ssa")
 	cowboySSA.Spec.Intent = "1"
-	applyPatch, err = json.Marshal(cowboySSA)
-	require.NoError(t, err)
+	applyPatch = encodeJSON(t, cowboySSA)
 	cowboy, err = wwUser1VC.WildwestV1alpha1().Cowboys("default").
 		Patch(logicalcluster.WithCluster(ctx, consumerWorkspace), "cowboy-via-vw-ssa", types.ApplyPatchType, applyPatch, metav1.PatchOptions{FieldManager: "e2e-test-runner"})
 	require.NoError(t, err)

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -263,6 +263,17 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 		Patch(logicalcluster.WithCluster(ctx, consumerWorkspace), "cowboy-via-vw", types.ApplyPatchType, applyPatch, metav1.PatchOptions{FieldManager: "e2e-test-runner", Force: pointer.Bool(true)})
 	require.NoError(t, err)
 
+	t.Logf("patching a non-existent cowboy with user-1 via APIExport virtual workspace server should fail")
+	patchedCowboy = cowboy.DeepCopy()
+	patchedCowboy.Spec.Intent = "1"
+	source = encodeJSON(t, cowboy)
+	target = encodeJSON(t, patchedCowboy)
+	mergePatch, err = jsonpatch.CreateMergePatch(source, target)
+	require.NoError(t, err)
+	cowboy, err = wwUser1VC.WildwestV1alpha1().Cowboys("default").
+		Patch(logicalcluster.WithCluster(ctx, consumerWorkspace), "cowboy-via-vw-merge-patch", types.MergePatchType, mergePatch, metav1.PatchOptions{})
+	require.EqualError(t, err, "cowboys.wildwest.dev \"cowboy-via-vw-merge-patch\" not found")
+
 	t.Logf("create a cowboy with user-1 via APIExport virtual workspace server using Server-Side Apply")
 	cowboySSA := newCowboy("default", "cowboy-via-vw-ssa")
 	cowboySSA.Spec.Intent = "1"


### PR DESCRIPTION
## Summary

This PR switches update operations made to the virtual workspace API server, to calling create operations on the forwarding API server, for non-existent objects. This enables support for server-side apply patch requests in that case.

## Related issue(s)

Fixes #1852