### PR TITLE
:seedling: pkg/server: enable audit logging in virtual workspace apiserver

### DIFF
--- a/cmd/virtual-workspaces/command/cmd.go
+++ b/cmd/virtual-workspaces/command/cmd.go
@@ -138,6 +138,9 @@ func Run(ctx context.Context, o *options.Options) error {
 	if err := o.Authorization.ApplyTo(&recommendedConfig.Config, virtualWorkspaces); err != nil {
 		return err
 	}
+	if err := o.Audit.ApplyTo(&recommendedConfig.Config); err != nil {
+		return err
+	}
 	rootAPIServerConfig, err := virtualrootapiserver.NewRootAPIConfig(recommendedConfig, []virtualrootapiserver.InformerStart{
 		wildcardKubeInformers.Start,
 		wildcardKcpInformers.Start,

--- a/cmd/virtual-workspaces/options/options.go
+++ b/cmd/virtual-workspaces/options/options.go
@@ -47,6 +47,7 @@ type Options struct {
 	SecureServing  genericapiserveroptions.SecureServingOptions
 	Authentication genericapiserveroptions.DelegatingAuthenticationOptions
 	Authorization  virtualworkspacesoptions.Authorization
+	Audit          genericapiserveroptions.AuditOptions
 
 	Logs logs.Options
 
@@ -62,6 +63,7 @@ func NewOptions() *Options {
 		SecureServing:  *genericapiserveroptions.NewSecureServingOptions(),
 		Authentication: *genericapiserveroptions.NewDelegatingAuthenticationOptions(),
 		Authorization:  *virtualworkspacesoptions.NewAuthorization(),
+		Audit:          *genericapiserveroptions.NewAuditOptions(),
 		Logs:           *logs.NewOptions(),
 
 		VirtualWorkspaces: *virtualworkspacesoptions.NewOptions(),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -474,7 +474,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.Options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, controllerConfig, delegationChainHead, s.GenericConfig.Authentication, s.GenericConfig.ExternalAddress, s.preHandlerChainMux); err != nil {
+		if err := s.installVirtualWorkspaces(ctx, controllerConfig, delegationChainHead, s.GenericConfig.Authentication, s.GenericConfig.ExternalAddress, s.GenericConfig.AuditPolicyRuleEvaluator, s.preHandlerChainMux); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/virtual.go
+++ b/pkg/server/virtual.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	kaudit "k8s.io/apiserver/pkg/audit"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/rest"
@@ -44,6 +45,7 @@ func (s *Server) installVirtualWorkspaces(
 	server *genericapiserver.GenericAPIServer,
 	auth genericapiserver.AuthenticationInfo,
 	externalAddress string,
+	auditEvaluator kaudit.PolicyRuleEvaluator,
 	preHandlerChainMux mux,
 ) error {
 	logger := klog.FromContext(ctx)
@@ -87,6 +89,8 @@ func (s *Server) installVirtualWorkspaces(
 	rootAPIServerConfig.GenericConfig.ExternalAddress = externalAddress
 
 	completedRootAPIServerConfig := rootAPIServerConfig.Complete()
+	completedRootAPIServerConfig.GenericConfig.AuditBackend = server.AuditBackend
+	completedRootAPIServerConfig.GenericConfig.AuditPolicyRuleEvaluator = auditEvaluator
 
 	rootAPIServer, err := completedRootAPIServerConfig.New(genericapiserver.NewEmptyDelegate())
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This enables audit logging in the virtual workspace apiserver (`/services/.*` handler).

## Related issue(s)

None
