### PR TITLE
🌱 Upgrade to logicalcluster v2.0.0-alpha.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/kcp-dev/apimachinery v0.0.0-20220912132244-efe716c18e43
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
-	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/muesli/reflow v0.1.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
@@ -26,6 +26,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
 	go.etcd.io/etcd/client/pkg/v3 v3.5.1
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/multierr v1.7.0
@@ -128,7 +129,6 @@ require (
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
-	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.1 // indirect
 	go.etcd.io/etcd/client/v2 v2.305.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -480,8 +480,8 @@ github.com/kcp-dev/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-2
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/pod-security-admission v0.0.0-20220915135949-eeba459ad2a1/go.mod h1:Iim5xqRnknXtHPXyZjZdfxEdASa/l/nHShGazinoYbQ=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20220915135949-eeba459ad2a1/go.mod h1:7+QSUfC8FyVELcrtSpeAUGrgUoXlUQ+ZT32QCeoR91s=
 github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39 h1:yjKFd2obDNUfHZibLfN5QogaIjPnQ58H9SwCKsIko1g=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3 h1:+DwIG/loh2nDB9c/FqNvLzFFq/YtBliLxAfw/uWNzyE=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
## Summary
Upgrade to logicalcluster v2.0.0-alpha.3, which removed the v1 package.

## Related issue(s)

https://github.com/kcp-dev/logicalcluster/pull/24
