### PR TITLE
✨ pkg/virtual/apiexport: add maximal permission policy authorization

### DIFF
--- a/pkg/authorization/anonymizer.go
+++ b/pkg/authorization/anonymizer.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// NewAnonymizer returns an authorizer anonymizing authorization decisions and error cases of a delegate authorizer.
+func NewAnonymizer(authorizerName string, delegate authorizer.Authorizer) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		dec, reason, err := delegate.Authorize(ctx, attr)
+
+		switch dec {
+		case authorizer.DecisionAllow:
+			reason = "access granted"
+		case authorizer.DecisionDeny:
+			reason = "access denied"
+		case authorizer.DecisionNoOpinion:
+			reason = "access denied"
+		}
+
+		if err != nil {
+			return dec, reason, fmt.Errorf("an error occurred in: %v", authorizerName)
+		}
+
+		return dec, reason, nil
+	})
+}

--- a/pkg/authorization/audit_logger.go
+++ b/pkg/authorization/audit_logger.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"fmt"
+
+	kaudit "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+const (
+	auditDecision = "decision"
+	auditReason   = "reason"
+)
+
+// NewAuditLogger returns an authorizer that logs every decision of the delegate authorizer
+// for the given audit prefix key.
+// Note: the prefix key must not contain a trailing slash `/`.
+func NewAuditLogger(auditPrefix string, delegate authorizer.Authorizer) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		dec, reason, err := delegate.Authorize(ctx, attr)
+
+		auditReason := reason
+		if err != nil {
+			auditReason = fmt.Sprintf("reason: %q, error: %v", reason, err)
+		}
+
+		kaudit.AddAuditAnnotations(
+			ctx,
+			auditPrefix+"/"+auditDecision, DecisionString(dec),
+			auditPrefix+"/"+auditReason, auditReason,
+		)
+
+		return dec, reason, err
+	})
+}

--- a/pkg/authorization/bootstrap_policy_authorizer.go
+++ b/pkg/authorization/bootstrap_policy_authorizer.go
@@ -58,7 +58,7 @@ func (a *BootstrapPolicyAuthorizer) Authorize(ctx context.Context, attr authoriz
 
 	kaudit.AddAuditAnnotations(
 		ctx,
-		BootstrapPolicyAuditDecision, decisionString(dec),
+		BootstrapPolicyAuditDecision, DecisionString(dec),
 		BootstrapPolicyAuditReason, fmt.Sprintf("bootstrap policy reason: %v", reason),
 	)
 

--- a/pkg/authorization/decision.go
+++ b/pkg/authorization/decision.go
@@ -24,7 +24,8 @@ const (
 	DecisionDenied    = "Denied"
 )
 
-func decisionString(dec authorizer.Decision) string {
+// DecisionString returns a kcp-opinionated string representation of an authorizer decision for audit logging.
+func DecisionString(dec authorizer.Decision) string {
 	switch dec {
 	case authorizer.DecisionNoOpinion:
 		return DecisionNoOpinion

--- a/pkg/authorization/local_authorizer.go
+++ b/pkg/authorization/local_authorizer.go
@@ -97,7 +97,7 @@ func (a *LocalAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribu
 
 	kaudit.AddAuditAnnotations(
 		ctx,
-		LocalAuditDecision, decisionString(dec),
+		LocalAuditDecision, DecisionString(dec),
 		LocalAuditReason, fmt.Sprintf("cluster %q or bootstrap policy reason: %v", cluster.Name, reason),
 	)
 

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -216,7 +216,7 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 
 		kaudit.AddAuditAnnotations(
 			ctx,
-			TopLevelContentAuditDecision, decisionString(dec),
+			TopLevelContentAuditDecision, DecisionString(dec),
 			TopLevelContentAuditReason, fmt.Sprintf(`forbidden by root workspace RBAC, verb="access" resource="workspaces/content", name=%q, reason=%q`, requestTopLevelOrgName, reason),
 		)
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -286,7 +286,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	c.preHandlerChainMux = &handlerChainMuxes{}
 	c.GenericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, genericConfig *genericapiserver.Config) (secure http.Handler) {
 		apiHandler = WithWildcardListWatchGuard(apiHandler)
-		apiHandler = WithWildcardIdentity(apiHandler)
+		apiHandler = WithRequestIdentity(apiHandler)
 		apiHandler = authorization.WithDeepSubjectAccessReview(apiHandler)
 
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, genericConfig)

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -237,18 +237,12 @@ func WithInClusterServiceAccountRequestRewrite(handler http.Handler) http.Handle
 	})
 }
 
-// WithWildcardIdentity checks wildcard list/watch requests for an APIExport identity for the resource in the path.
+// WithRequestIdentity checks list/watch requests for an APIExport identity for the resource in the path.
 // If it finds one (e.g. /api/v1/services:identityabcd1234/default/my-service), it places the identity from the path
 // to the context, updates the request to remove the identity from the path, and updates requestInfo.Resource to also
 // remove the identity. Finally, it hands off to the passed in handler to handle the request.
-func WithWildcardIdentity(handler http.Handler) http.Handler {
+func WithRequestIdentity(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		cluster := request.ClusterFrom(req.Context())
-		if cluster == nil || !cluster.Wildcard {
-			handler.ServeHTTP(w, req)
-			return
-		}
-
 		requestInfo, ok := request.RequestInfoFrom(req.Context())
 		if !ok {
 			responsewriters.ErrorNegotiated(
@@ -260,7 +254,7 @@ func WithWildcardIdentity(handler http.Handler) http.Handler {
 
 		updatedReq, err := processResourceIdentity(req, requestInfo)
 		if err != nil {
-			klog.FromContext(req.Context()).WithValues("operation", "WithWildcardIdentity", "path", req.URL.Path).Error(err, "unable to determine resource")
+			klog.FromContext(req.Context()).WithValues("operation", "WithRequestIdentity", "path", req.URL.Path).Error(err, "unable to determine resource")
 
 			responsewriters.ErrorNegotiated(
 				apierrors.NewInternalError(err),

--- a/pkg/virtual/apiexport/authorizer/content.go
+++ b/pkg/virtual/apiexport/authorizer/content.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	kaudit "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/kubernetes"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	kcpauth "github.com/kcp-dev/kcp/pkg/authorization"
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+const (
+	VirtualAPIExportNotPermittedReason = "virtual apiexport access not permitted"
+	VirtualAPIExportPermittedReason    = "virtual apiexport access permitted"
+)
+
+const (
+	VirtualAPIExportContentAuditPrefix   = "virtual.apiexport.content.authorization.kcp.dev/"
+	VirtualAPIExportContentAuditDecision = VirtualAPIExportContentAuditPrefix + "decision"
+	VirtualAPIExportContentAuditReason   = VirtualAPIExportContentAuditPrefix + "reason"
+)
+
+type apiExportsContentAuthorizer struct {
+	newDelegatedAuthorizer func(clusterName string) (authorizer.Authorizer, error)
+	delegate               authorizer.Authorizer
+}
+
+// NewAPIExportsContentAuthorizer creates a new authorizer that checks
+// if the user has access to the `apiexports/content` subresource using the same verb as the requested resource.
+// The given kube cluster client is used to execute a SAR request against the cluster of the current in-flight API export.
+// If the SAR decision allows access, the given delegate authorizer is executed to proceed the authorizer chain,
+// else access is denied.
+func NewAPIExportsContentAuthorizer(delegate authorizer.Authorizer, kubeClusterClient kubernetes.ClusterInterface) authorizer.Authorizer {
+	return &apiExportsContentAuthorizer{
+		newDelegatedAuthorizer: func(clusterName string) (authorizer.Authorizer, error) {
+			return delegated.NewDelegatedAuthorizer(logicalcluster.New(clusterName), kubeClusterClient)
+		},
+		delegate: delegate,
+	}
+}
+
+func (a *apiExportsContentAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	apiDomainKey := dynamiccontext.APIDomainKeyFrom(ctx)
+	parts := strings.Split(string(apiDomainKey), "/")
+	if len(parts) < 2 {
+		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("invalid API domain key")
+	}
+
+	apiExportCluster, apiExportName := parts[0], parts[1]
+	authz, err := a.newDelegatedAuthorizer(apiExportCluster)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("error creating delegated authorizer for API export cluster: %w", err)
+	}
+
+	SARAttributes := authorizer.AttributesRecord{
+		APIGroup:        apisv1alpha1.SchemeGroupVersion.Group,
+		APIVersion:      apisv1alpha1.SchemeGroupVersion.Version,
+		User:            attr.GetUser(),
+		Verb:            attr.GetVerb(),
+		Name:            apiExportName,
+		Resource:        "apiexports",
+		ResourceRequest: true,
+		Subresource:     "content",
+	}
+
+	dec, reason, err := authz.Authorize(ctx, SARAttributes)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("error authorizing RBAC in API export cluster: %w", err)
+	}
+
+	kaudit.AddAuditAnnotations(
+		ctx,
+		VirtualAPIExportContentAuditDecision, kcpauth.DecisionString(dec),
+		VirtualAPIExportContentAuditReason, fmt.Sprintf("API export cluster RBAC reason: %v", reason),
+	)
+
+	if dec == authorizer.DecisionAllow {
+		return a.delegate.Authorize(ctx, attr)
+	}
+
+	return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, nil
+}

--- a/pkg/virtual/apiexport/authorizer/content.go
+++ b/pkg/virtual/apiexport/authorizer/content.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
-	kaudit "k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/kubernetes"
 
@@ -31,17 +30,6 @@ import (
 	kcpauth "github.com/kcp-dev/kcp/pkg/authorization"
 	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
-)
-
-const (
-	VirtualAPIExportNotPermittedReason = "virtual apiexport access not permitted"
-	VirtualAPIExportPermittedReason    = "virtual apiexport access permitted"
-)
-
-const (
-	VirtualAPIExportContentAuditPrefix   = "virtual.apiexport.content.authorization.kcp.dev/"
-	VirtualAPIExportContentAuditDecision = VirtualAPIExportContentAuditPrefix + "decision"
-	VirtualAPIExportContentAuditReason   = VirtualAPIExportContentAuditPrefix + "reason"
 )
 
 type apiExportsContentAuthorizer struct {
@@ -55,25 +43,29 @@ type apiExportsContentAuthorizer struct {
 // If the SAR decision allows access, the given delegate authorizer is executed to proceed the authorizer chain,
 // else access is denied.
 func NewAPIExportsContentAuthorizer(delegate authorizer.Authorizer, kubeClusterClient kubernetes.ClusterInterface) authorizer.Authorizer {
-	return &apiExportsContentAuthorizer{
+	auth := &apiExportsContentAuthorizer{
 		newDelegatedAuthorizer: func(clusterName string) (authorizer.Authorizer, error) {
 			return delegated.NewDelegatedAuthorizer(logicalcluster.New(clusterName), kubeClusterClient)
 		},
 		delegate: delegate,
 	}
+
+	return kcpauth.NewAnonymizer("virtual apiexport content authorizer",
+		kcpauth.NewAuditLogger("virtual.apiexport.content.authorization.kcp.dev", auth))
 }
 
 func (a *apiExportsContentAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 	apiDomainKey := dynamiccontext.APIDomainKeyFrom(ctx)
 	parts := strings.Split(string(apiDomainKey), "/")
 	if len(parts) < 2 {
-		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("invalid API domain key")
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("invalid API domain key")
 	}
 
 	apiExportCluster, apiExportName := parts[0], parts[1]
 	authz, err := a.newDelegatedAuthorizer(apiExportCluster)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("error creating delegated authorizer for API export cluster: %w", err)
+		return authorizer.DecisionNoOpinion, "",
+			fmt.Errorf("error creating delegated authorizer for API export %q, workspace %q: %w", apiExportName, apiExportCluster, err)
 	}
 
 	SARAttributes := authorizer.AttributesRecord{
@@ -89,18 +81,14 @@ func (a *apiExportsContentAuthorizer) Authorize(ctx context.Context, attr author
 
 	dec, reason, err := authz.Authorize(ctx, SARAttributes)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("error authorizing RBAC in API export cluster: %w", err)
+		return authorizer.DecisionNoOpinion, "",
+			fmt.Errorf("error authorizing RBAC in API export %q, workspace %q: %w", apiExportName, apiExportCluster, err)
 	}
-
-	kaudit.AddAuditAnnotations(
-		ctx,
-		VirtualAPIExportContentAuditDecision, kcpauth.DecisionString(dec),
-		VirtualAPIExportContentAuditReason, fmt.Sprintf("API export cluster RBAC reason: %v", reason),
-	)
 
 	if dec == authorizer.DecisionAllow {
 		return a.delegate.Authorize(ctx, attr)
 	}
 
-	return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, nil
+	return dec, fmt.Sprintf("API export: %q, workspace: %q RBAC decision: %v",
+		apiExportName, apiExportCluster, reason), nil
 }

--- a/pkg/virtual/apiexport/authorizer/content_test.go
+++ b/pkg/virtual/apiexport/authorizer/content_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+func TestContentAuthorizer(t *testing.T) {
+	for _, tc := range []struct {
+		name                              string
+		contentDecision, expectedDecision authorizer.Decision
+	}{
+		{
+			name:             "content access allowed",
+			contentDecision:  authorizer.DecisionAllow,
+			expectedDecision: authorizer.DecisionAllow,
+		},
+		{
+			name:             "content access denied",
+			contentDecision:  authorizer.DecisionDeny,
+			expectedDecision: authorizer.DecisionDeny,
+		},
+		{
+			name:             "content access no opinion",
+			contentDecision:  authorizer.DecisionNoOpinion,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &apiExportsContentAuthorizer{
+				newDelegatedAuthorizer: func(clusterName string) (authorizer.Authorizer, error) {
+					return authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+						return tc.contentDecision, "", nil
+					}), nil
+				},
+				delegate: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+					return tc.contentDecision, "", nil
+				}),
+			}
+
+			ctx := dynamiccontext.WithAPIDomainKey(context.Background(), dynamiccontext.APIDomainKey("foo/bar"))
+			dec, _, err := auth.Authorize(ctx, &authorizer.AttributesRecord{
+				User: &user.DefaultInfo{},
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedDecision, dec)
+		})
+	}
+}

--- a/pkg/virtual/apiexport/authorizer/maximal_permission_policy.go
+++ b/pkg/virtual/apiexport/authorizer/maximal_permission_policy.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clusters"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
+	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+const (
+	VirtualAPIExportMaximumPermissionPolicyAuditPrefix   = "virtual.apiexport.maxpermissionpolicy.authorization.kcp.dev/"
+	VirtualAPIExportMaximumPermissionPolicyAuditDecision = VirtualAPIExportMaximumPermissionPolicyAuditPrefix + "decision"
+	VirtualAPIExportMaximumPermissionPolicyAuditReason   = VirtualAPIExportMaximumPermissionPolicyAuditPrefix + "reason"
+)
+
+type maximalPermissionAuthorizer struct {
+	getAPIExport            func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error)
+	newDeepSARAuthorizer    func(clusterName logicalcluster.Name) (authorizer.Authorizer, error)
+	getAPIExportsByIdentity func(identityHash string) ([]*apisv1alpha1.APIExport, error)
+}
+
+// NewMaximalPermissionAuthorizer creates an authorizer that checks the maximal permission policy
+// for the requested resource if the resource is a claimed resource in the requested API export.
+// The check is omitted if the requested resource itself is not associated with an API export.
+//
+// If the request is a cluster request the authorizer skips authorization if the request is not for a bound resource.
+// If the request is a wildcard request this check is skipped because no unique API binding can be determined.
+func NewMaximalPermissionAuthorizer(deepSARClient kubernetes.ClusterInterface, apiExportInformer apisinformers.APIExportInformer, apiBindingInformer apisinformers.APIBindingInformer) authorizer.Authorizer {
+	apiExportLister := apiExportInformer.Lister()
+	apiExportIndexer := apiExportInformer.Informer().GetIndexer()
+
+	return &maximalPermissionAuthorizer{
+		getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+			return apiExportLister.Get(clusters.ToClusterAwareKey(logicalcluster.New(clusterName), apiExportName))
+		},
+		getAPIExportsByIdentity: func(identityHash string) ([]*apisv1alpha1.APIExport, error) {
+			return indexers.ByIndex[*apisv1alpha1.APIExport](apiExportIndexer, indexers.APIExportByIdentity, identityHash)
+		},
+		newDeepSARAuthorizer: func(clusterName logicalcluster.Name) (authorizer.Authorizer, error) {
+			return delegated.NewDelegatedAuthorizer(clusterName, deepSARClient)
+		},
+	}
+}
+
+func (a *maximalPermissionAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+	apiDomainKey := dynamiccontext.APIDomainKeyFrom(ctx)
+	parts := strings.Split(string(apiDomainKey), "/")
+	if len(parts) < 2 {
+		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("invalid API domain key")
+	}
+
+	claimingAPIExportCluster := parts[0]
+	claimingAPIExportName := parts[1]
+
+	claimingAPIExport, err := a.getAPIExport(claimingAPIExportCluster, claimingAPIExportName)
+	if kerrors.IsNotFound(err) {
+		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("API export not found: %w", err)
+	}
+
+	claimedIdentityHash, found := getClaimedIdentity(claimingAPIExport, attr)
+	if !found {
+		// it's a resource in the claiming API export, hence unclaimed
+		return authorizer.DecisionAllow, "unclaimed resource", nil
+	}
+	if claimedIdentityHash == "" {
+		// it's a native k8s resource (secret, configmap, ...), or a system kcp CRD resource (apis.kcp.dev)
+		// For neither case a maximum permission policy can exist.
+		return authorizer.DecisionAllow, "unclaimable resource", nil
+	}
+
+	apiExportsProvidingClaimedResources, err := a.getAPIExportsByIdentity(claimedIdentityHash)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, fmt.Errorf("error getting API export identity: %q: %w", claimedIdentityHash, err)
+	}
+
+	if len(apiExportsProvidingClaimedResources) == 0 {
+		// a claimed identity hash exists but not API export can be found referring to it (potentially eventually consistent).
+		// In this case be safe and deny the request, forcing the caller to retry.
+		return authorizer.DecisionDeny, VirtualAPIExportNotPermittedReason, nil
+	}
+
+	// multiple claimed API exports can share the same identity hash (even in different workspaces).
+	// All maximum permission policies must grant access because at this point no deterministic API export can be picked.
+	for _, apiExportProvidingClaimedResource := range apiExportsProvidingClaimedResources {
+		if apiExportProvidingClaimedResource.Spec.MaximalPermissionPolicy == nil {
+			continue
+		}
+
+		if apiExportProvidingClaimedResource.Spec.MaximalPermissionPolicy.Local == nil {
+			continue
+		}
+
+		authz, err := a.newDeepSARAuthorizer(logicalcluster.From(apiExportProvidingClaimedResource))
+		if err != nil {
+			return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, err
+		}
+
+		dec, _, err := authz.Authorize(ctx, prefixAttributes(attr))
+		if err != nil {
+			return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, err
+		}
+
+		// all maximum permission policies must grant access
+		if dec != authorizer.DecisionAllow {
+			return authorizer.DecisionNoOpinion, VirtualAPIExportNotPermittedReason, nil
+		}
+	}
+
+	return authorizer.DecisionAllow, "all claimed API exports granted access", nil
+}
+
+func getClaimedIdentity(apiExport *apisv1alpha1.APIExport, attr authorizer.Attributes) (string, bool) {
+	for i := range apiExport.Spec.PermissionClaims {
+		if apiExport.Spec.PermissionClaims[i].Resource == attr.GetResource() &&
+			apiExport.Spec.PermissionClaims[i].Group == attr.GetAPIGroup() {
+			return apiExport.Spec.PermissionClaims[i].IdentityHash, true
+		}
+	}
+	return "", false
+}
+
+func prefixAttributes(attr authorizer.Attributes) *authorizer.AttributesRecord {
+	prefixedUser := &user.DefaultInfo{
+		Name:  apisv1alpha1.MaximalPermissionPolicyRBACUserGroupPrefix + attr.GetUser().GetName(),
+		UID:   attr.GetUser().GetUID(),
+		Extra: attr.GetUser().GetExtra(),
+	}
+
+	prefixedUser.Groups = make([]string, 0, len(attr.GetUser().GetGroups()))
+	for _, g := range attr.GetUser().GetGroups() {
+		prefixedUser.Groups = append(prefixedUser.Groups, apisv1alpha1.MaximalPermissionPolicyRBACUserGroupPrefix+g)
+	}
+
+	return &authorizer.AttributesRecord{
+		User:            prefixedUser,
+		Verb:            attr.GetVerb(),
+		Namespace:       attr.GetNamespace(),
+		APIGroup:        attr.GetAPIGroup(),
+		APIVersion:      attr.GetAPIVersion(),
+		Resource:        attr.GetResource(),
+		Subresource:     attr.GetSubresource(),
+		Name:            attr.GetName(),
+		ResourceRequest: attr.IsResourceRequest(),
+		Path:            attr.GetPath(),
+	}
+}

--- a/pkg/virtual/apiexport/authorizer/maximal_permission_policy_test.go
+++ b/pkg/virtual/apiexport/authorizer/maximal_permission_policy_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"testing"
+
+	logicalcluster "github.com/kcp-dev/logicalcluster/v2"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
+	for _, tc := range []struct {
+		name                    string
+		attr                    authorizer.Attributes
+		apidomainKey            string
+		getAPIExport            func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error)
+		getAPIExportsByIdentity func(identityHash string) ([]*apisv1alpha1.APIExport, error)
+		newDeepSARAuthorizer    func(clusterName logicalcluster.Name) (authorizer.Authorizer, error)
+
+		expectedErr      string
+		expectedDecision authorizer.Decision
+		expectedReason   string
+	}{
+		{
+			name:             "invalid domain key",
+			attr:             &authorizer.AttributesRecord{User: &user.DefaultInfo{}},
+			apidomainKey:     "",
+			expectedDecision: authorizer.DecisionNoOpinion,
+			expectedErr:      "invalid API domain key",
+		},
+		{
+			name:         "no claimed identities",
+			attr:         &authorizer.AttributesRecord{User: &user.DefaultInfo{}},
+			apidomainKey: "foo/bar",
+			getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+				return &apisv1alpha1.APIExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooExport",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey: "someWorkspace",
+						},
+					},
+				}, nil
+			},
+
+			expectedDecision: authorizer.DecisionAllow,
+			expectedReason:   `unclaimed resource in API export: "fooExport", workspace :"someWorkspace"`,
+		},
+		{
+			name: "claimed identity without idenity hash",
+			attr: &authorizer.AttributesRecord{
+				User:     &user.DefaultInfo{},
+				APIGroup: "claimedGroup",
+				Resource: "claimedResource",
+			},
+			apidomainKey: "foo/bar",
+			getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+				return &apisv1alpha1.APIExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooExport",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey: "someWorkspace",
+						},
+					},
+					Spec: apisv1alpha1.APIExportSpec{
+						PermissionClaims: []apisv1alpha1.PermissionClaim{
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "someGroup",
+									Resource: "someResource",
+								},
+							},
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "claimedGroup",
+									Resource: "claimedResource",
+								},
+							},
+						},
+					},
+				}, nil
+			},
+
+			expectedDecision: authorizer.DecisionAllow,
+			expectedReason:   `unclaimable resource, identity hash not set in claiming API export: "fooExport", workspace :"someWorkspace"`,
+		},
+		{
+			name: "claimed identity without api export",
+			attr: &authorizer.AttributesRecord{
+				User:     &user.DefaultInfo{},
+				APIGroup: "claimedGroup",
+				Resource: "claimedResource",
+			},
+			apidomainKey: "foo/bar",
+			getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+				return &apisv1alpha1.APIExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooExport",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey: "someWorkspace",
+						},
+					},
+					Spec: apisv1alpha1.APIExportSpec{
+						PermissionClaims: []apisv1alpha1.PermissionClaim{
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "someGroup",
+									Resource: "someResource",
+								},
+							},
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "claimedGroup",
+									Resource: "claimedResource",
+								},
+								IdentityHash: "123",
+							},
+						},
+					},
+				}, nil
+			},
+			getAPIExportsByIdentity: func(identityHash string) ([]*apisv1alpha1.APIExport, error) {
+				return []*apisv1alpha1.APIExport{}, nil
+			},
+
+			expectedDecision: authorizer.DecisionDeny,
+			expectedReason:   `no API export providing claimed resources found for identity hash: "123"`,
+		},
+		{
+			name: "claimed identity with api export having no maximum permission policy",
+			attr: &authorizer.AttributesRecord{
+				User:     &user.DefaultInfo{},
+				APIGroup: "claimedGroup",
+				Resource: "claimedResource",
+			},
+			apidomainKey: "foo/bar",
+			getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+				return &apisv1alpha1.APIExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooExport",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey: "someWorkspace",
+						},
+					},
+					Spec: apisv1alpha1.APIExportSpec{
+						PermissionClaims: []apisv1alpha1.PermissionClaim{
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "someGroup",
+									Resource: "someResource",
+								},
+							},
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "claimedGroup",
+									Resource: "claimedResource",
+								},
+								IdentityHash: "123",
+							},
+						},
+					},
+				}, nil
+			},
+			getAPIExportsByIdentity: func(identityHash string) ([]*apisv1alpha1.APIExport, error) {
+				return []*apisv1alpha1.APIExport{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "foo",
+						},
+					},
+				}, nil
+			},
+
+			expectedDecision: authorizer.DecisionAllow,
+			expectedReason:   `all claimed API exports granted access`,
+		},
+		{
+			name: "claimed identity with api export having maximum permission policy granting access",
+			attr: &authorizer.AttributesRecord{
+				User:     &user.DefaultInfo{},
+				APIGroup: "claimedGroup",
+				Resource: "claimedResource",
+			},
+			apidomainKey: "foo/bar",
+			getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+				return &apisv1alpha1.APIExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooExport",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey: "someWorkspace",
+						},
+					},
+					Spec: apisv1alpha1.APIExportSpec{
+						PermissionClaims: []apisv1alpha1.PermissionClaim{
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "someGroup",
+									Resource: "someResource",
+								},
+							},
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "claimedGroup",
+									Resource: "claimedResource",
+								},
+								IdentityHash: "123",
+							},
+						},
+					},
+				}, nil
+			},
+			getAPIExportsByIdentity: func(identityHash string) ([]*apisv1alpha1.APIExport, error) {
+				return []*apisv1alpha1.APIExport{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "foo",
+						},
+						Spec: apisv1alpha1.APIExportSpec{
+							MaximalPermissionPolicy: &apisv1alpha1.MaximalPermissionPolicy{Local: &apisv1alpha1.LocalAPIExportPolicy{}},
+						},
+					},
+				}, nil
+			},
+			newDeepSARAuthorizer: func(clusterName logicalcluster.Name) (authorizer.Authorizer, error) {
+				return authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+					return authorizer.DecisionAllow, "", nil
+				}), nil
+			},
+
+			expectedDecision: authorizer.DecisionAllow,
+			expectedReason:   `all claimed API exports granted access`,
+		},
+		{
+			name: "claimed identity with api export having maximum permission policy denying access",
+			attr: &authorizer.AttributesRecord{
+				User:     &user.DefaultInfo{},
+				APIGroup: "claimedGroup",
+				Resource: "claimedResource",
+			},
+			apidomainKey: "foo/bar",
+			getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+				return &apisv1alpha1.APIExport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "fooExport",
+						Annotations: map[string]string{
+							logicalcluster.AnnotationKey: "someWorkspace",
+						},
+					},
+					Spec: apisv1alpha1.APIExportSpec{
+						PermissionClaims: []apisv1alpha1.PermissionClaim{
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "someGroup",
+									Resource: "someResource",
+								},
+							},
+							{
+								GroupResource: apisv1alpha1.GroupResource{
+									Group:    "claimedGroup",
+									Resource: "claimedResource",
+								},
+								IdentityHash: "123",
+							},
+						},
+					},
+				}, nil
+			},
+			getAPIExportsByIdentity: func(identityHash string) ([]*apisv1alpha1.APIExport, error) {
+				return []*apisv1alpha1.APIExport{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "fooExport",
+							Annotations: map[string]string{
+								logicalcluster.AnnotationKey: "someWorkspace",
+							},
+						},
+						Spec: apisv1alpha1.APIExportSpec{
+							MaximalPermissionPolicy: &apisv1alpha1.MaximalPermissionPolicy{Local: &apisv1alpha1.LocalAPIExportPolicy{}},
+						},
+					},
+				}, nil
+			},
+			newDeepSARAuthorizer: func(clusterName logicalcluster.Name) (authorizer.Authorizer, error) {
+				return authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+					return authorizer.DecisionDeny, "access denied", nil
+				}), nil
+			},
+
+			expectedDecision: authorizer.DecisionNoOpinion,
+			expectedReason:   `API export: "fooExport", workspace: "someWorkspace" RBAC decision: access denied`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := dynamiccontext.WithAPIDomainKey(context.Background(), dynamiccontext.APIDomainKey(tc.apidomainKey))
+			auth := &maximalPermissionAuthorizer{
+				getAPIExport:            tc.getAPIExport,
+				getAPIExportsByIdentity: tc.getAPIExportsByIdentity,
+				newDeepSARAuthorizer:    tc.newDeepSARAuthorizer,
+			}
+			dec, reason, err := auth.Authorize(ctx, tc.attr)
+			errString := ""
+			if err != nil {
+				errString = err.Error()
+			}
+			require.Equal(t, errString, tc.expectedErr)
+			require.Equal(t, tc.expectedDecision, dec)
+			require.Equal(t, tc.expectedReason, reason)
+		})
+	}
+}

--- a/pkg/virtual/apiexport/authorizer/maximal_permission_policy_test.go
+++ b/pkg/virtual/apiexport/authorizer/maximal_permission_policy_test.go
@@ -70,7 +70,7 @@ func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 			expectedReason:   `unclaimed resource in API export: "fooExport", workspace :"someWorkspace"`,
 		},
 		{
-			name: "claimed identity without idenity hash",
+			name: "claimed identity without identity hash",
 			attr: &authorizer.AttributesRecord{
 				User:     &user.DefaultInfo{},
 				APIGroup: "claimedGroup",

--- a/pkg/virtual/apiexport/options/options.go
+++ b/pkg/virtual/apiexport/options/options.go
@@ -24,6 +24,7 @@ import (
 	kubernetesclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/kcp-dev/kcp/pkg/authorization"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/builder"
@@ -70,6 +71,10 @@ func (o *APIExport) NewVirtualWorkspaces(
 	if err != nil {
 		return nil, err
 	}
+	deepSARClient, err := kubernetesclient.NewClusterForConfig(authorization.WithDeepSARConfig(rest.CopyConfig(config)))
+	if err != nil {
+		return nil, err
+	}
 
-	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), kubeClusterClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
+	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), kubeClusterClient, deepSARClient, dynamicClusterClient, kcpClusterClient, wildcardKcpInformers)
 }

--- a/pkg/virtual/framework/forwardingregistry/store.go
+++ b/pkg/virtual/framework/forwardingregistry/store.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kcp-dev/logicalcluster/v2"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -277,11 +275,8 @@ func clientGetter(dynamicClusterClient dynamic.ClusterInterface, namespaceScoped
 		}
 		gvr := resource
 		clusterName := cluster.Name
-		if cluster.Wildcard {
-			clusterName = logicalcluster.Wildcard
-			if apiExportIdentityHash != "" {
-				gvr.Resource += ":" + apiExportIdentityHash
-			}
+		if apiExportIdentityHash != "" {
+			gvr.Resource += ":" + apiExportIdentityHash
 		}
 
 		if namespaceScoped {

--- a/test/e2e/fixtures/apifixtures/apibinding.go
+++ b/test/e2e/fixtures/apifixtures/apibinding.go
@@ -18,6 +18,7 @@ package apifixtures
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -59,9 +60,14 @@ func BindToExport(
 		},
 	}
 
-	t.Logf("Creating APIBinding %s|%s", bindingClusterName, binding.Name)
-	_, err := clusterClient.ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, bindingClusterName), binding, metav1.CreateOptions{})
-	require.NoError(t, err, "error creating APIBinding %s|%s", bindingClusterName, binding.Name)
+	framework.Eventually(t, func() (bool, string) {
+		t.Logf("Creating APIBinding %s|%s", bindingClusterName, binding.Name)
+		_, err := clusterClient.ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, bindingClusterName), binding, metav1.CreateOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error creating APIBinding %s|%s: %v", bindingClusterName, binding.Name, err)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 	framework.Eventually(t, func() (bool, string) {
 		b, err := clusterClient.ApisV1alpha1().APIBindings().Get(logicalcluster.WithCluster(ctx, bindingClusterName), binding.Name, metav1.GetOptions{})

--- a/test/e2e/framework/auth-tokens.csv
+++ b/test/e2e/framework/auth-tokens.csv
@@ -1,4 +1,5 @@
 user-1-token,user-1,1111-1111-1111-1111,"team-1"
 user-2-token,user-2,2222-2222-2222-2222,"team-2"
 user-3-token,user-3,3333-3333-3333-3333,"team-3"
-admin-token,admin,4444-4444-4444-4444,"system:masters"
+user-4-token,user-4,4444-4444-4444-4444,"team-4"
+admin-token,admin,5555-5555-5555-5555,"system:masters"

--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -294,7 +294,7 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	_, err = user2DynamicVWClient.Cluster(logicalcluster.Wildcard).Resource(schema.GroupVersionResource{Version: "v1", Resource: "sheriffs", Group: "wild.wild.west"}).List(ctx, metav1.ListOptions{})
 	require.ErrorContains(
 		t, err,
-		`sheriffs.wild.wild.west is forbidden: User "user-2" cannot list resource "sheriffs" in API group "wild.wild.west" at the cluster scope: virtual apiexport access not permitted`,
+		`sheriffs.wild.wild.west is forbidden: User "user-2" cannot list resource "sheriffs" in API group "wild.wild.west" at the cluster scope: access denied`,
 		"user-2 must not be allowed to list sheriff resources")
 
 	_, err = user2DynamicVWClient.Cluster(logicalcluster.Wildcard).Resource(schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}).List(ctx, metav1.ListOptions{})

--- a/test/e2e/virtual/apiexport/crd_cowboys.yaml
+++ b/test/e2e/virtual/apiexport/crd_cowboys.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: cowboys.wildwest.dev
+spec:
+  group: wildwest.dev
+  names:
+    kind: Cowboy
+    listKind: CowboyList
+    plural: cowboys
+    singular: cowboy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cowboy is part of the wild west
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CowboySpec holds the desired state of the Cowboy.
+            properties:
+              intent:
+                type: string
+            type: object
+          status:
+            description: CowboyStatus communicates the observed state of the Cowboy.
+            properties:
+              result:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

This adds maximal permission policy authorization to the virtual apiexport apiserver. Currently, this is not enforced at all.

## Related issue(s)

Part of #1219
Fixes #1337

/cc @sttts 