### PR TITLE
:bug: Add resourcequota to the list of internal resources.

### DIFF
--- a/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_reconcile.go
+++ b/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_reconcile.go
@@ -261,4 +261,14 @@ var syncerInternalAPIs = []internalapis.InternalAPI{
 		Instance:      &corev1.ServiceAccount{},
 		ResourceScope: apiextensionsv1.NamespaceScoped,
 	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "resourcequotas",
+			Singular: "resourcequota",
+			Kind:     "ResourceQuota",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.ResourceQuota{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
 }


### PR DESCRIPTION
## Summary

This allows controllers/apiexports to claim resourcequotas.
Otherwise APIBindings fail. 

~~~
  - lastTransitionTime: "2022-09-22T09:41:22Z"
    message: '1 unexpected and/or invalid permission claims (showing first 1): unexpected/invalid
      claim for resourcequotas. (identity "")'
    reason: InvalidPermissionClaims
    severity: Error
    status: "False"
    type: PermissionClaimsValid
~~~

I tested locally and was able after the change to claim resourcequotas and get them reconciled in a controller.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>
