### PR TITLE
:seedling: cache: exposes the cache-server under "/services/cache" path

### DIFF
--- a/docs/cache-server.md
+++ b/docs/cache-server.md
@@ -98,7 +98,7 @@ That means the schema is implicit, maintained, and enforced by the shards pushin
 
 The server exposes the following path:
 
-`/shards/{shard-name}/clusters/{cluster-name}/apis/group/version/namespaces/{namespace-name}/resource/{resource-name}`
+`/services/cache/shards/{shard-name}/clusters/{cluster-name}/apis/group/version/namespaces/{namespace-name}/resource/{resource-name}`
 
 Parameters:
 
@@ -112,11 +112,11 @@ Parameters:
 
 For example:
 
-`/shards/*/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports`: for listing apiexports for all shards and clusters
+`/services/cache/shards/*/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports`: for listing apiexports for all shards and clusters
 
-`/shards/amber/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports`: for listing apiexports for amber shard for all clusters
+`/services/cache/shards/amber/clusters/*/apis/apis.kcp.dev/v1alpha1/apiexports`: for listing apiexports for amber shard for all clusters
 
-`/shards/sapphire/clusters/system:sapphire/apis/apis.kcp.dev/v1alpha1/apiexports`: for listing apiexports for sapphire shard stored in system:sapphire cluster
+`/services/cache/shards/sapphire/clusters/system:sapphire/apis/apis.kcp.dev/v1alpha1/apiexports`: for listing apiexports for sapphire shard stored in system:sapphire cluster
 
 #### On the storage layer
 

--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -136,6 +136,7 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 		apiHandler = filters.WithAuditEventClusterAnnotation(apiHandler)
 		apiHandler = filters.WithClusterScope(apiHandler)
 		apiHandler = WithShardScope(apiHandler)
+		apiHandler = WithServiceScope(apiHandler)
 		return apiHandler
 	}
 
@@ -158,7 +159,8 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions) (*Config, error) {
 	// an ordered list of HTTP round trippers that add
 	// shard and cluster awareness to all clients that use
 	// the loopback config.
-	rt := cacheclient.WithShardNameFromContextRoundTripper(serverConfig.LoopbackClientConfig)
+	rt := cacheclient.WithCacheServiceRoundTripper(serverConfig.LoopbackClientConfig)
+	rt = cacheclient.WithShardNameFromContextRoundTripper(rt)
 	rt = cacheclient.WithDefaultShardRoundTripper(rt, shard.Wildcard)
 	rt = cacheclient.WithShardNameFromObjectRoundTripper(
 		rt,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
We already have `services/apiexports` for accessing resources exposed by the VW server. 
This PR adds `/services/cache` for accessing resources hosted on the cache-server.
Thanks to that the same path will be exposed no matter if the cache-server is running in a standalone mode or in-process with the kcp-server.

## Related issue(s)

Fixes #
