### PR TITLE
🐛 Create VirtualWorkSpaceURL on first APIBinding

### DIFF
--- a/pkg/indexers/apibinding.go
+++ b/pkg/indexers/apibinding.go
@@ -74,3 +74,15 @@ func IndexAPIBindingByBoundResources(obj interface{}) ([]string, error) {
 func APIBindingBoundResourceValue(clusterName logicalcluster.Name, group, resource string) string {
 	return fmt.Sprintf("%s|%s.%s", clusterName, resource, group)
 }
+
+const APIBindingsByAPIExport = "APIBindingByAPIExport"
+
+// IndexAPIBindingByAPIExport indexes the APIBindings by their APIExport's Reference Path and Name.
+func IndexAPIBindingByAPIExport(obj interface{}) ([]string, error) {
+	apiBinding, ok := obj.(*apisv1alpha1.APIBinding)
+	if !ok {
+		return []string{}, fmt.Errorf("obj %T is not an APIBinding", obj)
+	}
+
+	return []string{ClusterPathAndAPIExportName(apiBinding.Spec.Reference.Workspace.Path, apiBinding.Spec.Reference.Workspace.ExportName)}, nil
+}

--- a/pkg/indexers/apiexport.go
+++ b/pkg/indexers/apiexport.go
@@ -28,7 +28,7 @@ import (
 const (
 	// APIExportByIdentity is the indexer name for retrieving APIExports by identity hash.
 	APIExportByIdentity = "APIExportByIdentity"
-	// APIExportBySecret is the indexer name for retrieving APIExports by
+	// APIExportBySecret is the indexer name for retrieving APIExports by secret.
 	APIExportBySecret = "APIExportSecret"
 )
 
@@ -64,4 +64,8 @@ func IndexAPIExportBySecret(obj interface{}) ([]string, error) {
 	}
 
 	return []string{kcpcache.ToClusterAwareKey(logicalcluster.From(apiExport).String(), ref.Namespace, ref.Name)}, nil
+}
+
+func ClusterPathAndAPIExportName(clusterPath, exportName string) string {
+	return fmt.Sprintf("%s|%s", clusterPath, exportName)
 }

--- a/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_reconcile.go
@@ -95,6 +95,17 @@ func (c *controller) reconcile(ctx context.Context, apiExport *apisv1alpha1.APIE
 		)
 	}
 
+	// check if any APIBindings are bound to this APIExport. If so, add a virtualworkspaceURL
+	apiBindings, err := c.getAPIBindingsForAPIExport(clusterName, apiExport.Name)
+	if err != nil {
+		return fmt.Errorf("error checking for APIBindings with APIExport %s|%s: %w", clusterName, apiExport.Name, err)
+	}
+
+	// If there are no bindings, then we can't create a URL yet.
+	if len(apiBindings) == 0 {
+		return nil
+	}
+
 	if err := c.updateVirtualWorkspaceURLs(ctx, apiExport); err != nil {
 		conditions.MarkFalse(
 			apiExport,

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -718,6 +718,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 		kubeClusterClient,
 		s.KubeSharedInformerFactory.Core().V1().Namespaces(),
 		s.KubeSharedInformerFactory.Core().V1().Secrets(),
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 	)
 	if err != nil {
 		return err

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -102,6 +102,11 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 
 	setUpServiceProvider(ctx, dynamicClusterClient, kcpClients, serviceProviderWorkspace, cfg, t)
 
+	t.Logf("test that the virtualWorkspaceURL is not set on initial APIExport creation")
+	apiExport, err := kcpClients.ApisV1alpha1().APIExports().Get(logicalcluster.WithCluster(ctx, serviceProviderWorkspace), "today-cowboys", metav1.GetOptions{})
+	require.Empty(t, apiExport.Status.VirtualWorkspaces)
+	require.NoError(t, err, "error getting APIExport")
+
 	// create API bindings in consumerWorkspace as user-3 with only bind permissions in serviceProviderWorkspace but not general access.
 	user3KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err, "failed to construct client for user-3")
@@ -127,7 +132,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "expected all ClusterWorkspaceShards to have a VirtualWorkspaceURL assigned")
 
 	t.Logf("test that the admin user can use the virtual workspace to get cowboys")
-	apiExport, err := kcpClients.ApisV1alpha1().APIExports().Get(logicalcluster.WithCluster(ctx, serviceProviderWorkspace), "today-cowboys", metav1.GetOptions{})
+	apiExport, err = kcpClients.ApisV1alpha1().APIExports().Get(logicalcluster.WithCluster(ctx, serviceProviderWorkspace), "today-cowboys", metav1.GetOptions{})
 	require.NoError(t, err, "error getting APIExport")
 	require.Len(t, apiExport.Status.VirtualWorkspaces, clusterWorkspaceShardVirtualWorkspaceURLs.Len(), "unexpected virtual workspace URLs: %#v", apiExport.Status.VirtualWorkspaces)
 


### PR DESCRIPTION
## Summary

Defer creating an APIExport's first virtualWorkspaceURL until the first APIBinding is created.

## Related issue(s)

Fixes #1183
