### PR TITLE
:bug: fix: apigen to write files when previous versions are not present

### DIFF
--- a/cmd/apigen/main.go
+++ b/cmd/apigen/main.go
@@ -114,6 +114,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	if _, err := os.Stat(opts.outputDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(opts.outputDir, os.FileMode(0755)); err != nil {
+			logger.Error(err, "Could not create directory to write output files.")
+			os.Exit(1)
+		}
+	}
 	previousApiResourceSchemas, err := loadAPIResourceSchemas(logger, opts.outputDir)
 	if err != nil {
 		logger.Error(err, "Could not load previous APIResourceSchemas.")


### PR DESCRIPTION
When the output dir specified through flag is not present, the apigen command fails with an error. This PR fixes the same by creating a new output directory.

Previously when the output directory is not present:
```
$ apigen --input-dir=config/crd --output-dir=kcp/
INFO[0000] Loading CustomResourceDefinitions from config/crd  logger=apigen
INFO[0000] Loaded CustomResourceDefinition for catalogentries.catalog.kcp.dev from config/crd/catalog.kcp.dev_catalogentries.yaml  logger=apigen
INFO[0000] Loaded 1 CustomResourceDefinitions            logger=apigen
INFO[0000] Loading APIResourceSchemas from kcp/          logger=apigen
ERRO[0000] Could not load previous APIResourceSchemas.   error="lstat kcp/: no such file or directory" logger=apigen
```

Now, when output dir is not present, the command creates one and writes the Resourceschemas and APIExport yaml.
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization


Fixes #
