### PR TITLE
:seedling: Deprecate APIResourceImport.Spec.Location

### DIFF
--- a/pkg/apis/apiresource/v1alpha1/apiresourceimport_types.go
+++ b/pkg/apis/apiresource/v1alpha1/apiresourceimport_types.go
@@ -29,7 +29,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=kcp
-// +kubebuilder:printcolumn:name="Location",type="string",JSONPath=`.spec.location`,priority=1
 // +kubebuilder:printcolumn:name="Schema update strategy",type="string",JSONPath=`.spec.schemaUpdateStrategy`,priority=2
 // +kubebuilder:printcolumn:name="API Version",type="string",JSONPath=`.metadata.annotations.apiresource\.kcp\.dev/apiVersion`,priority=3
 // +kubebuilder:printcolumn:name="API Resource",type="string",JSONPath=`.spec.plural`,priority=4
@@ -102,9 +101,10 @@ type APIResourceImportSpec struct {
 	// +optional
 	SchemaUpdateStrategy SchemaUpdateStrategyType `json:"schemaUpdateStrategy,omitempty"`
 
-	// Locaton the API resource is imported from
-	// This field is required
-	Location string `json:"location"`
+	// Location is a deprecated field. It previously contained the name
+	// of the SyncTarget that created this resource. This can now be found
+	// via the OwnerReferences field.
+	DeprecatedLocation string `json:"location"`
 }
 
 // APIResourceImportConditionType is a valid value for APIResourceImportCondition.Type

--- a/pkg/reconciler/workload/heartbeat/heartbeat_controller.go
+++ b/pkg/reconciler/workload/heartbeat/heartbeat_controller.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	apiresourceinformer "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apiresource/v1alpha1"
 	workloadinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/reconciler/workload/basecontroller"
 )
@@ -28,7 +27,6 @@ import (
 func NewController(
 	kcpClusterClient kcpclient.Interface,
 	clusterInformer workloadinformers.SyncTargetInformer,
-	apiResourceImportInformer apiresourceinformer.APIResourceImportInformer,
 	heartbeatThreshold time.Duration,
 ) (*basecontroller.ClusterReconciler, error) {
 	cm := &clusterManager{
@@ -40,7 +38,6 @@ func NewController(
 		cm,
 		kcpClusterClient,
 		clusterInformer,
-		apiResourceImportInformer,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -515,7 +515,6 @@ func (s *Server) installSyncTargetHeartbeatController(ctx context.Context, confi
 	c, err := heartbeat.NewController(
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
-		s.KcpSharedInformerFactory.Apiresource().V1alpha1().APIResourceImports(),
 		s.Options.Controllers.SyncTargetHeartbeat.HeartbeatThreshold,
 	)
 	if err != nil {

--- a/pkg/syncer/apiimporter.go
+++ b/pkg/syncer/apiimporter.go
@@ -287,7 +287,7 @@ func (i *APIImporter) ImportAPIs(ctx context.Context) {
 					},
 				},
 				Spec: apiresourcev1alpha1.APIResourceImportSpec{
-					Location:             i.syncTargetName,
+					DeprecatedLocation:   i.syncTargetName,
 					SchemaUpdateStrategy: apiresourcev1alpha1.UpdateUnpublished,
 					CommonAPIResourceSpec: apiresourcev1alpha1.CommonAPIResourceSpec{
 						GroupVersion: apiresourcev1alpha1.GroupVersion{


### PR DESCRIPTION
This field is used by the syncer and various controllers to identify which SyncTarget owns the import. However, we can do this using the SyncTarget owner reference.
    
Removing this field would decouple the `apiresource` API group from the `workload` API group - i.e. this is currently the only place in the `apiresource` types where we refer to a `workload` concept.
    
Removing it would also remove a point of SyncTarget vs Location vs Cluster confusion.

The syncer and synctargetexports controller uses the Location field to identify the SyncTarget which owns the import. We can use the SyncTarget owner reference instead.

The heartbeat controller is currently using it to trigger reconciliation of a SyncTarget when there are updates to its imports, but that doesn't seem to be necessary at all.


