### PR TITLE
cache-client: fix npe when the context wasn't set

### DIFF
--- a/pkg/cache/client/context.go
+++ b/pkg/cache/client/context.go
@@ -37,5 +37,9 @@ func WithShardInContext(parent context.Context, shard shard.Name) context.Contex
 // ShardFromContext returns the value of the shard key on the ctx,
 // or an empty Name if there is no shard key.
 func ShardFromContext(ctx context.Context) shard.Name {
-	return ctx.Value(shardContextKey).(shard.Name)
+	shard, ok := ctx.Value(shardContextKey).(shard.Name)
+	if !ok {
+		return ""
+	}
+	return shard
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
it will panic when the context is not set.

## Related issue(s)

Fixes #