### PR TITLE
✨ Update kcp sync command to support global kubernetes APIExport

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,8 @@ jobs:
       # Install kind with a local registry
       - uses: container-tools/kind-action@v1
         name: Kubernetes KinD Cluster w/local registry
+        with:
+          version: v0.14.0
 
       - run: |-
           go install github.com/google/ko@latest
@@ -67,6 +69,8 @@ jobs:
     # Install kind with a local registry
     - uses: container-tools/kind-action@v1
       name: Kubernetes KinD Cluster w/local registry
+      with:
+        version: v0.14.0
 
     - run: |-
         go install github.com/google/ko@latest

--- a/config/rootcompute/bootstrap.go
+++ b/config/rootcompute/bootstrap.go
@@ -34,6 +34,9 @@ import (
 //go:embed *.yaml
 var fs embed.FS
 
+// RootComuteWorkspace is the workspace to host common kubernetes APIs
+var RootComputeWorkspace = logicalcluster.New("root:compute")
+
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
@@ -44,9 +47,8 @@ func Bootstrap(ctx context.Context, apiExtensionClusterClient apiextensionsclien
 		return err
 	}
 
-	computeWorkspace := logicalcluster.New("root:compute")
-	computeDiscoveryClient := apiExtensionClusterClient.Cluster(computeWorkspace).Discovery()
-	computeDynamicClient := dynamicClusterClient.Cluster(computeWorkspace)
+	computeDiscoveryClient := apiExtensionClusterClient.Cluster(RootComputeWorkspace).Discovery()
+	computeDynamicClient := dynamicClusterClient.Cluster(RootComputeWorkspace)
 
 	return kube124.Bootstrap(ctx, computeDiscoveryClient, computeDynamicClient, batteriesIncluded)
 }

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -270,7 +270,7 @@ spec:
 		APIImportPollIntervalString: "1m",
 		QPS:                         123.4,
 		Burst:                       456,
-	}, "kcp-syncer-sync-target-name-34b23c4k")
+	}, "kcp-syncer-sync-target-name-34b23c4k", []string{"resource1", "resource2"})
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))
 }
@@ -523,7 +523,7 @@ spec:
 		Burst:                       456,
 		APIImportPollIntervalString: "1m",
 		FeatureGatesString:          "myfeature=true",
-	}, "kcp-syncer-sync-target-name-34b23c4k")
+	}, "kcp-syncer-sync-target-name-34b23c4k", []string{"resource1", "resource2"})
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))
 }

--- a/pkg/reconciler/workload/defaultplacement/defaultplacement_indexes.go
+++ b/pkg/reconciler/workload/defaultplacement/defaultplacement_indexes.go
@@ -22,6 +22,8 @@ import (
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 )
 
 func indexByWorkspace(obj interface{}) ([]string, error) {
@@ -32,4 +34,17 @@ func indexByWorkspace(obj interface{}) ([]string, error) {
 
 	lcluster := logicalcluster.From(metaObj)
 	return []string{lcluster.String()}, nil
+}
+
+func indexByLocationWorkspace(obj interface{}) ([]string, error) {
+	placement, ok := obj.(*schedulingv1alpha1.Placement)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a Placement, but is %T", obj)
+	}
+
+	if placement.Status.SelectedLocation == nil {
+		return []string{}, nil
+	}
+
+	return []string{placement.Status.SelectedLocation.Path}, nil
 }

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -791,6 +791,7 @@ func (s *Server) installDefaultPlacementController(ctx context.Context, config *
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 		s.KcpSharedInformerFactory.Scheduling().V1alpha1().Placements(),
+		s.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
 	)
 	if err != nil {
 		return err
@@ -922,6 +923,7 @@ func (s *Server) installWorkloadsAPIExportController(ctx context.Context, config
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.KcpSharedInformerFactory.Apiresource().V1alpha1().NegotiatedAPIResources(),
+		s.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
 	)
 	if err != nil {
 		return err

--- a/pkg/syncer/resourcesync/controller.go
+++ b/pkg/syncer/resourcesync/controller.go
@@ -336,9 +336,9 @@ func (c *Controller) patchSyncTargetCondition(ctx context.Context, cluster logic
 
 	patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 	if err != nil {
-		return fmt.Errorf("failed to create patch for LocationDomain %s|%s: %w", cluster, new.Name, err)
+		return fmt.Errorf("failed to create patch for syncTarget %s|%s: %w", cluster, new.Name, err)
 	}
-	logger.V(2).Info("patching placement", "patch", string(patchBytes))
+	logger.V(2).Info("patching syncTarget", "patch", string(patchBytes))
 	_, uerr := c.kcpClusterClient.Cluster(cluster).WorkloadV1alpha1().SyncTargets().Patch(logicalcluster.WithCluster(ctx, cluster), new.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 	return uerr
 }

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -78,6 +78,7 @@ type syncerFixture struct {
 	syncTargetName        string
 
 	extraResourcesToSync []string
+	apiExports           []string
 	prepareDownstream    func(config *rest.Config, isFakePCluster bool)
 }
 
@@ -91,6 +92,12 @@ func WithSyncTarget(clusterName logicalcluster.Name, name string) SyncerOption {
 func WithExtraResources(resources ...string) SyncerOption {
 	return func(t *testing.T, sf *syncerFixture) {
 		sf.extraResourcesToSync = append(sf.extraResourcesToSync, resources...)
+	}
+}
+
+func WithAPIExports(exports ...string) SyncerOption {
+	return func(t *testing.T, sf *syncerFixture) {
+		sf.apiExports = append(sf.apiExports, exports...)
 	}
 }
 
@@ -133,6 +140,9 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	}
 	for _, resource := range sf.extraResourcesToSync {
 		pluginArgs = append(pluginArgs, "--resources="+resource)
+	}
+	for _, export := range sf.apiExports {
+		pluginArgs = append(pluginArgs, "--apiexports="+export)
 	}
 	syncerYAML := RunKcpCliPlugin(t, kubeconfigPath, pluginArgs)
 

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
@@ -30,13 +32,12 @@ import (
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	clientgodiscovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
-	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
-	schedulingv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/scheduling/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
@@ -44,7 +45,10 @@ import (
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
-func TestRootComputeWorkspace(t *testing.T) {
+// TestSyncTargetLocalExport is to test that user import kubernetes API in synctarget workspace and use it,
+// instead of using global kubernetes APIExport.
+// TODO(qiujian16) This might be removed when we do not support local export later.
+func TestSyncTargetLocalExport(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -54,7 +58,6 @@ func TestRootComputeWorkspace(t *testing.T) {
 
 	orgClusterName := framework.NewOrganizationFixture(t, source)
 	computeClusterName := framework.NewWorkspaceFixture(t, source, orgClusterName)
-	consumerWorkspace := framework.NewWorkspaceFixture(t, source, orgClusterName)
 
 	kcpClients, err := clientset.NewClusterForConfig(source.BaseConfig(t))
 	require.NoError(t, err, "failed to construct kcp cluster client for server")
@@ -63,7 +66,9 @@ func TestRootComputeWorkspace(t *testing.T) {
 
 	syncTargetName := fmt.Sprintf("synctarget-%d", +rand.Intn(1000000))
 	t.Logf("Creating a SyncTarget and syncer in %s", computeClusterName)
-	syncerFixture := framework.NewSyncerFixture(t, source, computeClusterName,
+	syncTarget := framework.NewSyncerFixture(t, source, computeClusterName,
+		framework.WithAPIExports(""),
+		framework.WithExtraResources("services"),
 		framework.WithSyncTarget(computeClusterName, syncTargetName),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
@@ -75,17 +80,10 @@ func TestRootComputeWorkspace(t *testing.T) {
 			t.Logf("Installing test CRDs into sink cluster...")
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
-				metav1.GroupResource{Group: "apps.k8s.io", Resource: "deployments"},
-				metav1.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
 			)
 			require.NoError(t, err)
 		}),
 	).Start(t)
-
-	t.Logf("Patch synctarget with new export")
-	patchData := `{"spec":{"supportedAPIExports":[{"workspace":{"path":"root:compute","exportName":"kubernetes"}}]}}`
-	_, err = kcpClients.Cluster(computeClusterName).WorkloadV1alpha1().SyncTargets().Patch(ctx, syncTargetName, types.MergePatchType, []byte(patchData), metav1.PatchOptions{})
-	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computeClusterName).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
@@ -93,7 +91,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 			return false
 		}
 
-		if len(syncTarget.Status.SyncedResources) != 3 {
+		if len(syncTarget.Status.SyncedResources) != 1 {
 			return false
 		}
 
@@ -101,72 +99,49 @@ func TestRootComputeWorkspace(t *testing.T) {
 			syncTarget.Status.SyncedResources[0].State != workloadv1alpha1.ResourceSchemaAcceptedState {
 			return false
 		}
-		if syncTarget.Status.SyncedResources[1].Resource != "ingresses" ||
-			syncTarget.Status.SyncedResources[1].State != workloadv1alpha1.ResourceSchemaAcceptedState {
-			return false
-		}
 
 		return true
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
-	t.Logf("Create an APIBinding in consumer workspace %q that points to the kubernetes export", consumerWorkspace)
-	apiBinding := &apisv1alpha1.APIBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubernetes",
-		},
-		Spec: apisv1alpha1.APIBindingSpec{
-			Reference: apisv1alpha1.ExportReference{
-				Workspace: &apisv1alpha1.WorkspaceExportReference{
-					Path:       "root:compute",
-					ExportName: "kubernetes",
-				},
-			},
-		},
-	}
+	// create virtual workspace rest configs
+	rawConfig, err := source.RawConfig()
+	require.NoError(t, err)
+	virtualWorkspaceRawConfig := rawConfig.DeepCopy()
+	virtualWorkspaceRawConfig.Clusters["syncvervw"] = rawConfig.Clusters["base"].DeepCopy()
+	virtualWorkspaceRawConfig.Clusters["syncvervw"].Server = rawConfig.Clusters["base"].Server + "/services/syncer/" + computeClusterName.String() + "/" + syncTargetName + "/" + syncTarget.SyncerConfig.SyncTargetUID
+	virtualWorkspaceRawConfig.Contexts["syncvervw"] = rawConfig.Contexts["base"].DeepCopy()
+	virtualWorkspaceRawConfig.Contexts["syncvervw"].Cluster = "syncvervw"
+	virtualWorkspaceConfig, err := clientcmd.NewNonInteractiveClientConfig(*virtualWorkspaceRawConfig, "syncvervw", nil, nil).ClientConfig()
+	require.NoError(t, err)
+	virtualWorkspaceConfig = kcpclienthelper.SetMultiClusterRoundTripper(rest.AddUserAgent(rest.CopyConfig(virtualWorkspaceConfig), t.Name()))
 
-	_, err = kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Create(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding, metav1.CreateOptions{})
+	virtualWorkspaceiscoverClusterClient, err := clientgodiscovery.NewDiscoveryClientForConfig(virtualWorkspaceConfig)
 	require.NoError(t, err)
 
-	t.Logf("Wait for binding to be ready")
+	t.Logf("Wait for service API from synctarget workspace to be served in synctarget virtual workspace.")
 	require.Eventually(t, func() bool {
-		binding, err := kcpClients.Cluster(consumerWorkspace).ApisV1alpha1().APIBindings().Get(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-
-		return conditions.IsTrue(binding, apisv1alpha1.InitialBindingCompleted)
+		_, existingAPIResourceLists, err := virtualWorkspaceiscoverClusterClient.WithCluster(logicalcluster.Wildcard).ServerGroupsAndResources()
+		if err != nil {
+			return false
+		}
+		// requiredAPIResourceList includes all core APIs plus services API
+		return len(cmp.Diff([]*metav1.APIResourceList{
+			requiredAPIResourceListWithService(computeClusterName, computeClusterName)}, sortAPIResourceList(existingAPIResourceLists))) == 0
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
-	t.Logf("create a placement")
-	p1 := &schedulingv1alpha1.Placement{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-		},
-		Spec: schedulingv1alpha1.PlacementSpec{
-			LocationSelectors: []metav1.LabelSelector{{}},
-			NamespaceSelector: &metav1.LabelSelector{},
-			LocationResource: schedulingv1alpha1.GroupVersionResource{
-				Group:    "workload.kcp.dev",
-				Version:  "v1alpha1",
-				Resource: "synctargets",
-			},
-			LocationWorkspace: computeClusterName.String(),
-		},
-	}
-	_, err = kcpClients.Cluster(consumerWorkspace).SchedulingV1alpha1().Placements().Create(logicalcluster.WithCluster(ctx, consumerWorkspace), p1, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	t.Logf("Wait for placement to be ready")
-	framework.Eventually(t, func() (bool, string) {
-		placement, err := kcpClients.Cluster(consumerWorkspace).SchedulingV1alpha1().Placements().Get(logicalcluster.WithCluster(ctx, consumerWorkspace), "test", metav1.GetOptions{})
+	t.Logf("Synctarget should be authorized to access downstream clusters")
+	require.Eventually(t, func() bool {
+		syncTarget, err := kcpClients.Cluster(computeClusterName).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Sprintf("failed to get placement: %v", err)
+			return false
 		}
 
-		return conditions.IsTrue(placement, schedulingv1alpha1.PlacementReady), fmt.Sprintf("placement is not ready: %v", placement)
+		return conditions.IsTrue(syncTarget, workloadv1alpha1.SyncerAuthorized)
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Wait for being able to list Services in the user workspace")
 	require.Eventually(t, func() bool {
-		_, err := kubeClusterClient.CoreV1().Services("default").List(logicalcluster.WithCluster(ctx, consumerWorkspace), metav1.ListOptions{})
+		_, err := kubeClusterClient.CoreV1().Services("default").List(logicalcluster.WithCluster(ctx, computeClusterName), metav1.ListOptions{})
 		if errors.IsNotFound(err) {
 			t.Logf("service err %v", err)
 			return false
@@ -178,7 +153,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Logf("Create a service in the user workspace")
-	_, err = kubeClusterClient.CoreV1().Services("default").Create(logicalcluster.WithCluster(ctx, consumerWorkspace), &corev1.Service{
+	_, err = kubeClusterClient.CoreV1().Services("default").Create(logicalcluster.WithCluster(ctx, computeClusterName), &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "first",
 			Labels: map[string]string{
@@ -198,7 +173,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 
 	t.Logf("Wait for the service to be synced to the downstream cluster")
 	framework.Eventually(t, func() (bool, string) {
-		downstreamServices, err := syncerFixture.DownstreamKubeClient.CoreV1().Services("").List(ctx, metav1.ListOptions{
+		downstreamServices, err := syncTarget.DownstreamKubeClient.CoreV1().Services("").List(ctx, metav1.ListOptions{
 			LabelSelector: "test.workload.kcp.dev=" + syncTargetName,
 		})
 

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -114,9 +114,8 @@ func TestScheduling(t *testing.T) {
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Log("Wait for \"kubernetes\" apiexport")
-	var export *apisv1alpha1.APIExport
 	require.Eventually(t, func() bool {
-		export, err = kcpClusterClient.ApisV1alpha1().APIExports().Get(logicalcluster.WithCluster(ctx, negotiationClusterName), "kubernetes", metav1.GetOptions{})
+		_, err := kcpClusterClient.ApisV1alpha1().APIExports().Get(logicalcluster.WithCluster(ctx, negotiationClusterName), "kubernetes", metav1.GetOptions{})
 		return err == nil
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
@@ -128,24 +127,6 @@ func TestScheduling(t *testing.T) {
 			return false, ""
 		}
 		return binding.Status.Phase == apisv1alpha1.APIBindingPhaseBound, toYaml(binding)
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-
-	t.Log("Wait for APIResourceSchemas to show up in the negotiation workspace")
-	require.Eventually(t, func() bool {
-		schemas, err := kcpClusterClient.ApisV1alpha1().APIResourceSchemas().List(logicalcluster.WithCluster(ctx, negotiationClusterName), metav1.ListOptions{})
-		if err != nil {
-			t.Logf("Failed to list APIResourceSchemas: %v", err)
-			return false
-		}
-
-		return len(schemas.Items) > 0
-	}, wait.ForeverTestTimeout, time.Millisecond*100)
-
-	t.Log("Wait for APIResourceSchemas to show up in the APIExport spec")
-	require.Eventually(t, func() bool {
-		export, err := kcpClusterClient.ApisV1alpha1().APIExports().Get(logicalcluster.WithCluster(ctx, negotiationClusterName), export.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		return len(export.Spec.LatestResourceSchemas) > 0
 	}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 	t.Log("Create a location in the negotiation workspace")

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -70,7 +70,6 @@ func TestSyncerLifecycle(t *testing.T) {
 	// response.
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsClusterName,
 		framework.WithExtraResources("persistentvolumes"),
-		framework.WithExtraResources("services"),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
 				// Only need to install services and ingresses in a logical cluster


### PR DESCRIPTION
- do not add apiresourceschmea in synctarget's local APIExport
- add exports flag in sync command
- setup syncer's rbac on physical cluster based on synctarget status.

Signed-off-by: Jian Qiu <jqiu@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This is to introduce the export flag in sync command. After this fix, the fix includes
- do not add apiresourceschmea in synctarget's local APIExport
- add exports flag in sync command
- setup syncer's rbac on physical cluster based on synctarget status.

After this change, the sync command will be changed:
1. run `kubectl kcp sync` without resource flag will sync resources in kubernetes APIExport in root:compute workspace
2. run `kubectl kcp sync --resources xxx` will sync both resources specified in the flag and kubernetes APIExport in root:compute workspace
3. run `kubectl kcp sync --apiexports workspace1|export1` will sync resources in specified export.
4. run `kubectl kcp sync --resources xxx --apiexports ` will sync resource xxx but not those in kubernetes APIExport in root:compute workspace.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/1960
