### PR TITLE
:seedling: apibinding, types: remove ancestor check

### DIFF
--- a/config/crds/apis.kcp.dev_apibindings.yaml
+++ b/config/crds/apis.kcp.dev_apibindings.yaml
@@ -99,9 +99,8 @@ spec:
                         type: string
                       path:
                         description: path is an absolute reference to a workspace,
-                          e.g. root:org:ws. The workspace must be some ancestor or
-                          a child of some ancestor. If it is unset, the path of the
-                          APIBinding is used.
+                          e.g. root:org:ws. If it is unset, the path of the APIBinding
+                          is used.
                         pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:
@@ -164,9 +163,8 @@ spec:
                         type: string
                       path:
                         description: path is an absolute reference to a workspace,
-                          e.g. root:org:ws. The workspace must be some ancestor or
-                          a child of some ancestor. If it is unset, the path of the
-                          APIBinding is used.
+                          e.g. root:org:ws. If it is unset, the path of the APIBinding
+                          is used.
                         pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:

--- a/config/crds/workload.kcp.dev_synctargets.yaml
+++ b/config/crds/workload.kcp.dev_synctargets.yaml
@@ -102,9 +102,8 @@ spec:
                           type: string
                         path:
                           description: path is an absolute reference to a workspace,
-                            e.g. root:org:ws. The workspace must be some ancestor
-                            or a child of some ancestor. If it is unset, the path
-                            of the APIBinding is used.
+                            e.g. root:org:ws. If it is unset, the path of the APIBinding
+                            is used.
                           pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
                       required:

--- a/config/root-phase0/apiexport-workload.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.dev.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220909-c255fd13.synctargets.workload.kcp.dev
+  - v220923-836dfac8.synctargets.workload.kcp.dev
 status: {}

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220909-c255fd13.synctargets.workload.kcp.dev
+  name: v220923-836dfac8.synctargets.workload.kcp.dev
 spec:
   group: workload.kcp.dev
   names:
@@ -98,9 +98,8 @@ spec:
                         type: string
                       path:
                         description: path is an absolute reference to a workspace,
-                          e.g. root:org:ws. The workspace must be some ancestor or
-                          a child of some ancestor. If it is unset, the path of the
-                          APIBinding is used.
+                          e.g. root:org:ws. If it is unset, the path of the APIBinding
+                          is used.
                         pattern: ^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                     required:

--- a/pkg/admission/apibinding/apibinding_admission_test.go
+++ b/pkg/admission/apibinding/apibinding_admission_test.go
@@ -237,19 +237,20 @@ func TestValidate(t *testing.T) {
 			authzDecision: authorizer.DecisionAllow,
 		},
 		{
-			name: "Create: complete non-ancestor absolute workspace reference fails",
+			name: "Create: complete non-ancestor absolute workspace reference does not fail",
 			attr: createAttr(
 				newAPIBinding().withName("test").withAbsoluteWorkspaceReference("root:some-other-org:bla", "someExport").
-					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:some-other-org:bla")).APIBinding,
+					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:some-other-org:bla:someExport")).APIBinding,
 			),
-			expectedErrors: []string{"spec.reference.workspace.path: not pointing to an ancestor or child of an ancestor of \"root:org:ws\""},
+			authzDecision: authorizer.DecisionAllow,
 		},
 		{
-			name: "Create: complete child absolute workspace reference fails",
+			name: "Create: complete child absolute workspace reference does not fail",
 			attr: createAttr(
-				newAPIBinding().withName("test").withAbsoluteWorkspaceReference("root:org:ws:child", "someExport").APIBinding,
+				newAPIBinding().withName("test").withAbsoluteWorkspaceReference("root:org:ws:child", "someExport").
+					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:org:ws:child:someExport")).APIBinding,
 			),
-			expectedErrors: []string{"spec.reference.workspace.path: not pointing to an ancestor or child of an ancestor of \"root:org:ws\""},
+			authzDecision: authorizer.DecisionAllow,
 		},
 		{
 			name: "Create: complete workspace reference fails with no authorization decision",
@@ -449,7 +450,7 @@ func TestValidate(t *testing.T) {
 			err := o.Validate(ctx, tc.attr, nil)
 
 			wantErr := len(tc.expectedErrors) > 0
-			require.Equal(t, wantErr, err != nil)
+			require.Equal(t, wantErr, err != nil, "err: %v", err)
 
 			if err != nil {
 				t.Logf("Got admission errors: %v", err)

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -113,9 +113,8 @@ type ExportReference struct {
 // WorkspaceExportReference describes an API and backing implementation that are provided by an actor in the
 // specified Workspace.
 type WorkspaceExportReference struct {
-	// path is an absolute reference to a workspace, e.g. root:org:ws. The workspace must
-	// be some ancestor or a child of some ancestor. If it is unset, the path of the APIBinding
-	// is used.
+	// path is an absolute reference to a workspace, e.g. root:org:ws.
+	// If it is unset, the path of the APIBinding is used.
 	// +optional
 	// +kubebuilder:validation:Pattern:="^root(:[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	Path string `json:"path,omitempty"`

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2028,7 +2028,7 @@ func schema_pkg_apis_apis_v1alpha1_WorkspaceExportReference(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"path": {
 						SchemaProps: spec.SchemaProps{
-							Description: "path is an absolute reference to a workspace, e.g. root:org:ws. The workspace must be some ancestor or a child of some ancestor. If it is unset, the path of the APIBinding is used.",
+							Description: "path is an absolute reference to a workspace, e.g. root:org:ws. If it is unset, the path of the APIBinding is used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/virtual/framework/internalapis/fixtures/synctargets.yaml
+++ b/pkg/virtual/framework/internalapis/fixtures/synctargets.yaml
@@ -65,9 +65,8 @@ spec:
                         type: string
                       path:
                         description: path is an absolute reference to a workspace,
-                          e.g. root:org:ws. The workspace must be some ancestor or
-                          a child of some ancestor. If it is unset, the path of the
-                          APIBinding is used.
+                          e.g. root:org:ws. If it is unset, the path of the APIBinding
+                          is used.
                         type: string
                     required:
                     - exportName


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This removes ancestor checks for API bindings.

## Related issue(s)

Follow-up for #1739
Fixes #2059