### PR TITLE
:seedling:  Update batteries-included option usage

### DIFF
--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -182,10 +182,11 @@ func (o *Options) rawFlags() cliflag.NamedFlagSets {
 		`A list of batteries included (= default objects that might be unwanted in production, but are very helpful in trying out kcp or for development). These are the possible values: %s.
 
 - cluster-workspace-types: creates "organization" and "team" ClusterWorkspaceTypes in the root workspace.
-- user:                  creates an additional non-admin user and context named "user" in the admin.kubeconfig
+- root-compute-workspace:  create a root:compute workspace, and kubernetes APIExport in it for deployments/services/ingresses
+- user:                    creates an additional non-admin user and context named "user" in the admin.kubeconfig
 
 Prefixing with - or + means to remove from the default set or add to the default set.`,
-		strings.Join(batteries.All.Difference(batteries.Defaults).List(), ","),
+		strings.Join(batteries.All.List(), ","),
 	))
 
 	return fss


### PR DESCRIPTION
## Summary

The possible values include the defaults, and we're missing the new option recently added via #1962

## Related issue(s)

Covers option discussed in #1959

