### PR TITLE
:bug: fix 'make install' on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ build-kind-images: build-kind-images-ko
 install: WHAT ?= ./cmd/...
 install:
 	GOOS=$(OS) GOARCH=$(ARCH) go install -ldflags="$(LDFLAGS)" $(WHAT)
-	ln -sfr $(INSTALL_GOBIN)/kubectl-workspace $(INSTALL_GOBIN)/kubectl-ws
-	ln -sfr $(INSTALL_GOBIN)/kubectl-workspace $(INSTALL_GOBIN)/kubectl-workspaces
+	ln -sf $(INSTALL_GOBIN)/kubectl-workspace $(INSTALL_GOBIN)/kubectl-ws
+	ln -sf $(INSTALL_GOBIN)/kubectl-workspace $(INSTALL_GOBIN)/kubectl-workspaces
 .PHONY: install
 
 $(GOLANGCI_LINT):


### PR DESCRIPTION
When `make install` is run on Mac it gives the error:

```
ln -sfr /Users/vnarsing/go/bin/kubectl-workspace /Users/vnarsing/go/bin/kubectl-ws
ln: illegal option -- r
usage: ln [-s [-F] | -L | -P] [-f | -i] [-hnv] source_file [target_file]
    ln [-s [-F] | -L | -P] [-f | -i] [-hnv] source_file ... target_dir
    link source_file target_file
make: *** [install] Error 1
```

Since `-r` is not supported in Mac. 
