### PR TITLE
:bug: Revert "syncer: remove finalizer if downstream resource has been deleted"

### DIFF
--- a/pkg/syncer/shared/finalizer.go
+++ b/pkg/syncer/shared/finalizer.go
@@ -54,6 +54,12 @@ func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersion
 		return nil
 	}
 
+	// TODO(jmprusi): This check will need to be against "GetDeletionTimestamp()" when using the syncer virtual workspace.
+	if upstreamObj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+syncTargetKey] == "" {
+		// Do nothing: the object should not be deleted anymore for this location on the KCP side
+		return nil
+	}
+
 	upstreamObj = upstreamObj.DeepCopy()
 
 	// Remove the syncer finalizer.

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -382,18 +382,7 @@ func TestSyncerProcess(t *testing.T) {
 			syncTargetName:        "us-west1",
 
 			expectActionsOnFrom: []clienttesting.Action{},
-			expectActionsOnTo: []clienttesting.Action{
-				updateDeploymentAction("test",
-					changeUnstructured(
-						toUnstructured(t, changeDeployment(
-							deployment("theDeployment", "test", "root:org:ws", map[string]string{}, map[string]string{}, nil))),
-						// The following "changes" are required for the test to pass, as it expects some empty/nil fields to be there
-						setNestedField(map[string]interface{}{}, "metadata", "labels"),
-						setNestedField([]interface{}{}, "metadata", "finalizers"),
-						setNestedField(nil, "spec", "selector"),
-					),
-				),
-			},
+			expectActionsOnTo:   []clienttesting.Action{},
 		},
 		"StatusSyncer with AdvancedScheduling, update status upstream": {
 			upstreamLogicalCluster: "root:org:ws",


### PR DESCRIPTION
## Summary

Revert the latest syncer changes causing issues with the e2e tests and syncer stability.