### PR TITLE
:seedling: cache: moves common HTTP handlers to a shared pkg

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -131,7 +131,6 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 		apiHandler = genericapiserver.DefaultBuildHandlerChainBeforeAuthz(apiHandler, genericConfig)
 		apiHandler = filters.WithAuditEventClusterAnnotation(apiHandler)
 		apiHandler = filters.WithClusterScope(apiHandler)
-		apiHandler = filters.WithAcceptHeader(apiHandler)
 		apiHandler = WithShardScope(apiHandler)
 		return apiHandler
 	}

--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -41,7 +41,7 @@ import (
 
 	cacheserveroptions "github.com/kcp-dev/kcp/pkg/cache/server/options"
 	"github.com/kcp-dev/kcp/pkg/embeddedetcd"
-	kcpserver "github.com/kcp-dev/kcp/pkg/server"
+	"github.com/kcp-dev/kcp/pkg/server/filters"
 )
 
 const resyncPeriod = 10 * time.Hour
@@ -129,10 +129,9 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 	serverConfig.Config.BuildHandlerChainFunc = func(apiHandler http.Handler, genericConfig *genericapiserver.Config) (secure http.Handler) {
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, genericConfig)
 		apiHandler = genericapiserver.DefaultBuildHandlerChainBeforeAuthz(apiHandler, genericConfig)
-		apiHandler = kcpserver.WithClusterAnnotation(apiHandler)
-		apiHandler = kcpserver.WithClusterScope(apiHandler)
-		apiHandler = kcpserver.WithAcceptHeader(apiHandler)
-		apiHandler = kcpserver.WithUserAgent(apiHandler)
+		apiHandler = filters.WithAuditEventClusterAnnotation(apiHandler)
+		apiHandler = filters.WithClusterScope(apiHandler)
+		apiHandler = filters.WithAcceptHeader(apiHandler)
 		apiHandler = WithShardScope(apiHandler)
 		return apiHandler
 	}

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/kcp-dev/logicalcluster/v2"
-	"github.com/munnerz/goautoneg"
 
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -47,6 +46,7 @@ import (
 	tenancylisters "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
+	"github.com/kcp-dev/kcp/pkg/server/filters"
 )
 
 // SystemCRDLogicalCluster is the logical cluster we install system CRDs into for now. These are needed
@@ -169,26 +169,6 @@ func (c *apiBindingAwareCRDLister) List(ctx context.Context, selector labels.Sel
 	return ret, nil
 }
 
-func isPartialMetadataRequest(ctx context.Context) bool {
-	accept := ctx.Value(acceptHeaderContextKey).(string)
-	if accept == "" {
-		return false
-	}
-
-	return isPartialMetadataHeader(accept)
-}
-
-func isPartialMetadataHeader(accept string) bool {
-	clauses := goautoneg.ParseAccept(accept)
-	for _, clause := range clauses {
-		if clause.Params["as"] == "PartialObjectMetadata" || clause.Params["as"] == "PartialObjectMetadataList" {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (c *apiBindingAwareCRDLister) Refresh(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 	crdKey := clusters.ToClusterAwareKey(logicalcluster.From(crd), crd.Name)
 
@@ -235,7 +215,7 @@ func (c *apiBindingAwareCRDLister) Get(ctx context.Context, name string) (*apiex
 		return nil, err
 	}
 
-	partialMetadataRequest := isPartialMetadataRequest(ctx)
+	partialMetadataRequest := filters.IsPartialMetadataRequest(ctx)
 
 	if crd == nil {
 		// Not a system CRD, so check in priority order: identity, wildcard, "normal" single cluster

--- a/pkg/server/apiextensions_test.go
+++ b/pkg/server/apiextensions_test.go
@@ -131,25 +131,3 @@ func TestDecorateCRDWithBinding(t *testing.T) {
 		})
 	}
 }
-
-func Test_isPartialMetadataHeader(t *testing.T) {
-	tests := map[string]struct {
-		accept string
-		want   bool
-	}{
-		"empty header": {
-			accept: "",
-			want:   false,
-		},
-		"metadata informer factory": {
-			accept: "application/vnd.kubernetes.protobuf;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json",
-			want:   true,
-		},
-	}
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			got := isPartialMetadataHeader(test.accept)
-			require.Equal(t, test.want, got)
-		})
-	}
-}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -57,6 +57,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
 	bootstrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
+	kcpfilters "github.com/kcp-dev/kcp/pkg/server/filters"
 	kcpserveroptions "github.com/kcp-dev/kcp/pkg/server/options"
 	"github.com/kcp-dev/kcp/pkg/server/options/batteries"
 	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
@@ -322,11 +323,11 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 			apiHandler = tunneler.WithSyncerTunnel(apiHandler)
 		}
 		apiHandler = WithWorkspaceProjection(apiHandler, shardVirtualWorkspaceURL)
-		apiHandler = WithClusterAnnotation(apiHandler)
+		apiHandler = kcpfilters.WithAuditEventClusterAnnotation(apiHandler)
 		apiHandler = WithAuditAnnotation(apiHandler) // Must run before any audit annotation is made
-		apiHandler = WithClusterScope(apiHandler)
+		apiHandler = kcpfilters.WithClusterScope(apiHandler)
 		apiHandler = WithInClusterServiceAccountRequestRewrite(apiHandler)
-		apiHandler = WithAcceptHeader(apiHandler)
+		apiHandler = kcpfilters.WithAcceptHeader(apiHandler)
 		apiHandler = WithUserAgent(apiHandler)
 
 		return apiHandler

--- a/pkg/server/filters/filters.go
+++ b/pkg/server/filters/filters.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The KCP Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -151,8 +154,8 @@ func WithAcceptHeader(apiHandler http.Handler) http.Handler {
 //
 // A PartialObjectMetadata request gets only object metadata.
 func IsPartialMetadataRequest(ctx context.Context) bool {
-	accept := ctx.Value(acceptHeaderContextKey).(string)
-	if accept == "" {
+	accept, ok := ctx.Value(acceptHeaderContextKey).(string)
+	if !ok || accept == "" {
 		return false
 	}
 

--- a/pkg/server/filters/filters.go
+++ b/pkg/server/filters/filters.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2022 The KCP Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/munnerz/goautoneg"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	kaudit "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/kubernetes/pkg/genericcontrolplane"
+)
+
+type (
+	acceptHeaderContextKeyType int
+)
+
+const (
+	workspaceAnnotation = "tenancy.kcp.dev/workspace"
+
+	// clusterKey is the context key for the request namespace.
+	acceptHeaderContextKey acceptHeaderContextKeyType = iota
+)
+
+var (
+	reClusterName = regexp.MustCompile(`^([a-z]([a-z0-9-]{0,61}[a-z0-9])?:)*[a-z]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
+	errorScheme = runtime.NewScheme()
+	errorCodecs = serializer.NewCodecFactory(errorScheme)
+)
+
+func init() {
+	errorScheme.AddUnversionedTypes(metav1.Unversioned,
+		&metav1.Status{},
+	)
+}
+
+// WithAuditEventClusterAnnotation adds the cluster name into the annotation of an audit
+// event. Needs initialized annotations.
+func WithAuditEventClusterAnnotation(handler http.Handler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cluster := request.ClusterFrom(req.Context())
+		if cluster != nil {
+			kaudit.AddAuditAnnotation(req.Context(), workspaceAnnotation, cluster.Name.String())
+		}
+
+		handler.ServeHTTP(w, req)
+	})
+}
+
+// WithClusterScope reads a cluster name from the URL path and puts it into the context.
+// It also trims "/clusters/" prefix from the URL.
+// If the path doesn't contain the cluster name then a default "system:admin" name is assigned.
+func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var clusterName logicalcluster.Name
+		if path := req.URL.Path; strings.HasPrefix(path, "/clusters/") {
+			path = strings.TrimPrefix(path, "/clusters/")
+
+			i := strings.Index(path, "/")
+			if i == -1 {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewBadRequest(fmt.Sprintf("unable to parse cluster: no `/` found in path %s", path)),
+					errorCodecs, schema.GroupVersion{},
+					w, req)
+				return
+			}
+			clusterName, path = logicalcluster.New(path[:i]), path[i:]
+			req.URL.Path = path
+			newURL, err := url.Parse(req.URL.String())
+			if err != nil {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewInternalError(fmt.Errorf("unable to resolve %s, err %w", req.URL.Path, err)),
+					errorCodecs, schema.GroupVersion{},
+					w, req)
+				return
+			}
+			req.URL = newURL
+		} else {
+			clusterName = logicalcluster.New(req.Header.Get(logicalcluster.ClusterHeader))
+		}
+
+		var cluster request.Cluster
+
+		// This is necessary so wildcard (cross-cluster) partial metadata requests can succeed. The storage layer needs
+		// to know if a request is for partial metadata to be able to extract the cluster name from storage keys
+		// properly.
+		cluster.PartialMetadataRequest = IsPartialMetadataRequest(req.Context())
+
+		switch {
+		case clusterName == logicalcluster.Wildcard:
+			// HACK: just a workaround for testing
+			cluster.Wildcard = true
+			// fallthrough
+			cluster.Name = logicalcluster.Wildcard
+		case clusterName.Empty():
+			cluster.Name = genericcontrolplane.LocalAdminCluster
+		default:
+			if !reClusterName.MatchString(clusterName.String()) {
+				responsewriters.ErrorNegotiated(
+					apierrors.NewBadRequest(fmt.Sprintf("invalid cluster: %q does not match the regex", clusterName)),
+					errorCodecs, schema.GroupVersion{},
+					w, req)
+				return
+			}
+			cluster.Name = clusterName
+		}
+
+		ctx := request.WithCluster(req.Context(), cluster)
+
+		apiHandler.ServeHTTP(w, req.WithContext(ctx))
+	}
+}
+
+// WithAcceptHeader makes the Accept header available for code in the handler chain. It is needed for
+// Wildcard requests, when finding the CRD with a common schema. For PartialObjectMeta requests we cand
+// weaken the schema requirement and allow different schemas across workspaces.
+func WithAcceptHeader(apiHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := context.WithValue(req.Context(), acceptHeaderContextKey, req.Header.Get("Accept"))
+		apiHandler.ServeHTTP(w, req.WithContext(ctx))
+	})
+}
+
+// IsPartialMetadataRequest determines if it is PartialObjectMetadata request
+// based on the value stored in the context.
+//
+// A PartialObjectMetadata request gets only object metadata.
+func IsPartialMetadataRequest(ctx context.Context) bool {
+	accept := ctx.Value(acceptHeaderContextKey).(string)
+	if accept == "" {
+		return false
+	}
+
+	return isPartialMetadataHeader(accept)
+}
+
+func isPartialMetadataHeader(accept string) bool {
+	clauses := goautoneg.ParseAccept(accept)
+	for _, clause := range clauses {
+		if clause.Params["as"] == "PartialObjectMetadata" || clause.Params["as"] == "PartialObjectMetadataList" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/server/filters/filters_test.go
+++ b/pkg/server/filters/filters_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The KCP Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,9 +25,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/yaml"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func Test_isPartialMetadataHeader(t *testing.T) {
@@ -51,7 +54,7 @@ func Test_isPartialMetadataHeader(t *testing.T) {
 
 func TestClusterWorkspaceNamePattern(t *testing.T) {
 	_, fileName, _, _ := runtime.Caller(0)
-	bs, err := ioutil.ReadFile(filepath.Join(filepath.Dir(fileName), "..", "..", "config/crds/tenancy.kcp.dev_clusterworkspaces.yaml"))
+	bs, err := ioutil.ReadFile(filepath.Join(filepath.Dir(fileName), "..", "..", "../config/crds/tenancy.kcp.dev_clusterworkspaces.yaml"))
 	require.NoError(t, err)
 	var crd apiextensionsv1.CustomResourceDefinition
 	err = yaml.Unmarshal(bs, &crd)

--- a/pkg/server/filters/filters_test.go
+++ b/pkg/server/filters/filters_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 The KCP Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func Test_isPartialMetadataHeader(t *testing.T) {
+	tests := map[string]struct {
+		accept string
+		want   bool
+	}{
+		"empty header": {
+			accept: "",
+			want:   false,
+		},
+		"metadata informer factory": {
+			accept: "application/vnd.kubernetes.protobuf;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json",
+			want:   true,
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := isPartialMetadataHeader(test.accept)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestClusterWorkspaceNamePattern(t *testing.T) {
+	_, fileName, _, _ := runtime.Caller(0)
+	bs, err := ioutil.ReadFile(filepath.Join(filepath.Dir(fileName), "..", "..", "config/crds/tenancy.kcp.dev_clusterworkspaces.yaml"))
+	require.NoError(t, err)
+	var crd apiextensionsv1.CustomResourceDefinition
+	err = yaml.Unmarshal(bs, &crd)
+	require.NoError(t, err)
+	require.Len(t, crd.Spec.Versions, 1, "crd should have exactly one version, update the test when this changes")
+
+	namePattern := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["metadata"].Properties["name"].Pattern
+	require.True(t, strings.HasPrefix(namePattern, "^"), "cluster name pattern should end with $")
+	require.True(t, strings.HasSuffix(namePattern, "$"), "cluster name pattern should start with ^")
+
+	namePattern = strings.Trim(namePattern, "^$")
+	require.Equal(t, fmt.Sprintf("^(%s:)*%s$", namePattern, namePattern), reClusterName.String(), "logical cluster regex should match ClusterWorkspace name pattern")
+}
+
+func TestReCluster(t *testing.T) {
+	tests := []struct {
+		cluster string
+		valid   bool
+	}{
+		{"", false},
+
+		{"root", true},
+		{"root:foo", true},
+		{"root:foo:bar", true},
+
+		{"system", true},
+		{"system:foo", true},
+		{"system:foo:bar", true},
+
+		{"f", true},
+		{"foo", true},
+		{"foo:b", true},
+		{"foo:bar", true},
+		{"foo:bar0", true},
+		{"foo:bar-bar", true},
+		{"foo:b123456789012345678901234567891", true},
+		{"foo:b1234567890123456789012345678912", true},
+		{"test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
+
+		{"root:", false},
+		{":root", false},
+		{"root::foo", false},
+		{"root:föö:bär", false},
+		{"foo:bar_bar", false},
+		{"foo:0", false},
+		{"foo:0bar", false},
+		{"foo/bar", false},
+		{"foo:bar-", false},
+		{"foo:-bar", false},
+		{"test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060-w:b1234567890123456789012345678912", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cluster, func(t *testing.T) {
+			if got := reClusterName.MatchString(tt.cluster); got != tt.valid {
+				t.Errorf("reCluster.MatchString(%q) = %v, want %v", tt.cluster, got, tt.valid)
+			}
+		})
+	}
+}

--- a/pkg/server/handler_test.go
+++ b/pkg/server/handler_test.go
@@ -17,85 +17,15 @@ limitations under the License.
 package server
 
 import (
-	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"sigs.k8s.io/yaml"
 )
-
-func TestClusterWorkspaceNamePattern(t *testing.T) {
-	_, fileName, _, _ := runtime.Caller(0)
-	bs, err := ioutil.ReadFile(filepath.Join(filepath.Dir(fileName), "..", "..", "config/crds/tenancy.kcp.dev_clusterworkspaces.yaml"))
-	require.NoError(t, err)
-	var crd apiextensionsv1.CustomResourceDefinition
-	err = yaml.Unmarshal(bs, &crd)
-	require.NoError(t, err)
-	require.Len(t, crd.Spec.Versions, 1, "crd should have exactly one version, update the test when this changes")
-
-	namePattern := crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["metadata"].Properties["name"].Pattern
-	require.True(t, strings.HasPrefix(namePattern, "^"), "cluster name pattern should end with $")
-	require.True(t, strings.HasSuffix(namePattern, "$"), "cluster name pattern should start with ^")
-
-	namePattern = strings.Trim(namePattern, "^$")
-	require.Equal(t, fmt.Sprintf("^(%s:)*%s$", namePattern, namePattern), reClusterName.String(), "logical cluster regex should match ClusterWorkspace name pattern")
-}
-
-func TestReCluster(t *testing.T) {
-	tests := []struct {
-		cluster string
-		valid   bool
-	}{
-		{"", false},
-
-		{"root", true},
-		{"root:foo", true},
-		{"root:foo:bar", true},
-
-		{"system", true},
-		{"system:foo", true},
-		{"system:foo:bar", true},
-
-		{"f", true},
-		{"foo", true},
-		{"foo:b", true},
-		{"foo:bar", true},
-		{"foo:bar0", true},
-		{"foo:bar-bar", true},
-		{"foo:b123456789012345678901234567891", true},
-		{"foo:b1234567890123456789012345678912", true},
-		{"test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
-
-		{"root:", false},
-		{":root", false},
-		{"root::foo", false},
-		{"root:föö:bär", false},
-		{"foo:bar_bar", false},
-		{"foo:0", false},
-		{"foo:0bar", false},
-		{"foo/bar", false},
-		{"foo:bar-", false},
-		{"foo:-bar", false},
-		{"test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060-w:b1234567890123456789012345678912", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.cluster, func(t *testing.T) {
-			if got := reClusterName.MatchString(tt.cluster); got != tt.valid {
-				t.Errorf("reCluster.MatchString(%q) = %v, want %v", tt.cluster, got, tt.valid)
-			}
-		})
-	}
-}
 
 func TestProcessResourceIdentity(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
It moves common HTTP handlers to a separate package.
Those handlers are used by the kcp-server and the cache-server.
Since we are going to run the cache from the kcp.
Importing will cause a cycle. 
Thus common functionality is moved to a common package.

## Related issue(s)

Fixes #
