### PR TITLE
🌱  cache-server: disable ServerSideApply feature

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -113,6 +113,11 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 
 	serverConfig := genericapiserver.NewRecommendedConfig(apiextensionsapiserver.Codecs)
 
+	// disable SSA since the cache server should not change objects in any way
+	// note, that this will break when (if) the feature is locked, until then we should be fine
+	if err := utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.ServerSideApply)); err != nil {
+		return nil, err
+	}
 	if err := opts.ServerRunOptions.ApplyTo(&serverConfig.Config); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
disabling SSA stops the cache server from modifying "managedFields" field.

## Related issue(s)

https://github.com/kcp-dev/kcp/issues/342
