### PR TITLE
:bug: fix- nil context in workspace-use plugin

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -103,7 +103,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 			if err := useWorkspaceOpts.Validate(); err != nil {
 				return err
 			}
-			return useWorkspaceOpts.Run(cmd.Context())
+			return useWorkspaceOpts.Run(c.Context())
 		},
 	}
 	useWorkspaceOpts.BindFlags(useCmd)


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Wrong command context was passed in `ws use` subcommand because of which there was a null pointer error when using it.

Issue:
Workspace use command run from building kubectl-kcp binary gives null pointer error. The passed command context was from parent (workspace command) was getting closed, causing seg fault. 
```
➜  kcp git:(debug/ws-use) ✗ ./bin/kubectl-kcp ws use webapp-back
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x4d6b83d]

goroutine 1 [running]:
golang.org/x/time/rate.(*Limiter).WaitN(0xc000181c20, {0x0, 0x0}, 0x1)
	/Users/vnarsing/go/pkg/mod/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8/rate/rate.go:234 +0x1bd
```
## Related issue(s)

Fixes #
