### PR TITLE
:bug: Detect kubectl plugin via FlagSet Name

### DIFF
--- a/cmd/kubectl-kcp/main.go
+++ b/cmd/kubectl-kcp/main.go
@@ -20,10 +20,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/pflag"
+
 	"github.com/kcp-dev/kcp/cmd/kubectl-kcp/cmd"
 )
 
 func main() {
+	flags := pflag.NewFlagSet("kubectl-kcp", pflag.ExitOnError)
+	pflag.CommandLine = flags
+
 	cmd := cmd.KubectlKcpCommand()
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/cmd/kubectl-workspace/main.go
+++ b/cmd/kubectl-workspace/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	flags := pflag.NewFlagSet("kubectl-kcp", pflag.ExitOnError)
+	flags := pflag.NewFlagSet("kubectl-workspace", pflag.ExitOnError)
 	pflag.CommandLine = flags
 
 	workspaceCmd, err := cmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.7.1
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
 	go.etcd.io/etcd/client/pkg/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -676,8 +676,9 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace h1:9PNP1jnUjRhfmGMlkXHjYPishpcw4jpSt/V/xYY3FMA=
+github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=

--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -18,10 +18,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"path"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -70,7 +69,7 @@ func New(streams genericclioptions.IOStreams) (*cobra.Command, error) {
 	cmdOpts := plugin.NewUseWorkspaceOptions(streams)
 
 	cliName := "kubectl"
-	if path.Base(os.Args[0]) == "kubectl-kcp" {
+	if pflag.CommandLine.Name() == "kubectl-kcp" {
 		cliName = "kubectl kcp"
 	}
 


### PR DESCRIPTION
## Summary

The current approach uses the binary name, which won't work in the case where code gets run via [hack/generate/cli-doc/gen-cli-doc.go](https://github.com/kcp-dev/kcp/blob/main/hack/generate/cli-doc/gen-cli-doc.go)

Fixes #2119
