### PR TITLE
Syncer: Adds validation to make --sync-target-uid flag required

### DIFF
--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -87,6 +87,8 @@ func (options *Options) Validate() error {
 	if options.FromKubeconfig == "" {
 		return errors.New("--from-kubeconfig is required")
 	}
-
+	if options.SyncTargetUID == "" {
+		return errors.New("--sync-target-uid is required")
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds validation to make the syncer `--sync-target-uid` flag required

Without this flag, the syncer will fail to sync resources, so it doesn't make sense that it is not required.