### PR TITLE
:bug: *: split meta namespace keys correctly

### DIFF
--- a/pkg/admission/kubequota/kubequota_clusterworkspace_monitor.go
+++ b/pkg/admission/kubequota/kubequota_clusterworkspace_monitor.go
@@ -113,8 +113,13 @@ func (m *clusterWorkspaceDeletionMonitor) processNextWorkItem() bool {
 }
 
 func (m *clusterWorkspaceDeletionMonitor) process(key string) error {
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return nil
+	}
 	// e.g. root:org<separator>ws
-	parent, name := clusters.SplitClusterAwareKey(key)
+	parent, name := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	// turn it into root:org:ws
 	clusterName := parent.Join(name)

--- a/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
@@ -70,9 +70,15 @@ func NewApiExportIdentityProviderController(
 		FilterFunc: func(obj interface{}) bool {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err != nil {
+				runtime.HandleError(err)
 				return false
 			}
-			clusterName, _ := clusters.SplitClusterAwareKey(key)
+			_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+			if err != nil {
+				runtime.HandleError(err)
+				return false
+			}
+			clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 			return clusterName == tenancyv1alpha1.RootCluster
 		},
 		Handler: cache.ResourceEventHandlerFuncs{
@@ -86,6 +92,7 @@ func NewApiExportIdentityProviderController(
 		FilterFunc: func(obj interface{}) bool {
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err != nil {
+				runtime.HandleError(err)
 				return false
 			}
 			_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/reconciler/kubequota/kubequota_controller.go
+++ b/pkg/reconciler/kubequota/kubequota_controller.go
@@ -224,8 +224,13 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 // process processes a single key from the queue.
 func (c *Controller) process(ctx context.Context, key string) error {
 	logger := klog.FromContext(ctx)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return nil
+	}
 	// e.g. root:org<separator>ws
-	parent, name := clusters.SplitClusterAwareKey(key)
+	parent, name := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	// turn it into root:org:ws
 	clusterName := parent.Join(name)

--- a/pkg/reconciler/scheduling/location/location_controller.go
+++ b/pkg/reconciler/scheduling/location/location_controller.go
@@ -150,7 +150,12 @@ func (c *controller) enqueueSyncTarget(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	lcluster, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	lcluster, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 	domains, err := c.locationIndexer.ByIndex(byWorkspace, lcluster.String())
 	if err != nil {
 		runtime.HandleError(err)

--- a/pkg/reconciler/scheduling/placement/placement_controller.go
+++ b/pkg/reconciler/scheduling/placement/placement_controller.go
@@ -188,7 +188,12 @@ func (c *controller) enqueueNamespace(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	placements, err := c.placementIndexer.ByIndex(byWorkspace, clusterName.String())
 	if err != nil {
@@ -212,7 +217,12 @@ func (c *controller) enqueueLocation(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	placements, err := c.placementIndexer.ByIndex(byLocationWorkspace, clusterName.String())
 	if err != nil {

--- a/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_controller.go
@@ -157,7 +157,12 @@ func (c *Controller) enqueueShard(obj interface{}) {
 		}
 	}
 
-	_, name := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	_, name := clusters.SplitClusterAwareKey(clusterAwareName)
 	workspaces, err := c.workspaceIndexer.ByIndex(byCurrentShard, name)
 	if err != nil {
 		runtime.HandleError(err)
@@ -180,7 +185,12 @@ func (c *Controller) enqueueBinding(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 	if clusterName == tenancyv1alpha1.RootCluster {
 		return
 	}

--- a/pkg/reconciler/workload/namespace/namespace_controller.go
+++ b/pkg/reconciler/workload/namespace/namespace_controller.go
@@ -152,7 +152,12 @@ func (c *controller) enqueuePlacement(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	nss, err := c.namespaceIndexer.ByIndex(byWorkspace, clusterName.String())
 	if err != nil {

--- a/pkg/reconciler/workload/placement/placement_controller.go
+++ b/pkg/reconciler/workload/placement/placement_controller.go
@@ -167,7 +167,12 @@ func (c *controller) enqueueLocation(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	placements, err := c.placementIndexer.ByIndex(byLocationWorkspace, clusterName.String())
 	if err != nil {
@@ -198,7 +203,12 @@ func (c *controller) enqueueSyncTarget(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	placements, err := c.placementIndexer.ByIndex(byLocationWorkspace, clusterName.String())
 	if err != nil {

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -390,7 +390,12 @@ func (c *Controller) enqueueSyncTarget(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, name := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, name := clusters.SplitClusterAwareKey(clusterAwareName)
 	finalizer := syncershared.SyncerFinalizerNamePrefix + workloadv1alpha1.ToSyncTargetKey(clusterName, name)
 
 	listers, _ := c.ddsif.Listers()

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
@@ -136,7 +136,12 @@ func (c *APIReconciler) enqueueAPIResourceSchema(obj interface{}, logger logr.Lo
 		return
 	}
 
-	clusterName, name := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	clusterName, name := clusters.SplitClusterAwareKey(clusterAwareName)
 	exports, err := c.apiExportIndexer.ByIndex(byWorkspace, clusterName.String())
 	if err != nil {
 		runtime.HandleError(err)
@@ -226,7 +231,12 @@ func (c *APIReconciler) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (c *APIReconciler) process(ctx context.Context, key string) error {
-	clusterName, apiExportName := clusters.SplitClusterAwareKey(key)
+	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(err)
+		return nil
+	}
+	clusterName, apiExportName := clusters.SplitClusterAwareKey(clusterAwareName)
 	apiDomainKey := dynamiccontext.APIDomainKey(clusterName.String() + "/" + apiExportName)
 
 	logger := klog.FromContext(ctx).WithValues("apiDomainKey", apiDomainKey)


### PR DESCRIPTION
If we encode a key with MetaNamespaceKeyFunc, we must decode it with SplitMetaNamespaceKey, instead of assuming no namespace was encoded.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @sttts @ncdc 