### PR TITLE
:bug: pkg/admission/webhook: differentiate states

### DIFF
--- a/pkg/admission/webhook/generic_webhook.go
+++ b/pkg/admission/webhook/generic_webhook.go
@@ -96,12 +96,13 @@ func (p *WebhookDispatcher) getAPIBindingWorkspace(attr admission.Attributes, cl
 	for _, obj := range objs {
 		apiBinding := obj.(*apisv1alpha1.APIBinding)
 		for _, br := range apiBinding.Status.BoundResources {
-			if apiBinding.Status.BoundAPIExport == nil || apiBinding.Status.BoundAPIExport.Workspace == nil {
+			if apiBinding.Status.BoundAPIExport != nil && apiBinding.Status.BoundAPIExport.Workspace == nil {
 				// this will never happen today. But as soon as we add other reference types (like exports), this log output will remind out of necessary work here.
 				klog.Errorf("APIBinding %s has no referenced workspace", clusterName, apiBinding.Name)
 				continue
 			}
-			if br.Group == attr.GetResource().Group && br.Resource == attr.GetResource().Resource {
+			if apiBinding.Status.BoundAPIExport != nil && apiBinding.Status.BoundAPIExport.Workspace != nil &&
+				br.Group == attr.GetResource().Group && br.Resource == attr.GetResource().Resource {
 				return logicalcluster.New(apiBinding.Status.BoundAPIExport.Workspace.Path), true, nil
 			}
 		}


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Only if a bound API export is set but no bound API export workspace we want to log. This fixes it.

## Related issue(s)

Related with #2028
Follow-up for #2029