### PR TITLE
:bug: syncer: bifurcate the namespace controller

### DIFF
--- a/pkg/syncer/namespace/namespace_downstream_controller.go
+++ b/pkg/syncer/namespace/namespace_downstream_controller.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/third_party/keyfunctions"
+)
+
+const (
+	controllerNameRoot       = "kcp-workload-syncer-namespace"
+	downstreamControllerName = controllerNameRoot + "-downstream"
+)
+
+type DownstreamController struct {
+	queue workqueue.RateLimitingInterface
+
+	deleteDownstreamNamespace func(ctx context.Context, namespace string) error
+	upstreamNamespaceExists   func(clusterName logicalcluster.Name, upstreamNamespaceName string) (bool, error)
+	getDownstreamNamespace    func(name string) (runtime.Object, error)
+
+	syncTargetName      string
+	syncTargetWorkspace logicalcluster.Name
+	syncTargetUID       types.UID
+	syncTargetKey       string
+}
+
+func NewDownstreamController(
+	syncTargetWorkspace logicalcluster.Name,
+	syncTargetName, syncTargetKey string,
+	syncTargetUID types.UID,
+	downstreamClient dynamic.Interface,
+	upstreamInformers, downstreamInformers dynamicinformer.DynamicSharedInformerFactory,
+) (*DownstreamController, error) {
+	namespaceGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	logger := logging.WithReconciler(klog.Background(), downstreamControllerName)
+
+	c := DownstreamController{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), downstreamControllerName),
+
+		deleteDownstreamNamespace: func(ctx context.Context, namespace string) error {
+			return downstreamClient.Resource(namespaceGVR).Delete(ctx, namespace, metav1.DeleteOptions{})
+		},
+		upstreamNamespaceExists: func(clusterName logicalcluster.Name, upstreamNamespaceName string) (bool, error) {
+			upstreamNamespaceKey := clusters.ToClusterAwareKey(clusterName, upstreamNamespaceName)
+			_, exists, err := upstreamInformers.ForResource(namespaceGVR).Informer().GetIndexer().GetByKey(upstreamNamespaceKey)
+			return exists, err
+		},
+		getDownstreamNamespace: func(downstreamNamespaceName string) (runtime.Object, error) {
+			return downstreamInformers.ForResource(namespaceGVR).Lister().Get(downstreamNamespaceName)
+		},
+
+		syncTargetName:      syncTargetName,
+		syncTargetWorkspace: syncTargetWorkspace,
+		syncTargetUID:       syncTargetUID,
+		syncTargetKey:       syncTargetKey,
+	}
+
+	// Those handlers are for start/resync cases, in case a namespace deletion event is missed, these handlers
+	// will make sure that we cleanup the namespace in downstream after restart/resync.
+	downstreamInformers.ForResource(namespaceGVR).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.AddToQueue(obj, logger)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.AddToQueue(newObj, logger)
+		},
+	})
+
+	logger.V(2).Info("Set up downstream namespace informer", "syncTargetWorkspace", syncTargetWorkspace, "syncTargetName", syncTargetName, "syncTargetKey", syncTargetKey)
+
+	return &c, nil
+}
+
+func (c *DownstreamController) AddToQueue(obj interface{}, logger logr.Logger) {
+	key, err := keyfunctions.DeletionHandlingMetaNamespaceKeyFunc(obj) // note: this is *not* a cluster-aware key
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	logger.V(4).Info("queueing namespace", "key", key)
+	c.queue.Add(key)
+}
+
+// Start starts N worker processes processing work items.
+func (c *DownstreamController) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), downstreamControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *DownstreamController) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *DownstreamController) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	namespaceKey := key.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), namespaceKey)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, namespaceKey); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", downstreamControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}

--- a/pkg/syncer/namespace/namespace_downstream_process.go
+++ b/pkg/syncer/namespace/namespace_downstream_process.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+func (c *DownstreamController) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+	_, namespaceName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "invalid key")
+		return nil
+	}
+
+	downstreamNamespaceObj, err := c.getDownstreamNamespace(namespaceName)
+	if apierrors.IsNotFound(err) {
+		logger.V(4).Info("downstream namespace not found, ignoring key", "namespace", namespaceName)
+		return nil
+	} else if err != nil {
+		logger.Error(err, "failed to get downstream namespace", "namespace", namespaceName)
+		return nil
+	}
+
+	downstreamNamespace := downstreamNamespaceObj.(*unstructured.Unstructured)
+	logger = logging.WithObject(logger, downstreamNamespace)
+
+	namespaceLocatorJSON := downstreamNamespace.GetAnnotations()[shared.NamespaceLocatorAnnotation]
+	if namespaceLocatorJSON == "" {
+		logger.Error(nil, "downstream namespace has no namespaceLocator annotation")
+		return nil
+	}
+
+	nsLocator := shared.NamespaceLocator{}
+	if err := json.Unmarshal([]byte(namespaceLocatorJSON), &nsLocator); err != nil {
+		logger.Error(err, "failed to unmarshal namespace locator", "namespaceLocator", namespaceLocatorJSON)
+		return nil
+	}
+	logger = logger.WithValues("upstreamWorkspace", nsLocator.Workspace, "upstreamNamespace", nsLocator.Namespace)
+	exists, err := c.upstreamNamespaceExists(nsLocator.Workspace, nsLocator.Namespace)
+	if err != nil {
+		logger.Error(err, "failed to check if upstream namespace exists")
+		return nil
+	}
+	if !exists {
+		logger.Info("deleting downstream namespace because the upstream namespace doesn't exist")
+		return c.deleteDownstreamNamespace(ctx, namespaceName)
+	}
+	// The upstream namespace still exists, nothing to do.
+	return nil
+}

--- a/pkg/syncer/namespace/namespace_upstream_process_test.go
+++ b/pkg/syncer/namespace/namespace_upstream_process_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clusters"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+func TestSyncerNamespaceUpstreamProcess(t *testing.T) {
+	tests := map[string]struct {
+		upstreamNamespaceExists bool
+		deletedNamespace        string
+
+		upstreamNamespaceExistsError                    error
+		getDownstreamNamespaceError                     error
+		getDownstreamNamespaceFromNamespaceLocatorError error
+
+		eventOrigin string // upstream or downstream
+	}{
+		"NamespaceSyncer remove downstream namespace when upstream namespace has been deleted, expect downstream namespace deletion": {
+			upstreamNamespaceExists: false,
+			deletedNamespace:        "kcp-hcbsa8z6c2er",
+			eventOrigin:             "upstream",
+		},
+		"NamespaceSyncer, upstream event, no deletion as there is a matching upstream namespace, expect no namespace deletion": {
+			upstreamNamespaceExists: true,
+			deletedNamespace:        "",
+			eventOrigin:             "upstream",
+		},
+		"NamespaceSyncer, upstream event, error trying to get the upstream namespace, expect no namespace deletion": {
+			upstreamNamespaceExistsError: errors.New("error"),
+			deletedNamespace:             "",
+			eventOrigin:                  "upstream",
+		},
+		"NamespaceSyncer, upstream event, error trying to get the downstream namespace, expect no namespace deletion": {
+			getDownstreamNamespaceError:                     errors.New("error"),
+			getDownstreamNamespaceFromNamespaceLocatorError: errors.New("error"),
+			deletedNamespace:                                "",
+			eventOrigin:                                     "upstream",
+		},
+		"NamespaceSyncer, upstream event, downstream namespace is not found, expect no namespace deletion": {
+			getDownstreamNamespaceError:                     apierrors.NewNotFound(schema.GroupResource(metav1.GroupResource{Group: "", Resource: ""}), "not-found"),
+			getDownstreamNamespaceFromNamespaceLocatorError: apierrors.NewNotFound(schema.GroupResource(metav1.GroupResource{Group: "", Resource: ""}), "not-found"),
+			deletedNamespace:                                "",
+			eventOrigin:                                     "upstream",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			downstreamNamespace := namespace(logicalcluster.New(""), "kcp-hcbsa8z6c2er", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+			}, map[string]string{
+				"kcp.dev/namespace-locator": `{"syncTarget":{"workspace":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"workspace":"root:org:ws","namespace":"test"}`,
+			})
+			syncTargetWorkspace := logicalcluster.New("root:org:ws")
+			syncTargetName := "us-west1"
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(syncTargetWorkspace, syncTargetName)
+			deletedNamespace := ""
+
+			nsController := UpstreamController{
+				deleteDownstreamNamespace: func(ctx context.Context, downstreamNamespaceName string) error {
+					deletedNamespace = downstreamNamespaceName
+					return nil
+				},
+				upstreamNamespaceExists: func(clusterName logicalcluster.Name, upstreamNamespaceName string) (bool, error) {
+					return tc.upstreamNamespaceExists, tc.upstreamNamespaceExistsError
+				},
+				getDownstreamNamespaceFromNamespaceLocator: func(namespaceLocator shared.NamespaceLocator) (runtime.Object, error) {
+					nsJSON, _ := json.Marshal(downstreamNamespace)
+					unstructured := &unstructured.Unstructured{}
+					_ = json.Unmarshal(nsJSON, unstructured)
+					return unstructured, tc.getDownstreamNamespaceFromNamespaceLocatorError
+				},
+				syncTargetName:      syncTargetName,
+				syncTargetWorkspace: syncTargetWorkspace,
+				syncTargetUID:       types.UID("syncTargetUID"),
+				syncTargetKey:       syncTargetKey,
+			}
+
+			var key string
+			if tc.eventOrigin == "downstream" {
+				key = downstreamNamespace.GetName()
+			} else if tc.eventOrigin == "upstream" {
+				key = clusters.ToClusterAwareKey(logicalcluster.New("root:org:ws"), "test")
+			} else {
+				t.Fatalf("unexpected event origin: %s", tc.eventOrigin)
+			}
+
+			err := nsController.process(ctx, key)
+			require.NoError(t, err)
+			require.Equal(t, tc.deletedNamespace, deletedNamespace)
+		})
+	}
+}


### PR DESCRIPTION
Today, one controller/workqueue is used to drive two separate reconciliation flows: reacting to events in the upstream and downstream informers. The presence of a cluster in the queue key is used to infer which informers the event came from.

This is hard to reason about, and the logic for the two cases is entirely separate, and, furthermore, when we're syncing to a kcp logical cluster, the "downstream" objects have a cluster set and the keys do not follow the expected format.

Instead of inferring things from stringified keys in one queue, we can just split the two controllers and explicitly use cluster-aware or cluster-unaware keyfunctions where necessary.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Needed for #1958 
/assign @jmprusi 
/cc @ncdc 