### PR TITLE
🐛 apibinder: don't use external address for now

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -641,7 +641,8 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 	config = rest.CopyConfig(config)
 	kcpclienthelper.SetMultiClusterRoundTripper(config)
 	config = rest.AddUserAgent(config, initialization.ControllerName)
-	config.Host = fmt.Sprintf("https://%v%s", s.GenericConfig.ExternalAddress, initializingworkspacesbuilder.URLFor(tenancyv1alpha1.ClusterWorkspaceAPIBindingsInitializer))
+	// TODO(ncdc): support standalone vw server when --shard-virtual-workspace-url is set
+	config.Host += initializingworkspacesbuilder.URLFor(tenancyv1alpha1.ClusterWorkspaceAPIBindingsInitializer)
 	initializingWorkspacesKcpClusterClient, err := kcpclient.NewForConfig(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

When the vw server is colocated in kcp, the apibinder controller was trying to connect to the external address for
/services/initializingworkspaces. This works when there is no front proxy, but if there is one, we get x509 verification errors, because the client making the request is the local loopback client, and there is no way for that to work against the front proxy.

## Related issue(s)

Fixes #2094
