### PR TITLE
:seedling: identitycache: refactor to not use fake clients in testing

### DIFF
--- a/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
@@ -22,20 +22,24 @@ import (
 	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	kubernetesclient "k8s.io/client-go/kubernetes"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clusters"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	configshard "github.com/kcp-dev/kcp/config/shard"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
 )
 
@@ -61,10 +65,27 @@ func NewApiExportIdentityProviderController(
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
 
 	c := &controller{
-		queue:                        queue,
-		kubeClient:                   kubeClusterClient.Cluster(configshard.SystemShardCluster),
-		configMapLister:              configMapInformer.Lister(),
-		remoteShardApiExportsIndexer: remoteShardApiExportInformer.Informer().GetIndexer(),
+		queue: queue,
+		createConfigMap: func(ctx context.Context, cluster logicalcluster.Name, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			return kubeClusterClient.Cluster(cluster).CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		},
+		getConfigMap: func(cluster logicalcluster.Name, namespace, name string) (*corev1.ConfigMap, error) {
+			return configMapInformer.Lister().ConfigMaps(namespace).Get(clusters.ToClusterAwareKey(cluster, name))
+		},
+		updateConfigMap: func(ctx context.Context, cluster logicalcluster.Name, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			return kubeClusterClient.Cluster(cluster).CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+		},
+		listAPIExportsFromRemoteShard: func(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
+			rawApiExports, err := remoteShardApiExportInformer.Informer().GetIndexer().ByIndex(indexers.ByLogicalCluster, cluster.String())
+			if err != nil {
+				return nil, err
+			}
+			var exports []*apisv1alpha1.APIExport
+			for i := range rawApiExports {
+				exports = append(exports, rawApiExports[i].(*apisv1alpha1.APIExport))
+			}
+			return exports, nil
+		},
 	}
 
 	remoteShardApiExportInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -158,8 +179,9 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 type controller struct {
-	queue                        workqueue.RateLimitingInterface
-	kubeClient                   kubernetesclient.Interface
-	configMapLister              corelisters.ConfigMapLister
-	remoteShardApiExportsIndexer cache.Indexer
+	queue                         workqueue.RateLimitingInterface
+	createConfigMap               func(ctx context.Context, cluster logicalcluster.Name, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	getConfigMap                  func(cluster logicalcluster.Name, namespace, name string) (*corev1.ConfigMap, error)
+	updateConfigMap               func(ctx context.Context, cluster logicalcluster.Name, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	listAPIExportsFromRemoteShard func(logicalcluster.Name) ([]*apisv1alpha1.APIExport, error)
 }

--- a/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
@@ -76,15 +76,7 @@ func NewApiExportIdentityProviderController(
 			return kubeClusterClient.Cluster(cluster).CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
 		},
 		listAPIExportsFromRemoteShard: func(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
-			rawApiExports, err := remoteShardApiExportInformer.Informer().GetIndexer().ByIndex(indexers.ByLogicalCluster, cluster.String())
-			if err != nil {
-				return nil, err
-			}
-			var exports []*apisv1alpha1.APIExport
-			for i := range rawApiExports {
-				exports = append(exports, rawApiExports[i].(*apisv1alpha1.APIExport))
-			}
-			return exports, nil
+			return indexers.ByIndex[*apisv1alpha1.APIExport](remoteShardApiExportInformer.Informer().GetIndexer(), indexers.ByLogicalCluster, cluster.String())
 		},
 	}
 

--- a/pkg/reconciler/apis/identitycache/api_export_identity_reconcile.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_reconcile.go
@@ -23,16 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clusters"
 
 	configshard "github.com/kcp-dev/kcp/config/shard"
-	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/indexers"
 )
 
 func (c *controller) reconcile(ctx context.Context) error {
-	rawApiExports, err := c.remoteShardApiExportsIndexer.ByIndex(indexers.ByLogicalCluster, tenancyv1alpha1.RootCluster.String())
+	apiExports, err := c.listAPIExportsFromRemoteShard(tenancyv1alpha1.RootCluster)
 	if err != nil {
 		return err
 	}
@@ -43,17 +40,16 @@ func (c *controller) reconcile(ctx context.Context) error {
 		},
 		Data: map[string]string{},
 	}
-	for _, rawApiExport := range rawApiExports {
-		apiExport := rawApiExport.(*apisv1alpha1.APIExport)
+	for _, apiExport := range apiExports {
 		if apiExport.Status.IdentityHash == "" {
 			return nil // we cannot do anything here, we will get notified when an identity is assigned.
 		}
 		requiredApiExportIdentitiesConfigMap.Data[apiExport.Name] = apiExport.Status.IdentityHash
 	}
 
-	apiExportIdentitiesConfigMap, err := c.configMapLister.ConfigMaps("default").Get(clusters.ToClusterAwareKey(configshard.SystemShardCluster, ConfigMapName))
+	apiExportIdentitiesConfigMap, err := c.getConfigMap(configshard.SystemShardCluster, "default", ConfigMapName)
 	if apierrors.IsNotFound(err) {
-		_, err := c.kubeClient.CoreV1().ConfigMaps("default").Create(ctx, requiredApiExportIdentitiesConfigMap, metav1.CreateOptions{})
+		_, err := c.createConfigMap(ctx, configshard.SystemShardCluster, "default", requiredApiExportIdentitiesConfigMap)
 		return err
 	}
 	if err != nil {
@@ -62,7 +58,7 @@ func (c *controller) reconcile(ctx context.Context) error {
 	if !equality.Semantic.DeepEqual(apiExportIdentitiesConfigMap.Data, requiredApiExportIdentitiesConfigMap.Data) {
 		toUpdateResourceIdentitiesConfigMap := apiExportIdentitiesConfigMap.DeepCopy()
 		toUpdateResourceIdentitiesConfigMap.Data = requiredApiExportIdentitiesConfigMap.Data
-		_, err := c.kubeClient.CoreV1().ConfigMaps("default").Update(ctx, toUpdateResourceIdentitiesConfigMap, metav1.UpdateOptions{})
+		_, err := c.updateConfigMap(ctx, configshard.SystemShardCluster, "default", toUpdateResourceIdentitiesConfigMap)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Fake clients were not proving us with much benefit here, and we weren't even creating informers from the clients in testing, so we can make a more robust test suite by using the member function approach.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @p0lyn0mial 
/assign @ncdc 
part of #2167 