### PR TITLE
:seedling: Combine Dockerfile kubectl layers to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ WORKDIR /
 COPY --from=builder workspace/bin/kcp-front-proxy workspace/bin/kcp workspace/bin/virtual-workspaces /
 COPY --from=builder workspace/bin/kubectl-* /usr/local/bin
 RUN apk add --update curl && rm -rf /var/cache/apk/*
-RUN curl -fL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$(uname -m | sed 's/aarch.*/arm64/;s/armv8.*/arm64/;s/x86_64/amd64/')/kubectl"
-RUN chmod +x /usr/local/bin/kubectl
+RUN curl -fL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$(uname -m | sed 's/aarch.*/arm64/;s/armv8.*/arm64/;s/x86_64/amd64/')/kubectl" && \
+  chmod +x /usr/local/bin/kubectl
 ENV KUBECONFIG=/etc/kcp/config/admin.kubeconfig
 RUN mkdir -p /data && \
     chown 65532:65532 /data


### PR DESCRIPTION
## Summary
Combining the chmod with the download avoids creating another layer, which saves about 45MB currently

