### PR TITLE
🌱 cache server: stop serving subresources for built-in resources

### DIFF
--- a/pkg/cache/server/bootstrap/bootstrap.go
+++ b/pkg/cache/server/bootstrap/bootstrap.go
@@ -56,6 +56,7 @@ func Bootstrap(ctx context.Context, apiExtensionsClusterClient apiextensionsclie
 					XPreserveUnknownFields: pointer.BoolPtr(true),
 				},
 			} // wipe the schema, we don't need validation
+			v.Subresources = nil // wipe subresources so that updates don't have to be made against the status endpoint
 		}
 		crds = append(crds, crd)
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
this will allows us to update both the spec and status of an object atomically.

normally, when the status subresource is enabled,
callers have to use the /status endpoint for updating the status field.

updates to a regular endpoint simply ignore the status field.
## Related issue(s)

will be used by https://github.com/kcp-dev/kcp/pull/2024
required to complete https://github.com/kcp-dev/kcp/issues/342

