### PR TITLE
:book: add github actions to push docs 

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -1,0 +1,116 @@
+name: Generate and push docs
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths:
+      - "cmd/**"
+      - "docs/**"
+      - "pkg/**"
+      - "README.md"
+  workflow_dispatch:
+
+jobs:
+  generate-and-push:
+    name: Generate and push docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+          path: kcp
+      - uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: docs
+      - uses: actions/setup-go@v3
+        with:
+          go-version: v1.18
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.104.3"
+          extended: true
+
+      # install npm dependencies
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install dependencies
+      - run: cd kcp/docs && npm install && npm ci
+
+      - name: Copy readmes
+        run: tail -n +4 kcp/README.md >> docs/content/en/main/_index.md
+
+      - name: Generate CLI and CRD docs
+        run: cd kcp && make generate-docs
+
+      - name: Build hugo docs
+        run: cd kcp/docs && hugo --minify
+
+      # This step check if the trigger is a tag and if so, it will update the version in the
+      # config.toml file and mark it as archived, since the tag is also a latest main, the same
+      # content is rebuilt using updated config and folder name. The folder thus generated is saved
+      # as archive in gh-pages branch.
+      - name: Update version info on tag for archive
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mv kcp/docs/public public
+          cd kcp/docs
+          cat <<EOF > temp.txt
+          #version-start
+          archived_version = true
+          version = "${{ github.ref }}"
+          EOF
+          ed config.toml<<EOF
+          /^#version-start
+          +,/^#version-end/-1d
+          -r !sed -n '/^#version-start/,/^#version-end/p' temp.txt | grep -v '^#'
+          w
+          q
+          EOF
+          mv content/en/main content/en/${{ github.ref }}
+          hugo --minify
+          rsync -av public/${{ github.ref }} ../../docs
+
+      - name: Push to gh-pages on tag for archive
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cd docs
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Static archive of docs for ${{ github.ref }}"
+          git push
+
+      - name: Copy everything from archive to docs
+        run: rsync -av docs public
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: public/
+
+  # Deployment Job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    needs: generate-and-push
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ update-contextual-logging: $(LOGCHECK)
 
 generate-docs:
 	go run hack/generate/cli-doc/gen-cli-doc.go
+	./hack/generate/crd-ref/run-crd-ref-gen.sh
 
 vendor: ## Vendor the dependencies
 	go mod tidy

--- a/hack/generate/cli-doc/gen-cli-doc.go
+++ b/hack/generate/cli-doc/gen-cli-doc.go
@@ -31,7 +31,7 @@ func main() {
 		log.Fatalf("Failed to get current directory: %v", err)
 	}
 
-	cliDocsPath := filepath.Join(currentDir, "docs", "cli")
+	cliDocsPath := filepath.Join(currentDir, "docs", "content", "en", "main", "cli")
 
 	if err := os.RemoveAll(cliDocsPath); err != nil {
 		log.Fatalf("Failed to remove existing generated docs: %v", err)

--- a/hack/generate/crd-ref/config.yaml
+++ b/hack/generate/crd-ref/config.yaml
@@ -1,0 +1,95 @@
+# Copyright 2021 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+template_path: ./crd.template.md
+
+source_repositories:
+  - url: https://github.com/kcp-dev/kcp
+    organization: kcp-dev
+    short_name: kcp
+    commit_reference: main
+    crd_paths:
+      - config/crds
+    cr_paths:
+      - docs/cr
+    metadata:
+      apiresourceimports.apiresource.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - apiresource
+      negotiatedapiresources.apiresource.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - apiresource
+      apibindings.apis.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - apis
+      apiexports.apis.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - apis
+      apiresourceschemas.apis.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - apis
+      locations.scheduling.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - schuduling
+          - location
+      placements.scheduling.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - scheduling
+          - placements
+      clusterworkspaces.tenancy.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - tenancy
+          - workspaces
+      clusterworkspaceshards.tenancy.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - tenancy
+          - workspaces
+          - shards
+      clusterworkspacetypes.tenancy.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - tenancy
+          - workspaces
+          - types
+      workspaces.tenancy.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - tenancy
+          - workspaces
+      synctargets.workload.kcp.dev:
+        owner:
+          - https://github.com/kcp-dev/kcp
+        topics:
+          - workload
+          - synctargets

--- a/hack/generate/crd-ref/crd.template.md
+++ b/hack/generate/crd-ref/crd.template.md
@@ -1,0 +1,119 @@
+---
+title: {{ .Title }} CRD schema reference (group {{ .Group }})
+linkTitle: {{ .Title }}
+description: |
+{{- if .Description }}
+{{ .Description | indent 2 }}
+{{- else }}
+  Custom resource definition (CRD) schema reference page for the {{ .Title }} 
+  resource ({{ .NamePlural }}.{{ .Group }}), as part of the Giant Swarm 
+  Management API documentation.
+{{- end }}
+weight: {{ .Weight }}
+layout: crd
+---
+
+{{- with .Metadata.Deprecation }}
+{{ "{{" }}% pageinfo color="warning" %{{ "}}"}}
+{{- with .Info }}
+{{ . }}
+{{- end }}
+{{- with .ReplacedBy }}
+This CRD is being replaced by <a href="../{{ .FullName }}/">{{ .ShortName }}</a>.
+{{- end }}
+{{"{{% /pageinfo %}}"}}
+{{- end }}
+
+## {{ .Title }}
+
+<dl class="crd-meta">
+<dt class="fullname">Full name:</dt>
+<dd class="fullname">{{ .NamePlural }}.{{ .Group }}</dd>
+<dt class="groupname">Group:</dt>
+<dd class="groupname">{{ .Group }}</dd>
+<dt class="singularname">Singular name:</dt>
+<dd class="singularname">{{ .NameSingular }}</dd>
+<dt class="pluralname">Plural name:</dt>
+<dd class="pluralname">{{ .NamePlural }}</dd>
+<dt class="scope">Scope:</dt>
+<dd class="scope">{{ .Scope }}</dd>
+<dt class="versions">Versions:</dt>
+<dd class="versions">
+{{- range .Versions -}}
+<a class="version" href="#{{.}}" title="Show schema for version {{.}}">{{.}}</a>
+{{- end -}}
+</dd>
+</dl>
+
+{{ if .VersionSchemas }}
+{{ $versionSchemas := .VersionSchemas }}
+{{ range .Versions -}}
+{{ $versionName := . -}}
+{{ $versionSchema := (index $versionSchemas $versionName) -}}
+<div class="crd-schema-version">
+<h2 id="{{$versionName}}">Version {{$versionName}}</h2>
+
+{{ with $versionSchema.ExampleCR }}
+<h3 id="crd-example-{{$versionName}}">Example CR</h3>
+
+```yaml
+{{ .|raw -}}
+```
+
+{{end}}
+
+<h3 id="property-details-{{$versionName}}">Properties</h3>
+
+{{ range $versionSchema.Properties }}
+<div class="property depth-{{.Depth}}">
+<div class="property-header">
+<h3 class="property-path" id="{{$versionName}}-{{.Path}}">{{.Path}}</h3>
+</div>
+<div class="property-body">
+<div class="property-meta">
+{{with .Type}}<span class="property-type">{{.}}</span>{{end}}
+{{ if not .Required }}
+{{ else -}}
+<span class="property-required">Required</span>
+{{ end -}}
+</div>
+{{with .Description}}
+<div class="property-description">
+{{.|markdown}}
+</div>
+{{end}}
+</div>
+</div>
+{{ end }}
+
+{{ if $versionSchema.Annotations }}
+<h3 id="annotation-details-{{$versionName}}">Annotations</h3>
+
+{{ range $versionSchema.Annotations }}
+<div class="annotation">
+<div class="annotation-header">
+<h3 class="annotation-path" id="{{.CRDVersion}}-{{.Annotation}}">{{.Annotation}}</h3>
+</div>
+<div class="annotation-body">
+<div class="annotation-meta">
+{{with .Release}}<span class="annotation-release">{{.}}</span>{{end}}
+</div>
+{{with .Documentation}}
+<div class="annotation-description">
+{{.|markdown}}
+</div>
+{{end}}
+</div>
+</div>
+{{ end }}
+{{ end }}
+
+</div>
+{{end}}
+
+{{ else }}
+<div class="crd-noversions">
+<p>We currently cannot show any schema information on this <abbr title="custom resource definition">CRD</abbr>. Sorry for the inconvenience!</p>
+<p>Please refer to the <a href="https://pkg.go.dev/github.com/giantswarm/apiextensions/pkg/apis/">Godoc</a> or <a href="https://github.com/giantswarm/apiextensions/tree/master/pkg/apis">source</a> for details.</p>
+</div>
+{{ end }}

--- a/hack/generate/crd-ref/run-crd-ref-gen.sh
+++ b/hack/generate/crd-ref/run-crd-ref-gen.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+CRD_DOCS_GENERATOR_VERSION=0.10.0
+# set destination to crd-reference directory in the docs
+DESTINATION="docs/content/en/main/crd-reference"
+
+# Clear output folder
+find "${PWD}/${DESTINATION}" -type f -not -name "_index.md" | xargs -I '{}' rm '{}'
+
+# Generate new content
+podman run --rm \
+    -v ${PWD}/${DESTINATION}:/opt/crd-docs-generator/output:z \
+    -v ${PWD}/hack/generate/crd-ref:/opt/crd-docs-generator/config:z \
+    quay.io/giantswarm/crd-docs-generator:${CRD_DOCS_GENERATOR_VERSION} \
+    --config /opt/crd-docs-generator/config/config.yaml

--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -21,7 +21,7 @@ VERSION=$(grep "go 1." go.mod | sed 's/go //')
 
 grep "tag: \"" .ci-operator.yaml | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in .ci-operator.yaml, expected ${VERSION}"; exit 1; }
 grep "FROM golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
-grep "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
+grep -w "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
 # Note CONTRIBUTING.md isn't copied in the Dockerfile
 if [ -e CONTRIBUTING.md ]; then
   grep "golang.org/doc/install" CONTRIBUTING.md | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in CONTRIBUTING.md expected ${VERSION}"; exit 1; }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This GitHub Actions does the following:
- generates CLI docs
- generates CRD refs
- saves new tags as archive in gh-pages branch for doc versioning
- builds and deploys hugo docs to github pages

## Needs

- depends on PR #2120
- depends on PR #2219 

