### PR TITLE
:bug: Allow go to determine ARCH and OS during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ LOGCHECK_BIN := logcheck
 LOGCHECK := $(TOOLS_GOBIN_DIR)/$(LOGCHECK_BIN)-$(LOGCHECK_VER)
 export LOGCHECK # so hack scripts can use it
 
-ARCH := $(subst 64,,$(shell uname -p | sed s/x86_/amd/))64
-OS := "" #fallback to go build default behaviour, but it can be overridden from outside
+ARCH := $(go env GOARCH)
+OS := $(go env GOOS)
 
 KUBE_MAJOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output | sed 's/v\([0-9]*\).*/\1/')
 KUBE_MINOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output | sed "s/v[0-9]*\.\([0-9]*\).*/\1/")


### PR DESCRIPTION
## Summary
Allow go to determine ARCH and OS during build

## Related issue(s)

Fixes #2088 
