### PR TITLE
✨ pkg/admission/apibinding: verify workspace reference for existence

### DIFF
--- a/pkg/admission/apibinding/apibinding_admission_test.go
+++ b/pkg/admission/apibinding/apibinding_admission_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/admission/helpers"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
 
 func createAttr(apiBinding *apisv1alpha1.APIBinding) admission.Attributes {
@@ -442,6 +443,9 @@ func TestValidate(t *testing.T) {
 						tc.authzDecision,
 						tc.authzError,
 					}, nil
+				},
+				getWorkspace: func(name string) (*tenancyv1alpha1.ClusterWorkspace, error) {
+					return nil, errors.New("not implemented")
 				},
 			}
 

--- a/test/e2e/apibinding/apibinding_test.go
+++ b/test/e2e/apibinding/apibinding_test.go
@@ -146,6 +146,23 @@ func TestAPIBinding(t *testing.T) {
 			serviceProviderWorkspace, cowboysAPIExport.Name)
 	}
 
+	apiBinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys",
+		},
+		Spec: apisv1alpha1.APIBindingSpec{
+			Reference: apisv1alpha1.ExportReference{
+				Workspace: &apisv1alpha1.WorkspaceExportReference{
+					Path:       "root:some-org:non-existent",
+					ExportName: "today-cowboys",
+				},
+			},
+		},
+	}
+
+	_, err = kcpClusterClient.ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, serviceProvider1Workspace), apiBinding, metav1.CreateOptions{})
+	require.ErrorContains(t, err, `apibindings.apis.kcp.dev "cowboys" is forbidden: clusterworkspace.tenancy.kcp.dev "root:some-org|non-existent" not found`)
+
 	bindConsumerToProvider := func(consumerWorkspace, providerWorkspace logicalcluster.Name) {
 		t.Logf("Create an APIBinding in %q that points to the today-cowboys export from %q", consumerWorkspace, providerWorkspace)
 		apiBinding := &apisv1alpha1.APIBinding{


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This adds a check to apibinding admission to verify the referenced api binding workspace reference actually exists.
Conincidentally it enhances user facing messages.

@ncdc @stevekuznetsov i believe the addition call is worth it, it augments the workspace existence check and enhances user messaging, wdyt?

also cc @sttts 

## Related issue(s)

Fixes #1786
