### PR TITLE
:bug: Removes the logical-cluster & sync-target labels from syncer namespace

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -29,9 +29,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kcp-syncer-sync-target-name-34b23c4k
-  labels:
-    workload.kcp.io/logical-cluster: root_default_foo
-    workload.kcp.io/sync-target: sync-target-name
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -188,9 +185,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kcp-syncer-sync-target-name-34b23c4k
-  labels:
-    workload.kcp.io/logical-cluster: root_default_foo
-    workload.kcp.io/sync-target: sync-target-name
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{.Namespace}}
-  labels:
-    workload.kcp.io/logical-cluster: {{.LabelSafeLogicalCluster}}
-    workload.kcp.io/sync-target: {{.SyncTarget}}
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
## Summary
Removing the following labels from the Namespace yaml definition generated while performing a workload sync operation:
```
labels:
    workload.kcp.io/logical-cluster: {{.LabelSafeLogicalCluster}}
    workload.kcp.io/sync-target: {{.SyncTarget}}
```

Fixes #1843 
