### PR TITLE
:bug: Set ARCH using go env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ LOGCHECK_BIN := logcheck
 LOGCHECK := $(TOOLS_GOBIN_DIR)/$(LOGCHECK_BIN)-$(LOGCHECK_VER)
 export LOGCHECK # so hack scripts can use it
 
-ARCH := $(subst 64,,$(shell uname -p | sed s/x86_/amd/))64
+ARCH := $(shell go env GOARCH)
 OS := "" #fallback to go build default behaviour, but it can be overridden from outside
 
 KUBE_MAJOR_VERSION := $(shell go mod edit -json | jq '.Require[] | select(.Path == "k8s.io/kubernetes") | .Version' --raw-output | sed 's/v\([0-9]*\).*/\1/')


### PR DESCRIPTION
Signed-off-by: Jian Qiu <jqiu@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`make build` fails on mac os due to run ARCH. Change to use ARCH in go env instead

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/2088
