### PR TITLE
:sparkles: Add command to create APIBindings

### DIFF
--- a/cmd/kubectl-kcp/cmd/kubectlKcp.go
+++ b/cmd/kubectl-kcp/cmd/kubectlKcp.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
+	bindcmd "github.com/kcp-dev/kcp/pkg/cliplugins/bind/cmd"
 	crdcmd "github.com/kcp-dev/kcp/pkg/cliplugins/crd/cmd"
 	workloadcmd "github.com/kcp-dev/kcp/pkg/cliplugins/workload/cmd"
 	workspacecmd "github.com/kcp-dev/kcp/pkg/cliplugins/workspace/cmd"
@@ -79,6 +80,9 @@ func KubectlKcpCommand() *cobra.Command {
 
 	crdCmd := crdcmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	root.AddCommand(crdCmd)
+
+	bindCmd := bindcmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root.AddCommand(bindCmd)
 
 	return root
 }

--- a/contrib/demos-unmaintained/demo/prototype3-script/apibinding/cert-manager-apibinding.yaml
+++ b/contrib/demos-unmaintained/demo/prototype3-script/apibinding/cert-manager-apibinding.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   reference:
     workspace:
-      name: cert-manager-service
+      path: root:cert-manager-service
       exportName: cert-manager-stable

--- a/pkg/cliplugins/bind/cmd/cmd.go
+++ b/pkg/cliplugins/bind/cmd/cmd.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/kcp-dev/kcp/pkg/cliplugins/bind/plugin"
+)
+
+var (
+	bindExampleUses = `
+	# Create an APIBinding named "my-binding" that binds to the APIExport "my-export" in the "root:my-service" workspace.
+	%[1]s bind apiexport root:my-service:my-export --name my-binding
+	`
+)
+
+func New(streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "bind",
+		Short:            "Bind different types into current workspace.",
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	bindOpts := plugin.NewBindOptions(streams)
+	bindCmd := &cobra.Command{
+		Use:          "apiexport <workspace_path:apiexport-name>",
+		Short:        "Bind to an APIExport",
+		Example:      fmt.Sprintf(bindExampleUses, "kubectl kcp"),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := bindOpts.Complete(args); err != nil {
+				return err
+			}
+
+			if err := bindOpts.Validate(); err != nil {
+				return err
+			}
+
+			return bindOpts.Run(cmd.Context())
+		},
+	}
+	bindOpts.BindFlags(bindCmd)
+
+	cmd.AddCommand(bindCmd)
+	return cmd
+}

--- a/pkg/cliplugins/bind/plugin/bind.go
+++ b/pkg/cliplugins/bind/plugin/bind.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/pkg/cliplugins/base"
+	pluginhelpers "github.com/kcp-dev/kcp/pkg/cliplugins/helpers"
+)
+
+// BindOptions contains the options for creating an APIBinding.
+type BindOptions struct {
+	*base.Options
+	// APIExportRef is the argument accepted by the command. It contains the
+	// reference to where APIExport exists. For ex: <absolute_ref_to_workspace>:<apiexport>.
+	APIExportRef string
+	// Name of the APIBinding.
+	APIBindingName string
+	// BindWaitTimeout is how long to wait for the APIBinding to be created and successful.
+	BindWaitTimeout time.Duration
+}
+
+// NewBindOptions returns new BindOptions.
+func NewBindOptions(streams genericclioptions.IOStreams) *BindOptions {
+	return &BindOptions{
+		Options: base.NewOptions(streams),
+	}
+}
+
+// BindFlags binds fields to cmd's flagset.
+func (b *BindOptions) BindFlags(cmd *cobra.Command) {
+	b.Options.BindFlags(cmd)
+
+	cmd.Flags().StringVar(&b.APIBindingName, "name", b.APIBindingName, "Name of the APIBinding to create.")
+	cmd.Flags().DurationVar(&b.BindWaitTimeout, "timeout", time.Second*30, "Duration to wait for APIBinding to be created successfully.")
+}
+
+// Complete ensures all fields are initialized.
+func (b *BindOptions) Complete(args []string) error {
+	if err := b.Options.Complete(); err != nil {
+		return err
+	}
+
+	if len(args) > 0 {
+		b.APIExportRef = args[0]
+	}
+	return nil
+}
+
+// Validate validates the BindOptions are complete and usable.
+func (b *BindOptions) Validate() error {
+	if b.APIExportRef == "" {
+		return errors.New("`root:ws:apiexport_object` reference to bind is required as an argument")
+	}
+
+	if !strings.HasPrefix(b.APIExportRef, "root") || !logicalcluster.New(b.APIExportRef).IsValid() {
+		return fmt.Errorf("fully qualified reference to workspace where APIExport exists is required. The format is `root:<ws>:<apiexport>`")
+	}
+
+	return b.Options.Validate()
+}
+
+// Run creates an apibinding for the user.
+func (b *BindOptions) Run(ctx context.Context) error {
+	config, err := b.ClientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	workspacePath, apiExportName := logicalcluster.New(b.APIExportRef).Split()
+
+	// if apibindingName is not provided, default it to <apiExportname>.
+	apiBindingName := b.APIBindingName
+	if apiBindingName == "" {
+		apiBindingName = apiExportName
+	}
+
+	_, currentClusterName, err := pluginhelpers.ParseClusterURL(config.Host)
+	if err != nil {
+		return fmt.Errorf("current URL %q does not point to cluster workspace", config.Host)
+	}
+
+	binding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: apiBindingName,
+		},
+		Spec: apisv1alpha1.APIBindingSpec{
+			Reference: apisv1alpha1.ExportReference{
+				Workspace: &apisv1alpha1.WorkspaceExportReference{
+					Path:       workspacePath.String(),
+					ExportName: apiExportName,
+				},
+			},
+		},
+	}
+
+	kcpclient, err := newKCPClusterClient(config)
+	if err != nil {
+		return err
+	}
+
+	createdBinding, err := kcpclient.Cluster(currentClusterName).ApisV1alpha1().APIBindings().Create(ctx, binding, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintf(b.Out, "apibinding %s created. Waiting to successfully bind ...\n", binding.Name); err != nil {
+		return err
+	}
+
+	// wait for phase to be bound
+	if createdBinding.Status.Phase != apisv1alpha1.APIBindingPhaseBound {
+		if err := wait.PollImmediate(time.Millisecond*500, b.BindWaitTimeout, func() (done bool, err error) {
+			createdBinding, err := kcpclient.Cluster(currentClusterName).ApisV1alpha1().APIBindings().Get(ctx, binding.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if createdBinding.Status.Phase == apisv1alpha1.APIBindingPhaseBound {
+				return true, nil
+			}
+			return false, nil
+		}); err != nil {
+			return fmt.Errorf("could not bind %s: %w", binding.Name, err)
+		}
+	}
+
+	if _, err := fmt.Fprintf(b.Out, "%s created and bound.\n", binding.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newKCPClusterClient(config *rest.Config) (kcpclient.ClusterInterface, error) {
+	clusterConfig := rest.CopyConfig(config)
+	u, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = ""
+	clusterConfig.Host = u.String()
+	clusterConfig.UserAgent = rest.DefaultKubernetesUserAgent()
+	return kcpclient.NewClusterForConfig(clusterConfig)
+}


### PR DESCRIPTION
This PR adds a cli command for users to be able to bind to an APIExport.

```
kubectl kcp bind apiexport <ws_ref:export_obj> —-name <name of APIBinding> 
Required arguments 
- path of the APIExport to bind to. Needs to be the absolute reference to workspace.

Optional flag
Name - name of the apibinding which is created. It defaults to name of apiexport”
```

Example:
```
➜  kcp git:(cmd/kcp-bind) ✗ ./bin/kubectl-kcp bind apiexport root:webapp:cert-manager-stable
apibinding cert-manager-stable created. Waiting to successfully bind ...
cert-manager-stable created and bound.
```

Design doc: https://docs.google.com/document/d/1J31wXY1-2aCyyGFjUlusKoHDzV-zktAmRdIMjMf4OR0/edit 

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Add command to help users bind to an APIExport. 


