### PR TITLE
🌱 cache: annotate apiresourceschema that will be replicated to the cache server

### DIFF
--- a/config/root-phase0/apiresourceschema-apiresourceimports.apiresource.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-apiresourceimports.apiresource.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220628-546034da.apiresourceimports.apiresource.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaces.tenancy.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220915-b4cf5d4e.clusterworkspaces.tenancy.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-clusterworkspaceshards.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaceshards.tenancy.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220803-e095b93c.clusterworkspaceshards.tenancy.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspacetypes.tenancy.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220923-596b9074.clusterworkspacetypes.tenancy.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-locations.scheduling.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-locations.scheduling.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220801-c65c674d4.locations.scheduling.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-negotiatedapiresources.apiresource.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-negotiatedapiresources.apiresource.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220628-546034da.negotiatedapiresources.apiresource.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-placements.scheduling.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-placements.scheduling.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220909-c255fd13.placements.scheduling.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220923-836dfac8.synctargets.workload.kcp.dev
 spec:

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.dev.yaml
@@ -1,6 +1,8 @@
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
+  annotations:
+    internal.sharding.kcp.dev/replicate: "true"
   creationTimestamp: null
   name: v220915-b4cf5d4e.workspaces.tenancy.kcp.dev
 spec:


### PR DESCRIPTION
adds "internal.sharding.kcp.dev/replicate" annotation to all apiresourceschema from the root workspace.

objects with that annotation are replicated to the cache server.
this PR has no effect until the replication controller and the cache server is started.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

https://github.com/kcp-dev/kcp/issues/342
