### PR TITLE
:sparkles: Add cluster-wide resources support to the resource reconciler

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -105,10 +105,10 @@
 /pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go:66:4: function "Info" should not be used, convert to contextual logging
 /pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go:66:4: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go:70:5: Key positional arguments are expected to be inlined constant strings. Please replace &{tenancyv1alpha1 ExperimentalClusterWorkspaceOwnerAnnotationKey} provided with string value.
-/pkg/reconciler/workload/resource/resource_controller.go:372:32: function "Enabled" should not be used, convert to contextual logging
-/pkg/reconciler/workload/resource/resource_controller.go:372:32: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/workload/resource/resource_controller.go:372:8: function "Enabled" should not be used, convert to contextual logging
-/pkg/reconciler/workload/resource/resource_controller.go:372:8: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:422:32: function "Enabled" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:422:32: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:422:8: function "Enabled" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:422:8: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:165:2: function "Infof" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:165:2: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:179:2: function "Infof" should not be used, convert to contextual logging
@@ -122,7 +122,7 @@
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:331:2: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:333:3: function "Errorf" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_reconcile.go:58:5: function "Warningf" should not be used, convert to contextual logging
-/pkg/server/controllers.go:996:4: function "Errorf" should not be used, convert to contextual logging
+/pkg/server/controllers.go:997:4: function "Errorf" should not be used, convert to contextual logging
 /pkg/server/home_workspaces.go:352:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/home_workspaces.go:638:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
@@ -137,14 +137,14 @@
 /pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:131:3: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:149:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:321:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/status/status_process.go:100:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/status/status_process.go:100:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:100:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:134:4: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:152:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:366:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/status/status_process.go:138:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/status/status_process.go:138:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:138:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:68:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/status/status_process.go:68:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
 /pkg/syncer/syncer.go:166:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetNameKey} provided with string value.
 /pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetNameKey} provided with string value.
 /pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetWorkspaceKey} provided with string value.

--- a/pkg/reconciler/workload/placement/placement_controller.go
+++ b/pkg/reconciler/workload/placement/placement_controller.go
@@ -68,7 +68,7 @@ func NewController(
 		syncTargetLister:  syncTargetInformer.Lister(),
 		syncTargetIndexer: syncTargetInformer.Informer().GetIndexer(),
 
-		placmentLister:   placementInformer.Lister(),
+		placementLister:  placementInformer.Lister(),
 		placementIndexer: placementInformer.Informer().GetIndexer(),
 	}
 
@@ -156,7 +156,7 @@ type controller struct {
 	syncTargetLister  workloadlisters.SyncTargetLister
 	syncTargetIndexer cache.Indexer
 
-	placmentLister   schedulinglisters.PlacementLister
+	placementLister  schedulinglisters.PlacementLister
 	placementIndexer cache.Indexer
 }
 
@@ -268,7 +268,7 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (c *controller) process(ctx context.Context, key string) error {
-	obj, err := c.placmentLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
+	obj, err := c.placementLister.Get(key) // TODO: clients need a way to scope down the lister per-cluster
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil // object deleted before we handled it

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -381,9 +381,6 @@ func (c *Controller) processGVR(ctx context.Context, gvrstr string) error {
 // namespaceBlocklist holds a set of namespaces that should never be synced from kcp to physical clusters.
 var namespaceBlocklist = sets.NewString("kube-system", "kube-public", "kube-node-lease")
 
-// syncableClusterScopedResources holds a set of cluster-wide GVR that are allowed to be synced.
-var syncableClusterScopedResources = sets.NewString(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}.String())
-
 // enqueueResourcesForNamespace adds the resources contained by the given
 // namespace to the queue if there scheduling label differs from the namespace's.
 func (c *Controller) enqueueResourcesForNamespace(ns *corev1.Namespace) error {

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	schedulinginformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/scheduling/v1alpha1"
 	workloadinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/workload/v1alpha1"
 	workloadlisters "github.com/kcp-dev/kcp/pkg/client/listers/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/indexers"
@@ -60,6 +61,7 @@ func NewController(
 	ddsif *informer.DynamicDiscoverySharedInformerFactory,
 	syncTargetInformer workloadinformers.SyncTargetInformer,
 	namespaceInformer coreinformers.NamespaceInformer,
+	placementInformer schedulinginformers.PlacementInformer,
 ) (*Controller, error) {
 	resourceQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-namespace-resource")
 	gvrQueue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-namespace-gvr")

--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -82,7 +82,7 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 
 	} else {
 		// We only allow some cluster-wide types of resources.
-		if !syncableClusterScopedResources.Has(gvr.String()) {
+		if !syncershared.SyncableClusterScopedResources.Has(gvr.String()) {
 			logger.V(5).Info("skipping syncing cluster-scoped resource because it is not in the allowed list of syncable cluster-scoped resources", "name", obj.GetName())
 			return nil
 		}

--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -34,11 +34,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	syncershared "github.com/kcp-dev/kcp/pkg/syncer/shared"
 )
@@ -49,28 +47,64 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 	logger := logging.WithObject(logging.WithReconciler(klog.Background(), controllerName), obj).WithValues("groupVersionResource", gvr.String(), "logicalCluster", lclusterName.String())
 	logger.V(4).Info("reconciling resource")
 
-	// If the resource is not namespaced (incl if the resource is itself a
-	// namespace), ignore it.
-	if obj.GetNamespace() == "" {
-		logger.V(4).Info("resource had no namespace; ignoring")
+	// if the resource is a namespace, let's return early. nothing to do.
+	namespaceGVR := &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	if gvr == namespaceGVR {
+		logger.V(5).Info("resource is a namespace; ignoring")
 		return nil
 	}
 
-	if namespaceBlocklist.Has(obj.GetNamespace()) {
-		logger.V(4).Info("skipping syncing namespace")
-		return nil
-	}
+	var err error
+	var expectedSyncTargetKeys sets.String
+	expectedDeletedSynctargetKeys := make(map[string]string)
 
-	// Align the resource's assigned cluster with the namespace's assigned
-	// cluster.
-	// First, get the namespace object (from the cached lister).
-	ns, err := c.namespaceLister.Get(clusters.ToClusterAwareKey(lclusterName, obj.GetNamespace()))
-	if apierrors.IsNotFound(err) {
-		// Namespace was deleted; this resource will eventually get deleted too, so ignore
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("error reconciling resource %s|%s/%s: error getting namespace: %w", lclusterName, obj.GetNamespace(), obj.GetName(), err)
+	namespaceName := obj.GetNamespace()
+	// We need to handle namespaced and non-namespaced resources differently, as namespaced resources
+	// will get the locations from its namespace, and non-namespaced will get the locations from all the
+	// workspace placements.
+	if namespaceName != "" {
+		logger := logger.WithValues("namespace", namespaceName)
+		if namespaceBlocklist.Has(namespaceName) {
+			logger.V(4).Info("skipping syncing namespace because it is in the block list")
+			return nil
+		}
+
+		namespace, err := c.getNamespace(lclusterName, namespaceName)
+		if apierrors.IsNotFound(err) {
+			// Namespace was deleted; this resource will eventually get deleted too, so ignore
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error reconciling resource %s|%s/%s: error getting namespace: %w", lclusterName, namespaceName, obj.GetName(), err)
+		}
+
+		expectedSyncTargetKeys, expectedDeletedSynctargetKeys = locations(namespace.GetAnnotations(), namespace.GetLabels(), false)
+
+	} else {
+		// We only allow some cluster-wide types of resources.
+		if !syncableClusterScopedResources.Has(gvr.String()) {
+			logger.V(5).Info("skipping syncing cluster-scoped resource because it is not in the allowed list of syncable cluster-scoped resources", "name", obj.GetName())
+			return nil
+		}
+
+		logger.Info("reconciling cluster-wide resource", "name", obj.GetName(), "labels", obj.GetLabels())
+
+		// now we need to calculate the synctargets that need to be deleted.
+		// we do this by getting the current locations of the resource and
+		// comparing against the expected locations.
+
+		expectedSyncTargetKeys, err = c.getValidSyncTargetKeysForWorkspace(logicalcluster.From(obj))
+		if err != nil {
+			logger.Error(err, "error getting valid sync target keys for workspace")
+			return nil
+		}
+
+		deletionTimestamp := time.Now().Format(time.RFC3339)
+		currentLocations, _ := locations(obj.GetAnnotations(), obj.GetLabels(), false)
+
+		for _, location := range currentLocations.Difference(expectedSyncTargetKeys).List() {
+			expectedDeletedSynctargetKeys[location] = deletionTimestamp
+		}
 	}
 
 	var annotationPatch, labelPatch map[string]interface{}
@@ -80,7 +114,7 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 		annotationPatch = propagateDeletionTimestamp(logger, obj)
 	} else {
 		// We only need to compute the new placements if the resource is not being deleted.
-		annotationPatch, labelPatch = computePlacement(ns, obj)
+		annotationPatch, labelPatch = computePlacement(expectedSyncTargetKeys, expectedDeletedSynctargetKeys, obj)
 	}
 
 	// clean finalizers from removed syncers
@@ -94,17 +128,16 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 
 		syncTargetKey := strings.TrimPrefix(f, syncershared.SyncerFinalizerNamePrefix)
 		logger = logger.WithValues("syncTargetKey", syncTargetKey)
-		objs, err := c.syncTargetIndexer.ByIndex(indexers.SyncTargetsBySyncTargetKey, syncTargetKey)
+		_, found, err := c.getSyncTargetFromKey(syncTargetKey)
 		if err != nil {
-			logger.Error(err, "error getting SyncTarget via index")
+			logger.Error(err, "error checking if sync target key exists")
 			continue
 		}
-		if len(objs) == 0 {
+		if !found {
 			logger.V(3).Info("SyncTarget under the key was deleted, removing finalizer")
 			continue
 		}
-		aCluster := objs[0].(*workloadv1alpha1.SyncTarget)
-		logging.WithObject(logger, aCluster).V(5).Info("keeping finalizer because of SyncTarget")
+		logger.V(4).Info("SyncTarget under the key still exists, keeping finalizer")
 		filteredFinalizers = append(filteredFinalizers, f)
 	}
 
@@ -144,8 +177,14 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 	}
 
 	logger.WithValues("patch", string(patchBytes)).V(2).Info("patching resource")
-	if _, err := c.dynClusterClient.Resource(*gvr).Namespace(ns.Name).
-		Patch(logicalcluster.WithCluster(ctx, lclusterName), obj.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+	if namespaceName != "" {
+		if _, err := c.dynClusterClient.Resource(*gvr).Namespace(namespaceName).Patch(logicalcluster.WithCluster(ctx, lclusterName), obj.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if _, err := c.dynClusterClient.Resource(*gvr).Patch(logicalcluster.WithCluster(ctx, lclusterName), obj.GetName(), types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		return err
 	}
 
@@ -177,9 +216,9 @@ func computePlacement(expectedSyncTargetKeys sets.String, expectedDeletedSynctar
 	annotationPatch = map[string]interface{}{}
 	labelPatch = map[string]interface{}{}
 
-	// unschedule objects on locations where the namespace is not scheduled
+	// unschedule objects from SyncTargets that are no longer expected.
 	for _, loc := range currentSynctargetKeys.Difference(expectedSyncTargetKeys).List() {
-		// That's an inconsistent state, probably due to the namespace deletion reaching its grace period => let's repair it
+		// That's an inconsistent state, in case of namespaced resources, it's probably due to the namespace deletion reaching its grace period => let's repair it
 		var hasSyncerFinalizer, hasClusterFinalizer bool
 		// Check if there's still the syncer or the cluster finalizer.
 		for _, finalizer := range obj.GetFinalizers() {
@@ -197,27 +236,34 @@ func computePlacement(expectedSyncTargetKeys sets.String, expectedDeletedSynctar
 		} else {
 			if _, found := obj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc]; found {
 				annotationPatch[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc] = nil
-				labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = nil
 			}
+			labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = nil
 		}
 	}
 
-	// sync deletion timestamps if both namespace and object are scheduled
+	// sync deletion timestamps if the location is expected to be deleted.
 	for _, loc := range expectedSyncTargetKeys.Intersection(currentSynctargetKeys).List() {
 		if expectedTimestamp, ok := expectedDeletedSynctargetKeys[loc]; ok {
-			if currentTimestamp, ok := currentSynctargetKeysDeleting[loc]; !ok || currentTimestamp != expectedTimestamp {
+			if _, ok := currentSynctargetKeysDeleting[loc]; !ok {
 				annotationPatch[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc] = expectedTimestamp
 			}
 		}
 	}
 
-	// set label on unscheduled objects if namespace is scheduled and not deleting
+	// If the resource is namespaced, set the initial resource state to Sync, otherwise set it to Pending.
+	// TODO(jmprusi): ResourceStatePending will be the default state once there is a default coordinators for resources.
+	resourceState := workloadv1alpha1.ResourceStateSync
+	if obj.GetNamespace() == "" {
+		resourceState = workloadv1alpha1.ResourceStatePending
+	}
+
+	// set label on unscheduled objects if resource is scheduled and not deleting
 	for _, loc := range expectedSyncTargetKeys.Difference(currentSynctargetKeys).List() {
-		if val := expectedDeletedSynctargetKeys[loc]; val != "" {
+		if _, ok := expectedDeletedSynctargetKeys[loc]; ok {
 			continue
 		}
 		// TODO(sttts): add way to go into pending state first, maybe with a namespace annotation
-		labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = string(workloadv1alpha1.ResourceStateSync)
+		labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = string(resourceState)
 	}
 
 	if len(annotationPatch) == 0 {
@@ -248,9 +294,4 @@ func (c *Controller) reconcileGVR(gvr schema.GroupVersionResource) error {
 		c.enqueueResource(gvr, obj)
 	}
 	return nil
-}
-
-func validRFC3339(ts string) bool {
-	_, err := time.Parse(time.RFC3339, ts)
-	return err == nil
 }

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -350,6 +350,7 @@ func (s *Server) installWorkloadResourceScheduler(ctx context.Context, config *r
 		s.DynamicDiscoverySharedInformerFactory,
 		s.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
 		s.KubeSharedInformerFactory.Core().V1().Namespaces(),
+		s.KcpSharedInformerFactory.Scheduling().V1alpha1().Placements(),
 	)
 	if err != nil {
 		return err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -92,7 +92,8 @@ func NewServer(c CompletedConfig) (*Server, error) {
 		indexers.AppendOrDie(
 			indexers.NamespaceScoped(),
 			cache.Indexers{
-				indexers.BySyncerFinalizerKey: indexers.IndexBySyncerFinalizerKey,
+				indexers.BySyncerFinalizerKey:           indexers.IndexBySyncerFinalizerKey,
+				indexers.ByClusterResourceStateLabelKey: indexers.IndexByClusterResourceStateLabelKey,
 			},
 		),
 	)

--- a/pkg/syncer/shared/helpers.go
+++ b/pkg/syncer/shared/helpers.go
@@ -20,9 +20,13 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/util/sets"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 )
+
+// SyncableClusterScopedResources holds a set of cluster-wide GVR that are allowed to be synced.
+var SyncableClusterScopedResources = sets.NewString(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}.String())
 
 // DeprecatedGetAssignedSyncTarget returns one assigned sync target in Sync state. It will
 // likely lead to broken behaviour when there is one of those labels on a resource.

--- a/test/e2e/fixtures/kube/core.k8s.io_persistentvolumes.yaml
+++ b/test/e2e/fixtures/kube/core.k8s.io_persistentvolumes.yaml
@@ -1,0 +1,1265 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: persistentvolumes.core
+spec:
+  conversion:
+    strategy: None
+  group: ""
+  names:
+    kind: PersistentVolume
+    listKind: PersistentVolumeList
+    plural: persistentvolumes
+    shortNames:
+      - pv
+    singular: persistentvolume
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description:
+            "PersistentVolume (PV) is a storage resource provisioned by an
+            administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes"
+          properties:
+            apiVersion:
+              description:
+                "APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              type: string
+            kind:
+              description:
+                "Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              type: string
+            metadata:
+              type: object
+            spec:
+              description:
+                "spec defines a specification of a persistent volume owned
+                by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes"
+              properties:
+                accessModes:
+                  description:
+                    "accessModes contains all ways the volume can be mounted.
+                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes"
+                  items:
+                    type: string
+                  type: array
+                awsElasticBlockStore:
+                  description:
+                    "awsElasticBlockStore represents an AWS Disk resource
+                    that is attached to a kubelet's host machine and then exposed to
+                    the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+                  properties:
+                    fsType:
+                      description:
+                        'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      type: string
+                    partition:
+                      description:
+                        'partition is the partition in the volume that you
+                        want to mount. If omitted, the default is to mount by volume
+                        name. Examples: For volume /dev/sda1, you specify the partition
+                        as "1". Similarly, the volume partition for /dev/sda is "0"
+                        (or you can leave the property empty).'
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description:
+                        "readOnly value true will force the readOnly setting
+                        in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+                      type: boolean
+                    volumeID:
+                      description:
+                        "volumeID is unique ID of the persistent disk resource
+                        in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+                      type: string
+                  required:
+                    - volumeID
+                  type: object
+                azureDisk:
+                  description:
+                    azureDisk represents an Azure Data Disk mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    cachingMode:
+                      description:
+                        "cachingMode is the Host Caching mode: None, Read
+                        Only, Read Write."
+                      type: string
+                    diskName:
+                      description:
+                        diskName is the Name of the data disk in the blob
+                        storage
+                      type: string
+                    diskURI:
+                      description: diskURI is the URI of data disk in the blob storage
+                      type: string
+                    fsType:
+                      description:
+                        fsType is Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    kind:
+                      description:
+                        "kind expected values are Shared: multiple blob disks
+                        per storage account  Dedicated: single blob disk per storage
+                        account  Managed: azure managed data disk (only in managed availability
+                        set). defaults to shared"
+                      type: string
+                    readOnly:
+                      description:
+                        readOnly Defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                  required:
+                    - diskName
+                    - diskURI
+                  type: object
+                azureFile:
+                  description:
+                    azureFile represents an Azure File Service mount on the
+                    host and bind mount to the pod.
+                  properties:
+                    readOnly:
+                      description:
+                        readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretName:
+                      description:
+                        secretName is the name of secret that contains Azure
+                        Storage Account Name and Key
+                      type: string
+                    secretNamespace:
+                      description:
+                        secretNamespace is the namespace of the secret that
+                        contains Azure Storage Account Name and Key default is the same
+                        as the Pod
+                      type: string
+                    shareName:
+                      description: shareName is the azure Share Name
+                      type: string
+                  required:
+                    - secretName
+                    - shareName
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description:
+                    "capacity is the description of the persistent volume's
+                    resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity"
+                  type: object
+                cephfs:
+                  description:
+                    cephFS represents a Ceph FS mount on the host that shares
+                    a pod's lifetime
+                  properties:
+                    monitors:
+                      description:
+                        "monitors is Required: Monitors is a collection of
+                        Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+                      items:
+                        type: string
+                      type: array
+                    path:
+                      description:
+                        "path is Optional: Used as the mounted root, rather
+                        than the full Ceph tree, default is /"
+                      type: string
+                    readOnly:
+                      description:
+                        "readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+                      type: boolean
+                    secretFile:
+                      description:
+                        "secretFile is Optional: SecretFile is the path to
+                        key ring for User, default is /etc/ceph/user.secret More info:
+                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+                      type: string
+                    secretRef:
+                      description:
+                        "secretRef is Optional: SecretRef is reference to
+                        the authentication secret for User, default is empty. More info:
+                        https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    user:
+                      description:
+                        "user is Optional: User is the rados user name, default
+                        is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+                      type: string
+                  required:
+                    - monitors
+                  type: object
+                cinder:
+                  description:
+                    "cinder represents a cinder volume attached and mounted
+                    on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
+                  properties:
+                    fsType:
+                      description:
+                        'fsType Filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Examples: "ext4",
+                        "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      type: string
+                    readOnly:
+                      description:
+                        "readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
+                      type: boolean
+                    secretRef:
+                      description:
+                        "secretRef is Optional: points to a secret object
+                        containing parameters used to connect to OpenStack."
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    volumeID:
+                      description:
+                        "volumeID used to identify the volume in cinder.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
+                      type: string
+                  required:
+                    - volumeID
+                  type: object
+                claimRef:
+                  description:
+                    "claimRef is part of a bi-directional binding between
+                    PersistentVolume and PersistentVolumeClaim. Expected to be non-nil
+                    when bound. claim.VolumeName is the authoritative bind between PV
+                    and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding"
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description:
+                        'If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object.'
+                      type: string
+                    kind:
+                      description: "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                      type: string
+                    name:
+                      description: "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                      type: string
+                    namespace:
+                      description: "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                      type: string
+                    resourceVersion:
+                      description:
+                        "Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency"
+                      type: string
+                    uid:
+                      description: "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids"
+                      type: string
+                  type: object
+                csi:
+                  description:
+                    csi represents storage that is handled by an external
+                    CSI driver (Beta feature).
+                  properties:
+                    controllerExpandSecretRef:
+                      description:
+                        controllerExpandSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI driver
+                        to complete the CSI ControllerExpandVolume call. This is an
+                        beta field and requires enabling ExpandCSIVolumes feature gate.
+                        This field is optional, and may be empty if no secret is required.
+                        If the secret object contains more than one secret, all secrets
+                        are passed.
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    controllerPublishSecretRef:
+                      description:
+                        controllerPublishSecretRef is a reference to the
+                        secret object containing sensitive information to pass to the
+                        CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume
+                        calls. This field is optional, and may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secrets are passed.
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    driver:
+                      description:
+                        driver is the name of the driver to use for this
+                        volume. Required.
+                      type: string
+                    fsType:
+                      description:
+                        fsType to mount. Must be a filesystem type supported
+                        by the host operating system. Ex. "ext4", "xfs", "ntfs".
+                      type: string
+                    nodeExpandSecretRef:
+                      description:
+                        nodeExpandSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI driver
+                        to complete the CSI NodeExpandVolume call. This is an alpha
+                        field and requires enabling CSINodeExpandSecret feature gate.
+                        This field is optional, may be omitted if no secret is required.
+                        If the secret object contains more than one secret, all secrets
+                        are passed.
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    nodePublishSecretRef:
+                      description:
+                        nodePublishSecretRef is a reference to the secret
+                        object containing sensitive information to pass to the CSI driver
+                        to complete the CSI NodePublishVolume and NodeUnpublishVolume
+                        calls. This field is optional, and may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secrets are passed.
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    nodeStageSecretRef:
+                      description:
+                        nodeStageSecretRef is a reference to the secret object
+                        containing sensitive information to pass to the CSI driver to
+                        complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume
+                        calls. This field is optional, and may be empty if no secret
+                        is required. If the secret object contains more than one secret,
+                        all secrets are passed.
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    readOnly:
+                      description:
+                        readOnly value to pass to ControllerPublishVolumeRequest.
+                        Defaults to false (read/write).
+                      type: boolean
+                    volumeAttributes:
+                      additionalProperties:
+                        type: string
+                      description: volumeAttributes of the volume to publish.
+                      type: object
+                    volumeHandle:
+                      description:
+                        volumeHandle is the unique volume name returned by
+                        the CSI volume plugin’s CreateVolume to refer to the volume
+                        on all subsequent calls. Required.
+                      type: string
+                  required:
+                    - driver
+                    - volumeHandle
+                  type: object
+                fc:
+                  description:
+                    fc represents a Fibre Channel resource that is attached
+                    to a kubelet's host machine and then exposed to the pod.
+                  properties:
+                    fsType:
+                      description:
+                        fsType is the filesystem type to mount. Must be a
+                        filesystem type supported by the host operating system. Ex.
+                        "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    lun:
+                      description: "lun is Optional: FC target lun number"
+                      format: int32
+                      type: integer
+                    readOnly:
+                      description:
+                        "readOnly is Optional: Defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts."
+                      type: boolean
+                    targetWWNs:
+                      description:
+                        "targetWWNs is Optional: FC target worldwide names
+                        (WWNs)"
+                      items:
+                        type: string
+                      type: array
+                    wwids:
+                      description:
+                        "wwids Optional: FC volume world wide identifiers
+                        (wwids) Either wwids or combination of targetWWNs and lun must
+                        be set, but not both simultaneously."
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                flexVolume:
+                  description:
+                    flexVolume represents a generic volume resource that
+                    is provisioned/attached using an exec based plugin.
+                  properties:
+                    driver:
+                      description:
+                        driver is the name of the driver to use for this
+                        volume.
+                      type: string
+                    fsType:
+                      description:
+                        fsType is the Filesystem type to mount. Must be a
+                        filesystem type supported by the host operating system. Ex.
+                        "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume
+                        script.
+                      type: string
+                    options:
+                      additionalProperties:
+                        type: string
+                      description:
+                        "options is Optional: this field holds extra command
+                        options if any."
+                      type: object
+                    readOnly:
+                      description:
+                        "readOnly is Optional: defaults to false (read/write).
+                        ReadOnly here will force the ReadOnly setting in VolumeMounts."
+                      type: boolean
+                    secretRef:
+                      description:
+                        "secretRef is Optional: SecretRef is reference to
+                        the secret object containing sensitive information to pass to
+                        the plugin scripts. This may be empty if no secret object is
+                        specified. If the secret object contains more than one secret,
+                        all secrets are passed to the plugin scripts."
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                  required:
+                    - driver
+                  type: object
+                flocker:
+                  description:
+                    flocker represents a Flocker volume attached to a kubelet's
+                    host machine and exposed to the pod for its usage. This depends
+                    on the Flocker control service being running
+                  properties:
+                    datasetName:
+                      description:
+                        datasetName is Name of the dataset stored as metadata
+                        -> name on the dataset for Flocker should be considered as deprecated
+                      type: string
+                    datasetUUID:
+                      description:
+                        datasetUUID is the UUID of the dataset. This is unique
+                        identifier of a Flocker dataset
+                      type: string
+                  type: object
+                gcePersistentDisk:
+                  description:
+                    "gcePersistentDisk represents a GCE Disk resource that
+                    is attached to a kubelet's host machine and then exposed to the
+                    pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+                  properties:
+                    fsType:
+                      description:
+                        'fsType is filesystem type of the volume that you
+                        want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      type: string
+                    partition:
+                      description:
+                        'partition is the partition in the volume that you
+                        want to mount. If omitted, the default is to mount by volume
+                        name. Examples: For volume /dev/sda1, you specify the partition
+                        as "1". Similarly, the volume partition for /dev/sda is "0"
+                        (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      format: int32
+                      type: integer
+                    pdName:
+                      description:
+                        "pdName is unique name of the PD resource in GCE.
+                        Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+                      type: string
+                    readOnly:
+                      description:
+                        "readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+                      type: boolean
+                  required:
+                    - pdName
+                  type: object
+                glusterfs:
+                  description:
+                    "glusterfs represents a Glusterfs volume that is attached
+                    to a host and exposed to the pod. Provisioned by an admin. More
+                    info: https://examples.k8s.io/volumes/glusterfs/README.md"
+                  properties:
+                    endpoints:
+                      description:
+                        "endpoints is the endpoint name that details Glusterfs
+                        topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod"
+                      type: string
+                    endpointsNamespace:
+                      description:
+                        "endpointsNamespace is the namespace that contains
+                        Glusterfs endpoint. If this field is empty, the EndpointNamespace
+                        defaults to the same namespace as the bound PVC. More info:
+                        https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod"
+                      type: string
+                    path:
+                      description: "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod"
+                      type: string
+                    readOnly:
+                      description:
+                        "readOnly here will force the Glusterfs volume to
+                        be mounted with read-only permissions. Defaults to false. More
+                        info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod"
+                      type: boolean
+                  required:
+                    - endpoints
+                    - path
+                  type: object
+                hostPath:
+                  description:
+                    "hostPath represents a directory on the host. Provisioned
+                    by a developer or tester. This is useful for single-node development
+                    and testing only! On-host storage is not supported in any way and
+                    WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+                  properties:
+                    path:
+                      description:
+                        "path of the directory on the host. If the path is
+                        a symlink, it will follow the link to the real path. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+                      type: string
+                    type:
+                      description:
+                        'type for HostPath Volume Defaults to "" More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                      type: string
+                  required:
+                    - path
+                  type: object
+                iscsi:
+                  description:
+                    iscsi represents an ISCSI Disk resource that is attached
+                    to a kubelet's host machine and then exposed to the pod. Provisioned
+                    by an admin.
+                  properties:
+                    chapAuthDiscovery:
+                      description:
+                        chapAuthDiscovery defines whether support iSCSI Discovery
+                        CHAP authentication
+                      type: boolean
+                    chapAuthSession:
+                      description:
+                        chapAuthSession defines whether support iSCSI Session
+                        CHAP authentication
+                      type: boolean
+                    fsType:
+                      description:
+                        'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                      type: string
+                    initiatorName:
+                      description:
+                        initiatorName is the custom iSCSI Initiator Name.
+                        If initiatorName is specified with iscsiInterface simultaneously,
+                        new iSCSI interface <target portal>:<volume name> will be created
+                        for the connection.
+                      type: string
+                    iqn:
+                      description: iqn is Target iSCSI Qualified Name.
+                      type: string
+                    iscsiInterface:
+                      description:
+                        iscsiInterface is the interface Name that uses an
+                        iSCSI transport. Defaults to 'default' (tcp).
+                      type: string
+                    lun:
+                      description: lun is iSCSI Target Lun number.
+                      format: int32
+                      type: integer
+                    portals:
+                      description:
+                        portals is the iSCSI Target Portal List. The Portal
+                        is either an IP or ip_addr:port if the port is other than default
+                        (typically TCP ports 860 and 3260).
+                      items:
+                        type: string
+                      type: array
+                    readOnly:
+                      description:
+                        readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false.
+                      type: boolean
+                    secretRef:
+                      description:
+                        secretRef is the CHAP Secret for iSCSI target and
+                        initiator authentication
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    targetPortal:
+                      description:
+                        targetPortal is iSCSI Target Portal. The Portal is
+                        either an IP or ip_addr:port if the port is other than default
+                        (typically TCP ports 860 and 3260).
+                      type: string
+                  required:
+                    - targetPortal
+                    - iqn
+                    - lun
+                  type: object
+                local:
+                  description:
+                    local represents directly-attached storage with node
+                    affinity
+                  properties:
+                    fsType:
+                      description:
+                        fsType is the filesystem type to mount. It applies
+                        only when the Path is a block device. Must be a filesystem type
+                        supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+                        The default value is to auto-select a filesystem if unspecified.
+                      type: string
+                    path:
+                      description:
+                        path of the full path to the volume on the node.
+                        It can be either a directory or block device (disk, partition,
+                        ...).
+                      type: string
+                  required:
+                    - path
+                  type: object
+                mountOptions:
+                  description:
+                    'mountOptions is the list of mount options, e.g. ["ro",
+                    "soft"]. Not validated - mount will simply fail if one is invalid.
+                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options'
+                  items:
+                    type: string
+                  type: array
+                nfs:
+                  description:
+                    "nfs represents an NFS mount on the host. Provisioned
+                    by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+                  properties:
+                    path:
+                      description:
+                        "path that is exported by the NFS server. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+                      type: string
+                    readOnly:
+                      description:
+                        "readOnly here will force the NFS export to be mounted
+                        with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+                      type: boolean
+                    server:
+                      description:
+                        "server is the hostname or IP address of the NFS
+                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+                      type: string
+                  required:
+                    - server
+                    - path
+                  type: object
+                nodeAffinity:
+                  description:
+                    nodeAffinity defines constraints that limit what nodes
+                    this volume can be accessed from. This field influences the scheduling
+                    of pods that use this volume.
+                  properties:
+                    required:
+                      description:
+                        required specifies hard node constraints that must
+                        be met.
+                      properties:
+                        nodeSelectorTerms:
+                          description:
+                            Required. A list of node selector terms. The
+                            terms are ORed.
+                          items:
+                            description:
+                              A null or empty node selector term matches
+                              no objects. The requirements of them are ANDed. The TopologySelectorTerm
+                              type implements a subset of the NodeSelectorTerm.
+                            properties:
+                              matchExpressions:
+                                description:
+                                  A list of node selector requirements by
+                                  node's labels.
+                                items:
+                                  description:
+                                    A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description:
+                                        The label key that the selector applies
+                                        to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                        Possible enum values:
+                                         - `"DoesNotExist"`
+                                         - `"Exists"`
+                                         - `"Gt"`
+                                         - `"In"`
+                                         - `"Lt"`
+                                         - `"NotIn"`
+                                      type: string
+                                    values:
+                                      description:
+                                        An array of string values. If the
+                                        operator is In or NotIn, the values array must
+                                        be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. If the operator
+                                        is Gt or Lt, the values array must have a single
+                                        element, which will be interpreted as an integer.
+                                        This array is replaced during a strategic merge
+                                        patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchFields:
+                                description:
+                                  A list of node selector requirements by
+                                  node's fields.
+                                items:
+                                  description:
+                                    A node selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description:
+                                        The label key that the selector applies
+                                        to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+
+                                        Possible enum values:
+                                         - `"DoesNotExist"`
+                                         - `"Exists"`
+                                         - `"Gt"`
+                                         - `"In"`
+                                         - `"Lt"`
+                                         - `"NotIn"`
+                                      type: string
+                                    values:
+                                      description:
+                                        An array of string values. If the
+                                        operator is In or NotIn, the values array must
+                                        be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. If the operator
+                                        is Gt or Lt, the values array must have a single
+                                        element, which will be interpreted as an integer.
+                                        This array is replaced during a strategic merge
+                                        patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                        - nodeSelectorTerms
+                      type: object
+                  type: object
+                persistentVolumeReclaimPolicy:
+                  description: |-
+                    persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+
+                    Possible enum values:
+                     - `"Delete"` means the volume will be deleted from Kubernetes on release from its claim. The volume plugin must support Deletion.
+                     - `"Recycle"` means the volume will be recycled back into the pool of unbound persistent volumes on release from its claim. The volume plugin must support Recycling.
+                     - `"Retain"` means the volume will be left in its current phase (Released) for manual reclamation by the administrator. The default policy is Retain.
+                  type: string
+                photonPersistentDisk:
+                  description:
+                    photonPersistentDisk represents a PhotonController persistent
+                    disk attached and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description:
+                        fsType is the filesystem type to mount. Must be a
+                        filesystem type supported by the host operating system. Ex.
+                        "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    pdID:
+                      description:
+                        pdID is the ID that identifies Photon Controller
+                        persistent disk
+                      type: string
+                  required:
+                    - pdID
+                  type: object
+                portworxVolume:
+                  description:
+                    portworxVolume represents a portworx volume attached
+                    and mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description:
+                        fSType represents the filesystem type to mount Must
+                        be a filesystem type supported by the host operating system.
+                        Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    readOnly:
+                      description:
+                        readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    volumeID:
+                      description: volumeID uniquely identifies a Portworx volume
+                      type: string
+                  required:
+                    - volumeID
+                  type: object
+                quobyte:
+                  description:
+                    quobyte represents a Quobyte mount on the host that shares
+                    a pod's lifetime
+                  properties:
+                    group:
+                      description: group to map volume access to Default is no group
+                      type: string
+                    readOnly:
+                      description:
+                        readOnly here will force the Quobyte volume to be
+                        mounted with read-only permissions. Defaults to false.
+                      type: boolean
+                    registry:
+                      description:
+                        registry represents a single or multiple Quobyte
+                        Registry services specified as a string as host:port pair (multiple
+                        entries are separated with commas) which acts as the central
+                        registry for volumes
+                      type: string
+                    tenant:
+                      description:
+                        tenant owning the given Quobyte volume in the Backend
+                        Used with dynamically provisioned Quobyte volumes, value is
+                        set by the plugin
+                      type: string
+                    user:
+                      description:
+                        user to map volume access to Defaults to serivceaccount
+                        user
+                      type: string
+                    volume:
+                      description:
+                        volume is a string that references an already created
+                        Quobyte volume by name.
+                      type: string
+                  required:
+                    - registry
+                    - volume
+                  type: object
+                rbd:
+                  description:
+                    "rbd represents a Rados Block Device mount on the host
+                    that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md"
+                  properties:
+                    fsType:
+                      description:
+                        'fsType is the filesystem type of the volume that
+                        you want to mount. Tip: Ensure that the filesystem type is supported
+                        by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                        Implicitly inferred to be "ext4" if unspecified. More info:
+                        https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                      type: string
+                    image:
+                      description: "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      type: string
+                    keyring:
+                      description:
+                        "keyring is the path to key ring for RBDUser. Default
+                        is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      type: string
+                    monitors:
+                      description:
+                        "monitors is a collection of Ceph monitors. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      items:
+                        type: string
+                      type: array
+                    pool:
+                      description:
+                        "pool is the rados pool name. Default is rbd. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      type: string
+                    readOnly:
+                      description:
+                        "readOnly here will force the ReadOnly setting in
+                        VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      type: boolean
+                    secretRef:
+                      description:
+                        "secretRef is name of the authentication secret for
+                        RBDUser. If provided overrides keyring. Default is nil. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    user:
+                      description:
+                        "user is the rados user name. Default is admin. More
+                        info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                      type: string
+                  required:
+                    - monitors
+                    - image
+                  type: object
+                scaleIO:
+                  description:
+                    scaleIO represents a ScaleIO persistent volume attached
+                    and mounted on Kubernetes nodes.
+                  properties:
+                    fsType:
+                      description:
+                        fsType is the filesystem type to mount. Must be a
+                        filesystem type supported by the host operating system. Ex.
+                        "ext4", "xfs", "ntfs". Default is "xfs"
+                      type: string
+                    gateway:
+                      description: gateway is the host address of the ScaleIO API Gateway.
+                      type: string
+                    protectionDomain:
+                      description:
+                        protectionDomain is the name of the ScaleIO Protection
+                        Domain for the configured storage.
+                      type: string
+                    readOnly:
+                      description:
+                        readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description:
+                        secretRef references to the secret for ScaleIO user
+                        and other sensitive information. If this is not provided, Login
+                        operation will fail.
+                      properties:
+                        name:
+                          description:
+                            name is unique within a namespace to reference
+                            a secret resource.
+                          type: string
+                        namespace:
+                          description:
+                            namespace defines the space within which the
+                            secret name must be unique.
+                          type: string
+                      type: object
+                    sslEnabled:
+                      description:
+                        sslEnabled is the flag to enable/disable SSL communication
+                        with Gateway, default false
+                      type: boolean
+                    storageMode:
+                      description:
+                        storageMode indicates whether the storage for a volume
+                        should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                      type: string
+                    storagePool:
+                      description:
+                        storagePool is the ScaleIO Storage Pool associated
+                        with the protection domain.
+                      type: string
+                    system:
+                      description:
+                        system is the name of the storage system as configured
+                        in ScaleIO.
+                      type: string
+                    volumeName:
+                      description:
+                        volumeName is the name of a volume already created
+                        in the ScaleIO system that is associated with this volume source.
+                      type: string
+                  required:
+                    - gateway
+                    - system
+                    - secretRef
+                  type: object
+                storageClassName:
+                  description:
+                    storageClassName is the name of StorageClass to which
+                    this persistent volume belongs. Empty value means that this volume
+                    does not belong to any StorageClass.
+                  type: string
+                storageos:
+                  description:
+                    "storageOS represents a StorageOS volume that is attached
+                    to the kubelet's host machine and mounted into the pod More info:
+                    https://examples.k8s.io/volumes/storageos/README.md"
+                  properties:
+                    fsType:
+                      description:
+                        fsType is the filesystem type to mount. Must be a
+                        filesystem type supported by the host operating system. Ex.
+                        "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    readOnly:
+                      description:
+                        readOnly defaults to false (read/write). ReadOnly
+                        here will force the ReadOnly setting in VolumeMounts.
+                      type: boolean
+                    secretRef:
+                      description:
+                        secretRef specifies the secret to use for obtaining
+                        the StorageOS API credentials.  If not specified, default values
+                        will be attempted.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description:
+                            'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within
+                            a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]"
+                            (container with index 2 in this pod). This syntax is chosen
+                            only to have some well-defined way of referencing a part
+                            of an object.'
+                          type: string
+                        kind:
+                          description: "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                          type: string
+                        name:
+                          description: "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                          type: string
+                        namespace:
+                          description: "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                          type: string
+                        resourceVersion:
+                          description:
+                            "Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency"
+                          type: string
+                        uid:
+                          description: "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids"
+                          type: string
+                      type: object
+                    volumeName:
+                      description:
+                        volumeName is the human-readable name of the StorageOS
+                        volume.  Volume names are only unique within a namespace.
+                      type: string
+                    volumeNamespace:
+                      description:
+                        volumeNamespace specifies the scope of the volume
+                        within StorageOS.  If no namespace is specified then the Pod's
+                        namespace will be used.  This allows the Kubernetes name scoping
+                        to be mirrored within StorageOS for tighter integration. Set
+                        VolumeName to any name to override the default behaviour. Set
+                        to "default" if you are not using namespaces within StorageOS.
+                        Namespaces that do not pre-exist within StorageOS will be created.
+                      type: string
+                  type: object
+                volumeMode:
+                  description:
+                    volumeMode defines if a volume is intended to be used
+                    with a formatted filesystem or to remain in raw block state. Value
+                    of Filesystem is implied when not included in spec.
+                  type: string
+                vsphereVolume:
+                  description:
+                    vsphereVolume represents a vSphere volume attached and
+                    mounted on kubelets host machine
+                  properties:
+                    fsType:
+                      description:
+                        fsType is filesystem type to mount. Must be a filesystem
+                        type supported by the host operating system. Ex. "ext4", "xfs",
+                        "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                      type: string
+                    storagePolicyID:
+                      description:
+                        storagePolicyID is the storage Policy Based Management
+                        (SPBM) profile ID associated with the StoragePolicyName.
+                      type: string
+                    storagePolicyName:
+                      description:
+                        storagePolicyName is the storage Policy Based Management
+                        (SPBM) profile name.
+                      type: string
+                    volumePath:
+                      description:
+                        volumePath is the path that identifies vSphere volume
+                        vmdk
+                      type: string
+                  required:
+                    - volumePath
+                  type: object
+              type: object
+            status:
+              description:
+                "status represents the current information/status for the
+                persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes"
+              properties:
+                message:
+                  description:
+                    message is a human-readable message indicating details
+                    about why the volume is in this state.
+                  type: string
+                phase:
+                  description: |-
+                    phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
+
+                    Possible enum values:
+                     - `"Available"` used for PersistentVolumes that are not yet bound Available volumes are held by the binder and matched to PersistentVolumeClaims
+                     - `"Bound"` used for PersistentVolumes that are bound
+                     - `"Failed"` used for PersistentVolumes that failed to be correctly recycled or deleted after being released from a claim
+                     - `"Pending"` used for PersistentVolumes that are not available
+                     - `"Released"` used for PersistentVolumes where the bound PersistentVolumeClaim was deleted released volumes must be recycled before becoming available again this phase is used by the persistent volume claim binder to signal to another process to reclaim the resource
+                  type: string
+                reason:
+                  description:
+                    reason is a brief CamelCase string that describes any
+                    failure and is meant for machine parsing and tidy display in the
+                    CLI.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+    - v1

--- a/test/e2e/syncer/persistentvolume.yaml
+++ b/test/e2e/syncer/persistentvolume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: syncer-test-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  nfs:
+    path: /tmp
+    server: 127.0.0.1
+  storageClassName: standard
+  volumeMode: Filesystem


### PR DESCRIPTION
## Summary

This PR enables the Resource reconciler to label cluster-wide resources with the available synctargets for a workspace with the desired state of "pending". 

Currently, the list of allowed cluster-wide resources is hardcoded to "persistentvolumes" in preparation for upcoming storage work.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/1890
