### PR TITLE
:seedling: Stop shortening git sha used to update RH gitops repo

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -66,9 +66,9 @@ jobs:
 
       - name: Update sha and commit
         run: |-
-          sed -i -e 's/tag: "[0-9a-f]\{7\}"/tag: "${{ needs.build.outputs.sha_short }}"/' kcp/unstable-values.yaml
+          sed -i -e 's/tag: "[0-9a-f]\{7\}"/tag: "${{ github.sha }}"/' kcp/unstable-values.yaml
           git config user.email "klape+kcp-bot@redhat.com"
           git config user.name "KCP Bot"
           git add kcp/unstable-values.yaml
-          git commit -m "Automatic update of test environment to ${{ needs.build.outputs.sha_short }}"
+          git commit -m "Automatic update of test environment to ${{ github.sha }}"
           git push origin main


### PR DESCRIPTION
This is to support the use of Openshift CI images, which are tagged using the full git sha instead of the shortened one.

Note that the deploy job will still wait for the image to be built in Github Actions before applying the change to the gitops repo.  This can be addressed in a follow up PR to remove the build job when we are ready.
