### PR TITLE
:seedling: test/e2e: enable audit logs

### DIFF
--- a/test/e2e/framework/audit-policy.yaml
+++ b/test/e2e/framework/audit-policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+- RequestReceived
+omitManagedFields: true
+rules:
+- level: None
+  nonResourceURLs:
+  - "/api*"
+  - "/version"
+
+- level: Metadata
+  resources:
+  - group: ""
+    resources: ["secrets", "configmaps"]
+  - group: "authorization.k8s.io"
+    resources: ["subjectaccessreviews"]
+
+- level: Metadata
+  verbs: ["list", "watch"]
+
+- level: Metadata
+  verbs: ["get", "delete"]
+  omitStages:
+  - ResponseStarted
+
+- level: RequestResponse
+  verbs: ["create", "update", "patch"]
+  omitStages:
+  - ResponseStarted

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -51,6 +51,7 @@ import (
 )
 
 //go:embed *.csv
+//go:embed *.yaml
 var fs embed.FS
 
 // WriteTokenAuthFile writes the embedded token file to the current
@@ -64,21 +65,22 @@ var fs embed.FS
 // TODO(marun) Is there a way to avoid embedding by determining the
 // path to the file during test execution?
 func WriteTokenAuthFile(t *testing.T) string {
-	// This file is expected to be embedded from the package directory.
-	tokensFilename := "auth-tokens.csv"
+	return WriteEmbedFile(t, "auth-tokens.csv")
+}
 
-	data, err := fs.ReadFile(tokensFilename)
-	require.NoError(t, err, "error reading tokens file")
+func WriteEmbedFile(t *testing.T, source string) string {
+	data, err := fs.ReadFile(source)
+	require.NoErrorf(t, err, "error reading embed file: %q", source)
 
-	tokensPath := path.Join(t.TempDir(), tokensFilename)
-	tokensFile, err := os.Create(tokensPath)
-	require.NoError(t, err, "failed to create tokens file")
-	defer tokensFile.Close()
+	targetPath := path.Join(t.TempDir(), source)
+	targetFile, err := os.Create(targetPath)
+	require.NoErrorf(t, err, "failed to create target file: %q", targetPath)
+	defer targetFile.Close()
 
-	_, err = tokensFile.Write(data)
-	require.NoError(t, err, "error writing tokens file")
+	_, err = targetFile.Write(data)
+	require.NoError(t, err, "error writing target file: %q", targetPath)
 
-	return tokensPath
+	return targetPath
 }
 
 // Persistent mapping of test name to base temp dir used to ensure


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This adds audit logs for e2e tests.

## Related issue(s)
None
