### PR TITLE
🌱 cache: introduce the replication controller

### DIFF
--- a/pkg/reconciler/cache/replication/indexers.go
+++ b/pkg/reconciler/cache/replication/indexers.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"fmt"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+const (
+	// ByShardAndLogicalClusterAndNamespaceAndName is the name for the index that indexes by an object's shard and logical cluster, namespace and name
+	ByShardAndLogicalClusterAndNamespaceAndName = "kcp-byShardAndLogicalClusterAndNamespaceAndName"
+)
+
+// IndexByShardAndLogicalClusterAndNamespace is an index function that indexes by an object's shard and logical cluster, namespace and name
+func IndexByShardAndLogicalClusterAndNamespace(obj interface{}) ([]string, error) {
+	a, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
+	}
+	annotations := a.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	// TODO: rename to genericapirequest.ShardNameAnnotationKey
+	shardName := annotations[genericapirequest.AnnotationKey]
+
+	return []string{ShardAndLogicalClusterAndNamespaceKey(shardName, logicalcluster.From(a).String(), a.GetNamespace(), a.GetName())}, nil
+}
+
+// ShardAndLogicalClusterAndNamespaceKey creates an index key from the given parameters.
+// As of today this function is used by IndexByShardAndLogicalClusterAndNamespace indexer.
+func ShardAndLogicalClusterAndNamespaceKey(shard, cluster, namespace, name string) string {
+	var key string
+	if len(shard) > 0 {
+		key += shard + "|"
+	}
+	if len(cluster) > 0 {
+		key += cluster + "|"
+	}
+	if len(namespace) > 0 {
+		key += namespace + "/"
+	}
+	if len(key) == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s%s", key, name)
+}

--- a/pkg/reconciler/cache/replication/replication_controller.go
+++ b/pkg/reconciler/cache/replication/replication_controller.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
+	"github.com/kcp-dev/kcp/pkg/cache/client/shard"
+	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
+	apislisters "github.com/kcp-dev/kcp/pkg/client/listers/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/logging"
+)
+
+const (
+	// ControllerName hold this controller name.
+	ControllerName = "kcp-replication-controller"
+
+	// AnnotationKey is the name of the annotation key used to mark an object for replication.
+	AnnotationKey = "internal.sharding.kcp.dev/replicate"
+)
+
+// NewController returns a new replication controller.
+//
+// The replication controller copies objects of defined resources that have the "internal.sharding.kcp.dev/replicate" annotation to the cache server.
+//
+// The replicated object will be placed under the same cluster as the original object.
+// In addition to that, all replicated objects will be placed under the shard taken from the shardName argument.
+// For example: shards/{shardName}/clusters/{clusterName}/apis/apis.kcp.dev/v1alpha1/apiexports
+func NewController(
+	shardName string,
+	dynamicCacheClient dynamic.ClusterInterface,
+	dynamicLocalClient dynamic.ClusterInterface,
+	localApiExportInformer apisinformers.APIExportInformer,
+	cacheApiExportInformer apisinformers.APIExportInformer,
+) (*controller, error) {
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
+	c := &controller{
+		shardName:              shardName,
+		queue:                  queue,
+		dynamicCacheClient:     dynamicCacheClient,
+		dynamicLocalClient:     dynamicLocalClient,
+		localApiExportLister:   localApiExportInformer.Lister(),
+		cacheApiExportsIndexer: cacheApiExportInformer.Informer().GetIndexer(),
+	}
+
+	if err := cacheApiExportInformer.Informer().AddIndexers(cache.Indexers{
+		ByShardAndLogicalClusterAndNamespaceAndName: IndexByShardAndLogicalClusterAndNamespace,
+	}); err != nil {
+		return nil, err
+	}
+	c.cacheApiExportsIndexer = cacheApiExportInformer.Informer().GetIndexer()
+
+	localApiExportInformer.Informer().AddEventHandler(c.apiExportInformerEventHandler())
+	cacheApiExportInformer.Informer().AddEventHandler(c.apiExportInformerEventHandler())
+	return c, nil
+}
+
+func (c *controller) enqueueAPIExport(obj interface{}) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	gvr := apisv1alpha1.SchemeGroupVersion.WithResource("apiexports")
+	gvrKey := fmt.Sprintf("%v::%v", gvr.String(), key)
+	c.queue.Add(gvrKey)
+}
+
+// Start starts the controller, which stops when ctx.Done() is closed.
+func (c *controller) Start(ctx context.Context, workers int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(cacheclient.WithShardInContext(ctx, shard.New(c.shardName)), logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < workers; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	grKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(grKey)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), grKey.(string))
+	ctx = klog.NewContext(ctx, logger)
+	err := c.reconcile(ctx, grKey.(string))
+	if err == nil {
+		c.queue.Forget(grKey)
+		return true
+	}
+
+	runtime.HandleError(fmt.Errorf("%v failed with: %w", grKey, err))
+	c.queue.AddRateLimited(grKey)
+
+	return true
+}
+
+func (c *controller) apiExportInformerEventHandler() cache.FilteringResourceEventHandler {
+	return cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			apiExport, ok := obj.(*apisv1alpha1.APIExport)
+			if !ok {
+				return false
+			}
+			_, hasReplicationLabel := apiExport.Annotations[AnnotationKey]
+			return hasReplicationLabel
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { c.enqueueAPIExport(obj) },
+			UpdateFunc: func(_, obj interface{}) { c.enqueueAPIExport(obj) },
+			DeleteFunc: func(obj interface{}) { c.enqueueAPIExport(obj) },
+		},
+	}
+}
+
+type controller struct {
+	shardName string
+	queue     workqueue.RateLimitingInterface
+
+	dynamicCacheClient dynamic.ClusterInterface
+	dynamicLocalClient dynamic.ClusterInterface
+
+	localApiExportLister apislisters.APIExportLister
+
+	cacheApiExportsIndexer cache.Indexer
+}

--- a/pkg/reconciler/cache/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func (c *controller) reconcile(ctx context.Context, grKey string) error {
+	keyParts := strings.Split(grKey, "::")
+	if len(keyParts) != 2 {
+		return fmt.Errorf("incorrect key: %v, expected group.resource::key", grKey)
+	}
+	switch keyParts[0] {
+	case apisv1alpha1.SchemeGroupVersion.WithResource("apiexports").String():
+		return c.reconcileAPIExports(ctx, keyParts[1], apisv1alpha1.SchemeGroupVersion.WithResource("apiexports"))
+	default:
+		return fmt.Errorf("unsupported resource %v", keyParts[0])
+	}
+}
+
+// reconcileAPIExports makes sure that the ApiExport under the given key from the local shard is replicated to the cache server.
+// the replication function handles the following cases:
+//  1. creation of the object in the cache server when the cached object is not found in c.localApiExportLister
+//  2. deletion of the object from the cache server when the original/local object was removed OR was not found in c.localApiExportLister
+//  3. modification of the cached object to match the original one when meta.annotations, meta.labels, spec or status are different
+func (c *controller) reconcileAPIExports(ctx context.Context, key string, gvr schema.GroupVersionResource) error {
+	var cacheApiExport *apisv1alpha1.APIExport
+	var localApiExport *apisv1alpha1.APIExport
+	var cluster logicalcluster.Name
+	var namespace string
+	var apiExportName string
+	var err error
+	cluster, namespace, apiExportName, err = kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	cacheApiExport, err = c.retrieveApiExport(&gvr, cluster.String(), namespace, apiExportName)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	localApiExport, err = c.localApiExportLister.Get(key)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if errors.IsNotFound(err) {
+		// issue a live GET to make sure the localApiExport was removed
+		unstructuredLiveLocalApiExport, err := c.dynamicLocalClient.Cluster(cluster).Resource(gvr).Get(ctx, apiExportName, metav1.GetOptions{})
+		if err == nil {
+			return fmt.Errorf("the informer used by this controller is stale, the following APIExport was found on the local server: %s/%s/%s but was missing in the informer", cluster, unstructuredLiveLocalApiExport.GetNamespace(), unstructuredLiveLocalApiExport.GetName())
+		}
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	var unstructuredCacheApiExport *unstructured.Unstructured
+	var unstructuredLocalApiExport *unstructured.Unstructured
+	if cacheApiExport != nil {
+		unstructuredCacheApiExport, err = toUnstructured(cacheApiExport)
+		if err != nil {
+			return err
+		}
+		unstructuredCacheApiExport.SetKind("APIExport")
+		unstructuredCacheApiExport.SetAPIVersion(gvr.GroupVersion().String())
+	}
+	if localApiExport != nil {
+		unstructuredLocalApiExport, err = toUnstructured(localApiExport)
+		if err != nil {
+			return err
+		}
+		unstructuredLocalApiExport.SetKind("APIExport")
+		unstructuredLocalApiExport.SetAPIVersion(gvr.GroupVersion().String())
+	}
+	if cluster.Empty() && localApiExport != nil {
+		cluster = logicalcluster.From(localApiExport)
+	}
+
+	return c.reconcileUnstructuredObjects(ctx, cluster, &gvr, unstructuredCacheApiExport, unstructuredLocalApiExport)
+}
+
+func (c *controller) retrieveApiExport(gvr *schema.GroupVersionResource, clusterName, namespace, apiExportName string) (*apisv1alpha1.APIExport, error) {
+	cacheApiExports, err := c.cacheApiExportsIndexer.ByIndex(ByShardAndLogicalClusterAndNamespaceAndName, ShardAndLogicalClusterAndNamespaceKey(c.shardName, clusterName, namespace, apiExportName))
+	if err != nil {
+		return nil, err
+	}
+	if len(cacheApiExports) == 0 {
+		return nil, errors.NewNotFound(gvr.GroupResource(), apiExportName)
+	}
+	if len(cacheApiExports) > 1 {
+		return nil, fmt.Errorf("expected to find only one instance for the key %s, found %d", ShardAndLogicalClusterAndNamespaceKey(c.shardName, clusterName, namespace, apiExportName), len(cacheApiExports))
+	}
+	return cacheApiExports[0].(*apisv1alpha1.APIExport), nil
+}

--- a/pkg/reconciler/cache/replication/replication_reconcile_apiexports_test.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile_apiexports_test.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	apislisters "github.com/kcp-dev/kcp/pkg/client/listers/apis/v1alpha1"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = apisv1alpha1.AddToScheme(scheme)
+}
+
+func TestReconcileAPIExports(t *testing.T) {
+	scenarios := []struct {
+		name                                     string
+		initialLocalApiExports                   []runtime.Object
+		initialCacheApiExports                   []runtime.Object
+		initCacheFakeClientWithInitialApiExports bool
+		reconcileKey                             string
+		validateFunc                             func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name)
+	}{
+		{
+			name:                   "case 1: creation of the object in the cache server",
+			initialLocalApiExports: []runtime.Object{newAPIExport("foo")},
+			reconcileKey:           "root|foo",
+			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
+				if len(localClientActions) != 0 {
+					ts.Fatal("unexpected REST calls were made to the localDynamicClient")
+				}
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted for cacheDynamicClient", targetClusterCacheClient)
+				}
+				wasCacheApiExportValidated := false
+				for _, action := range cacheClientActions {
+					if action.Matches("create", "apiexports") {
+						createAction := action.(clientgotesting.CreateAction)
+						createdUnstructuredApiExport := createAction.GetObject().(*unstructured.Unstructured)
+						cacheApiExportFromUnstructured := &apisv1alpha1.APIExport{}
+						if err := runtime.DefaultUnstructuredConverter.FromUnstructured(createdUnstructuredApiExport.Object, cacheApiExportFromUnstructured); err != nil {
+							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
+						}
+
+						expectedApiExport := newAPIExport("foo")
+						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
+							ts.Errorf("unexpected ApiExport was creaetd:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
+						}
+						wasCacheApiExportValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't created")
+				}
+			},
+		},
+		{
+			name: "case 2: cached object is removed when local object was removed",
+			initialLocalApiExports: []runtime.Object{
+				func() *apisv1alpha1.APIExport {
+					t := metav1.NewTime(time.Now())
+					apiExport := newAPIExport("foo")
+					apiExport.DeletionTimestamp = &t
+					apiExport.Finalizers = []string{"aFinalizer"}
+					return apiExport
+				}(),
+			},
+			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initCacheFakeClientWithInitialApiExports: true,
+			reconcileKey:                             "root|foo",
+			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
+				if len(localClientActions) != 0 {
+					ts.Fatalf("wrong cluster = %s was targeted for cacheDynamicClient", targetClusterCacheClient)
+				}
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted", targetClusterCacheClient)
+				}
+				wasCacheApiExportValidated := false
+				for _, action := range cacheClientActions {
+					if action.Matches("delete", "apiexports") {
+						deleteAction := action.(clientgotesting.DeleteAction)
+						if deleteAction.GetName() != "foo" {
+							ts.Fatalf("unexpected APIExport was removed = %v, expected = %v", deleteAction.GetName(), "foo")
+						}
+						wasCacheApiExportValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't deleted")
+				}
+			},
+		},
+		{
+			name:                                     "case 2: cached object is removed when local object was not found",
+			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initCacheFakeClientWithInitialApiExports: true,
+			reconcileKey:                             "root|foo",
+			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted for cacheDynamicClient", targetClusterCacheClient)
+				}
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted for localDynamicClient", targetClusterLocalClient)
+				}
+				wasCacheApiExportDeletionValidated := false
+				wasCacheApiExportRetrievalValidated := false
+				for _, action := range localClientActions {
+					if action.Matches("get", "apiexports") {
+						getAction := action.(clientgotesting.GetAction)
+						if getAction.GetName() != "foo" {
+							ts.Fatalf("unexpected ApiExport was retrieved = %s, expected = %s", getAction.GetName(), "foo")
+						}
+						wasCacheApiExportRetrievalValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportRetrievalValidated {
+					ts.Errorf("before deleting an ApiExport the controller should live GET it")
+				}
+				for _, action := range cacheClientActions {
+					if action.Matches("delete", "apiexports") {
+						deleteAction := action.(clientgotesting.DeleteAction)
+						if deleteAction.GetName() != "foo" {
+							ts.Fatalf("unexpected APIExport was removed = %v, expected = %v", deleteAction.GetName(), "foo")
+						}
+						wasCacheApiExportDeletionValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportDeletionValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't deleted")
+				}
+			},
+		},
+		{
+			name: "case 3: update, metadata mismatch",
+			initialLocalApiExports: []runtime.Object{
+				func() *apisv1alpha1.APIExport {
+					apiExport := newAPIExport("foo")
+					apiExport.Labels["fooLabel"] = "fooLabelVal"
+					return apiExport
+				}(),
+			},
+			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initCacheFakeClientWithInitialApiExports: true,
+			reconcileKey:                             "root|foo",
+			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
+				if len(localClientActions) != 0 {
+					ts.Fatal("unexpected REST calls were made to the localDynamicClient")
+				}
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted for cacheDynamicClient", targetClusterCacheClient)
+				}
+				wasCacheApiExportValidated := false
+				for _, action := range cacheClientActions {
+					if action.Matches("update", "apiexports") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						updatedUnstructuredApiExport := updateAction.GetObject().(*unstructured.Unstructured)
+						cacheApiExportFromUnstructured := &apisv1alpha1.APIExport{}
+						if err := runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredApiExport.Object, cacheApiExportFromUnstructured); err != nil {
+							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
+						}
+
+						expectedApiExport := newAPIExport("foo")
+						expectedApiExport.Labels["fooLabel"] = "fooLabelVal"
+						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
+							ts.Errorf("unexpected update to the ApiExport:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
+						}
+						wasCacheApiExportValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't updated")
+				}
+			},
+		},
+		{
+			name: "case 3: update, spec changed",
+			initialLocalApiExports: []runtime.Object{
+				func() *apisv1alpha1.APIExport {
+					apiExport := newAPIExport("foo")
+					apiExport.Spec.PermissionClaims = []apisv1alpha1.PermissionClaim{{GroupResource: apisv1alpha1.GroupResource{}, IdentityHash: "abc"}}
+					return apiExport
+				}(),
+			},
+			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initCacheFakeClientWithInitialApiExports: true,
+			reconcileKey:                             "root|foo",
+			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
+				if len(localClientActions) != 0 {
+					ts.Fatal("unexpected REST calls were made to the localDynamicClient")
+				}
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted for cacheDynamicClient", targetClusterCacheClient)
+				}
+				wasCacheApiExportValidated := false
+				for _, action := range cacheClientActions {
+					if action.Matches("update", "apiexports") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						updatedUnstructuredApiExport := updateAction.GetObject().(*unstructured.Unstructured)
+						cacheApiExportFromUnstructured := &apisv1alpha1.APIExport{}
+						if err := runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredApiExport.Object, cacheApiExportFromUnstructured); err != nil {
+							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
+						}
+
+						expectedApiExport := newAPIExport("foo")
+						expectedApiExport.Spec.PermissionClaims = []apisv1alpha1.PermissionClaim{{GroupResource: apisv1alpha1.GroupResource{}, IdentityHash: "abc"}}
+						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
+							ts.Errorf("unexpected update to the ApiExport:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
+						}
+						wasCacheApiExportValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't updated")
+				}
+			},
+		},
+		{
+			name: "case 3: update, status changed",
+			initialLocalApiExports: []runtime.Object{
+				func() *apisv1alpha1.APIExport {
+					apiExport := newAPIExport("foo")
+					apiExport.Status.VirtualWorkspaces = []apisv1alpha1.VirtualWorkspace{{URL: "https://acme.dev"}}
+					return apiExport
+				}(),
+			},
+			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initCacheFakeClientWithInitialApiExports: true,
+			reconcileKey:                             "root|foo",
+			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
+				if len(localClientActions) != 0 {
+					ts.Fatal("unexpected REST calls were made to the localDynamicClient")
+				}
+				if targetClusterCacheClient.String() != "root" {
+					ts.Fatalf("wrong cluster = %s was targeted for cacheDynamicClient", targetClusterCacheClient)
+				}
+				wasCacheApiExportValidated := false
+				for _, action := range cacheClientActions {
+					if action.Matches("update", "apiexports") {
+						updateAction := action.(clientgotesting.UpdateAction)
+						updatedUnstructuredApiExport := updateAction.GetObject().(*unstructured.Unstructured)
+						cacheApiExportFromUnstructured := &apisv1alpha1.APIExport{}
+						if err := runtime.DefaultUnstructuredConverter.FromUnstructured(updatedUnstructuredApiExport.Object, cacheApiExportFromUnstructured); err != nil {
+							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
+						}
+
+						expectedApiExport := newAPIExport("foo")
+						expectedApiExport.Status.VirtualWorkspaces = []apisv1alpha1.VirtualWorkspace{{URL: "https://acme.dev"}}
+						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
+							ts.Errorf("unexpected update to the ApiExport:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
+						}
+						wasCacheApiExportValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't updated")
+				}
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(tt *testing.T) {
+			target := &controller{shardName: "amber"}
+			localApiExportIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			for _, obj := range scenario.initialLocalApiExports {
+				if err := localApiExportIndexer.Add(obj); err != nil {
+					tt.Error(err)
+				}
+			}
+			target.localApiExportLister = apislisters.NewAPIExportLister(localApiExportIndexer)
+			target.cacheApiExportsIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{ByShardAndLogicalClusterAndNamespaceAndName: IndexByShardAndLogicalClusterAndNamespace})
+			for _, obj := range scenario.initialCacheApiExports {
+				if err := target.cacheApiExportsIndexer.Add(obj); err != nil {
+					tt.Error(err)
+				}
+			}
+			fakeCacheDynamicClient := newFakeKcpClusterClient(dynamicfake.NewSimpleDynamicClient(scheme, func() []runtime.Object {
+				if scenario.initCacheFakeClientWithInitialApiExports {
+					return scenario.initialCacheApiExports
+				}
+				return []runtime.Object{}
+			}()...))
+			target.dynamicCacheClient = fakeCacheDynamicClient
+			fakeLocalDynamicClient := newFakeKcpClusterClient(dynamicfake.NewSimpleDynamicClient(scheme))
+			target.dynamicLocalClient = fakeLocalDynamicClient
+			if err := target.reconcileAPIExports(context.TODO(), scenario.reconcileKey, apisv1alpha1.SchemeGroupVersion.WithResource("apiexports")); err != nil {
+				tt.Fatal(err)
+			}
+			if scenario.validateFunc != nil {
+				scenario.validateFunc(tt, fakeCacheDynamicClient.fakeDs.Actions(), fakeLocalDynamicClient.fakeDs.Actions(), fakeCacheDynamicClient.cluster, fakeLocalDynamicClient.cluster)
+			}
+		})
+	}
+}
+
+func newAPIExport(name string) *apisv1alpha1.APIExport {
+	return &apisv1alpha1.APIExport{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apis.kcp.dev/v1alpha1",
+			Kind:       "APIExport",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{},
+			Annotations: map[string]string{
+				logicalcluster.AnnotationKey: "root",
+				"kcp.dev/shard":              "amber",
+			},
+			Name: name,
+		},
+		Spec: apisv1alpha1.APIExportSpec{
+			LatestResourceSchemas: []string{"lrs"},
+		},
+		Status: apisv1alpha1.APIExportStatus{
+			IdentityHash: fmt.Sprintf("%s-identity", name),
+		},
+	}
+}
+
+func newFakeKcpClusterClient(ds *dynamicfake.FakeDynamicClient) *fakeKcpClusterClient {
+	return &fakeKcpClusterClient{fakeDs: ds}
+}
+
+type fakeKcpClusterClient struct {
+	fakeDs  *dynamicfake.FakeDynamicClient
+	cluster logicalcluster.Name
+}
+
+func (f *fakeKcpClusterClient) Cluster(name logicalcluster.Name) dynamic.Interface {
+	f.cluster = name
+	return f.fakeDs
+}

--- a/pkg/reconciler/cache/replication/replication_reconcile_unstructured.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile_unstructured.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// reconcileUnstructuredObjects makes sure that the given cachedObject of the given GVR under the given key from the local shard is replicated to the cache server.
+//
+// this method handles the following cases:
+//  1. creation of the object in the cache server
+//     happens when the cacheObject is nil
+//  2. deletion of the object from the cache server
+//     happens when either of the following is true:
+//     - the localObject object is nil
+//     - the localObject was deleted
+//  3. modification of the object to match the original/local object
+//     happens when either of the following is true:
+//      - the localObject's metadata doesn't match the cacheObject
+//      - the localObject's spec doesn't match the cacheObject
+//      - the localObject's status doesn't match the cacheObject
+func (c *controller) reconcileUnstructuredObjects(ctx context.Context, cluster logicalcluster.Name, gvr *schema.GroupVersionResource, cacheObject *unstructured.Unstructured, localObject *unstructured.Unstructured) error {
+	if localObject == nil {
+		return c.handleObjectDeletion(ctx, cluster, gvr, cacheObject)
+	}
+	if localObject.GetDeletionTimestamp() != nil {
+		return c.handleObjectDeletion(ctx, cluster, gvr, cacheObject)
+	}
+
+	if cacheObject == nil {
+		// TODO: in the future the original RV will have to be stored in an annotation (?)
+		// so that the clients that need to modify the original/local object can do it
+		localObject.SetResourceVersion("")
+		_, err := c.dynamicCacheClient.Cluster(cluster).Resource(*gvr).Namespace(localObject.GetNamespace()).Create(ctx, localObject, metav1.CreateOptions{})
+		return err
+	}
+
+	metaChanged, err := ensureMeta(cacheObject, localObject)
+	if err != nil {
+		return err
+	}
+	remainingChanged, err := ensureRemaining(cacheObject, localObject)
+	if err != nil {
+		return err
+	}
+	if !metaChanged && !remainingChanged {
+		return nil
+	}
+
+	if metaChanged || remainingChanged {
+		_, err := c.dynamicCacheClient.Cluster(cluster).Resource(*gvr).Namespace(cacheObject.GetNamespace()).Update(ctx, cacheObject, metav1.UpdateOptions{})
+		return err
+	}
+	return nil
+}
+
+func (c *controller) handleObjectDeletion(ctx context.Context, cluster logicalcluster.Name, gvr *schema.GroupVersionResource, cacheObject *unstructured.Unstructured) error {
+	if cacheObject == nil {
+		return nil // the cached object already removed
+	}
+	if cacheObject.GetDeletionTimestamp() == nil {
+		return c.dynamicCacheClient.Cluster(cluster).Resource(*gvr).Delete(ctx, cacheObject.GetName(), metav1.DeleteOptions{})
+	}
+	return nil
+}
+
+// ensureMeta changes unstructuredCacheObject's metadata to match unstructuredLocalObject's metadata except the ResourceVersion and the shard annotation fields
+func ensureMeta(cacheObject *unstructured.Unstructured, localObject *unstructured.Unstructured) (changed bool, err error) {
+	cacheObjMetaRaw, hasCacheObjMetaRaw, err := unstructured.NestedFieldNoCopy(cacheObject.Object, "metadata")
+	if err != nil {
+		return false, err
+	}
+	cacheObjMeta, ok := cacheObjMetaRaw.(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("metadata field of unstructuredCacheObject is of the type %T, expected map[string]interface{}", cacheObjMetaRaw)
+	}
+	localObjMetaRaw, hasLocalObjMetaRaw, err := unstructured.NestedFieldNoCopy(localObject.Object, "metadata")
+	if err != nil {
+		return false, err
+	}
+	localObjMeta, ok := localObjMetaRaw.(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("metadata field of unstructuredLocalObjectMeta is of the type %T, expected map[string]interface{}", localObjMetaRaw)
+	}
+	if !hasLocalObjMetaRaw && !hasCacheObjMetaRaw {
+		return false, nil // no-op
+	}
+	if !hasLocalObjMetaRaw {
+		unstructured.RemoveNestedField(cacheObject.Object, "metadata")
+		return true, nil
+	}
+
+	// before we can compare the cache object we need to
+	// store, remove and then bring back fields that are unique only to the cache object
+	if cacheObjRV, found := cacheObjMeta["resourceVersion"]; found {
+		unstructured.RemoveNestedField(cacheObjMeta, "resourceVersion")
+		defer func() {
+			if err == nil {
+				err = unstructured.SetNestedField(cacheObject.Object, cacheObjRV, "metadata", "resourceVersion")
+			}
+		}()
+	}
+	if cacheObjAnnotationsRaw, found := cacheObjMeta["annotations"]; found {
+		cacheObjAnnotations, ok := cacheObjAnnotationsRaw.(map[string]interface{})
+		if !ok {
+			return false, fmt.Errorf("metadata.annotations field of unstructuredCacheObject is of the type %T, expected map[string]interface{}", cacheObjAnnotationsRaw)
+		}
+		if shard, hasShard := cacheObjAnnotations[genericrequest.AnnotationKey]; hasShard {
+			unstructured.RemoveNestedField(cacheObjAnnotations, genericrequest.AnnotationKey)
+			defer func() {
+				if err == nil {
+					err = unstructured.SetNestedField(cacheObject.Object, shard, "metadata", "annotations", genericrequest.AnnotationKey)
+				}
+			}()
+		}
+		// TODO: in the future the original RV will be stored in an annotation
+	}
+
+	// before we can compare with the local object we need to
+	// store, remove and then bring back the ResourceVersion on the local object
+	if localObjRV, found := localObjMeta["resourceVersion"]; found {
+		unstructured.RemoveNestedField(localObjMeta, "resourceVersion")
+		defer func() {
+			if err == nil {
+				localObjMeta["resourceVersion"] = localObjRV
+			}
+		}()
+	}
+
+	changed = !reflect.DeepEqual(cacheObjMeta, localObjMeta)
+	if !changed {
+		return false, nil
+	}
+
+	newCacheObjMeta := map[string]interface{}{}
+	for k, v := range localObjMeta {
+		newCacheObjMeta[k] = v
+	}
+	return true, unstructured.SetNestedMap(cacheObject.Object, newCacheObjMeta, "metadata")
+}
+
+// ensureRemaining changes unstructuredCacheObject to match unstructuredLocalObject except for the metadata field
+// returns true when the unstructuredCacheObject was updated.
+func ensureRemaining(cacheObject *unstructured.Unstructured, localObject *unstructured.Unstructured) (bool, error) {
+	cacheObjMeta, found, err := unstructured.NestedFieldNoCopy(cacheObject.Object, "metadata")
+	if err != nil {
+		return false, err
+	}
+	if found {
+		unstructured.RemoveNestedField(cacheObject.Object, "metadata")
+		defer func() {
+			cacheObject.Object["metadata"] = cacheObjMeta
+		}()
+	}
+
+	localObjMeta, found, err := unstructured.NestedFieldNoCopy(localObject.Object, "metadata")
+	if err != nil {
+		return false, err
+	}
+	if found {
+		unstructured.RemoveNestedField(localObject.Object, "metadata")
+		defer func() {
+			localObject.Object["metadata"] = localObjMeta
+		}()
+	}
+
+	changed := !reflect.DeepEqual(cacheObject.Object, localObject.Object)
+	if !changed {
+		return false, nil
+	}
+
+	newCacheObj := map[string]interface{}{}
+	for k, v := range localObject.Object {
+		newCacheObj[k] = v
+	}
+	cacheObject.Object = newCacheObj
+	return true, nil
+}
+
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+	unstructured := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = raw
+	return unstructured, nil
+}

--- a/pkg/reconciler/cache/replication/replication_reconcile_unstructured_test.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile_unstructured_test.go
@@ -1,0 +1,531 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package replication
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgotesting "k8s.io/client-go/testing"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func TestEnsureUnstructuredSpec(t *testing.T) {
+	scenarios := []struct {
+		name                    string
+		cacheObject             *unstructured.Unstructured
+		localObject             *unstructured.Unstructured
+		expectSpecChanged       bool
+		expectError             bool
+		validateCacheObjectSpec func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured)
+	}{
+		{
+			name:        "no-op: empty",
+			cacheObject: &unstructured.Unstructured{},
+			localObject: &unstructured.Unstructured{},
+		},
+		{
+			name:        "local has the spec but cached hasn't",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{}},
+			localObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			}},
+			expectSpecChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				if _, hasSpec := cacheObject.Object["spec"]; !hasSpec {
+					ts.Fatal("the cachedObject doesn't have the spec field")
+				}
+				if _, hasSpec := localObject.Object["spec"]; !hasSpec {
+					ts.Fatal("the localObject was modified and doesn't have the spec field anymore")
+				}
+			},
+		},
+		{
+			name: "cache has the spec but local hasn't",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{},
+			}},
+			localObject:       &unstructured.Unstructured{Object: map[string]interface{}{}},
+			expectSpecChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				if _, hasSpec := cacheObject.Object["spec"]; hasSpec {
+					ts.Fatal("the cacheObject has the spec field")
+				}
+				if _, hasSpec := localObject.Object["spec"]; hasSpec {
+					ts.Fatal("the localObject has the spec field")
+				}
+			},
+		},
+		{
+			name: "local different than cache",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"fieldA": "a"},
+			}},
+			localObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"fieldA": "a", "fieldB": "b"},
+			}},
+			expectSpecChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				expectedObject := &unstructured.Unstructured{Object: map[string]interface{}{
+					"spec": map[string]interface{}{"fieldA": "a", "fieldB": "b"},
+				}}
+				if !reflect.DeepEqual(cacheObject.Object, expectedObject.Object) {
+					ts.Errorf("received spec differs from the expected one :\n%s", cmp.Diff(cacheObject.Object, expectedObject.Object))
+				}
+			},
+		},
+		{
+			name: "cache different than local",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"fieldA": "a", "fieldB": "b"},
+			}},
+			localObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"spec": map[string]interface{}{"fieldA": "a"},
+			}},
+			expectSpecChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				expectedObject := &unstructured.Unstructured{Object: map[string]interface{}{
+					"spec": map[string]interface{}{"fieldA": "a"},
+				}}
+				if !reflect.DeepEqual(cacheObject.Object, expectedObject.Object) {
+					ts.Errorf("received spec differs from the expected one :\n%s", cmp.Diff(cacheObject.Object, expectedObject.Object))
+				}
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(tt *testing.T) {
+			specChanged, err := ensureRemaining(scenario.cacheObject, scenario.localObject)
+			if specChanged != scenario.expectSpecChanged {
+				tt.Fatalf("spec changed = %v, expected spec to be changed = %v", specChanged, scenario.expectSpecChanged)
+			}
+			if scenario.expectError && err == nil {
+				tt.Errorf("expected to get an error")
+			}
+			if !scenario.expectError && err != nil {
+				tt.Errorf("unexpected error: %v", err)
+			}
+			if scenario.validateCacheObjectSpec != nil {
+				scenario.validateCacheObjectSpec(tt, scenario.cacheObject, scenario.localObject)
+			}
+		})
+	}
+}
+
+func TestEnsureUnstructuredStatus(t *testing.T) {
+	scenarios := []struct {
+		name                    string
+		cacheObject             *unstructured.Unstructured
+		localObject             *unstructured.Unstructured
+		expectStatusChanged     bool
+		expectError             bool
+		validateCacheObjectSpec func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured)
+	}{
+		{
+			name:        "no-op: empty",
+			cacheObject: &unstructured.Unstructured{},
+			localObject: &unstructured.Unstructured{},
+		},
+		{
+			name:        "local has the status but cached hasn't",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{}},
+			localObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{},
+			}},
+			expectStatusChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				if _, hasStatus := cacheObject.Object["status"]; !hasStatus {
+					ts.Fatal("the cachedObject doesn't have the status field")
+				}
+				if _, hasStatus := localObject.Object["status"]; !hasStatus {
+					ts.Fatal("the localObject was modified and doesn't have the status field anymore")
+				}
+			},
+		},
+		{
+			name: "cache has the status but local hasn't",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{},
+			}},
+			localObject:         &unstructured.Unstructured{Object: map[string]interface{}{}},
+			expectStatusChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				if _, hasStatus := cacheObject.Object["status"]; hasStatus {
+					ts.Fatal("the cacheObject has the status field")
+				}
+				if _, hasStatus := localObject.Object["status"]; hasStatus {
+					ts.Fatal("the localObject has the status field")
+				}
+			},
+		},
+		{
+			name: "local different than cache",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{"fieldA": "a"},
+			}},
+			localObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{"fieldA": "a", "fieldB": "b"},
+			}},
+			expectStatusChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				expectedObject := &unstructured.Unstructured{Object: map[string]interface{}{
+					"status": map[string]interface{}{"fieldA": "a", "fieldB": "b"},
+				}}
+				if !reflect.DeepEqual(cacheObject.Object, expectedObject.Object) {
+					ts.Errorf("received status differs from the expected one :\n%s", cmp.Diff(cacheObject.Object, expectedObject.Object))
+				}
+			},
+		},
+		{
+			name: "cache different than local",
+			cacheObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{"fieldA": "a", "fieldB": "b"},
+			}},
+			localObject: &unstructured.Unstructured{Object: map[string]interface{}{
+				"status": map[string]interface{}{"fieldA": "a"},
+			}},
+			expectStatusChanged: true,
+			validateCacheObjectSpec: func(ts *testing.T, cacheObject, localObject *unstructured.Unstructured) {
+				expectedObject := &unstructured.Unstructured{Object: map[string]interface{}{
+					"status": map[string]interface{}{"fieldA": "a"},
+				}}
+				if !reflect.DeepEqual(cacheObject.Object, expectedObject.Object) {
+					ts.Errorf("received status differs from the expected one :\n%s", cmp.Diff(cacheObject.Object, expectedObject.Object))
+				}
+			},
+		},
+	}
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(tt *testing.T) {
+			statusChanged, err := ensureRemaining(scenario.cacheObject, scenario.localObject)
+			if statusChanged != scenario.expectStatusChanged {
+				tt.Fatalf("status changed = %v, expected spec to be changed = %v", statusChanged, scenario.expectStatusChanged)
+			}
+			if scenario.expectError && err == nil {
+				tt.Errorf("expected to get an error")
+			}
+			if !scenario.expectError && err != nil {
+				tt.Errorf("unexpected error: %v", err)
+			}
+			if scenario.validateCacheObjectSpec != nil {
+				scenario.validateCacheObjectSpec(tt, scenario.cacheObject, scenario.localObject)
+			}
+		})
+	}
+}
+
+func TestEnsureUnstructuredMeta(t *testing.T) {
+	scenarios := []struct {
+		name                    string
+		cacheObjectMeta         metav1.ObjectMeta
+		localObjectMeta         metav1.ObjectMeta
+		validateCacheObjectMeta func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta)
+		expectObjectMetaChanged bool
+	}{
+		{
+			name: "no-op: empty",
+		},
+		{
+			name:            "no-op: equal",
+			cacheObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "b"}},
+			localObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"a": "b"}},
+		},
+		{
+			name:            "no-op: equal with rv",
+			cacheObjectMeta: metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b"}},
+			localObjectMeta: metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b"}},
+			validateCacheObjectMeta: func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta) {
+				expectedCacheObjectMeta := metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b"}}
+				if !reflect.DeepEqual(cacheObjectMeta, expectedCacheObjectMeta) {
+					ts.Errorf("received metadata differs from the expected one :\n%s", cmp.Diff(cacheObjectMeta, expectedCacheObjectMeta))
+				}
+
+				expectedLocalObjectMeta := metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b"}}
+				if !reflect.DeepEqual(localObjectMeta, expectedLocalObjectMeta) {
+					ts.Errorf("local object's metadata mustn't be changed, diff :\n%s", cmp.Diff(localObjectMeta, expectedLocalObjectMeta))
+				}
+			},
+		},
+		{
+			name:                    "annotations on local different",
+			cacheObjectMeta:         metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b"}},
+			localObjectMeta:         metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b", "foo": "bar"}},
+			expectObjectMetaChanged: true,
+			validateCacheObjectMeta: func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta) {
+				expectedCacheObjectMeta := metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b", "foo": "bar"}}
+				if !reflect.DeepEqual(cacheObjectMeta, expectedCacheObjectMeta) {
+					ts.Errorf("received metadata differs from the expected one :\n%s", cmp.Diff(cacheObjectMeta, expectedCacheObjectMeta))
+				}
+
+				expectedLocalObjectMeta := metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b", "foo": "bar"}}
+				if !reflect.DeepEqual(localObjectMeta, expectedLocalObjectMeta) {
+					ts.Errorf("local object's metadata mustn't be changed, diff :\n%s", cmp.Diff(localObjectMeta, expectedLocalObjectMeta))
+				}
+			},
+		},
+		{
+			name:                    "annotations on cached different",
+			cacheObjectMeta:         metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b", "foo": "bar"}},
+			localObjectMeta:         metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b"}},
+			expectObjectMetaChanged: true,
+			validateCacheObjectMeta: func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta) {
+				expectedCacheObjectMeta := metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b"}}
+				if !reflect.DeepEqual(cacheObjectMeta, expectedCacheObjectMeta) {
+					ts.Errorf("received metadata differs from the expected one :\n%s", cmp.Diff(cacheObjectMeta, expectedCacheObjectMeta))
+				}
+
+				expectedLocalObjectMeta := metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b"}}
+				if !reflect.DeepEqual(localObjectMeta, expectedLocalObjectMeta) {
+					ts.Errorf("local object's metadata mustn't be changed, diff :\n%s", cmp.Diff(localObjectMeta, expectedLocalObjectMeta))
+				}
+			},
+		},
+		{
+			name:                    "annotations on local diff and cached has a shard name",
+			cacheObjectMeta:         metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b", "kcp.dev/shard": "amber"}},
+			localObjectMeta:         metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b", "foo": "bar"}},
+			expectObjectMetaChanged: true,
+			validateCacheObjectMeta: func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta) {
+				expectedCacheObjectMeta := metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"a": "b", "kcp.dev/shard": "amber", "foo": "bar"}}
+				if !reflect.DeepEqual(cacheObjectMeta, expectedCacheObjectMeta) {
+					ts.Errorf("received metadata differs from the expected one :\n%s", cmp.Diff(cacheObjectMeta, expectedCacheObjectMeta))
+				}
+
+				expectedLocalObjectMeta := metav1.ObjectMeta{ResourceVersion: "2", Annotations: map[string]string{"a": "b", "foo": "bar"}}
+				if !reflect.DeepEqual(localObjectMeta, expectedLocalObjectMeta) {
+					ts.Errorf("local object's metadata mustn't be changed, diff :\n%s", cmp.Diff(localObjectMeta, expectedLocalObjectMeta))
+				}
+			},
+		},
+		{
+			name:                    "no annotations on local, shard name is preserved on cached",
+			cacheObjectMeta:         metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"kcp.dev/shard": "amber"}},
+			localObjectMeta:         metav1.ObjectMeta{},
+			expectObjectMetaChanged: true,
+			validateCacheObjectMeta: func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta) {
+				expectedCacheObjectMeta := metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"kcp.dev/shard": "amber"}}
+				if !reflect.DeepEqual(cacheObjectMeta, expectedCacheObjectMeta) {
+					ts.Errorf("received metadata differs from the expected one :\n%s", cmp.Diff(cacheObjectMeta, expectedCacheObjectMeta))
+				}
+
+				expectedLocalObjectMeta := metav1.ObjectMeta{}
+				if !reflect.DeepEqual(localObjectMeta, expectedLocalObjectMeta) {
+					ts.Errorf("local object's metadata mustn't be changed, diff :\n%s", cmp.Diff(localObjectMeta, expectedLocalObjectMeta))
+				}
+			},
+		},
+		{
+			name:                    "an arbitrary field on meta",
+			cacheObjectMeta:         metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"kcp.dev/shard": "amber"}},
+			localObjectMeta:         metav1.ObjectMeta{Finalizers: []string{"f1"}},
+			expectObjectMetaChanged: true,
+			validateCacheObjectMeta: func(ts *testing.T, cacheObjectMeta, localObjectMeta metav1.ObjectMeta) {
+				expectedCacheObjectMeta := metav1.ObjectMeta{ResourceVersion: "1", Annotations: map[string]string{"kcp.dev/shard": "amber"}, Finalizers: []string{"f1"}}
+				if !reflect.DeepEqual(cacheObjectMeta, expectedCacheObjectMeta) {
+					ts.Errorf("received metadata differs from the expected one :\n%s", cmp.Diff(cacheObjectMeta, expectedCacheObjectMeta))
+				}
+
+				expectedLocalObjectMeta := metav1.ObjectMeta{Finalizers: []string{"f1"}}
+				if !reflect.DeepEqual(localObjectMeta, expectedLocalObjectMeta) {
+					ts.Errorf("local object's metadata mustn't be changed, diff :\n%s", cmp.Diff(localObjectMeta, expectedLocalObjectMeta))
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(tt *testing.T) {
+			cacheApiExport := &apisv1alpha1.APIExport{ObjectMeta: scenario.cacheObjectMeta}
+			unstructuredCacheApiExport, err := toUnstructured(cacheApiExport)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			localApiExport := &apisv1alpha1.APIExport{ObjectMeta: scenario.localObjectMeta}
+			unstructuredLocalApiExport, err := toUnstructured(localApiExport)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			metaChanged, err := ensureMeta(unstructuredCacheApiExport, unstructuredLocalApiExport)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			if metaChanged != scenario.expectObjectMetaChanged {
+				tt.Fatalf("metadata changed = %v, expected metadata to be changed = %v", metaChanged, scenario.expectObjectMetaChanged)
+			}
+			if scenario.validateCacheObjectMeta != nil {
+				cacheApiExportFromUnstructured := &apisv1alpha1.APIExport{}
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredCacheApiExport.Object, cacheApiExportFromUnstructured); err != nil {
+					tt.Fatalf("failed to convert unstructured to APIExport: %v", err)
+				}
+
+				localApiExportFromUnstructured := &apisv1alpha1.APIExport{}
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredLocalApiExport.Object, localApiExportFromUnstructured); err != nil {
+					tt.Fatalf("failed to convert unstructured to APIExport: %v", err)
+				}
+
+				scenario.validateCacheObjectMeta(tt, cacheApiExportFromUnstructured.ObjectMeta, localApiExportFromUnstructured.ObjectMeta)
+			}
+		})
+	}
+}
+
+func TestHandleUnstructuredObjectDeletion(t *testing.T) {
+	scenarios := []struct {
+		name                        string
+		cacheObject                 *apisv1alpha1.APIExport
+		validateCacheObjectDeletion func(ts *testing.T, actions []clientgotesting.Action)
+	}{
+		{
+			name: "no-op",
+		},
+		{
+			name:        "DeletionTimestamp filed not set on cacheObject",
+			cacheObject: newAPIExport("foo"),
+			validateCacheObjectDeletion: func(ts *testing.T, actions []clientgotesting.Action) {
+				wasCacheApiExportValidated := false
+				for _, action := range actions {
+					if action.Matches("delete", "apiexports") {
+						deleteAction := action.(clientgotesting.DeleteAction)
+						if deleteAction.GetName() != "foo" {
+							ts.Fatalf("unexpected APIExport was removed = %v, expected = %v", deleteAction.GetName(), "foo")
+						}
+						wasCacheApiExportValidated = true
+						break
+					}
+				}
+				if !wasCacheApiExportValidated {
+					ts.Errorf("an ApiExport on the cache sever wasn't deleted")
+				}
+			},
+		},
+		{
+			name: "no-op when DeletionTimestamp filed set",
+			cacheObject: func() *apisv1alpha1.APIExport {
+				t := metav1.NewTime(time.Now())
+				apiExport := newAPIExport("foo")
+				apiExport.DeletionTimestamp = &t
+				return apiExport
+			}(),
+			validateCacheObjectDeletion: func(ts *testing.T, actions []clientgotesting.Action) {
+				if len(actions) > 0 {
+					ts.Fatalf("didn't expect any API calls, got %v", actions)
+				}
+			},
+		},
+		{
+			name: "no-op when DeletionTimestamp filed and Finalizers are set",
+			cacheObject: func() *apisv1alpha1.APIExport {
+				t := metav1.NewTime(time.Now())
+				apiExport := newAPIExport("foo")
+				apiExport.DeletionTimestamp = &t
+				apiExport.Finalizers = []string{"aFinalizer"}
+				return apiExport
+			}(),
+			validateCacheObjectDeletion: func(ts *testing.T, actions []clientgotesting.Action) {
+				if len(actions) > 0 {
+					ts.Fatalf("didn't expect any API calls, got %v", actions)
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(tt *testing.T) {
+			var unstructuredCacheObject *unstructured.Unstructured
+			var err error
+			if scenario.cacheObject != nil {
+				unstructuredCacheObject, err = toUnstructured(scenario.cacheObject)
+				if err != nil {
+					tt.Fatal(err)
+				}
+			}
+			gvr := apisv1alpha1.SchemeGroupVersion.WithResource("apiexports")
+			target := &controller{}
+			fakeDynamicClient := newFakeKcpClusterClient(dynamicfake.NewSimpleDynamicClient(scheme, func() []runtime.Object {
+				if unstructuredCacheObject == nil {
+					return []runtime.Object{}
+				}
+				return []runtime.Object{unstructuredCacheObject}
+			}()...))
+			target.dynamicCacheClient = fakeDynamicClient
+
+			err = target.handleObjectDeletion(context.TODO(), logicalcluster.New("root"), &gvr, unstructuredCacheObject)
+			if err != nil {
+				tt.Fatal(err)
+			}
+			if scenario.validateCacheObjectDeletion != nil {
+				scenario.validateCacheObjectDeletion(tt, fakeDynamicClient.fakeDs.Actions())
+			}
+		})
+	}
+}
+
+// TestToUnstructured test if changing an unstructured obj won't change the original object
+func TestToUnstructured(t *testing.T) {
+	apiExport := newAPIExport("a1")
+	apiExport.Spec.MaximalPermissionPolicy = &apisv1alpha1.MaximalPermissionPolicy{Local: &apisv1alpha1.LocalAPIExportPolicy{}}
+	unstructuredApiExport, err := toUnstructured(apiExport)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// manipulate map (a reference type)
+	if err := unstructured.SetNestedField(unstructuredApiExport.Object, "valForNewAnnotation", "metadata", "annotations", "newAnnotation"); err != nil {
+		t.Fatal(err)
+	}
+	if newAnnotationVal := unstructuredApiExport.GetAnnotations()["newAnnotation"]; newAnnotationVal != "valForNewAnnotation" {
+		t.Fatalf("unexpected value %v for newAnnotation", newAnnotationVal)
+	}
+
+	if _, hasNewAnnotation := apiExport.Annotations["newAnnotation"]; hasNewAnnotation {
+		t.Fatal("didn't expect changing unstructuredApiExport annotation will also change the original apiExport object")
+	}
+
+	// manipulate string (a simple type)
+	if err := unstructured.SetNestedField(unstructuredApiExport.Object, "newName", "metadata", "name"); err != nil {
+		t.Fatal(err)
+	}
+	if unstructuredApiExport.GetName() != "newName" {
+		t.Fatalf("unexpected name %v", unstructuredApiExport.GetName())
+	}
+	if apiExport.Name != "a1" {
+		t.Fatal("didn't expect changing unstructuredApiExport name will also change the original apiExport object")
+	}
+
+	// manipulate pinter (a reference type)
+	unstructured.RemoveNestedField(unstructuredApiExport.Object, "spec", "maximalPermissionPolicy")
+	_, maximalPolicyFound, err := unstructured.NestedFieldNoCopy(unstructuredApiExport.Object, "spec", "maximalPermissionPolicy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if maximalPolicyFound {
+		t.Fatal("didn't expect to find spec.maximalPermissionPolicy")
+	}
+	if apiExport.Spec.MaximalPermissionPolicy == nil {
+		t.Fatal("apiExport.Spec.MaximalPermissionPolicy was removed")
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The new controller copies objects of defined resources that have the `internal.sharding.kcp.dev/replicate` annotation to the cache server.
The replicated object will be placed under the same cluster as the original object.
In addition to that, all replicated objects will be placed under the shard taken from the shardName argument.
For example: shards/{shardName}/clusters/{clusterName}/apis/apis.kcp.dev/v1alpha1/apiexports

As of today the controller replicates the ApiExport resources.
The reconcileAPIExports function handles the following cases:
1. creation of the object in the cache server
   happens when the cached object is not found in c.cacheApiExportsIndexer
2. deletion of the object from the cache server
   happens when either of the following is true:
   - the original/local object was removed
   - the original/local object was not found in c.localApiExport
3. modification of the object to match the original object
   happens when either of the following is true:
    - the original object's metadata doesn't match the cached one.
    - the original object's spec doesn't match the cached one.
    - the original object's status doesn't match the cached one.

TODO:
 - in a follow-up PR I am going to add `APIResourceSchema` to this controller

## Related issue(s)

https://github.com/kcp-dev/kcp/issues/342
