### PR TITLE
:bug:  Fix bugs in the resource controller

### DIFF
--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -448,7 +448,7 @@ func locations(annotations, labels map[string]string, skipPending bool) (locatio
 	}
 	for k := range annotations {
 		if strings.HasPrefix(k, workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix) {
-			deleting.Insert(strings.TrimPrefix(k, workloadv1alpha1.ClusterResourceStateLabelPrefix))
+			deleting.Insert(strings.TrimPrefix(k, workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix))
 		}
 	}
 	return

--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -85,7 +85,7 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 	// clean finalizers from removed syncers
 	filteredFinalizers := make([]string, 0, len(obj.GetFinalizers()))
 	for _, f := range obj.GetFinalizers() {
-		logger = logger.WithValues("finalizer", f)
+		logger := logger.WithValues("finalizer", f)
 		if !strings.HasPrefix(f, syncershared.SyncerFinalizerNamePrefix) {
 			filteredFinalizers = append(filteredFinalizers, f)
 			continue

--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -176,8 +176,10 @@ func computePlacement(ns *corev1.Namespace, obj metav1.Object) (annotationPatch 
 	// create merge patch
 	annotationPatch = map[string]interface{}{}
 	labelPatch = map[string]interface{}{}
+
+	// unschedule objects on locations where the namespace is not scheduled
 	for _, loc := range objLocations.Difference(nsLocations).List() {
-		// location was removed from namespace, but is still on the object
+		// That's an inconsistent state, probably due to the namespace deletion reaching its grace period => let's repair it
 		var hasSyncerFinalizer, hasClusterFinalizer bool
 		// Check if there's still the syncer or the cluster finalizer.
 		for _, finalizer := range obj.GetFinalizers() {
@@ -199,7 +201,9 @@ func computePlacement(ns *corev1.Namespace, obj metav1.Object) (annotationPatch 
 			}
 		}
 	}
-	for _, loc := range nsLocations.Intersection(nsLocations).List() {
+
+	// sync deletion timestamps if both namespace and object are scheduled
+	for _, loc := range nsLocations.Intersection(objLocations).List() {
 		if nsTimestamp, found := ns.Annotations[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc]; found && validRFC3339(nsTimestamp) {
 			objTimestamp, found := obj.GetAnnotations()[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc]
 			if !found || !validRFC3339(objTimestamp) {
@@ -207,8 +211,12 @@ func computePlacement(ns *corev1.Namespace, obj metav1.Object) (annotationPatch 
 			}
 		}
 	}
+
+	// set label on unscheduled objects if namespace is scheduled and not deleting
 	for _, loc := range nsLocations.Difference(objLocations).List() {
-		// location was missing on the object
+		if nsDeleting.Has(loc) {
+			continue
+		}
 		// TODO(sttts): add way to go into pending state first, maybe with a namespace annotation
 		labelPatch[workloadv1alpha1.ClusterResourceStateLabelPrefix+loc] = string(workloadv1alpha1.ResourceStateSync)
 	}

--- a/pkg/reconciler/workload/resource/resource_reconcile_test.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile_test.go
@@ -80,6 +80,14 @@ func TestComputePlacement(t *testing.T) {
 				"state.workload.kcp.dev/cluster-1": "Sync",
 			},
 		},
+		{name: "syncing but deleting namespace, unscheduled object, don't schedule the object at all",
+			ns: namespace(map[string]string{
+				"deletion.internal.workload.kcp.dev/cluster-1": "2002-10-02T10:00:00-05:00",
+			}, map[string]string{
+				"state.workload.kcp.dev/cluster-1": "Sync",
+			}),
+			obj: object(nil, nil, nil, nil),
+		},
 		{name: "new location on namespace",
 			ns: namespace(nil, map[string]string{
 				"state.workload.kcp.dev/cluster-1": "Sync",


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

## Summary

This PR fixes several bugs in the resource controller:
- We should not add the `RequestState` label to [Sync](url) for a `SyncTarget` when the namespace already has the deletion annotation for this `SyncTarget`. It doesn't make sense to start syncing a resource to a SyncTarget while the intent already expressed on the namespace is to delete all resources from this `SyncTarget`
- Additional small fixes in the resource `computePlacement` function.

See the individual commits for more information
 
## Related issue(s)

Bugs spotted while debugging the Syncer Virtual Transformations e2e test 