### PR TITLE
🐛 syncer: apply name transformations to spec controller downstream informer

### DIFF
--- a/pkg/syncer/shared/helpers.go
+++ b/pkg/syncer/shared/helpers.go
@@ -19,6 +19,8 @@ package shared
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 )
 
@@ -33,4 +35,18 @@ func DeprecatedGetAssignedSyncTarget(labels map[string]string) string {
 		}
 	}
 	return ""
+}
+
+// GetUpstreamResourceName returns the name with which the resource is known upstream.
+func GetUpstreamResourceName(downstreamResourceGVR schema.GroupVersionResource, downstreamResourceName string) string {
+	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+
+	if downstreamResourceGVR == configMapGVR && downstreamResourceName == "kcp-root-ca.crt" {
+		return "kube-root-ca.crt"
+	}
+	if downstreamResourceGVR == secretGVR && strings.HasPrefix(downstreamResourceName, "kcp-default-token") {
+		return strings.TrimPrefix(downstreamResourceName, "kcp-")
+	}
+	return downstreamResourceName
 }

--- a/pkg/syncer/shared/helpers_test.go
+++ b/pkg/syncer/shared/helpers_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetUpstreamResourceName(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		gvr      schema.GroupVersionResource
+		resource string
+		want     string
+	}{
+		{
+			name:     "kcp-root-ca.crt configmap, should be translated to kube-root-ca.crt",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			resource: "kcp-root-ca.crt",
+			want:     "kube-root-ca.crt",
+		},
+		{
+			name:     "not kcp-root-ca.crt configmap, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			resource: "my-configmap",
+			want:     "my-configmap",
+		},
+		{
+			name:     "a default token secret with kcp prefix, should be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+			resource: "kcp-default-token-1234",
+			want:     "default-token-1234",
+		},
+		{
+			name:     "a non default token secret without kcp prefix, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+			resource: "my-super-secret",
+			want:     "my-super-secret",
+		},
+		{
+			name:     "a different GVR than configmap or secret, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "random", Version: "v1", Resource: "another"},
+			resource: "kcp-foo",
+			want:     "kcp-foo",
+		},
+		{
+			name:     "a configmap with a kcp prefix, shouldn't be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			resource: "kcp-default-token-1234",
+			want:     "kcp-default-token-1234",
+		},
+		{
+			name:     "invalid GVR, should not be translated",
+			gvr:      schema.GroupVersionResource{Group: "", Version: "", Resource: ""},
+			resource: "kcp-foo",
+			want:     "kcp-foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetUpstreamResourceName(tt.gvr, tt.resource); got != tt.want {
+				t.Errorf("GetUpstreamResourceName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -158,7 +158,7 @@ func NewSpecSyncer(gvrs []schema.GroupVersionResource, syncTargetWorkspace logic
 						logicalcluster.AnnotationKey: nsLocator.Workspace.String(),
 					},
 					Namespace: nsLocator.Namespace,
-					Name:      name,
+					Name:      shared.GetUpstreamResourceName(gvr, name),
 				}
 				c.AddToQueue(gvr, m)
 			},

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -100,7 +100,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	}
 	if !exists {
 		klog.Infof("Downstream GVR %q object %s/%s does not exist. Removing finalizer upstream", gvr.String(), downstreamNamespace, downstreamName)
-		return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamInformers, c.upstreamClient, upstreamNamespace, c.syncTargetKey, upstreamWorkspace, getUpstreamResourceName(gvr, downstreamName))
+		return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, c.upstreamInformers, c.upstreamClient, upstreamNamespace, c.syncTargetKey, upstreamWorkspace, shared.GetUpstreamResourceName(gvr, downstreamName))
 	}
 
 	// update upstream status
@@ -112,7 +112,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 }
 
 func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamNamespace string, upstreamLogicalCluster logicalcluster.Name, downstreamObj *unstructured.Unstructured) error {
-	upstreamName := getUpstreamResourceName(gvr, downstreamObj.GetName())
+	upstreamName := shared.GetUpstreamResourceName(gvr, downstreamObj.GetName())
 
 	downstreamStatus, statusExists, err := unstructured.NestedFieldCopy(downstreamObj.UnstructuredContent(), "status")
 	if err != nil {
@@ -175,18 +175,4 @@ func (c *Controller) updateStatusInUpstream(ctx context.Context, gvr schema.Grou
 	}
 	klog.Infof("Updated status of resource %q %s|%s/%s from pcluster namespace %s", gvr.String(), upstreamLogicalCluster, upstreamNamespace, upstreamName, downstreamObj.GetNamespace())
 	return nil
-}
-
-// getUpstreamResourceName returns the name with which the resource is known upstream.
-func getUpstreamResourceName(downstreamResourceGVR schema.GroupVersionResource, downstreamResourceName string) string {
-	configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
-	secretGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
-
-	if downstreamResourceGVR == configMapGVR && downstreamResourceName == "kcp-root-ca.crt" {
-		return "kube-root-ca.crt"
-	}
-	if downstreamResourceGVR == secretGVR && strings.HasPrefix(downstreamResourceName, "kcp-default-token") {
-		return strings.TrimPrefix(downstreamResourceName, "kcp-")
-	}
-	return downstreamResourceName
 }


### PR DESCRIPTION
## Summary

Specific resources (kcp-root-ca.crt configmap and kcp-* secrets) weren't recreated if deleted downstream due to a missing name transformation. This PR fixes that.
