### PR TITLE
🌱 cache: replication controller: attach the shard annotation during object creation

### DIFF
--- a/pkg/reconciler/cache/replication/replication_reconcile_apiexports_test.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile_apiexports_test.go
@@ -75,7 +75,7 @@ func TestReconcileAPIExports(t *testing.T) {
 							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
 						}
 
-						expectedApiExport := newAPIExport("foo")
+						expectedApiExport := newAPIExportWithShardAnnotation("foo")
 						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
 							ts.Errorf("unexpected ApiExport was creaetd:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
 						}
@@ -99,7 +99,7 @@ func TestReconcileAPIExports(t *testing.T) {
 					return apiExport
 				}(),
 			},
-			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initialCacheApiExports:                   []runtime.Object{newAPIExportWithShardAnnotation("foo")},
 			initCacheFakeClientWithInitialApiExports: true,
 			reconcileKey:                             "root|foo",
 			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
@@ -127,7 +127,7 @@ func TestReconcileAPIExports(t *testing.T) {
 		},
 		{
 			name:                                     "case 2: cached object is removed when local object was not found",
-			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initialCacheApiExports:                   []runtime.Object{newAPIExportWithShardAnnotation("foo")},
 			initCacheFakeClientWithInitialApiExports: true,
 			reconcileKey:                             "root|foo",
 			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
@@ -176,7 +176,7 @@ func TestReconcileAPIExports(t *testing.T) {
 					return apiExport
 				}(),
 			},
-			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initialCacheApiExports:                   []runtime.Object{newAPIExportWithShardAnnotation("foo")},
 			initCacheFakeClientWithInitialApiExports: true,
 			reconcileKey:                             "root|foo",
 			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
@@ -196,7 +196,7 @@ func TestReconcileAPIExports(t *testing.T) {
 							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
 						}
 
-						expectedApiExport := newAPIExport("foo")
+						expectedApiExport := newAPIExportWithShardAnnotation("foo")
 						expectedApiExport.Labels["fooLabel"] = "fooLabelVal"
 						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
 							ts.Errorf("unexpected update to the ApiExport:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
@@ -219,7 +219,7 @@ func TestReconcileAPIExports(t *testing.T) {
 					return apiExport
 				}(),
 			},
-			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initialCacheApiExports:                   []runtime.Object{newAPIExportWithShardAnnotation("foo")},
 			initCacheFakeClientWithInitialApiExports: true,
 			reconcileKey:                             "root|foo",
 			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
@@ -239,7 +239,7 @@ func TestReconcileAPIExports(t *testing.T) {
 							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
 						}
 
-						expectedApiExport := newAPIExport("foo")
+						expectedApiExport := newAPIExportWithShardAnnotation("foo")
 						expectedApiExport.Spec.PermissionClaims = []apisv1alpha1.PermissionClaim{{GroupResource: apisv1alpha1.GroupResource{}, IdentityHash: "abc"}}
 						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
 							ts.Errorf("unexpected update to the ApiExport:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
@@ -262,7 +262,7 @@ func TestReconcileAPIExports(t *testing.T) {
 					return apiExport
 				}(),
 			},
-			initialCacheApiExports:                   []runtime.Object{newAPIExport("foo")},
+			initialCacheApiExports:                   []runtime.Object{newAPIExportWithShardAnnotation("foo")},
 			initCacheFakeClientWithInitialApiExports: true,
 			reconcileKey:                             "root|foo",
 			validateFunc: func(ts *testing.T, cacheClientActions []clientgotesting.Action, localClientActions []clientgotesting.Action, targetClusterCacheClient, targetClusterLocalClient logicalcluster.Name) {
@@ -282,7 +282,7 @@ func TestReconcileAPIExports(t *testing.T) {
 							ts.Fatalf("failed to convert unstructured to APIExport: %v", err)
 						}
 
-						expectedApiExport := newAPIExport("foo")
+						expectedApiExport := newAPIExportWithShardAnnotation("foo")
 						expectedApiExport.Status.VirtualWorkspaces = []apisv1alpha1.VirtualWorkspace{{URL: "https://acme.dev"}}
 						if !equality.Semantic.DeepEqual(cacheApiExportFromUnstructured, expectedApiExport) {
 							ts.Errorf("unexpected update to the ApiExport:\n%s", cmp.Diff(cacheApiExportFromUnstructured, expectedApiExport))
@@ -342,7 +342,6 @@ func newAPIExport(name string) *apisv1alpha1.APIExport {
 			Labels: map[string]string{},
 			Annotations: map[string]string{
 				logicalcluster.AnnotationKey: "root",
-				"kcp.dev/shard":              "amber",
 			},
 			Name: name,
 		},
@@ -353,6 +352,12 @@ func newAPIExport(name string) *apisv1alpha1.APIExport {
 			IdentityHash: fmt.Sprintf("%s-identity", name),
 		},
 	}
+}
+
+func newAPIExportWithShardAnnotation(name string) *apisv1alpha1.APIExport {
+	apiExport := newAPIExport(name)
+	apiExport.Annotations["kcp.dev/shard"] = "amber"
+	return apiExport
 }
 
 func newFakeKcpClusterClient(ds *dynamicfake.FakeDynamicClient) *fakeKcpClusterClient {

--- a/pkg/reconciler/cache/replication/replication_reconcile_unstructured.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile_unstructured.go
@@ -56,6 +56,12 @@ func (c *controller) reconcileUnstructuredObjects(ctx context.Context, cluster l
 		// TODO: in the future the original RV will have to be stored in an annotation (?)
 		// so that the clients that need to modify the original/local object can do it
 		localObject.SetResourceVersion("")
+		annotations := localObject.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[genericrequest.AnnotationKey] = c.shardName
+		localObject.SetAnnotations(annotations)
 		_, err := c.dynamicCacheClient.Cluster(cluster).Resource(*gvr).Namespace(localObject.GetNamespace()).Create(ctx, localObject, metav1.CreateOptions{})
 		return err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
to avoid an additional UPDATE request, mismatch on the Generation, CreationTime or UID field, replicated objects will have those fields set. by setting the shard name during object creation we instruct the cache server to stop updating/changing those fields in any way. in addition to that, the cache server will remove the annotation before persisting the object because a shard name is calculated based on the storage prefix.

## Related issue(s)

requires https://github.com/kcp-dev/kubernetes/pull/106 and https://github.com/kcp-dev/kubernetes/pull/107

part of https://github.com/kcp-dev/kcp/issues/342