### PR TITLE
:sparkles: Allow use of JSON logging format

### DIFF
--- a/cmd/kcp-front-proxy/main.go
+++ b/cmd/kcp-front-proxy/main.go
@@ -31,6 +31,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/component-base/cli"
 	utilflag "k8s.io/component-base/cli/flag"
+	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/component-base/version"
 
 	frontproxyoptions "github.com/kcp-dev/kcp/cmd/kcp-front-proxy/options"

--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/config"
 	"k8s.io/component-base/logs"
+	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/component-base/term"
 	"k8s.io/component-base/version"
 	"k8s.io/klog/v2"

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"k8s.io/component-base/cli"
+	_ "k8s.io/component-base/logs/json/register"
 
 	"github.com/kcp-dev/kcp/cmd/syncer/cmd"
 )

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,7 @@ github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=

--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -120,7 +120,7 @@ var (
 		"service-account-max-token-expiration",    // The maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.
 
 		// logs flags
-		"logging-format",      // Sets the log format. Permitted formats: "text".
+		"logging-format",      // Sets the log format. Permitted formats: "text", "json".
 		"log-flush-frequency", // Maximum number of seconds between log flushes
 		"v",                   // number for the log level verbosity
 		"vmodule",             // comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)


### PR DESCRIPTION
Registers the JSON logging format in the commands:

* kcp
* kcp-front-proxy
* syncer

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

#1694 
