### PR TITLE
🌱 WithClusterScope: should not assign a default cluster name

### DIFF
--- a/pkg/server/filters/filters.go
+++ b/pkg/server/filters/filters.go
@@ -35,7 +35,6 @@ import (
 	kaudit "k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/kubernetes/pkg/genericcontrolplane"
 )
 
 type (
@@ -120,9 +119,7 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 			cluster.Wildcard = true
 			// fallthrough
 			cluster.Name = logicalcluster.Wildcard
-		case clusterName.Empty():
-			cluster.Name = genericcontrolplane.LocalAdminCluster
-		default:
+		case !clusterName.Empty():
 			if !reClusterName.MatchString(clusterName.String()) {
 				responsewriters.ErrorNegotiated(
 					apierrors.NewBadRequest(fmt.Sprintf("invalid cluster: %q does not match the regex", clusterName)),
@@ -134,7 +131,6 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 		}
 
 		ctx := request.WithCluster(req.Context(), cluster)
-
 		apiHandler.ServeHTTP(w, req.WithContext(ctx))
 	}
 }

--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -270,9 +270,11 @@ func (h *homeWorkspaceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 
 	ctx := req.Context()
 	logger := klog.FromContext(ctx)
-	lcluster, err := request.ValidClusterFrom(ctx)
-	if err != nil {
-		responsewriters.InternalError(rw, req, err)
+	lcluster := request.ClusterFrom(req.Context())
+	if lcluster == nil {
+		// this is not a home workspace request
+		// just pass it to the next handler
+		h.apiHandler.ServeHTTP(rw, req)
 		return
 	}
 	logger = logging.WithCluster(logger, lcluster)

--- a/pkg/server/home_workspaces_test.go
+++ b/pkg/server/home_workspaces_test.go
@@ -1258,14 +1258,13 @@ func TestServeHTTP(t *testing.T) {
 		expectedResponseHeaders map[string]string
 	}{
 		{
-			testName:           "Error when no cluster in context",
+			testName:           "delegate to the next handler when no cluster in context",
 			contextUser:        &kuser.DefaultInfo{Name: "user-1"},
 			contextRequestInfo: &request.RequestInfo{},
 			synced:             true,
 
-			expectedStatusCode:   500,
-			expectedToDelegate:   false,
-			expectedResponseBody: `Internal Server Error: "/dummy-target": no cluster in the request context - RequestInfo: &amp;request.RequestInfo{IsResourceRequest:false, Path:"", Verb:"", APIPrefix:"", APIGroup:"", APIVersion:"", Namespace:"", Resource:"", Subresource:"", Name:"", Parts:[]string(nil)}`,
+			expectedStatusCode: 200,
+			expectedToDelegate: true,
 		},
 		{
 			testName:           "Error when no user in context",

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -607,6 +607,7 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 		// write kubeconfig to disk, next to kcp kubeconfig
 		kcpAdminConfig, _ := server.RawConfig()
 		var baseCluster = *kcpAdminConfig.Clusters["base"] // shallow copy
+		baseCluster.Server = fmt.Sprintf("%s/clusters/system:admin", baseCluster.Server)
 		virtualWorkspaceKubeConfig := clientcmdapi.Config{
 			Clusters: map[string]*clientcmdapi.Cluster{
 				"shard": &baseCluster,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
clients should specify a cluster name before storing something in the db as that leads to more readable code.
the server should not assign a default cluster name.

at the moment requests without a cluster name are rejected by the storage layer.

Things to consider:
reject a request without a name in the filter
will this break some external clients?

## Related issue(s)

Fixes #