### PR TITLE
:sparkles: Add profiler support to front proxy and virtual workspaces

### DIFF
--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -21,6 +21,7 @@ import (
 	goflags "flag"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"time"
 
@@ -91,6 +92,11 @@ routed based on paths.`,
 			}
 			if errs := options.Validate(); errs != nil {
 				return errors.NewAggregate(errs)
+			}
+
+			if options.ProfilerAddress != "" {
+				//nolint:errcheck
+				go http.ListenAndServe(options.ProfilerAddress, nil)
 			}
 
 			var servingInfo *genericapiserver.SecureServingInfo

--- a/cmd/kcp-front-proxy/options/options.go
+++ b/cmd/kcp-front-proxy/options/options.go
@@ -35,8 +35,9 @@ type Options struct {
 	Proxy          proxyoptions.Options
 	Logs           *logs.Options
 
-	RootKubeconfig string
-	RootDirectory  string
+	RootKubeconfig  string
+	RootDirectory   string
+	ProfilerAddress string
 }
 
 func NewOptions() *Options {
@@ -69,6 +70,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")
+
+	fs.StringVar(&o.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to")
 }
 
 func (o *Options) Complete() error {

--- a/cmd/virtual-workspaces/options/options.go
+++ b/cmd/virtual-workspaces/options/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	Logs logs.Options
 
 	VirtualWorkspaces virtualworkspacesoptions.Options
+	ProfilerAddress   string
 }
 
 func NewOptions() *Options {
@@ -67,6 +68,7 @@ func NewOptions() *Options {
 		Logs:           *logs.NewOptions(),
 
 		VirtualWorkspaces: *virtualworkspacesoptions.NewOptions(),
+		ProfilerAddress:   "",
 	}
 
 	opts.SecureServing.ServerCert.CertKey.CertFile = filepath.Join(".", ".kcp", "apiserver.crt")
@@ -87,6 +89,7 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	_ = cobra.MarkFlagRequired(flags, "kubeconfig")
 
 	flags.StringVar(&o.Context, "context", o.Context, "Name of the context in the kubeconfig file to use")
+	flags.StringVar(&o.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to")
 }
 
 func (o *Options) Validate() error {

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -26,9 +26,6 @@
 /cmd/test-server/kcp/shard.go:188:5: function "V" should not be used, convert to contextual logging
 /cmd/test-server/kcp/shard.go:192:6: function "Enabled" should not be used, convert to contextual logging
 /cmd/test-server/kcp/shard.go:192:6: function "V" should not be used, convert to contextual logging
-/cmd/virtual-workspaces/command/cmd.go:164:2: function "Infof" should not be used, convert to contextual logging
-/cmd/virtual-workspaces/command/cmd.go:99:4: function "Infof" should not be used, convert to contextual logging
-/cmd/virtual-workspaces/command/cmd.go:99:4: function "V" should not be used, convert to contextual logging
 /config/crds/bootstrap.go:128:2: function "Infof" should not be used, convert to contextual logging
 /config/crds/bootstrap.go:128:2: function "V" should not be used, convert to contextual logging
 /config/crds/bootstrap.go:149:5: function "Infof" should not be used, convert to contextual logging

--- a/pkg/virtual/options/options.go
+++ b/pkg/virtual/options/options.go
@@ -72,6 +72,7 @@ func (o *Options) NewVirtualWorkspaces(
 	wildcardKubeInformers kubernetesinformers.SharedInformerFactory,
 	wildcardKcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
+
 	workspaces, err := o.Workspaces.NewVirtualWorkspaces(rootPathPrefix, config, wildcardKubeInformers, wildcardKcpInformers)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
Adds profiler address as command line argument

Fixes https://github.com/kcp-dev/kcp/issues/1836

Screenshot: 
![Screenshot from 2022-09-19 20-44-37](https://user-images.githubusercontent.com/54092533/191048663-e86287e9-ea54-452a-9737-8e85895a225c.png)

