### PR TITLE
:seedling: tenancy: allow single-character logical cluster names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/kcp-dev/apimachinery v0.0.0-20220912132244-efe716c18e43
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
-	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/muesli/reflow v0.1.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822

--- a/go.sum
+++ b/go.sum
@@ -479,8 +479,9 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-202209151359
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20220915135949-eeba459ad2a1 h1:0QU37h5MVjWo3rUOaNRMOVjvqFzsNC4XwrW7RayweY4=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20220915135949-eeba459ad2a1/go.mod h1:Iim5xqRnknXtHPXyZjZdfxEdASa/l/nHShGazinoYbQ=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20220915135949-eeba459ad2a1/go.mod h1:7+QSUfC8FyVELcrtSpeAUGrgUoXlUQ+ZT32QCeoR91s=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 h1:6EMfOioekQNrpcHEK7k2ANBWogFMlf+3xTB3CC4k+2s=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39 h1:yjKFd2obDNUfHZibLfN5QogaIjPnQ58H9SwCKsIko1g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.5
-	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39
 	github.com/onsi/gomega v1.10.1
 	github.com/stretchr/testify v1.7.1
 	k8s.io/api v0.24.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -286,8 +286,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1 h1:6EMfOioekQNrpcHEK7k2ANBWogFMlf+3xTB3CC4k+2s=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39 h1:yjKFd2obDNUfHZibLfN5QogaIjPnQ58H9SwCKsIko1g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/apis/tenancy/v1alpha1/helper/helper.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper.go
@@ -18,7 +18,6 @@ package helper
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
@@ -27,10 +26,8 @@ import (
 	"github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
 
-var lclusterRegExp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9](:[a-z][a-z0-9-]*[a-z0-9])*$`)
-
 func IsValidCluster(cluster logicalcluster.Name) bool {
-	if !lclusterRegExp.MatchString(cluster.String()) {
+	if !cluster.IsValid() {
 		return false
 	}
 

--- a/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/tenancy/v1alpha1/helper/helper_test.go
@@ -30,6 +30,8 @@ func TestIsValidCluster(t *testing.T) {
 		{"", false},
 
 		{"root", true},
+		{"root:a", true},
+		{"root:a:b", true},
 		{"root:foo", true},
 		{"root:foo:bar", true},
 
@@ -49,7 +51,6 @@ func TestIsValidCluster(t *testing.T) {
 		{"root::foo", false},
 		{"root:föö:bär", false},
 		{"root:bar_bar", false},
-		{"root:a", false},
 		{"root:0a", false},
 		{"root:0bar", false},
 		{"root/bar", false},


### PR DESCRIPTION
Fixes #2018

Update to kcp-dev/logicalcluster#23 to pull in a fix to allow single-character names.

