### PR TITLE
🌱 cache: makes all internal clients shard and cluster aware

### DIFF
--- a/pkg/cache/client/round_tripper.go
+++ b/pkg/cache/client/round_tripper.go
@@ -149,7 +149,7 @@ func (c *DefaultShardRoundTripper) RoundTrip(req *http.Request) (*http.Response,
 	return c.delegate.RoundTrip(req)
 }
 
-// WithShardNameFromObjectRoundTripper wraps an existing config's with ShardNameFromObjectRoundTripper.
+// WithShardNameFromObjectRoundTripper wraps an existing config with ShardNameFromObjectRoundTripper.
 //
 // Note: it is the caller responsibility to make a copy of the rest config
 func WithShardNameFromObjectRoundTripper(cfg *rest.Config, requestInfoResolver func(*http.Request) (string, string, error), supportedResources ...string) *rest.Config {

--- a/pkg/cache/server/handler.go
+++ b/pkg/cache/server/handler.go
@@ -90,12 +90,11 @@ func WithShardScope(handler http.Handler) http.Handler {
 		case shardName == "*":
 			shard = "*"
 		case len(shardName) == 0:
-			// because we don't store a shard name in an object.
-			// requests without a shard name won't be able to find associated data and will fail.
-			// as of today we don't instruct controllers used by the apiextention server
-			// how to assign/extract a shard name to/from an object.
-			// so we need to set a default name here, otherwise these controllers will fail.
-			shard = "system:cache:server"
+			responsewriters.ErrorNegotiated(
+				apierrors.NewBadRequest("a shard name is required"),
+				errorCodecs, schema.GroupVersion{},
+				w, req)
+			return
 		default:
 			if !shardNameRegExp.MatchString(shardName) {
 				responsewriters.ErrorNegotiated(


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.
-->

## Summary
provides an ordered list of HTTP round-trippers that add shard and cluster awareness to all clients that use the loopback config.

requires https://github.com/kcp-dev/kcp/pull/1926 and https://github.com/kcp-dev/kubernetes/pull/100

## Related issue(s)

Fixes #