### PR TITLE
🐛 kubectl-kcp: remove duplicated NewFlagSet

### DIFF
--- a/cmd/kubectl-kcp/cmd/kubectlKcp.go
+++ b/cmd/kubectl-kcp/cmd/kubectlKcp.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/component-base/version"
@@ -36,9 +35,6 @@ import (
 )
 
 func KubectlKcpCommand() *cobra.Command {
-	flags := pflag.NewFlagSet("kubectl-kcp", pflag.ExitOnError)
-	pflag.CommandLine = flags
-
 	root := &cobra.Command{
 		Use:   "kcp",
 		Short: "kubectl plugin for KCP",


### PR DESCRIPTION
## Summary

In #2121 I added this to the main.go (which is consistent with most other usage) but missed it was already done here, so cleaning up the duplication

## Related issue(s)

Related to fix for #2119
