### PR TITLE
🐛 bug fix Add maximal permission policy for compute APIExport

### DIFF
--- a/config/rootcompute/kube-1.24/clusterrole-kubernetes-maximal-permission-policy.yaml
+++ b/config/rootcompute/kube-1.24/clusterrole-kubernetes-maximal-permission-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: compute:apiexport:kubernetes:maximal-permission-policy
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["*"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments/status"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses/status"]
+  verbs: ["get", "list", "watch"]

--- a/config/rootcompute/kube-1.24/clusterrolebinding-kubernetes-maximal-permission-policy.yaml
+++ b/config/rootcompute/kube-1.24/clusterrolebinding-kubernetes-maximal-permission-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: compute:authenticated:apiexport:kubernetes:maximal-permission-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: compute:apiexport:kubernetes:maximal-permission-policy
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: apis.kcp.dev:binding:system:authenticated


### PR DESCRIPTION
Signed-off-by: Jian Qiu <jqiu@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the root:compute kubernetes APIExport should add maximal permission policy RBAC.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/1959
