### PR TITLE
home-ws: wait for tenancy binding readiness

### DIFF
--- a/test/e2e/homeworkspaces/home_workspaces_test.go
+++ b/test/e2e/homeworkspaces/home_workspaces_test.go
@@ -44,7 +44,6 @@ func TestUserHomeWorkspaces(t *testing.T) {
 
 	type runningServer struct {
 		framework.RunningServer
-		orgClusterName                logicalcluster.Name
 		kubeClusterClient             kubernetes.ClusterInterface
 		rootShardKcpClusterClient     kcpclientset.ClusterInterface
 		kcpUserClusterClients         []kcpclientset.ClusterInterface
@@ -153,8 +152,6 @@ func TestUserHomeWorkspaces(t *testing.T) {
 			ctx, cancelFunc := context.WithCancel(context.Background())
 			t.Cleanup(cancelFunc)
 
-			orgClusterName := framework.NewOrganizationFixture(t, server)
-
 			// create non-virtual clients
 			kcpConfig := server.BaseConfig(t)
 			rootShardCfg := server.RootShardSystemMasterBaseConfig(t)
@@ -176,7 +173,6 @@ func TestUserHomeWorkspaces(t *testing.T) {
 
 			testCase.work(ctx, t, runningServer{
 				RunningServer:                 server,
-				orgClusterName:                orgClusterName,
 				kubeClusterClient:             kubeClusterClient,
 				rootShardKcpClusterClient:     rootShardKcpClusterClient,
 				kcpUserClusterClients:         kcpUserClusterClients,


### PR DESCRIPTION
## Summary
If the incoming request is in the home workspaces hierarchy and it's for `clusterworkspaces`, there is a chance the tenancy APIBinding is not yet ready (or the cache is stale). If that is the case, return a retry-after to give the APIBinding cache a
chance to catch up.

## Related issue(s)

Fixes #1693 