### PR TITLE
:seedling: Improve syncer/nsmap local testing experience

### DIFF
--- a/docs/syncer.md
+++ b/docs/syncer.md
@@ -208,12 +208,20 @@ This assumes that KCP is also being run locally.
     syncTargetName=<mycluster>
     syncTargetUID=$(kubectl get synctarget $syncTargetName -o jsonpath="{.metadata.uid}")
     fromCluster=$(kubectl ws current --short)
+    syncerNamespace="kcp-syncer-${syncTargetName}-test"
+    ```
+
+1. Run the DNS mapper:
+
+    ```bash
+    kubectl --kubeconfig=$HOME/.kube/config create namespace $syncerNamespace
+    NAMESPACE=$syncerNamespace KUBECONFIG=$HOME/.kube/config go run ./cmd/syncer dns start
     ```
 
 1. Run the following snippet:
 
     ```bash
-    go run ./cmd/syncer \
+    NAMESPACE=$syncerNamespace go run ./cmd/syncer \
       --from-kubeconfig=.kcp/admin.kubeconfig \
       --from-context=base \
       --to-kubeconfig=$HOME/.kube/config \
@@ -225,7 +233,8 @@ This assumes that KCP is also being run locally.
       --resources=secrets \
       --resources=serviceaccounts \
       --qps=30 \
-      --burst=20
+      --burst=20 \
+      --dns=localhost
     ```
 
 1. Wait for the kcp sync target to go ready:

--- a/pkg/dns/plugin/nsmap/config.go
+++ b/pkg/dns/plugin/nsmap/config.go
@@ -42,7 +42,7 @@ type OnUpdateFn func(ctx context.Context, configMap *corev1.ConfigMap)
 // notifies the given callback when an update occurs. This is a non-blocking function.
 func StartWatcher(ctx context.Context, callback OnUpdateFn) error {
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{},
+		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{}).ClientConfig()
 	if err != nil {
 		return err

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -198,6 +198,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	dnsIP := ""
 	// Get the DNS IP. The DNS service cannot be recreated as existing dnsConfig won't be updated.
 	err = wait.PollImmediate(2*time.Second, time.Minute, func() (bool, error) {
+		logger.Info(fmt.Sprintf("performing a DNS lookup of %s", cfg.DNSServer))
 		ips, err := net.LookupIP(cfg.DNSServer)
 		if len(ips) == 0 || err != nil {
 			return false, nil //nolint:nilerr

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -207,7 +207,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		return true, nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("DNS lookup of %s failed: %s", cfg.DNSServer, err)
 	}
 
 	logger.Info("Creating spec syncer")


### PR DESCRIPTION
We have docs on running the syncer locally, but they haven't been updated for #1708 

Also, we can improve our logging to help people figure out when the syncer is failing because of DNS lookups