### PR TITLE
cache-server: adds ShardNameFromObjectRoundTripper

### DIFF
--- a/pkg/cache/client/shard/shard.go
+++ b/pkg/cache/client/shard/shard.go
@@ -20,6 +20,11 @@ import (
 	"path"
 )
 
+const (
+	// AnnotationKey is the name of the annotation key used to denote an object's shard name.
+	AnnotationKey = "kcp.dev/shard"
+)
+
 // Name hold the name of a shard. It is used by the cache-server
 // to assign resources to a particular shard.
 type Name string


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
Knows how to read a shard name from an object and store it in the context. 
It should be only used by the internal kube-clients that are not aware of a shard name.

## Related issue(s)

Fixes #