### PR TITLE
🌱 pkg/apis: update logicalcluster to v2.0.0-alpha.3

### DIFF
--- a/pkg/apis/go.mod
+++ b/pkg/apis/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.5
-	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39
+	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	github.com/onsi/gomega v1.10.1
 	github.com/stretchr/testify v1.7.1
 	k8s.io/api v0.24.3

--- a/pkg/apis/go.sum
+++ b/pkg/apis/go.sum
@@ -286,8 +286,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39 h1:yjKFd2obDNUfHZibLfN5QogaIjPnQ58H9SwCKsIko1g=
-github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.1.0.20220919135525-b0e6f07aec39/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3 h1:+DwIG/loh2nDB9c/FqNvLzFFq/YtBliLxAfw/uWNzyE=
+github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3/go.mod h1:lfWJL764jKFJxZWOGuFuT3PCCLPo6lV5Cl8P7u9T05g=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
## Summary
Update go.mod in pkg/apis to bump logicalcluster to v2.0.0-alpha.3 to match the main go.mod file.

I missed this when doing #2070

## Related issue(s)

Fixes #
