### PR TITLE
🐛 Fix generated APIResourceSchema names

### DIFF
--- a/config/root-phase0/apiexport-scheduling.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-scheduling.kcp.dev.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   latestResourceSchemas:
   - v220801-c65c674d4.locations.scheduling.kcp.dev
-  - v220801-c65c674d4.placements.scheduling.kcp.dev
+  - v220909-c255fd13.placements.scheduling.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   latestResourceSchemas:
   - v220713-f9bb7307.clusterworkspacetypes.tenancy.kcp.dev
-  - v220801-c65c674d4.clusterworkspaces.tenancy.kcp.dev
   - v220801-c65c674d4.workspaces.tenancy.kcp.dev
+  - v220909-c255fd13.clusterworkspaces.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiexport-workload.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.dev.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220803-727d944d.synctargets.workload.kcp.dev
+  - v220909-c255fd13.synctargets.workload.kcp.dev
 status: {}

--- a/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
@@ -71,7 +71,7 @@ spec:
                 can be scheduled to. if the constraint is not fulfilled by the current
                 location stored in the status, movement will be attempted. \n Either
                 shard name or shard selector must be specified. \n If the no shard
-                constraints are specified, an arbitrary shard is chosen."
+                constraints are specified, an aribtrary shard is chosen."
               oneOf:
               - required:
                 - name

--- a/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220801-c65c674d4.clusterworkspaces.tenancy.kcp.dev
+  name: v220909-c255fd13.clusterworkspaces.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -71,7 +71,7 @@ spec:
                 can be scheduled to. if the constraint is not fulfilled by the current
                 location stored in the status, movement will be attempted. \n Either
                 shard name or shard selector must be specified. \n If the no shard
-                constraints are specified, an aribtrary shard is chosen."
+                constraints are specified, an arbitrary shard is chosen."
               oneOf:
               - required:
                 - name

--- a/config/root-phase0/apiresourceschema-placements.scheduling.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-placements.scheduling.kcp.dev.yaml
@@ -26,10 +26,10 @@ spec:
         state. In Pending or Unbound state, the selection rule can be updated to select
         another location. When the a namespace is annotated by another controller
         or user with the key of \"scheduling.kcp.dev/placement\", the namespace will
-        pick one placement, and this placement is transferred to Bound state. Any
-        update to spec of the placement is ignored in Bound state and reflected in
-        the conditions. The placement will turn back to Unbound state when no namespace
-        uses this placement any more."
+        pick one placement, and this placement is transfered to Bound state. Any update
+        to spec of the placement is ignored in Bound state and reflected in the conditions.
+        The placement will turn back to Unbound state when no namespace uses this
+        placement any more."
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -72,7 +72,7 @@ spec:
               - version
               type: object
             locationSelectors:
-              description: locationSelectors represents a slice of label selector
+              description: loacationSelectors represents a slice of label selector
                 to select a location, these label selectors are logically ORed.
               items:
                 description: A label selector is a label query over a set of resources.

--- a/config/root-phase0/apiresourceschema-placements.scheduling.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-placements.scheduling.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220801-c65c674d4.placements.scheduling.kcp.dev
+  name: v220909-c255fd13.placements.scheduling.kcp.dev
 spec:
   group: scheduling.kcp.dev
   names:
@@ -26,10 +26,10 @@ spec:
         state. In Pending or Unbound state, the selection rule can be updated to select
         another location. When the a namespace is annotated by another controller
         or user with the key of \"scheduling.kcp.dev/placement\", the namespace will
-        pick one placement, and this placement is transfered to Bound state. Any update
-        to spec of the placement is ignored in Bound state and reflected in the conditions.
-        The placement will turn back to Unbound state when no namespace uses this
-        placement any more."
+        pick one placement, and this placement is transferred to Bound state. Any
+        update to spec of the placement is ignored in Bound state and reflected in
+        the conditions. The placement will turn back to Unbound state when no namespace
+        uses this placement any more."
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -72,7 +72,7 @@ spec:
               - version
               type: object
             locationSelectors:
-              description: loacationSelectors represents a slice of label selector
+              description: locationSelectors represents a slice of label selector
                 to select a location, these label selectors are logically ORed.
               items:
                 description: A label selector is a label query over a set of resources.

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -210,7 +210,7 @@ spec:
                     default: Pending
                     description: state indicate whether the resources schema is compatible
                       to the SyncTarget. It must be updated by syncer after checking
-                      the API compatibility on SyncTarget.
+                      the API compaibility on SyncTarget.
                     enum:
                     - Pending
                     - Accepted

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220803-727d944d.synctargets.workload.kcp.dev
+  name: v220909-c255fd13.synctargets.workload.kcp.dev
 spec:
   group: workload.kcp.dev
   names:
@@ -210,7 +210,7 @@ spec:
                     default: Pending
                     description: state indicate whether the resources schema is compatible
                       to the SyncTarget. It must be updated by syncer after checking
-                      the API compaibility on SyncTarget.
+                      the API compatibility on SyncTarget.
                     enum:
                     - Pending
                     - Accepted


### PR DESCRIPTION
## Summary
#1908 applied spellcheck fixes to our generated APIResourceSchemas, and accidentally bypassed our verification checks to update their names. This reverts the changes to the generated files and then regenerates them with new names.

## Related issue(s)

Fixes #