### PR TITLE
pkg/virtual/workspaces/registry: fix panic sending to a closed channel

### DIFF
--- a/pkg/virtual/workspaces/registry/rest.go
+++ b/pkg/virtual/workspaces/registry/rest.go
@@ -429,6 +429,7 @@ func (w withProjection) ResultChan() <-chan watch.Event {
 	ch := w.delegate.ResultChan()
 
 	go func() {
+		defer close(w.ch)
 		for ev := range ch {
 			if ev.Object == nil {
 				w.ch <- ev
@@ -447,6 +448,5 @@ func (w withProjection) ResultChan() <-chan watch.Event {
 }
 
 func (w withProjection) Stop() {
-	defer close(w.ch)
 	w.delegate.Stop()
 }


### PR DESCRIPTION
## Summary

This PR should fix a panic in the `workspaces` virtual workspace. 

## Related issue(s)

A panic is occuring in the `workspaces` virtual workspace, forcing the virtual workspace command to restart:

```
panic: send on closed channel

goroutine 431 [running]:
github.com/kcp-dev/kcp/pkg/virtual/workspaces/registry.withProjection.ResultChan.func1()
/workspace/pkg/virtual/workspaces/registry/rest.go:442 +0xf7
created by github.com/kcp-dev/kcp/pkg/virtual/workspaces/registry.withProjection.ResultChan
/workspace/pkg/virtual/workspaces/registry/rest.go:431 +0xc5
```  