### PR TITLE
:sparkles:  *: use cluster-aware keyfuncs & splitters 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.1.2
-	github.com/kcp-dev/apimachinery v0.0.0-20220819164220-dbb759406933
+	github.com/kcp-dev/apimachinery v0.0.0-20220912132244-efe716c18e43
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
-github.com/kcp-dev/apimachinery v0.0.0-20220819164220-dbb759406933 h1:32by2A7rpm3Vmu9sQwSZjOdCGRmG+PQOLuusgcRdF0k=
-github.com/kcp-dev/apimachinery v0.0.0-20220819164220-dbb759406933/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
+github.com/kcp-dev/apimachinery v0.0.0-20220912132244-efe716c18e43 h1:vPv81j3mT5VYQ6YnCXrnKJQPeRNHwPcGJNsQNQfIG9Q=
+github.com/kcp-dev/apimachinery v0.0.0-20220912132244-efe716c18e43/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
 github.com/kcp-dev/kubernetes v0.0.0-20220909115719-01e2c80c52f8 h1:QS6YI6io2tHV6EINrv+4abuyyzT3sNP8reEXHcbyWqQ=
 github.com/kcp-dev/kubernetes v0.0.0-20220909115719-01e2c80c52f8/go.mod h1:x3RxHGS2ZEGxxiakIQx3KJJJ9T5Q0DqFKWjIjIRSGCY=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20220909115719-01e2c80c52f8 h1:4yLR2soAQuFX3CXrAvsc+yDWlmETQBDeKt/iF1srPtY=

--- a/pkg/indexers/apiexport.go
+++ b/pkg/indexers/apiexport.go
@@ -19,9 +19,8 @@ package indexers
 import (
 	"fmt"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
-
-	"k8s.io/client-go/tools/clusters"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 )
@@ -44,7 +43,7 @@ func IndexAPIExportByIdentity(obj interface{}) ([]string, error) {
 }
 
 // IndexAPIExportBySecret is an index function that indexes an APIExport by its identity secret references. Index values
-// are of the form <secret reference namespace>/<cluster name><separator><secret reference name> (cache keys).
+// are of the form <cluster name>|<secret reference namespace>/<secret reference name> (cache keys).
 func IndexAPIExportBySecret(obj interface{}) ([]string, error) {
 	apiExport, ok := obj.(*apisv1alpha1.APIExport)
 	if !ok {
@@ -64,6 +63,5 @@ func IndexAPIExportBySecret(obj interface{}) ([]string, error) {
 		return []string{}, nil
 	}
 
-	// TODO(ncdc): use future shared key func if we ever create one
-	return []string{ref.Namespace + "/" + clusters.ToClusterAwareKey(logicalcluster.From(apiExport), ref.Name)}, nil
+	return []string{kcpcache.ToClusterAwareKey(logicalcluster.From(apiExport).String(), ref.Namespace, ref.Name)}, nil
 }

--- a/pkg/localenvoy/controllers/ingress/envoyingresscontroller.go
+++ b/pkg/localenvoy/controllers/ingress/envoyingresscontroller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	networkingv1 "k8s.io/api/networking/v1"
@@ -109,7 +110,7 @@ func (c *Controller) enqueue(obj interface{}) {
 	}
 
 	// Enqueue the key from obj (could be root or leaf)
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/localenvoy/controlplane/translator.go
+++ b/pkg/localenvoy/controlplane/translator.go
@@ -30,12 +30,12 @@ import (
 	cachetypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -67,7 +67,7 @@ func (t *translator) translateIngress(ingress *networkingv1.Ingress) ([]cachetyp
 	}
 
 	// TODO(jmprusi): HTTP2 is set to false always, also allow for configuration of the timeout
-	ingressKey, err := cache.MetaNamespaceKeyFunc(ingress)
+	ingressKey, err := kcpcache.MetaClusterNamespaceKeyFunc(ingress)
 	if err != nil {
 		klog.Errorf("Error getting key for ingress %s: %v", ingress.Name, err)
 		return nil, nil

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -203,7 +204,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 }
 
 func (c *Controller) enqueueShard(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/apis/apibinding/apibinding_controller.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
@@ -250,7 +251,7 @@ type controller struct {
 
 // enqueueAPIBinding enqueues an APIBinding .
 func (c *controller) enqueueAPIBinding(obj interface{}, logger logr.Logger, logSuffix string) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -262,7 +263,7 @@ func (c *controller) enqueueAPIBinding(obj interface{}, logger logr.Logger, logS
 
 // enqueueAPIExport enqueues maps an APIExport to APIBindings for enqueuing.
 func (c *controller) enqueueAPIExport(obj interface{}, logger logr.Logger, logSuffix string) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -312,7 +313,7 @@ func (c *controller) enqueueCRD(obj interface{}, logger logr.Logger) {
 
 // enqueueAPIResourceSchema maps an APIResourceSchema to APIExports for enqueuing.
 func (c *controller) enqueueAPIResourceSchema(obj interface{}, logger logr.Logger, logSuffix string) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -111,7 +112,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -173,7 +174,7 @@ type controller struct {
 
 // enqueueAPIBinding enqueues an APIExport .
 func (c *controller) enqueueAPIExport(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -193,7 +194,7 @@ func (c *controller) enqueueAllAPIExports(clusterWorkspaceShard interface{}) {
 
 	logger := logging.WithObject(logging.WithReconciler(klog.Background(), controllerName), clusterWorkspaceShard.(*tenancyv1alpha1.ClusterWorkspaceShard))
 	for i := range list {
-		key, err := cache.MetaNamespaceKeyFunc(list[i])
+		key, err := kcpcache.MetaClusterNamespaceKeyFunc(list[i])
 		if err != nil {
 			runtime.HandleError(err)
 			continue
@@ -205,7 +206,7 @@ func (c *controller) enqueueAllAPIExports(clusterWorkspaceShard interface{}) {
 }
 
 func (c *controller) enqueueSecret(obj interface{}) {
-	secretKey, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	secretKey, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/apis/apiresource/controller.go
+++ b/pkg/reconciler/apis/apiresource/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -232,7 +233,7 @@ func toQueueElementType(oldObj, obj interface{}) (theType queueElementType, gvr 
 }
 
 func (c *Controller) enqueue(action resourceHandlerAction, oldObj, obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/apis/apiresource/negotiation.go
+++ b/pkg/reconciler/apis/apiresource/negotiation.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"reflect"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	crdhelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
@@ -31,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
@@ -401,7 +401,7 @@ func (c *Controller) ensureAPIResourceCompatibility(ctx context.Context, cluster
 	} else {
 		crdName += gvr.Group
 	}
-	crdkey, err := cache.MetaNamespaceKeyFunc(&metav1.PartialObjectMetadata{
+	crdkey, err := kcpcache.MetaClusterNamespaceKeyFunc(&metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crdName,
 			Annotations: map[string]string{
@@ -548,7 +548,7 @@ func (c *Controller) ensureAPIResourceCompatibility(ctx context.Context, cluster
 			}
 		}
 		apiResourceImportUpdateStatusFuncs = append(apiResourceImportUpdateStatusFuncs, func() error {
-			key, err := cache.MetaNamespaceKeyFunc(apiResourceImport)
+			key, err := kcpcache.MetaClusterNamespaceKeyFunc(apiResourceImport)
 			if err != nil {
 				logger.Error(err, "error", "caller", runtime.GetCaller())
 				return err
@@ -665,7 +665,7 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 		AdditionalPrinterColumns: crColumnDefinitions,
 	}
 
-	crdKey, err := cache.MetaNamespaceKeyFunc(&metav1.PartialObjectMetadata{
+	crdKey, err := kcpcache.MetaClusterNamespaceKeyFunc(&metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crdName,
 			Annotations: map[string]string{
@@ -853,7 +853,7 @@ func (c *Controller) cleanupNegotiatedAPIResource(ctx context.Context, clusterNa
 		crdName += "." + gvr.Group
 	}
 
-	crdKey, err := cache.MetaNamespaceKeyFunc(&metav1.PartialObjectMetadata{
+	crdKey, err := kcpcache.MetaClusterNamespaceKeyFunc(&metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crdName,
 			Annotations: map[string]string{

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -95,7 +96,7 @@ type resourceController struct {
 func (c *resourceController) enqueueForResource(logger logr.Logger, gvr schema.GroupVersionResource, obj interface{}) {
 	queueKey := strings.Join([]string{gvr.Resource, gvr.Version, gvr.Group}, ".")
 
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/reconciler/tenancy/clusterworkspacedeletion/clusterworkspace_deletion_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspacedeletion/clusterworkspace_deletion_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -94,7 +95,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/tenancy/clusterworkspaceshard/clusterworkspaceshard_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspaceshard/clusterworkspaceshard_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -80,7 +81,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/tenancy/clusterworkspacetype/clusterworkspacetype_controller.go
+++ b/pkg/reconciler/tenancy/clusterworkspacetype/clusterworkspacetype_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -115,7 +116,7 @@ type controller struct {
 
 // enqueueClusterWorkspaceType enqueues a ClusterWorkspaceType.
 func (c *controller) enqueueClusterWorkspaceType(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -135,7 +136,7 @@ func (c *controller) enqueueAllClusterWorkspaceTypes(clusterWorkspaceShard inter
 
 	logger := logging.WithObject(logging.WithReconciler(klog.Background(), controllerName), clusterWorkspaceShard.(*tenancyv1alpha1.ClusterWorkspaceShard))
 	for i := range list {
-		key, err := cache.MetaNamespaceKeyFunc(list[i])
+		key, err := kcpcache.MetaClusterNamespaceKeyFunc(list[i])
 		if err != nil {
 			runtime.HandleError(err)
 			continue

--- a/pkg/reconciler/workload/apiexport/workload_apiexport_controller.go
+++ b/pkg/reconciler/workload/apiexport/workload_apiexport_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -158,7 +159,7 @@ func (c *controller) enqueueNegotiatedAPIResource(obj interface{}) {
 }
 
 func (c *controller) enqueueAPIExport(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/workload/apiexportcreate/apiexportcreate_controller.go
+++ b/pkg/reconciler/workload/apiexportcreate/apiexportcreate_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -162,17 +163,16 @@ type controller struct {
 
 // enqueue adds the logical cluster to the queue.
 func (c *controller) enqueue(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	clusterName, _, _, err := kcpcache.SplitMetaClusterNamespaceKey(key)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	key = clusterName.String()
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), controllerName), key)

--- a/pkg/reconciler/workload/basecontroller/controller.go
+++ b/pkg/reconciler/workload/basecontroller/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -127,7 +128,7 @@ type queueAdapter struct {
 }
 
 func (a queueAdapter) EnqueueAfter(cl *workloadv1alpha1.SyncTarget, dur time.Duration) {
-	key, err := cache.MetaNamespaceKeyFunc(cl)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(cl)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -146,7 +147,7 @@ type ClusterReconciler struct {
 }
 
 func (c *ClusterReconciler) enqueue(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/workload/defaultplacement/defaultplacement_controller.go
+++ b/pkg/reconciler/workload/defaultplacement/defaultplacement_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -114,17 +115,16 @@ type controller struct {
 
 // enqueue adds the logical cluster to the queue.
 func (c *controller) enqueue(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	clusterName, _, _, err := kcpcache.SplitMetaClusterNamespaceKey(key)
 	if err != nil {
 		runtime.HandleError(err)
 		return
 	}
-	clusterName, _ := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), controllerName), clusterName.String())
 	if logObj, ok := obj.(logging.Object); ok {

--- a/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_controller.go
+++ b/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_controller.go
@@ -23,6 +23,8 @@ import (
 	"os/signal"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,7 +95,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_reconcile.go
+++ b/pkg/reconciler/workload/deploymentsplitter/deploymentsplitter_reconcile.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
@@ -117,7 +117,7 @@ func (c *Controller) reconcile(ctx context.Context, deployment *appsv1.Deploymen
 
 		if _, err := c.client.Deployments(rootDeployment.Namespace).UpdateStatus(ctx, rootDeployment, metav1.UpdateOptions{}); err != nil {
 			if errors.IsConflict(err) {
-				key, err := cache.MetaNamespaceKeyFunc(deployment)
+				key, err := kcpcache.MetaClusterNamespaceKeyFunc(deployment)
 				if err != nil {
 					return err
 				}

--- a/pkg/reconciler/workload/ingresssplitter/ingresssplitter_controller.go
+++ b/pkg/reconciler/workload/ingresssplitter/ingresssplitter_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
@@ -134,7 +135,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -237,7 +238,7 @@ func (c *Controller) ingressesFromService(obj interface{}) {
 	logger := logging.WithReconciler(klog.Background(), controllerName)
 	service := obj.(*corev1.Service)
 
-	serviceKey, err := cache.MetaNamespaceKeyFunc(service)
+	serviceKey, err := kcpcache.MetaClusterNamespaceKeyFunc(service)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/workload/ingresssplitter/tracker.go
+++ b/pkg/reconciler/workload/ingresssplitter/tracker.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"sync"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/logging"
@@ -67,13 +68,13 @@ func (t *tracker) add(ctx context.Context, ingress *networkingv1.Ingress, s *cor
 
 	logger.Info("tracking Service")
 
-	ingressKey, err := k8scache.MetaNamespaceKeyFunc(ingress)
+	ingressKey, err := kcpcache.MetaClusterNamespaceKeyFunc(ingress)
 	if err != nil {
 		logger.Error(err, "failed to get Ingress key")
 		return
 	}
 
-	serviceKey, err := k8scache.MetaNamespaceKeyFunc(s)
+	serviceKey, err := kcpcache.MetaClusterNamespaceKeyFunc(s)
 	if err != nil {
 		logger.Error(err, "failed to get Service key")
 		return

--- a/pkg/reconciler/workload/ingresssplitter/tracker_test.go
+++ b/pkg/reconciler/workload/ingresssplitter/tracker_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +28,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/clusters"
 )
 
 func TestTracker(t *testing.T) {
@@ -57,9 +57,7 @@ func TestTracker(t *testing.T) {
 		}
 	}
 
-	key := func(cluster logicalcluster.Name, ns, name string) string {
-		return ns + "/" + clusters.ToClusterAwareKey(cluster, name)
-	}
+	key := kcpcache.ToClusterAwareKey
 
 	// Set up 4 ingresses and 2 services
 	tracker.add(context.TODO(), newIngress("cluster1", "ns1", "i1"), newService("cluster1", "ns1", "s1"))
@@ -68,21 +66,21 @@ func TestTracker(t *testing.T) {
 	tracker.add(context.TODO(), newIngress("cluster1", "ns1", "i4"), newService("cluster1", "ns1", "s2"))
 
 	// Validate for both services
-	require.ElementsMatch(t, sets.NewString(key(logicalcluster.New("cluster1"), "ns1", "i1"), key(logicalcluster.New("cluster1"), "ns1", "i2")).List(), tracker.getIngressesForService(key(logicalcluster.New("cluster1"), "ns1", "s1")).List())
-	require.ElementsMatch(t, sets.NewString(key(logicalcluster.New("cluster1"), "ns1", "i3"), key(logicalcluster.New("cluster1"), "ns1", "i4")).List(), tracker.getIngressesForService(key(logicalcluster.New("cluster1"), "ns1", "s2")).List())
+	require.ElementsMatch(t, sets.NewString(key("cluster1", "ns1", "i1"), key("cluster1", "ns1", "i2")).List(), tracker.getIngressesForService(key("cluster1", "ns1", "s1")).List())
+	require.ElementsMatch(t, sets.NewString(key("cluster1", "ns1", "i3"), key("cluster1", "ns1", "i4")).List(), tracker.getIngressesForService(key("cluster1", "ns1", "s2")).List())
 
 	// Add an ingress/service pair that already exists & make sure it doesn't show up more than once
 	tracker.add(context.TODO(), newIngress("cluster1", "ns1", "i1"), newService("cluster1", "ns1", "s1"))
-	require.ElementsMatch(t, sets.NewString(key(logicalcluster.New("cluster1"), "ns1", "i1"), key(logicalcluster.New("cluster1"), "ns1", "i2")).List(), tracker.getIngressesForService(key(logicalcluster.New("cluster1"), "ns1", "s1")).List())
+	require.ElementsMatch(t, sets.NewString(key("cluster1", "ns1", "i1"), key("cluster1", "ns1", "i2")).List(), tracker.getIngressesForService(key("cluster1", "ns1", "s1")).List())
 
 	// Delete 1 ingress associated with 1 service & validate
-	tracker.deleteIngress(key(logicalcluster.New("cluster1"), "ns1", "i1"))
-	require.ElementsMatch(t, sets.NewString(key(logicalcluster.New("cluster1"), "ns1", "i2")).List(), tracker.getIngressesForService(key(logicalcluster.New("cluster1"), "ns1", "s1")).List())
+	tracker.deleteIngress(key("cluster1", "ns1", "i1"))
+	require.ElementsMatch(t, sets.NewString(key("cluster1", "ns1", "i2")).List(), tracker.getIngressesForService(key("cluster1", "ns1", "s1")).List())
 
 	// Deleting remaining ingress for service & validate
-	tracker.deleteIngress(key(logicalcluster.New("cluster1"), "ns1", "i2"))
-	require.ElementsMatch(t, sets.NewString().List(), tracker.getIngressesForService(key(logicalcluster.New("cluster1"), "ns1", "s1")).List())
+	tracker.deleteIngress(key("cluster1", "ns1", "i2"))
+	require.ElementsMatch(t, sets.NewString().List(), tracker.getIngressesForService(key("cluster1", "ns1", "s1")).List())
 
 	// Make sure delete for a nonexistent ingress is ok
-	tracker.deleteIngress(key(logicalcluster.New("cluster1"), "ns1", "404"))
+	tracker.deleteIngress(key("cluster1", "ns1", "404"))
 }

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -25,7 +25,6 @@ import (
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
-	"k8s.io/client-go/tools/clusters"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +39,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 

--- a/pkg/reconciler/workload/synctarget/synctarget_controller.go
+++ b/pkg/reconciler/workload/synctarget/synctarget_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,7 +86,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueueSyncTarget(obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -99,7 +100,7 @@ func (c *Controller) enqueueSyncTarget(obj interface{}) {
 func (c *Controller) enqueueWorkspaceShard(obj interface{}) {
 	logger := logging.WithObject(logging.WithReconciler(klog.Background(), controllerName), obj.(*tenancyv1alpha1.ClusterWorkspaceShard))
 	for _, syncTarget := range c.syncTargetIndexer.List() {
-		key, err := cache.MetaNamespaceKeyFunc(syncTarget)
+		key, err := kcpcache.MetaClusterNamespaceKeyFunc(syncTarget)
 		if err != nil {
 			runtime.HandleError(err)
 			return

--- a/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go
+++ b/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -155,7 +156,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueueSyncTarget(obj interface{}, logSuffix string) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -180,7 +181,7 @@ func (c *Controller) enqueueAPIResourceImport(obj interface{}) {
 }
 
 func (c *Controller) enqueueAPIExport(obj interface{}, logSuffix string) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -199,7 +200,7 @@ func (c *Controller) enqueueAPIExport(obj interface{}, logSuffix string) {
 
 // enqueueAPIResourceSchema maps an APIResourceSchema to APIExports for enqueuing.
 func (c *Controller) enqueueAPIResourceSchema(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/syncer/apiimporter.go
+++ b/pkg/syncer/apiimporter.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -214,7 +215,7 @@ func (i *APIImporter) ImportAPIs(ctx context.Context) {
 				apiResourceImportName += gvr.Group
 			}
 
-			clusterKey, err := cache.MetaNamespaceKeyFunc(&metav1.PartialObjectMetadata{
+			clusterKey, err := kcpcache.MetaClusterNamespaceKeyFunc(&metav1.PartialObjectMetadata{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: i.location,
 					Annotations: map[string]string{

--- a/pkg/syncer/namespace/namespace_upstream_controller.go
+++ b/pkg/syncer/namespace/namespace_upstream_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,7 +125,7 @@ func NewUpstreamController(
 }
 
 func (c *UpstreamController) AddToQueue(obj interface{}, logger logr.Logger) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/syncer/namespace/namespace_upstream_process.go
+++ b/pkg/syncer/namespace/namespace_upstream_process.go
@@ -19,10 +19,10 @@ package namespace
 import (
 	"context"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
@@ -30,12 +30,11 @@ import (
 
 func (c *UpstreamController) process(ctx context.Context, key string) error {
 	logger := klog.FromContext(ctx)
-	_, clusterAwareName, err := cache.SplitMetaNamespaceKey(key)
+	clusterName, _, namespaceName, err := kcpcache.SplitMetaClusterNamespaceKey(key)
 	if err != nil {
 		logger.Error(err, "invalid key")
 		return nil
 	}
-	clusterName, namespaceName := clusters.SplitClusterAwareKey(clusterAwareName)
 
 	exists, err := c.upstreamNamespaceExists(clusterName, namespaceName)
 	if err != nil {

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -189,7 +190,7 @@ type queueKey struct {
 }
 
 func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)
 		return

--- a/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_controller.go
+++ b/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -144,7 +145,7 @@ type APIReconciler struct {
 }
 
 func (c *APIReconciler) enqueueSyncTarget(obj interface{}, logger logr.Logger, logSuffix string) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -155,7 +156,7 @@ func (c *APIReconciler) enqueueSyncTarget(obj interface{}, logger logr.Logger, l
 }
 
 func (c *APIReconciler) enqueueAPIExport(obj interface{}, logger logr.Logger, logSuffix string) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -175,7 +176,7 @@ func (c *APIReconciler) enqueueAPIExport(obj interface{}, logger logr.Logger, lo
 
 // enqueueAPIResourceSchema maps an APIResourceSchema to APIExports for enqueuing.
 func (c *APIReconciler) enqueueAPIResourceSchema(obj interface{}, logger logr.Logger) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/virtual/workspaces/authorization/cache.go
+++ b/pkg/virtual/workspaces/authorization/cache.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -277,7 +279,7 @@ func (ac *AuthorizationCache) synchronizeWorkspaces(userSubjectRecordStore cache
 	}
 	for i := range workspaces {
 		workspace := workspaces[i]
-		workspaceKey, err := cache.MetaNamespaceKeyFunc(workspace)
+		workspaceKey, err := kcpcache.MetaClusterNamespaceKeyFunc(workspace)
 		if err != nil {
 			klog.Warning(err)
 		}

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -211,7 +212,7 @@ func ExpectClusterWorkspaces(ctx context.Context, t *testing.T, client kcpclient
 		return nil, errors.New("failed to wait for caches to sync")
 	}
 	return func(seed *tenancyv1alpha1.ClusterWorkspace, expectation ClusterWorkspaceExpectation) error {
-		key, err := cache.MetaNamespaceKeyFunc(seed)
+		key, err := kcpcache.MetaClusterNamespaceKeyFunc(seed)
 		if err != nil {
 			return err
 		}
@@ -242,7 +243,7 @@ func ExpectWorkspaceShards(ctx context.Context, t *testing.T, client kcpclient.I
 		return nil, errors.New("failed to wait for caches to sync")
 	}
 	return func(seed *tenancyv1alpha1.ClusterWorkspaceShard, expectation WorkspaceShardExpectation) error {
-		key, err := cache.MetaNamespaceKeyFunc(seed)
+		key, err := kcpcache.MetaClusterNamespaceKeyFunc(seed)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -140,11 +140,13 @@ func TestClusterController(t *testing.T) {
 					return true
 				}, wait.ForeverTestTimeout, time.Millisecond*100, "expected source to show status change")
 
+				t.Logf("Deleting object in the source")
 				err = servers[sourceClusterName].client.Cowboys(testNamespace).Delete(ctx, cowboy.Name, metav1.DeleteOptions{})
 				require.NoError(t, err, "error deleting source cowboy")
 
 				// TODO(ncdc): the expect code for cowboys currently expects the cowboy to exist. See if we can adjust it
 				// so we can reuse that here instead of polling.
+				t.Logf("Expecting the object in the sink to be deleted")
 				require.Eventually(t, func() bool {
 					_, err := servers[sinkClusterName].client.Cowboys(targetNamespace).Get(ctx, cowboy.Name, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)


### PR DESCRIPTION
go.mod: use newest kcp-dev/apimachinery

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: use cluster-aware keyfuncs & splitters

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


Part of #209 
Generated with https://github.com/kcp-dev/code-generator/pull/53

/assign @ncdc @sttts 