### PR TITLE
🌱 cache: annotate apiexports that will be replicated to the cache server

### DIFF
--- a/config/root-phase0/apiexport-apiresource.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-apiresource.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: apiresource.kcp.dev
 spec:

--- a/config/root-phase0/apiexport-scheduling.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-scheduling.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: scheduling.kcp.dev
 spec:

--- a/config/root-phase0/apiexport-shards.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-shards.tenancy.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: shards.tenancy.kcp.dev
 spec:

--- a/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: tenancy.kcp.dev
 spec:

--- a/config/root-phase0/apiexport-workload.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: workload.kcp.dev
 spec:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
adds `internal.sharding.kcp.dev/replicate` annotation to all apiexports from the root workspace.

note that this PR has no effect until the replication controller and the cache server is started.

## Related issue(s)

https://github.com/kcp-dev/kcp/issues/342
