### PR TITLE
✨ pkg/admission/apibinding: more informative authorization failure message

### DIFF
--- a/pkg/admission/apibinding/apibinding_admission.go
+++ b/pkg/admission/apibinding/apibinding_admission.go
@@ -215,7 +215,7 @@ func (o *apiBindingAdmission) checkAPIExportAccess(ctx context.Context, user use
 	if decision, _, err := authz.Authorize(ctx, bindAttr); err != nil {
 		return fmt.Errorf("unable to determine access to apiexports: %w", err)
 	} else if decision != authorizer.DecisionAllow {
-		return errors.New("missing verb='bind' permission on apiexports")
+		return fmt.Errorf("no permission to bind to export %q", apiExportName)
 	}
 
 	return nil

--- a/pkg/admission/apibinding/apibinding_admission_test.go
+++ b/pkg/admission/apibinding/apibinding_admission_test.go
@@ -259,7 +259,7 @@ func TestValidate(t *testing.T) {
 					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:org:workspaceName:someExport")).APIBinding,
 			),
 			authzDecision:  authorizer.DecisionNoOpinion,
-			expectedErrors: []string{"missing verb='bind' permission on apiexport"},
+			expectedErrors: []string{`no permission to bind to export "someExport"`},
 		},
 		{
 			name: "Create: complete workspace reference fails when denied",
@@ -268,7 +268,7 @@ func TestValidate(t *testing.T) {
 					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:org:workspaceName:someExport")).APIBinding,
 			),
 			authzDecision:  authorizer.DecisionDeny,
-			expectedErrors: []string{"missing verb='bind' permission on apiexports"},
+			expectedErrors: []string{`no permission to bind to export "someExport"`},
 		},
 		{
 			name: "Create: complete workspace reference fails when there's an error checking authorization",
@@ -335,7 +335,7 @@ func TestValidate(t *testing.T) {
 					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:org:workspaceName:someExport")).APIBinding,
 			),
 			authzDecision:  authorizer.DecisionNoOpinion,
-			expectedErrors: []string{"missing verb='bind' permission on apiexports"},
+			expectedErrors: []string{`no permission to bind to export "someExport"`},
 		},
 		{
 			name: "Update: complete workspace reference fails when denied",
@@ -346,7 +346,7 @@ func TestValidate(t *testing.T) {
 					withLabel(apisv1alpha1.InternalAPIBindingExportLabelKey, toSha224Base62("root:org:workspaceName:someExport")).APIBinding,
 			),
 			authzDecision:  authorizer.DecisionDeny,
-			expectedErrors: []string{"missing verb='bind' permission on apiexports"},
+			expectedErrors: []string{`no permission to bind to export "someExport"`},
 		},
 		{
 			name: "Update: complete workspace reference fails when there's an error checking authorization",

--- a/test/e2e/apibinding/apibinding_authorizer_test.go
+++ b/test/e2e/apibinding/apibinding_authorizer_test.go
@@ -281,6 +281,22 @@ func TestAPIBindingAuthorizer(t *testing.T) {
 			require.NoError(t, err, "expected error updating status of cowboys")
 		}
 	}
+
+	apiBinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cowboys",
+		},
+		Spec: apisv1alpha1.APIBindingSpec{
+			Reference: apisv1alpha1.ExportReference{
+				Workspace: &apisv1alpha1.WorkspaceExportReference{
+					Path:       "root:not-existent",
+					ExportName: "today-cowboys",
+				},
+			},
+		},
+	}
+	_, err = user3KcpClient.ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, consumer1Workspace), apiBinding, metav1.CreateOptions{})
+	require.ErrorContains(t, err, `no permission to bind to export "today-cowboys"`)
 }
 
 func createClusterRoleAndBindings(name, subjectName, subjectKind string, apiGroup, resource, resourceName string, verbs []string) (*rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding) {


### PR DESCRIPTION
## Summary
Improves the error message on non existent API export references.

## Related issue(s)

Fixes #1786
