### PR TITLE
:seedling: ci: don't use a local registry with kind for syncer e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,10 @@ jobs:
           go-version: v1.18
       - run: make build
 
-      # Install kind with a local registry
       - uses: container-tools/kind-action@v1
-        name: Kubernetes KinD Cluster w/local registry
+        name: Kubernetes KinD Cluster
+        with:
+          registry: false
 
       - run: |-
           go install github.com/google/ko@latest
@@ -64,9 +65,10 @@ jobs:
         go-version: v1.18
     - run: make build
 
-    # Install kind with a local registry
     - uses: container-tools/kind-action@v1
-      name: Kubernetes KinD Cluster w/local registry
+      name: Kubernetes KinD Cluster
+      with:
+        registry: false
 
     - run: |-
         go install github.com/google/ko@latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,20 @@ Then, to have your test use that shared kcp server, you add `-args --use-default
 ```shell
 go test ./test/e2e/apibinding -count 20 -failfast -args --use-default-kcp-server
 ```
+
+Syncer e2e tests in mode 1 have an additional option - by default, they run an in-process syncer against a logical
+cluster. However, with `make test-e2e-shared` they instead run the syncer on a physical cluster by supplying a
+kubeconfig for that cluster using the `--pcluster-kubeconfig` argument. Additionally, the syncer image and a test image
+are made available to that physical cluster and supplied to the tests via `--syncer-image` and `--kcp-test-image`.
+
+```shell
+make build-kind-images
+kind get kubeconfig > .kcp/kind.kubeconfig
+go test ./test/e2e/syncer -args --use-default-kcp-server --pcluster-kubeconfig=$(pwd)/.kcp/kind.kubeconfig \
+                                --syncer-image=kind.local/syncer-c2e307... \
+                                --kcp-test-image=kind.local/kcp-test-image-7d34ff7...
+```
+
 ## Community Roles
 
 ### Reviewers

--- a/docs/syncer.md
+++ b/docs/syncer.md
@@ -91,16 +91,15 @@ users have to install a special component named [syncer](https://github.com/kcp-
 
 ## For syncer development
 
-### Running in a kind cluster with a local registry
+### Running in a kind cluster using a locally built image
 
-You can run the syncer in a kind cluster for development.
+You can run the syncer using a locally built image in a kind cluster for development.
 
-1. Create a `kind` cluster with a local registry to simplify syncer development
-   by executing the following script:
+1. Create a `kind` cluster
 
-   ```bash
-   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/kubernetes-sigs/kind/main/site/static/examples/kind-with-registry.sh)"
-   ```
+    ```sh
+    kind create cluster
+    ```
 
 1. Install `ko`:
 
@@ -108,10 +107,10 @@ You can run the syncer in a kind cluster for development.
     go install github.com/google/ko@latest
     ```
 
-1. Build image and push to the local registry integrated with `kind`:
+1. Build image and push to the kind cluster:
 
     ```sh
-    KO_DOCKER_REPO=localhost:5001 ko publish ./cmd/syncer -t <image tag>
+    KO_DOCKER_REPO=kind.local ko publish ./cmd/syncer
     ```
 
     By default `ko` will build for `amd64`. To build for `arm64`
@@ -126,12 +125,12 @@ You can run the syncer in a kind cluster for development.
     Current workspace is "root:my-org" (type "root:organization").
     ```
 
-1. To use the image pushed to the local registry, supply `<image name>` to the
+1. To use the image pushed to the kind cluster, supply `<image name>` to the
    `kcp workload sync` plugin command, where `<image name>` is
    from the output of `ko publish`:
 
     ```sh
-    kubectl kcp workload sync <mycluster> --syncer-image <image name> -o syncer.yaml
+    kubectl kcp workload sync <mycluster> --syncer-image kind.local/syncer-<image hash> -o syncer.yaml
     ```
 
 1. Apply the manifest to the p-cluster:


### PR DESCRIPTION
For test-e2e-shared and test-e2e-sharded, we need a kind cluster and for our images (syncer, test-image) to be available from that cluster.

In github, we use the container-tools/kind-action to set up this kind cluster, which also sets up a local registry by default and configures the kind cluster to use it.

It turns out, if you want to reproduce this in your dev environment, you don't need to have this local registry setup because ko will happily side-load the image into the kind node. This seems pretty convenient.

Since the local registry isn't necessary, and probably not what you want when developing, let's not use it in CI for consistency.

See:
https://github.com/container-tools/kind-action/blob/main/registry.sh https://github.com/ko-build/ko/blob/main/pkg/publish/kind/write.go
