### PR TITLE
verify-go-versions.sh make CONTRIBUTING.md check conditional

### DIFF
--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -22,7 +22,10 @@ VERSION=$(grep "go 1." go.mod | sed 's/go //')
 grep "tag: \"" .ci-operator.yaml | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in .ci-operator.yaml, expected ${VERSION}"; exit 1; }
 grep "FROM golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
 grep "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
-grep "golang.org/doc/install" CONTRIBUTING.md | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in CONTRIBUTING.md expected ${VERSION}"; exit 1; }
+# Note CONTRIBUTING.md isn't copied in the Dockerfile
+if [ -e CONTRIBUTING.md ]; then
+  grep "golang.org/doc/install" CONTRIBUTING.md | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in CONTRIBUTING.md expected ${VERSION}"; exit 1; }
+fi
 if [ -z "${IGNORE_GO_VERSION}" ]; then
   go version | { ! grep -v go${VERSION}; } || { echo "Unexpected go version installed, expected ${VERSION}. Use IGNORE_GO_VERSION=1 to skip this check."; exit 1; }
 fi


### PR DESCRIPTION
## Summary

This check breaks the Dockerfile build as the file isn't COPY'd

## Related issue(s)

This was introduced via #1894 but I didn't notice that the `verify-go-versions` Makefile target is run by the default all/build target in the Dockerfile