### PR TITLE
:bug: cmd/Sync: remove serviceaccounts from default resource list

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -180,7 +180,7 @@ func (o *SyncOptions) Run(ctx context.Context) error {
 	// talking to kcp.
 	//
 	// TODO(marun) Consider allowing a user-specified and exclusive set of types.
-	requiredResourcesToSync := sets.NewString("deployments.apps", "secrets", "configmaps", "serviceaccounts")
+	requiredResourcesToSync := sets.NewString("deployments.apps", "secrets", "configmaps")
 	resourcesToSync := sets.NewString(o.ResourcesToSync...).Union(requiredResourcesToSync).List()
 
 	config, err := o.ClientConfig.ClientConfig()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Serviceaccounts are currently synced by default, but this shouldn't be the case as it will cause issue overriding downstream SAs.

