### PR TITLE
:bug: Don't schedule downstream resources

### DIFF
--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -60,6 +60,14 @@ func (c *Controller) reconcileResource(ctx context.Context, lclusterName logical
 		return nil
 	}
 
+	// Filter out resources which have been synced to a SyncTarget living on a KCP shard (typical e2e test situation)
+	if labels := obj.GetLabels(); labels != nil {
+		if _, ok := labels[workloadv1alpha1.InternalDownstreamClusterLabel]; ok {
+			logging.WithReconciler(klog.Background(), controllerName).WithValues("namespace", obj.GetNamespace()).V(2).Info("skipping scheduling resource: it is a SyncTarget resource")
+			return nil
+		}
+	}
+
 	// Align the resource's assigned cluster with the namespace's assigned
 	// cluster.
 	// First, get the namespace object (from the cached lister).


### PR DESCRIPTION
## Summary

The resource controller used to schedule resources which in fact were already the result of syncing (when a SyncTarget cluster is created as a KCP workspace). This is a typical use-case for e2e tests, and these resources should not take part in the resource scheduling: including them in resource scheduling makes the e2e test execution quite confusing.

This is a split of PR https://github.com/kcp-dev/kcp/pull/2126.

[Discussion started in the initial PR](https://github.com/kcp-dev/kcp/pull/2126#discussion_r987082954) should be continued here before merging.