### PR TITLE
pkg/authorization/apibinding_authorizer: fix nil panic

### DIFF
--- a/pkg/authorization/apibinding_authorizer.go
+++ b/pkg/authorization/apibinding_authorizer.go
@@ -224,7 +224,7 @@ func (a *apiBindingAccessAuthorizer) getAPIBindingReference(attr authorizer.Attr
 	for _, obj := range objs {
 		apiBinding := obj.(*apisv1alpha1.APIBinding)
 		for _, br := range apiBinding.Status.BoundResources {
-			if apiBinding.Status.BoundAPIExport.Workspace == nil {
+			if apiBinding.Status.BoundAPIExport == nil || apiBinding.Status.BoundAPIExport.Workspace == nil {
 				continue
 			}
 			if br.Group == attr.GetAPIGroup() && br.Resource == attr.GetResource() {


### PR DESCRIPTION
## Summary
apiBinding.Status.BoundAPIExport can be nil, causing a panic. This fixes it.

## Related issue(s)

Fixes #1919 