### PR TITLE
:seedling: cmd/kcp-front-proxy move filters into module

### DIFF
--- a/cmd/kcp-front-proxy/filters/filters.go
+++ b/cmd/kcp-front-proxy/filters/filters.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package filters
 
 import (
 	"net/http"
@@ -29,10 +29,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// withOptionalClientCert creates a handler that verifies a request's client
+// WithOptionalClientCert creates a handler that verifies a request's client
 // cert if one is presented but passes through to the next handler if one is
 // not.
-func withOptionalClientCert(handler, failed http.Handler, auth authenticator.Request) http.Handler {
+func WithOptionalClientCert(handler, failed http.Handler, auth authenticator.Request) http.Handler {
 	if auth == nil {
 		return handler
 	}
@@ -55,7 +55,7 @@ func withOptionalClientCert(handler, failed http.Handler, auth authenticator.Req
 	})
 }
 
-func newUnauthorizedHandler() http.Handler {
+func NewUnauthorizedHandler() http.Handler {
 	scheme := runtime.NewScheme()
 	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Group: "", Version: "v1"})
 	codecs := serializer.NewCodecFactory(scheme)

--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"
 
+	frontproxyfilters "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/filters"
 	frontproxyoptions "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/options"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
@@ -151,8 +152,8 @@ routed based on paths.`,
 			if err != nil {
 				return err
 			}
-			failedHandler := newUnauthorizedHandler()
-			handler = withOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
+			failedHandler := frontproxyfilters.NewUnauthorizedHandler()
+			handler = frontproxyfilters.WithOptionalClientCert(handler, failedHandler, authenticationInfo.Authenticator)
 
 			requestInfoFactory := requestinfo.NewFactory()
 			handler = server.WithInClusterServiceAccountRequestRewrite(handler)


### PR DESCRIPTION
## Summary
Minor refactoring, so that we can run a customized front-proxy without needing to copy the `filters.go`

## Related issue(s)
Related to discussions with @sttts where it was mentioned that we may want the ability to run a customized front-proxy for experimental reasons (specifically to test out rate-limiting at the proxy level)

