### PR TITLE
e2e: save data in some temporary directory

### DIFF
--- a/test/e2e/framework/config.go
+++ b/test/e2e/framework/config.go
@@ -107,7 +107,7 @@ func registerFlags(c *testConfig) {
 // workspace plugin with --kubeconfig.
 func WriteLogicalClusterConfig(t *testing.T, rawConfig clientcmdapi.Config, contextName string, clusterName logicalcluster.Name) (clientcmd.ClientConfig, string) {
 	logicalRawConfig := LogicalClusterRawConfig(rawConfig, clusterName, contextName)
-	artifactDir, err := CreateTempDirForTest(t, "artifacts")
+	artifactDir, _, err := ScratchDirs(t)
 	require.NoError(t, err)
 	pathSafeClusterName := strings.ReplaceAll(clusterName.String(), ":", "_")
 	kubeconfigPath := filepath.Join(artifactDir, fmt.Sprintf("%s.kubeconfig", pathSafeClusterName))

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -166,7 +166,7 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	// Apply the yaml output from the plugin to the downstream server
 	KubectlApply(t, downstreamKubeconfigPath, syncerYAML)
 
-	artifactDir, err := CreateTempDirForTest(t, "artifacts")
+	artifactDir, _, err := ScratchDirs(t)
 	if err != nil {
 		t.Errorf("failed to create temp dir for syncer artifacts: %v", err)
 	}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -64,16 +64,13 @@ var fs embed.FS
 // TODO(marun) Is there a way to avoid embedding by determining the
 // path to the file during test execution?
 func WriteTokenAuthFile(t *testing.T) string {
-	dataDir, err := CreateTempDirForTest(t, "data")
-	require.NoError(t, err)
-
 	// This file is expected to be embedded from the package directory.
 	tokensFilename := "auth-tokens.csv"
 
 	data, err := fs.ReadFile(tokensFilename)
 	require.NoError(t, err, "error reading tokens file")
 
-	tokensPath := path.Join(dataDir, tokensFilename)
+	tokensPath := path.Join(t.TempDir(), tokensFilename)
 	tokensFile, err := os.Create(tokensPath)
 	require.NoError(t, err, "failed to create tokens file")
 	defer tokensFile.Close()
@@ -145,11 +142,7 @@ func ScratchDirs(t *testing.T) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	dataDir, err := CreateTempDirForTest(t, "data")
-	if err != nil {
-		return "", "", err
-	}
-	return artifactDir, dataDir, nil
+	return artifactDir, t.TempDir(), nil
 }
 
 func (c *kcpServer) Artifact(t *testing.T, producer func() (runtime.Object, error)) {

--- a/test/e2e/reconciler/ingress/controller_test.go
+++ b/test/e2e/reconciler/ingress/controller_test.go
@@ -323,7 +323,7 @@ func TestIngressController(t *testing.T) {
 			require.NoError(t, err, "failed to pick envoy listener port")
 			xdsListenerPort, err := framework.GetFreePort(t)
 			require.NoError(t, err, "failed to pick xds listener port")
-			artifactDir, err := framework.CreateTempDirForTest(t, "artifacts")
+			artifactDir, _, err := framework.ScratchDirs(t)
 			require.NoError(t, err, "failed to create artifact dir for ingress-controller")
 			kubeconfigPath := filepath.Join(artifactDir, "ingress-controller.kubeconfig")
 			adminConfig, err := source.RawConfig()


### PR DESCRIPTION
If we need to track down e.g. the etcd WALs in the future based on
tests, we can think about this more.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @ncdc 