### PR TITLE
:seedling: turn off goreleaser from PRs and pushes to main

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,11 +1,7 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
-    branches:
-    - main
-    - 'release-*'
     tags:
     - 'v*'
 


### PR DESCRIPTION
Signed-off-by: Mohamed Chiheb <mohamed@giantswarm.io>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Make goreleaser runs only on tags

## Related issue(s)

Fixes #2037 
