### PR TITLE
:seedling: Syncer: Complete the move to structural logging

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -126,56 +126,28 @@
 /pkg/server/home_workspaces.go:352:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/home_workspaces.go:638:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
-/pkg/syncer/shared/finalizer.go:53:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/shared/finalizer.go:91:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/shared/finalizer.go:94:2: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/shared/finalizer.go:94:2: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_controller.go:141:6: function "InfoS" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_controller.go:141:6: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_controller.go:165:6: function "InfoS" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_controller.go:165:6: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:106:2: function "InfoS" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:106:2: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:111:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:128:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:128:3: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:138:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:138:3: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:141:4: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:168:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:235:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:282:4: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:285:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:311:2: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:311:2: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:322:4: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:325:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:325:3: function "V" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:378:6: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:407:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:410:2: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:56:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/spec/spec_process.go:67:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:106:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:125:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:125:3: function "V" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:135:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:141:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:160:4: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:160:4: function "V" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:165:4: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:168:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:181:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:184:2: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:52:2: function "InfoS" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:52:2: function "V" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:57:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:69:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:74:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/status/status_process.go:79:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/syncer/syncer.go:190:3: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/syncer.go:208:2: function "Infof" should not be used, convert to contextual logging
-/pkg/syncer/syncer.go:219:2: function "Infof" should not be used, convert to contextual logging
+/pkg/syncer/namespace/namespace_downstream_process.go:43:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:74:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:74:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_upstream_process.go:40:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/namespace/namespace_upstream_process.go:40:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_upstream_process.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_controller.go:141:16: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/spec/spec_controller.go:141:16: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:131:3: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:149:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:321:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/status/status_process.go:100:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/status/status_process.go:100:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:100:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
+/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
+/pkg/syncer/syncer.go:166:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetNameKey} provided with string value.
+/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetNameKey} provided with string value.
+/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetWorkspaceKey} provided with string value.
 /pkg/tunneler/dialer.go:148:8: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/dialer.go:148:8: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:157:3: function "Infof" should not be used, convert to contextual logging

--- a/pkg/logging/constants.go
+++ b/pkg/logging/constants.go
@@ -84,13 +84,13 @@ func From(obj Object) []interface{} {
 func FromPrefix(prefix string, obj Object) []interface{} {
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	return []interface{}{
-		prefix + "." + WorkspaceKey,
+		prefix + "." + string(WorkspaceKey),
 		logicalcluster.From(obj).String(),
-		prefix + "." + NamespaceKey,
+		prefix + "." + string(NamespaceKey),
 		obj.GetNamespace(),
-		prefix + "." + NameKey,
+		prefix + "." + string(NameKey),
 		obj.GetName(),
-		prefix + "." + APIVersionKey,
+		prefix + "." + string(APIVersionKey),
 		gvk.GroupVersion(),
 	}
 }

--- a/pkg/logging/tmc.go
+++ b/pkg/logging/tmc.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logging supplies common constants to ensure consistent use of structured logs.
+package logging
+
+const (
+	// SyncTargetKeyPrefix is the prefix used for all the keys related to a SyncTarget.
+	SyncTargetKeyPrefix = "syncTarget."
+
+	// SyncTargetWorkspaceKey is used to specify a workspace when a log is related to a SyncTarget.
+	SyncTargetWorkspaceKey = SyncTargetKeyPrefix + "workspace"
+	// SyncTargetNamespaceKey is used to specify a namespace when a log is related to a SyncTarget.
+	SyncTargetNamespaceKey = SyncTargetKeyPrefix + "namespace"
+	// SyncTargetNameKey is used to specify a name when a log is related to a SyncTarget.
+	SyncTargetNameKey = SyncTargetKeyPrefix + "name"
+
+	// DownstreamKeyPrefix is the prefix used for all the keys related to a downstream object.
+	DownstreamKeyPrefix = "downstream."
+
+	// DownstreamNamespaceKey is used to specify a namespace when a log is related to a downstream object.
+	DownstreamNamespaceKey = DownstreamKeyPrefix + "namespace"
+	// DownstreamNameKey is used to specify a name when a log is related to a downstream object.
+	DownstreamNameKey = DownstreamKeyPrefix + "name"
+)

--- a/pkg/syncer/namespace/namespace_downstream_process.go
+++ b/pkg/syncer/namespace/namespace_downstream_process.go
@@ -40,6 +40,8 @@ func (c *DownstreamController) process(ctx context.Context, key string) error {
 		return nil
 	}
 
+	logger = logger.WithValues(logging.DownstreamNamespaceKey, namespaceName)
+
 	// Always refresh the DNS ConfigMap
 	err = c.updateDNSConfigMap(ctx)
 	if err != nil {
@@ -48,10 +50,10 @@ func (c *DownstreamController) process(ctx context.Context, key string) error {
 
 	downstreamNamespaceObj, err := c.getDownstreamNamespace(namespaceName)
 	if apierrors.IsNotFound(err) {
-		logger.V(4).Info("downstream namespace not found, ignoring key", "namespace", namespaceName)
+		logger.V(4).Info("downstream namespace not found, ignoring key")
 		return nil
 	} else if err != nil {
-		logger.Error(err, "failed to get downstream namespace", "namespace", namespaceName)
+		logger.Error(err, "failed to get downstream namespace")
 		return nil
 	}
 
@@ -69,7 +71,7 @@ func (c *DownstreamController) process(ctx context.Context, key string) error {
 		logger.Error(err, "failed to unmarshal namespace locator", "namespaceLocator", namespaceLocatorJSON)
 		return nil
 	}
-	logger = logger.WithValues("upstreamWorkspace", nsLocator.Workspace, "upstreamNamespace", nsLocator.Namespace)
+	logger = logger.WithValues(logging.WorkspaceKey, nsLocator.Workspace, logging.NamespaceKey, nsLocator.Namespace)
 	exists, err := c.upstreamNamespaceExists(nsLocator.Workspace, nsLocator.Namespace)
 	if err != nil {
 		logger.Error(err, "failed to check if upstream namespace exists")

--- a/pkg/syncer/namespace/namespace_upstream_process.go
+++ b/pkg/syncer/namespace/namespace_upstream_process.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 
+	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 )
 
@@ -35,6 +36,8 @@ func (c *UpstreamController) process(ctx context.Context, key string) error {
 		logger.Error(err, "invalid key")
 		return nil
 	}
+
+	logger = logger.WithValues(logging.WorkspaceKey, clusterName, logging.NameKey, namespaceName)
 
 	exists, err := c.upstreamNamespaceExists(clusterName, namespaceName)
 	if err != nil {
@@ -72,6 +75,7 @@ func (c *UpstreamController) process(ctx context.Context, key string) error {
 	}
 
 	downstreamNamespaceName := downstreamNamespace.(*unstructured.Unstructured).GetName()
-	logger.V(2).Info("deleting downstream namespace because the upstream namespace doesn't exist", "downstreamNamespace", downstreamNamespaceName, "upstreamWorkspace", clusterName, "upstreamNamespace", namespaceName)
+	logger = logger.WithValues(logging.DownstreamNamespaceKey, downstreamNamespaceName)
+	logger.V(2).Info("deleting downstream namespace because the upstream namespace doesn't exist")
 	return c.deleteDownstreamNamespace(ctx, downstreamNamespaceName)
 }

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/informers"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
@@ -443,9 +444,10 @@ func TestDeepEqualApartFromStatus(t *testing.T) {
 			want: false,
 		},
 	}
+	logger := klog.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := deepEqualApartFromStatus(tt.args.a, tt.args.b); got != tt.want {
+			if got := deepEqualApartFromStatus(logger, tt.args.a, tt.args.b); got != tt.want {
 				t.Errorf("deepEqualApartFromStatus() = %v, want %v", got, tt.want)
 			}
 		})
@@ -962,6 +964,7 @@ func TestSyncerProcess(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+			logger := klog.FromContext(ctx)
 
 			kcpLogicalCluster := logicalcluster.New(tc.upstreamLogicalCluster)
 			syncTargetUID := tc.syncTargetUID
@@ -1001,7 +1004,7 @@ func TestSyncerProcess(t *testing.T) {
 
 			upstreamURL, err := url.Parse("https://kcp.dev:6443")
 			require.NoError(t, err)
-			controller, err := NewSpecSyncer(kcpLogicalCluster, tc.syncTargetName, syncTargetKey, upstreamURL, tc.advancedSchedulingEnabled, fromClusterClient, toClient, fromInformers, toInformers, fakeInformers, syncTargetUID, "8.8.8.8")
+			controller, err := NewSpecSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, upstreamURL, tc.advancedSchedulingEnabled, fromClusterClient, toClient, fromInformers, toInformers, fakeInformers, syncTargetUID, "8.8.8.8")
 			require.NoError(t, err)
 
 			fromInformers.Start(ctx.Done())

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/informers"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
@@ -527,6 +528,7 @@ func TestSyncerProcess(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+			logger := klog.FromContext(ctx)
 
 			kcpLogicalCluster := logicalcluster.New(tc.upstreamLogicalCluster)
 			if tc.syncTargetUID == "" {
@@ -560,7 +562,7 @@ func TestSyncerProcess(t *testing.T) {
 			toClientResourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, toClient)
 
 			fakeInformers := newFakeSyncerInformers(tc.gvr, toInformers, fromInformers)
-			controller, err := NewStatusSyncer(kcpLogicalCluster, tc.syncTargetName, syncTargetKey, tc.advancedSchedulingEnabled, toClusterClient, fromClient, toInformers, fromInformers, fakeInformers, tc.syncTargetUID)
+			controller, err := NewStatusSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, tc.advancedSchedulingEnabled, toClusterClient, fromClient, toInformers, fromInformers, fakeInformers, tc.syncTargetUID)
 			require.NoError(t, err)
 
 			toInformers.ForResource(tc.gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})

--- a/pkg/syncer/tunneler.go
+++ b/pkg/syncer/tunneler.go
@@ -48,8 +48,6 @@ func startSyncerTunnel(ctx context.Context, upstream, downstream *rest.Config, s
 
 	backoffMgr := wait.NewExponentialBackoffManager(initBackoff, maxBackoff, resetDuration, backoffFactor, jitter, clock)
 	logger := klog.FromContext(ctx)
-	logger.WithValues("target-workspace", syncTargetWorkspace, "target-name", syncTargetName)
-	ctx = klog.NewContext(ctx, logger)
 
 	wait.BackoffUntil(func() {
 		logger.V(5).Info("starting tunnel")
@@ -61,6 +59,8 @@ func startSyncerTunnel(ctx context.Context, upstream, downstream *rest.Config, s
 }
 
 func startTunneler(ctx context.Context, upstream, downstream *rest.Config, syncTargetWorkspace logicalcluster.Name, syncTargetName string) error {
+	logger := klog.FromContext(ctx)
+
 	// syncer --> kcp
 	clientUpstream, err := rest.HTTPClientFor(upstream)
 	if err != nil {
@@ -100,7 +100,7 @@ func startTunneler(ctx context.Context, upstream, downstream *rest.Config, syncT
 		return err
 	}
 
-	logger := klog.FromContext(ctx).WithValues("syncer-tunnel-url", dst)
+	logger = logger.WithValues("syncer-tunnel-url", dst)
 	logger.Info("connecting to destination URL")
 	l, err := tunneler.NewListener(clientUpstream, dst)
 	if err != nil {


### PR DESCRIPTION
## Summary

Complete the move to structural logging in the Syncer.
This has been started in a previous PR, but many places were not finished.
