### PR TITLE
Makefile: add update-contextual-logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,11 @@ lint: $(GOLANGCI_LINT) $(STATICCHECK) $(LOGCHECK)
 	$(GOLANGCI_LINT) run --timeout=10m ./...
 	$(STATICCHECK) -checks ST1019,ST1005 ./...
 	./hack/verify-contextual-logging.sh
-
 .PHONY: lint
+
+update-contextual-logging: $(LOGCHECK)
+	UPDATE=true ./hack/verify-contextual-logging.sh
+.PHONY: update-contextual-logging
 
 vendor: ## Vendor the dependencies
 	go mod tidy

--- a/hack/verify-contextual-logging.sh
+++ b/hack/verify-contextual-logging.sh
@@ -59,6 +59,6 @@ if ! changes="$(diff <(echo "${work_cleaned}")  <(echo "${log_cleaned}") )"; the
     echo "[ERROR] Current logging errors and saved logging errors do not match."
     echo "${changes}"
     echo
-    echo "[INFO] If you need to update the saved list, run \`UPDATE=true hack/verify-contextual-logging.sh\` and commit \`hack/logcheck.out\`'"
+    echo "[INFO] If you need to update the saved list, run \`make update-contextual-logging\` and commit \`hack/logcheck.out\`'"
     exit 1
 fi


### PR DESCRIPTION
The script alone does not find logcheck if it is not in the path. So, let's add a Makefile target that uses the tool download logic.