### PR TITLE
🐛 Syncer AdvancedScheduling fixes: Avoid syncing down the experimental status annotation.

### DIFF
--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -342,6 +342,8 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	// Strip cluster name annotation
 	downstreamAnnotations := downstreamObj.GetAnnotations()
 	delete(downstreamAnnotations, logicalcluster.AnnotationKey)
+	//TODO(jmprusi): To be removed when switching to the syncer Virtual Workspace transformations.
+	delete(downstreamAnnotations, workloadv1alpha1.InternalClusterStatusAnnotationPrefix+c.syncTargetKey)
 	// If we're left with 0 annotations, nil out the map so it's not included in the patch
 	if len(downstreamAnnotations) == 0 {
 		downstreamAnnotations = nil


### PR DESCRIPTION
## Summary

When the Syncer is running in AdvancedScheduling mode, the experimental status annotation is synced to the downstream resource, this PR removes that annotation when syncing the resource downstream.