### PR TITLE
:seedling: authz: remove the concept of a merged informer

### DIFF
--- a/pkg/authorization/apibinding_authorizer.go
+++ b/pkg/authorization/apibinding_authorizer.go
@@ -68,15 +68,15 @@ func NewAPIBindingAccessAuthorizer(kubeInformers kubernetesinformers.SharedInfor
 			clusterKubeInformer := rbacwrapper.FilterInformers(clusterName, kubeInformers.Rbac().V1())
 			bootstrapInformer := rbacwrapper.FilterInformers(genericcontrolplane.LocalAdminCluster, kubeInformers.Rbac().V1())
 
-			mergedClusterRoleInformer := rbacwrapper.MergedClusterRoleInformer(clusterKubeInformer.ClusterRoles(), bootstrapInformer.ClusterRoles())
-			mergedRoleInformer := rbacwrapper.MergedRoleInformer(clusterKubeInformer.Roles(), bootstrapInformer.Roles())
-			mergedClusterRoleBindingsInformer := rbacwrapper.MergedClusterRoleBindingInformer(clusterKubeInformer.ClusterRoleBindings(), bootstrapInformer.ClusterRoleBindings())
+			mergedClusterRoleLister := rbacwrapper.NewMergedClusterRoleLister(clusterKubeInformer.ClusterRoles().Lister(), bootstrapInformer.ClusterRoles().Lister())
+			mergedRoleLister := rbacwrapper.NewMergedRoleLister(clusterKubeInformer.Roles().Lister(), bootstrapInformer.Roles().Lister())
+			mergedClusterRoleBindingsLister := rbacwrapper.NewMergedClusterRoleBindingLister(clusterKubeInformer.ClusterRoleBindings().Lister(), bootstrapInformer.ClusterRoleBindings().Lister())
 
 			return rbac.New(
-				&rbac.RoleGetter{Lister: mergedRoleInformer.Lister()},
+				&rbac.RoleGetter{Lister: mergedRoleLister},
 				&rbac.RoleBindingLister{Lister: clusterKubeInformer.RoleBindings().Lister()},
-				&rbac.ClusterRoleGetter{Lister: mergedClusterRoleInformer.Lister()},
-				&rbac.ClusterRoleBindingLister{Lister: mergedClusterRoleBindingsInformer.Lister()},
+				&rbac.ClusterRoleGetter{Lister: mergedClusterRoleLister},
+				&rbac.ClusterRoleBindingLister{Lister: mergedClusterRoleBindingsLister},
 			)
 		},
 		delegate: delegate,

--- a/pkg/authorization/local_authorizer.go
+++ b/pkg/authorization/local_authorizer.go
@@ -80,13 +80,13 @@ func (a *LocalAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribu
 	filteredInformer := rbacwrapper.FilterInformers(reqScope, a.versionedInformers.Rbac().V1())
 	bootstrapInformer := rbacwrapper.FilterInformers(genericcontrolplane.LocalAdminCluster, a.versionedInformers.Rbac().V1())
 
-	mergedClusterRoleInformer := rbacwrapper.MergedClusterRoleInformer(filteredInformer.ClusterRoles(), bootstrapInformer.ClusterRoles())
-	mergedRoleInformer := rbacwrapper.MergedRoleInformer(filteredInformer.Roles(), bootstrapInformer.Roles())
+	mergedClusterRoleLister := rbacwrapper.NewMergedClusterRoleLister(filteredInformer.ClusterRoles().Lister(), bootstrapInformer.ClusterRoles().Lister())
+	mergedRoleLister := rbacwrapper.NewMergedRoleLister(filteredInformer.Roles().Lister(), bootstrapInformer.Roles().Lister())
 
 	scopedAuth := rbac.New(
-		&rbac.RoleGetter{Lister: mergedRoleInformer.Lister()},
+		&rbac.RoleGetter{Lister: mergedRoleLister},
 		&rbac.RoleBindingLister{Lister: filteredInformer.RoleBindings().Lister()},
-		&rbac.ClusterRoleGetter{Lister: mergedClusterRoleInformer.Lister()},
+		&rbac.ClusterRoleGetter{Lister: mergedClusterRoleLister},
 		&rbac.ClusterRoleBindingLister{Lister: filteredInformer.ClusterRoleBindings().Lister()},
 	)
 

--- a/pkg/authorization/toplevel_org_authorizer.go
+++ b/pkg/authorization/toplevel_org_authorizer.go
@@ -53,16 +53,16 @@ func NewTopLevelOrganizationAccessAuthorizer(versionedInformers kubernetesinform
 	rootKubeInformer := rbacwrapper.FilterInformers(tenancyv1alpha1.RootCluster, versionedInformers.Rbac().V1())
 	bootstrapInformer := rbacwrapper.FilterInformers(genericcontrolplane.LocalAdminCluster, versionedInformers.Rbac().V1())
 
-	mergedClusterRoleInformer := rbacwrapper.MergedClusterRoleInformer(rootKubeInformer.ClusterRoles(), bootstrapInformer.ClusterRoles())
-	mergedRoleInformer := rbacwrapper.MergedRoleInformer(rootKubeInformer.Roles(), bootstrapInformer.Roles())
-	mergedClusterRoleBindingsInformer := rbacwrapper.MergedClusterRoleBindingInformer(rootKubeInformer.ClusterRoleBindings(), bootstrapInformer.ClusterRoleBindings())
+	mergedClusterRoleLister := rbacwrapper.NewMergedClusterRoleLister(rootKubeInformer.ClusterRoles().Lister(), bootstrapInformer.ClusterRoles().Lister())
+	mergedRoleLister := rbacwrapper.NewMergedRoleLister(rootKubeInformer.Roles().Lister(), bootstrapInformer.Roles().Lister())
+	mergedClusterRoleBindingsLister := rbacwrapper.NewMergedClusterRoleBindingLister(rootKubeInformer.ClusterRoleBindings().Lister(), bootstrapInformer.ClusterRoleBindings().Lister())
 
 	return &topLevelOrgAccessAuthorizer{
 		rootAuthorizer: rbac.New(
-			&rbac.RoleGetter{Lister: mergedRoleInformer.Lister()},
+			&rbac.RoleGetter{Lister: mergedRoleLister},
 			&rbac.RoleBindingLister{Lister: rootKubeInformer.RoleBindings().Lister()},
-			&rbac.ClusterRoleGetter{Lister: mergedClusterRoleInformer.Lister()},
-			&rbac.ClusterRoleBindingLister{Lister: mergedClusterRoleBindingsInformer.Lister()},
+			&rbac.ClusterRoleGetter{Lister: mergedClusterRoleLister},
+			&rbac.ClusterRoleBindingLister{Lister: mergedClusterRoleBindingsLister},
 		),
 		clusterWorkspaceLister: clusterWorkspaceLister,
 		delegate:               delegate,

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -160,15 +160,15 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 	parentWorkspaceKubeInformer := rbacwrapper.FilterInformers(parentClusterName, a.rbacInformers)
 	bootstrapInformer := rbacwrapper.FilterInformers(genericcontrolplane.LocalAdminCluster, a.rbacInformers)
 
-	mergedClusterRoleInformer := rbacwrapper.MergedClusterRoleInformer(parentWorkspaceKubeInformer.ClusterRoles(), bootstrapInformer.ClusterRoles())
-	mergedRoleInformer := rbacwrapper.MergedRoleInformer(parentWorkspaceKubeInformer.Roles(), bootstrapInformer.Roles())
-	mergedClusterRoleBindingsInformer := rbacwrapper.MergedClusterRoleBindingInformer(parentWorkspaceKubeInformer.ClusterRoleBindings(), bootstrapInformer.ClusterRoleBindings())
+	mergedClusterRoleLister := rbacwrapper.NewMergedClusterRoleLister(parentWorkspaceKubeInformer.ClusterRoles().Lister(), bootstrapInformer.ClusterRoles().Lister())
+	mergedRoleLister := rbacwrapper.NewMergedRoleLister(parentWorkspaceKubeInformer.Roles().Lister(), bootstrapInformer.Roles().Lister())
+	mergedClusterRoleBindingsLister := rbacwrapper.NewMergedClusterRoleBindingLister(parentWorkspaceKubeInformer.ClusterRoleBindings().Lister(), bootstrapInformer.ClusterRoleBindings().Lister())
 
 	parentAuthorizer := rbac.New(
-		&rbac.RoleGetter{Lister: mergedRoleInformer.Lister()},
+		&rbac.RoleGetter{Lister: mergedRoleLister},
 		&rbac.RoleBindingLister{Lister: parentWorkspaceKubeInformer.RoleBindings().Lister()},
-		&rbac.ClusterRoleGetter{Lister: mergedClusterRoleInformer.Lister()},
-		&rbac.ClusterRoleBindingLister{Lister: mergedClusterRoleBindingsInformer.Lister()},
+		&rbac.ClusterRoleGetter{Lister: mergedClusterRoleLister},
+		&rbac.ClusterRoleBindingLister{Lister: mergedClusterRoleBindingsLister},
 	)
 
 	extraGroups := sets.NewString()

--- a/pkg/virtual/framework/wrappers/rbac/merging.go
+++ b/pkg/virtual/framework/wrappers/rbac/merging.go
@@ -22,32 +22,13 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	rbacinformers "k8s.io/client-go/informers/rbac/v1"
 	rbaclisters "k8s.io/client-go/listers/rbac/v1"
-	"k8s.io/client-go/tools/cache"
 )
 
-var _ rbacinformers.ClusterRoleInformer = (*mergedClusterRoleInformer)(nil)
-var _ rbaclisters.ClusterRoleLister = (*mergedClusterRoleLister)(nil)
+var _ rbaclisters.ClusterRoleBindingLister = (*mergedClusterRoleBindingLister)(nil)
 
-func MergedClusterRoleInformer(informers ...rbacinformers.ClusterRoleInformer) rbacinformers.ClusterRoleInformer {
-	return &mergedClusterRoleInformer{
-		informers: informers,
-	}
-}
-
-func MergedClusterRoleBindingInformer(informers ...rbacinformers.ClusterRoleBindingInformer) rbacinformers.ClusterRoleBindingInformer {
-	return &mergedClusterRoleBindingInformer{
-		informers: informers,
-	}
-}
-
-type mergedClusterRoleBindingInformer struct {
-	informers []rbacinformers.ClusterRoleBindingInformer
-}
-
-func (mergedClusterRoleBindingInformer) Informer() cache.SharedIndexInformer {
-	panic("not implemented")
+func NewMergedClusterRoleBindingLister(listers ...rbaclisters.ClusterRoleBindingLister) rbaclisters.ClusterRoleBindingLister {
+	return &mergedClusterRoleBindingLister{listers: listers}
 }
 
 type mergedClusterRoleBindingLister struct {
@@ -75,36 +56,14 @@ func (l mergedClusterRoleBindingLister) Get(name string) (*rbacv1.ClusterRoleBin
 	panic("not implemented")
 }
 
-func (m mergedClusterRoleBindingInformer) Lister() rbaclisters.ClusterRoleBindingLister {
-	aggregatedListers := make([]rbaclisters.ClusterRoleBindingLister, 0)
-	for _, inf := range m.informers {
-		aggregatedListers = append(aggregatedListers, inf.Lister())
-	}
-	return &mergedClusterRoleBindingLister{
-		listers: aggregatedListers,
-	}
-}
+var _ rbaclisters.ClusterRoleLister = (*mergedClusterRoleLister)(nil)
 
-type mergedClusterRoleInformer struct {
-	informers []rbacinformers.ClusterRoleInformer
+func NewMergedClusterRoleLister(listers ...rbaclisters.ClusterRoleLister) rbaclisters.ClusterRoleLister {
+	return &mergedClusterRoleLister{listers: listers}
 }
 
 type mergedClusterRoleLister struct {
 	listers []rbaclisters.ClusterRoleLister
-}
-
-func (i *mergedClusterRoleInformer) Informer() cache.SharedIndexInformer {
-	panic("not implemented")
-}
-
-func (i *mergedClusterRoleInformer) Lister() rbaclisters.ClusterRoleLister {
-	aggregatedListers := make([]rbaclisters.ClusterRoleLister, 0)
-	for _, inf := range i.informers {
-		aggregatedListers = append(aggregatedListers, inf.Lister())
-	}
-	return &mergedClusterRoleLister{
-		listers: aggregatedListers,
-	}
 }
 
 func (l *mergedClusterRoleLister) List(selector labels.Selector) (ret []*rbacv1.ClusterRole, err error) {
@@ -142,18 +101,11 @@ func (l *mergedClusterRoleLister) Get(name string) (*rbacv1.ClusterRole, error) 
 	return mergedItem, errorHolder
 }
 
-var _ rbacinformers.RoleInformer = (*mergedRoleInformer)(nil)
 var _ rbaclisters.RoleLister = (*mergedRoleLister)(nil)
 var _ rbaclisters.RoleNamespaceLister = (*mergedRoleNamespaceLister)(nil)
 
-func MergedRoleInformer(informers ...rbacinformers.RoleInformer) rbacinformers.RoleInformer {
-	return &mergedRoleInformer{
-		informers: informers,
-	}
-}
-
-type mergedRoleInformer struct {
-	informers []rbacinformers.RoleInformer
+func NewMergedRoleLister(listers ...rbaclisters.RoleLister) rbaclisters.RoleLister {
+	return &mergedRoleLister{listers: listers}
 }
 
 type mergedRoleLister struct {
@@ -162,20 +114,6 @@ type mergedRoleLister struct {
 
 type mergedRoleNamespaceLister struct {
 	listers []rbaclisters.RoleNamespaceLister
-}
-
-func (i *mergedRoleInformer) Informer() cache.SharedIndexInformer {
-	panic("not implemented")
-}
-
-func (i *mergedRoleInformer) Lister() rbaclisters.RoleLister {
-	aggregatedListers := make([]rbaclisters.RoleLister, 0)
-	for _, inf := range i.informers {
-		aggregatedListers = append(aggregatedListers, inf.Lister())
-	}
-	return &mergedRoleLister{
-		listers: aggregatedListers,
-	}
 }
 
 func (l *mergedRoleLister) List(selector labels.Selector) (ret []*rbacv1.Role, err error) {


### PR DESCRIPTION
No code ever relied on the merged informer doing anything other than merging the listers. Refactor to reflect this reality in the type.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @ncdc @sttts
/cc @s-urbaniak