### PR TITLE
🌱 authorisation: stop using the ValidClusterFrom method

### DIFF
--- a/pkg/authorization/local_authorizer.go
+++ b/pkg/authorization/local_authorizer.go
@@ -66,16 +66,13 @@ func (a *LocalAuthorizer) RulesFor(user user.Info, namespace string) ([]authoriz
 }
 
 func (a *LocalAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	cluster, err := genericapirequest.ValidClusterFrom(ctx)
-	if err != nil {
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster == nil || cluster.Name.Empty() {
 		kaudit.AddAuditAnnotations(
 			ctx,
 			LocalAuditDecision, DecisionNoOpinion,
-			LocalAuditReason, fmt.Sprintf("error getting cluster from request: %v", err),
+			LocalAuditReason, "empty cluster name",
 		)
-		return authorizer.DecisionNoOpinion, "", err
-	}
-	if cluster == nil || cluster.Name.Empty() {
 		return authorizer.DecisionNoOpinion, "", nil
 	}
 

--- a/pkg/authorization/system_crd_authorizer.go
+++ b/pkg/authorization/system_crd_authorizer.go
@@ -18,7 +18,6 @@ package authorization
 
 import (
 	"context"
-	"fmt"
 
 	kaudit "k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -45,15 +44,7 @@ func NewSystemCRDAuthorizer(delegate authorizer.Authorizer) authorizer.Authorize
 }
 
 func (a *SystemCRDAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	cluster, err := genericapirequest.ValidClusterFrom(ctx)
-	if err != nil {
-		kaudit.AddAuditAnnotations(
-			ctx,
-			SystemCRDAuditDecision, DecisionNoOpinion,
-			SystemCRDAuditReason, fmt.Sprintf("error getting cluster from request: %v", err),
-		)
-		return authorizer.DecisionNoOpinion, "", err
-	}
+	cluster := genericapirequest.ClusterFrom(ctx)
 	if cluster == nil || cluster.Name.Empty() {
 		kaudit.AddAuditAnnotations(
 			ctx,

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -86,14 +86,14 @@ func (a *topLevelOrgAccessAuthorizer) Authorize(ctx context.Context, attr author
 		return a.delegate.Authorize(ctx, attr)
 	}
 
-	cluster, err := genericapirequest.ValidClusterFrom(ctx)
-	if err != nil || cluster == nil || cluster.Name.Empty() {
+	cluster := genericapirequest.ClusterFrom(ctx)
+	if cluster == nil || cluster.Name.Empty() {
 		kaudit.AddAuditAnnotations(
 			ctx,
 			TopLevelContentAuditDecision, DecisionNoOpinion,
-			TopLevelContentAuditReason, fmt.Sprintf("error getting cluster from request: %v", err),
+			TopLevelContentAuditReason, "empty cluster name",
 		)
-		return authorizer.DecisionNoOpinion, WorkspaceAccessNotPermittedReason, err
+		return authorizer.DecisionNoOpinion, WorkspaceAccessNotPermittedReason, nil
 	}
 
 	if !cluster.Name.HasPrefix(tenancyv1alpha1.RootCluster) {

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -82,15 +82,7 @@ type workspaceContentAuthorizer struct {
 }
 
 func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-	cluster, err := genericapirequest.ValidClusterFrom(ctx)
-	if err != nil {
-		kaudit.AddAuditAnnotations(
-			ctx,
-			WorkspaceContentAuditDecision, DecisionNoOpinion,
-			WorkspaceContentAuditReason, fmt.Sprintf("error getting cluster from request: %v", err),
-		)
-		return authorizer.DecisionNoOpinion, WorkspaceAccessNotPermittedReason, err
-	}
+	cluster := genericapirequest.ClusterFrom(ctx)
 	// empty or non-root based workspaces have no meaning in the context of authorizing workspace content.
 	if cluster == nil || cluster.Name.Empty() || !cluster.Name.HasPrefix(tenancyv1alpha1.RootCluster) {
 		kaudit.AddAuditAnnotations(
@@ -151,7 +143,7 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 			WorkspaceContentAuditDecision, DecisionNoOpinion,
 			WorkspaceContentAuditReason, "root workspace access by non-root service account not permitted",
 		)
-		return authorizer.DecisionNoOpinion, WorkspaceAccessNotPermittedReason, err
+		return authorizer.DecisionNoOpinion, WorkspaceAccessNotPermittedReason, nil
 	}
 
 	// non-root workspaces must have a parent


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The `ValidClustrFrom` method doesn't allow for a cluster name to be empty.
Since the authorizers handle cases in which a cluster name wasn't provided using the `ClusterFrom` method leads to a more readable code.
The `ValidClusterFrom` returns an error when the name is empty which leads to slightly less readable code.

This is a follow-up from https://github.com/kcp-dev/kcp/pull/1871
## Related issue(s)

Fixes #
