### PR TITLE
✨ Check for identityHash in APIExport admission and support multiple versions for APIs in permission claims

### DIFF
--- a/pkg/admission/apiexport/OWNERS
+++ b/pkg/admission/apiexport/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- hasheddan

--- a/pkg/admission/apiexport/admission.go
+++ b/pkg/admission/apiexport/admission.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+
+	"github.com/kcp-dev/kcp/pkg/apis/apis"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	builtinapiexport "github.com/kcp-dev/kcp/pkg/virtual/apiexport/schemas/builtin"
+)
+
+// PluginName is the name used to identify this admission webhook.
+const PluginName = "apis.kcp.dev/APIExport"
+
+// Register registers the reserved name admission webhook.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			return NewAPIExportAdmission(builtinapiexport.IsBuiltInAPI), nil
+		})
+}
+
+// APIExportAdmission is an admission plugin for checking APIExport validity.
+type APIExportAdmission struct {
+	*admission.Handler
+
+	isBuiltIn func(apisv1alpha1.GroupResource) bool
+}
+
+// NewAPIExportAdmission constructs a new APIExportAdmission admission plugin.
+func NewAPIExportAdmission(isBuiltIn func(apisv1alpha1.GroupResource) bool) *APIExportAdmission {
+	return &APIExportAdmission{
+		Handler:   admission.NewHandler(admission.Create, admission.Update),
+		isBuiltIn: isBuiltIn,
+	}
+}
+
+// Ensure that the required admission interfaces are implemented.
+var _ = admission.ValidationInterface(&APIExportAdmission{})
+
+// Validate ensures that the APIExport is valid.
+func (e *APIExportAdmission) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
+	if a.GetResource().GroupResource() != apisv1alpha1.Resource("apiexports") {
+		return nil
+	}
+
+	if a.GetKind().GroupKind() != apisv1alpha1.Kind("APIExport") {
+		return nil
+	}
+
+	u, ok := a.GetObject().(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", a.GetObject())
+	}
+	ae := &apisv1alpha1.APIExport{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, ae); err != nil {
+		return fmt.Errorf("failed to convert unstructured to APIExport: %w", err)
+	}
+
+	for i, pc := range ae.Spec.PermissionClaims {
+		if pc.IdentityHash == "" && !e.isBuiltIn(pc.GroupResource) && pc.Group != apis.GroupName {
+			return admission.NewForbidden(a,
+				field.Invalid(
+					field.NewPath("spec").
+						Child("permissionClaims").
+						Index(i).
+						Child("identityHash"),
+					"",
+					"identityHash is required for API types that are not built-in"))
+		}
+	}
+
+	return nil
+}

--- a/pkg/admission/apiexport/admission_test.go
+++ b/pkg/admission/apiexport/admission_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/kcp-dev/kcp/pkg/admission/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func createAttr(name string, obj runtime.Object, kind, resource string) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(obj),
+		nil,
+		apisv1alpha1.Kind(kind).WithVersion("v1alpha1"),
+		"",
+		name,
+		apisv1alpha1.Resource(resource).WithVersion("v1alpha1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func updateAttr(name string, obj runtime.Object, kind, resource string) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(obj),
+		helpers.ToUnstructuredOrDie(obj),
+		apisv1alpha1.Kind(kind).WithVersion("v1alpha1"),
+		"",
+		name,
+		apisv1alpha1.Resource(resource).WithVersion("v1alpha1"),
+		"",
+		admission.Update,
+		&metav1.UpdateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func TestAdmission(t *testing.T) {
+	cases := map[string]struct {
+		attr        admission.Attributes
+		update      bool
+		kind        string
+		resource    string
+		hasIdentity bool
+		isBuiltIn   bool
+		modifyPCs   func([]apisv1alpha1.PermissionClaim) []apisv1alpha1.PermissionClaim
+		want        error
+	}{
+		"NotAPIExportKind": {
+			kind:      "Something",
+			resource:  "apiexports",
+			isBuiltIn: false,
+		},
+		"NotAPIExportResource": {
+			kind:      "APIExport",
+			resource:  "somethings",
+			isBuiltIn: false,
+		},
+		"ValidCreateBuiltInNoID": {
+			kind:      "APIExport",
+			resource:  "apiexports",
+			isBuiltIn: true,
+		},
+		"ForbiddenCreateNonBuiltInNoID": {
+			kind:      "APIExport",
+			resource:  "apiexports",
+			isBuiltIn: false,
+			want: field.Invalid(
+				field.NewPath("spec").
+					Child("permissionClaims").
+					Index(0).
+					Child("identityHash"),
+				"",
+				"identityHash is required for API types that are not built-in"),
+		},
+		"ForbiddenCreateMultipleNonBuiltInNoID": {
+			kind:        "APIExport",
+			resource:    "apiexports",
+			isBuiltIn:   false,
+			hasIdentity: true,
+			modifyPCs: func(pcs []apisv1alpha1.PermissionClaim) []apisv1alpha1.PermissionClaim {
+				pcs = append(pcs, apisv1alpha1.PermissionClaim{
+					GroupResource: apisv1alpha1.GroupResource{
+						Group:    "imnot",
+						Resource: "builtin",
+					},
+				})
+				return pcs
+			},
+			want: field.Invalid(
+				field.NewPath("spec").
+					Child("permissionClaims").
+					Index(1).
+					Child("identityHash"),
+				"",
+				"identityHash is required for API types that are not built-in"),
+		},
+		"ValidUpdateBuiltInNoID": {
+			update:    true,
+			kind:      "APIExport",
+			resource:  "apiexports",
+			isBuiltIn: true,
+		},
+		"ForbiddenUpdateNonBuiltInNoID": {
+			update:    true,
+			kind:      "APIExport",
+			resource:  "apiexports",
+			isBuiltIn: false,
+			want: field.Invalid(
+				field.NewPath("spec").
+					Child("permissionClaims").
+					Index(0).
+					Child("identityHash"),
+				"",
+				"identityHash is required for API types that are not built-in"),
+		},
+		"ForbiddenUpdateMultipleNonBuiltInNoID": {
+			update:      true,
+			kind:        "APIExport",
+			resource:    "apiexports",
+			isBuiltIn:   false,
+			hasIdentity: true,
+			modifyPCs: func(pcs []apisv1alpha1.PermissionClaim) []apisv1alpha1.PermissionClaim {
+				pcs = append(pcs, apisv1alpha1.PermissionClaim{
+					GroupResource: apisv1alpha1.GroupResource{
+						Group:    "imnot",
+						Resource: "builtin",
+					},
+				})
+				return pcs
+			},
+			want: field.Invalid(
+				field.NewPath("spec").
+					Child("permissionClaims").
+					Index(1).
+					Child("identityHash"),
+				"",
+				"identityHash is required for API types that are not built-in"),
+		},
+		"ValidCreateNonBuiltIn": {
+			kind:        "APIExport",
+			resource:    "apiexports",
+			hasIdentity: true,
+			isBuiltIn:   false,
+		},
+		"ValidUpdateNonBuiltIn": {
+			update:      true,
+			kind:        "APIExport",
+			resource:    "apiexports",
+			hasIdentity: true,
+			isBuiltIn:   false,
+		},
+		"ValidNoPermissionClaims": {
+			kind:     "APIExport",
+			resource: "apiexports",
+			modifyPCs: func(pc []apisv1alpha1.PermissionClaim) []apisv1alpha1.PermissionClaim {
+				return []apisv1alpha1.PermissionClaim{}
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ae := &apisv1alpha1.APIExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cool-something",
+				},
+				Spec: apisv1alpha1.APIExportSpec{
+					PermissionClaims: []apisv1alpha1.PermissionClaim{
+						{
+							GroupResource: apisv1alpha1.GroupResource{
+								Group:    "some",
+								Resource: "somethings",
+							},
+						},
+					},
+				},
+			}
+			if tc.hasIdentity {
+				ae.Spec.PermissionClaims[0].IdentityHash = "coolidentityhash"
+			}
+			if tc.modifyPCs != nil {
+				ae.Spec.PermissionClaims = tc.modifyPCs(ae.Spec.PermissionClaims)
+			}
+			var attr admission.Attributes
+			if tc.update {
+				attr = updateAttr("cool-something", ae, tc.kind, tc.resource)
+			} else {
+				attr = createAttr("cool-something", ae, tc.kind, tc.resource)
+			}
+			plugin := NewAPIExportAdmission(func(apisv1alpha1.GroupResource) bool {
+				return tc.isBuiltIn
+			})
+			if err := plugin.Validate(context.Background(), attr, nil); err != nil {
+				require.Contains(t, err.Error(), tc.want.Error())
+				return
+			}
+			if tc.want != nil {
+				t.Errorf("no error returned but expected: %s", tc.want.Error())
+			}
+		})
+	}
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/admission/apibinding"
 	"github.com/kcp-dev/kcp/pkg/admission/apibindingfinalizer"
+	"github.com/kcp-dev/kcp/pkg/admission/apiexport"
 	"github.com/kcp-dev/kcp/pkg/admission/apiresourceschema"
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspace"
 	"github.com/kcp-dev/kcp/pkg/admission/clusterworkspacefinalizer"
@@ -68,6 +69,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	clusterworkspaceshard.PluginName,
 	clusterworkspacetype.PluginName,
 	clusterworkspacetypeexists.PluginName,
+	apiexport.PluginName,
 	apibinding.PluginName,
 	apibindingfinalizer.PluginName,
 	kcpvalidatingwebhook.PluginName,
@@ -102,6 +104,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	clusterworkspacetype.Register(plugins)
 	clusterworkspacetypeexists.Register(plugins)
 	apiresourceschema.Register(plugins)
+	apiexport.Register(plugins)
 	apibinding.Register(plugins)
 	apibindingfinalizer.Register(plugins)
 	workspacenamespacelifecycle.Register(plugins)
@@ -130,6 +133,7 @@ var defaultOnPluginsInKcp = sets.NewString(
 	clusterworkspacetype.PluginName,
 	clusterworkspacetypeexists.PluginName,
 	apiresourceschema.PluginName,
+	apiexport.PluginName,
 	apibinding.PluginName,
 	apibindingfinalizer.PluginName,
 	kcpvalidatingwebhook.PluginName,

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
@@ -23,35 +23,22 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
-	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	certificatesv1 "k8s.io/api/certificates/v1"
-	coordinationv1 "k8s.io/api/coordination/v1"
-	corev1 "k8s.io/api/core/v1"
-	eventsv1 "k8s.io/api/events/v1"
-	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
-	flowcontrolv1beta2 "k8s.io/api/flowcontrol/v1beta2"
-	rbacv1 "k8s.io/api/rbac/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clusters"
 	"k8s.io/klog/v2"
-	"k8s.io/kube-openapi/pkg/common"
-	"k8s.io/kubernetes/pkg/api/genericcontrolplanescheme"
-	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 
 	"github.com/kcp-dev/kcp/pkg/apis/apis"
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1/permissionclaims"
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/schemas"
+	apiexportbuiltin "github.com/kcp-dev/kcp/pkg/virtual/apiexport/schemas/builtin"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
-	"github.com/kcp-dev/kcp/pkg/virtual/framework/internalapis"
 )
 
 func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.APIExport, apiDomainKey dynamiccontext.APIDomainKey) error {
@@ -92,10 +79,8 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 	clusterName := logicalcluster.From(apiExport)
 
 	// Find schemas for claimed resources
-	claims := map[schema.GroupResource]*apisv1alpha1.PermissionClaim{}
-	for i := range apiExport.Spec.PermissionClaims {
-		pc := &apiExport.Spec.PermissionClaims[i]
-
+	claims := map[schema.GroupResource]apisv1alpha1.PermissionClaim{}
+	for _, pc := range apiExport.Spec.PermissionClaims {
 		// APIExport resources have priority over claimed resources
 		gr := schema.GroupResource{Group: pc.Group, Resource: pc.Resource}
 		if _, found := apiResourceSchemas[gr]; found {
@@ -108,7 +93,11 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 		}
 
 		// internal APIs have no identity and a fixed schema.
-		if internal, internalSchema := isPermissionClaimForInternalAPI(pc); internal {
+		if apiexportbuiltin.IsBuiltInAPI(pc.GroupResource) {
+			internalSchema, err := apiexportbuiltin.GetBuiltInAPISchema(pc.GroupResource)
+			if err != nil {
+				return err
+			}
 			shallow := *internalSchema
 			if shallow.Annotations == nil {
 				shallow.Annotations = make(map[string]string)
@@ -127,7 +116,8 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 			claims[gr] = pc
 			continue
 		} else if pc.IdentityHash == "" {
-			// TODO: add validation through admission to avoid this case
+			// NOTE(hasheddan): this is checked by admission so we should never
+			// hit this case.
 			logger.Info("permission claim is not internal and does not have an identity hash", "claim", pc)
 			continue
 		}
@@ -192,8 +182,8 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 			}
 
 			var labelReqs labels.Requirements
-			if c := claims[gvr.GroupResource()]; c != nil {
-				key, label, err := permissionclaims.ToLabelKeyAndValue(clusterName, apiExport.Name, *c)
+			if c, ok := claims[gvr.GroupResource()]; ok {
+				key, label, err := permissionclaims.ToLabelKeyAndValue(clusterName, apiExport.Name, c)
 				if err != nil {
 					return fmt.Errorf(fmt.Sprintf("failed to convert permission claim %v to label key and value: %v", c, err))
 				}
@@ -274,239 +264,4 @@ func (c *APIReconciler) getSchemasFromAPIExport(apiExport *apisv1alpha1.APIExpor
 	}
 
 	return apiResourceSchemas, nil
-}
-
-func isPermissionClaimForInternalAPI(claim *apisv1alpha1.PermissionClaim) (bool, *apisv1alpha1.APIResourceSchema) {
-	for _, schema := range internalAPIResourceSchemas {
-		if claim.GroupResource.Group == schema.Spec.Group && claim.GroupResource.Resource == schema.Spec.Names.Plural {
-			return true, schema
-		}
-	}
-	return false, nil
-}
-
-// Create APIResourceSchemas for built-in APIs available as permission claims for APIExport virtual workspace.
-func init() {
-	schemes := []*runtime.Scheme{genericcontrolplanescheme.Scheme}
-	openAPIDefinitionsGetters := []common.GetOpenAPIDefinitions{generatedopenapi.GetOpenAPIDefinitions}
-
-	if apis, err := internalapis.CreateAPIResourceSchemas(schemes, openAPIDefinitionsGetters, InternalAPIs...); err != nil {
-		panic(err)
-	} else {
-		internalAPIResourceSchemas = apis
-	}
-}
-
-// internalAPIResourceSchemas contains a list of APIResourceSchema for built-in APIs that are
-// available to be permission-claimed for APIExport virtual workspace
-var internalAPIResourceSchemas []*apisv1alpha1.APIResourceSchema
-
-var InternalAPIs = []internalapis.InternalAPI{
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "namespaces",
-			Singular: "namespace",
-			Kind:     "Namespace",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.Namespace{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "configmaps",
-			Singular: "configmap",
-			Kind:     "ConfigMap",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.ConfigMap{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "events",
-			Singular: "event",
-			Kind:     "Event",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.Event{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "limitranges",
-			Singular: "limitrange",
-			Kind:     "LimitRange",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.LimitRange{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "resourcequotas",
-			Singular: "resourcequota",
-			Kind:     "ResourceQuota",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.ResourceQuota{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "secrets",
-			Singular: "secret",
-			Kind:     "Secret",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.Secret{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "serviceaccounts",
-			Singular: "serviceaccount",
-			Kind:     "ServiceAccount",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
-		Instance:      &corev1.ServiceAccount{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "clusterroles",
-			Singular: "clusterrole",
-			Kind:     "ClusterRole",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
-		Instance:      &rbacv1.ClusterRole{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "clusterrolebindings",
-			Singular: "clusterrolebinding",
-			Kind:     "ClusterRoleBinding",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
-		Instance:      &rbacv1.ClusterRoleBinding{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "roles",
-			Singular: "role",
-			Kind:     "Role",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
-		Instance:      &rbacv1.Role{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "rolebindings",
-			Singular: "rolebinding",
-			Kind:     "RoleBinding",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
-		Instance:      &rbacv1.RoleBinding{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "certificatesigningrequests",
-			Singular: "certificatesigningrequest",
-			Kind:     "CertificateSigningRequest",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "certificates.k8s.io", Version: "v1"},
-		Instance:      &certificatesv1.CertificateSigningRequest{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "leases",
-			Singular: "lease",
-			Kind:     "Lease",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "coordination.k8s.io", Version: "v1"},
-		Instance:      &coordinationv1.Lease{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "flowschemas",
-			Singular: "flowschema",
-			Kind:     "FlowSchema",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"},
-		Instance:      &flowcontrolv1beta1.FlowSchema{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "prioritylevelconfigurations",
-			Singular: "prioritylevelconfiguration",
-			Kind:     "PriorityLevelConfiguration",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"},
-		Instance:      &flowcontrolv1beta1.PriorityLevelConfiguration{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "flowschemas",
-			Singular: "flowschema",
-			Kind:     "FlowSchema",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2"},
-		Instance:      &flowcontrolv1beta2.FlowSchema{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "prioritylevelconfigurations",
-			Singular: "prioritylevelconfiguration",
-			Kind:     "PriorityLevelConfiguration",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2"},
-		Instance:      &flowcontrolv1beta2.PriorityLevelConfiguration{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-		HasStatus:     true,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "mutatingwebhookconfigurations",
-			Singular: "mutatingwebhookconfiguration",
-			Kind:     "MutatingWebhookConfiguration",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"},
-		Instance:      &admissionregistrationv1.MutatingWebhookConfiguration{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "validatingwebhookconfigurations",
-			Singular: "validatingwebhookconfiguration",
-			Kind:     "ValidatingWebhookConfiguration",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"},
-		Instance:      &admissionregistrationv1.ValidatingWebhookConfiguration{},
-		ResourceScope: apiextensionsv1.ClusterScoped,
-	},
-	{
-		Names: apiextensionsv1.CustomResourceDefinitionNames{
-			Plural:   "events",
-			Singular: "event",
-			Kind:     "Event",
-		},
-		GroupVersion:  schema.GroupVersion{Group: "events.k8s.io", Version: "v1"},
-		Instance:      &eventsv1.Event{},
-		ResourceScope: apiextensionsv1.NamespaceScoped,
-	},
 }

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
@@ -86,9 +86,10 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 		if _, found := apiResourceSchemas[gr]; found {
 			if otherClaim, found := claims[gr]; found {
 				logger.Info("permission claim is shadowed by another claim", "claim", pc, "otherClaim", otherClaim)
-			} else {
-				logger.Info("permission claim is shadowed by exported resource", "claim", pc)
+				continue
 			}
+
+			logger.Info("permission claim is shadowed by exported resource", "claim", pc)
 			continue
 		}
 
@@ -106,8 +107,9 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 			apiResourceSchemas[gr] = &shallow
 			claims[gr] = pc
 			continue
-		} else if pc.GroupResource.Group == apis.GroupName {
-			apisSchema, found := schemas.ApisKcpDevSchemas[pc.GroupResource.Resource]
+		}
+		if pc.Group == apis.GroupName {
+			apisSchema, found := schemas.ApisKcpDevSchemas[pc.Resource]
 			if !found {
 				logger.Info("permission claim is for an unknown resource", "claim", pc)
 				continue
@@ -115,7 +117,8 @@ func (c *APIReconciler) reconcile(ctx context.Context, apiExport *apisv1alpha1.A
 			apiResourceSchemas[gr] = apisSchema
 			claims[gr] = pc
 			continue
-		} else if pc.IdentityHash == "" {
+		}
+		if pc.IdentityHash == "" {
 			// NOTE(hasheddan): this is checked by admission so we should never
 			// hit this case.
 			logger.Info("permission claim is not internal and does not have an identity hash", "claim", pc)

--- a/pkg/virtual/apiexport/schemas/builtin/builtin.go
+++ b/pkg/virtual/apiexport/schemas/builtin/builtin.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	"fmt"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
+	flowcontrolv1beta2 "k8s.io/api/flowcontrol/v1beta2"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kubernetes/pkg/api/genericcontrolplanescheme"
+	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/internalapis"
+)
+
+// Create APIResourceSchemas for built-in APIs available as permission claims
+// for APIExport virtual workspace.
+// TODO(hasheddan): this could be handled via code generation.
+func init() {
+	schemes := []*runtime.Scheme{genericcontrolplanescheme.Scheme}
+	openAPIDefinitionsGetters := []common.GetOpenAPIDefinitions{generatedopenapi.GetOpenAPIDefinitions}
+
+	apis, err := internalapis.CreateAPIResourceSchemas(schemes, openAPIDefinitionsGetters, BuiltInAPIs...)
+	if err != nil {
+		panic(err)
+	}
+	builtInAPIResourceSchemas = make(map[apisv1alpha1.GroupResource]*apisv1alpha1.APIResourceSchema, len(apis))
+	for _, api := range apis {
+		builtInAPIResourceSchemas[apisv1alpha1.GroupResource{
+			Group:    api.Spec.Group,
+			Resource: api.Spec.Names.Plural,
+		}] = api
+	}
+}
+
+// IsBuiltInAPI indicates whether the API identified by group and resource is
+// built-in.
+func IsBuiltInAPI(gr apisv1alpha1.GroupResource) bool {
+	_, exists := builtInAPIResourceSchemas[gr]
+	return exists
+}
+
+// GetBuiltInAPISchema retrieves the APIResourceSchema for a built-in API.
+func GetBuiltInAPISchema(gr apisv1alpha1.GroupResource) (*apisv1alpha1.APIResourceSchema, error) {
+	schema, exists := builtInAPIResourceSchemas[gr]
+	if !exists {
+		return nil, fmt.Errorf("no schema found for built-in API %s.%s", gr.Resource, gr.Group)
+	}
+	return schema, nil
+}
+
+// builtInAPIResourceSchemas contains a list of APIResourceSchema for built-in
+// APIs that are available to be permission-claimed for APIExport virtual
+// workspace
+var builtInAPIResourceSchemas map[apisv1alpha1.GroupResource]*apisv1alpha1.APIResourceSchema
+
+// TODO(hasheddan): ideally this would not be public, but it is currently used
+// in e2e tests. Consider refactoring to only allow immutable access.
+var BuiltInAPIs = []internalapis.InternalAPI{
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "namespaces",
+			Singular: "namespace",
+			Kind:     "Namespace",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.Namespace{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "configmaps",
+			Singular: "configmap",
+			Kind:     "ConfigMap",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.ConfigMap{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "events",
+			Singular: "event",
+			Kind:     "Event",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.Event{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "limitranges",
+			Singular: "limitrange",
+			Kind:     "LimitRange",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.LimitRange{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "resourcequotas",
+			Singular: "resourcequota",
+			Kind:     "ResourceQuota",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.ResourceQuota{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "secrets",
+			Singular: "secret",
+			Kind:     "Secret",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.Secret{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "serviceaccounts",
+			Singular: "serviceaccount",
+			Kind:     "ServiceAccount",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.ServiceAccount{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "clusterroles",
+			Singular: "clusterrole",
+			Kind:     "ClusterRole",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
+		Instance:      &rbacv1.ClusterRole{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "clusterrolebindings",
+			Singular: "clusterrolebinding",
+			Kind:     "ClusterRoleBinding",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
+		Instance:      &rbacv1.ClusterRoleBinding{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "roles",
+			Singular: "role",
+			Kind:     "Role",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
+		Instance:      &rbacv1.Role{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "rolebindings",
+			Singular: "rolebinding",
+			Kind:     "RoleBinding",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1"},
+		Instance:      &rbacv1.RoleBinding{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "certificatesigningrequests",
+			Singular: "certificatesigningrequest",
+			Kind:     "CertificateSigningRequest",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "certificates.k8s.io", Version: "v1"},
+		Instance:      &certificatesv1.CertificateSigningRequest{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "leases",
+			Singular: "lease",
+			Kind:     "Lease",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "coordination.k8s.io", Version: "v1"},
+		Instance:      &coordinationv1.Lease{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "flowschemas",
+			Singular: "flowschema",
+			Kind:     "FlowSchema",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"},
+		Instance:      &flowcontrolv1beta1.FlowSchema{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "prioritylevelconfigurations",
+			Singular: "prioritylevelconfiguration",
+			Kind:     "PriorityLevelConfiguration",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta1"},
+		Instance:      &flowcontrolv1beta1.PriorityLevelConfiguration{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "flowschemas",
+			Singular: "flowschema",
+			Kind:     "FlowSchema",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2"},
+		Instance:      &flowcontrolv1beta2.FlowSchema{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "prioritylevelconfigurations",
+			Singular: "prioritylevelconfiguration",
+			Kind:     "PriorityLevelConfiguration",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2"},
+		Instance:      &flowcontrolv1beta2.PriorityLevelConfiguration{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "mutatingwebhookconfigurations",
+			Singular: "mutatingwebhookconfiguration",
+			Kind:     "MutatingWebhookConfiguration",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"},
+		Instance:      &admissionregistrationv1.MutatingWebhookConfiguration{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "validatingwebhookconfigurations",
+			Singular: "validatingwebhookconfiguration",
+			Kind:     "ValidatingWebhookConfiguration",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"},
+		Instance:      &admissionregistrationv1.ValidatingWebhookConfiguration{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "events",
+			Singular: "event",
+			Kind:     "Event",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "events.k8s.io", Version: "v1"},
+		Instance:      &eventsv1.Event{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+}

--- a/pkg/virtual/apiexport/schemas/builtin/builtin_test.go
+++ b/pkg/virtual/apiexport/schemas/builtin/builtin_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	// NOTE(hasheddan): the length of APIResourceSchemas should be two less than
+	// the list of internal APIs due to the fact that v1beta1 and v1beta2 API
+	// versions are registered for FlowSchemas and PriorityLevelConfigurations.
+	require.Equal(t, len(BuiltInAPIs)-2, len(builtInAPIResourceSchemas))
+}

--- a/pkg/virtual/syncer/schemas/builtin/builtin.go
+++ b/pkg/virtual/syncer/schemas/builtin/builtin.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/apis/core/install/genericcontrolplane"
+	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/virtual/framework/internalapis"
+)
+
+// syncerSchemas contains a list of internal APIs that should be exposed for the
+// syncer of any SyncTarget.
+var SyncerSchemas map[apisv1alpha1.GroupResource]*apisv1alpha1.APIResourceSchema
+
+func init() {
+	genericcontrolplane.Install(legacyscheme.Scheme)
+	schemes := []*runtime.Scheme{legacyscheme.Scheme}
+	openAPIDefinitionsGetters := []common.GetOpenAPIDefinitions{generatedopenapi.GetOpenAPIDefinitions}
+
+	apis, err := internalapis.CreateAPIResourceSchemas(schemes, openAPIDefinitionsGetters, syncerInternalAPIs...)
+	if err != nil {
+		panic(err)
+	}
+
+	SyncerSchemas = make(map[apisv1alpha1.GroupResource]*apisv1alpha1.APIResourceSchema, len(apis))
+	for _, api := range apis {
+		SyncerSchemas[apisv1alpha1.GroupResource{
+			Group:    api.Spec.Group,
+			Resource: api.Spec.Names.Plural,
+		}] = api
+	}
+}
+
+// syncerInternalAPIs provides a list of built-in APIs that are available for
+// all workspaces accessed via the syncer virtual workspace.
+var syncerInternalAPIs = []internalapis.InternalAPI{
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "namespaces",
+			Singular: "namespace",
+			Kind:     "Namespace",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.Namespace{},
+		ResourceScope: apiextensionsv1.ClusterScoped,
+		HasStatus:     true,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "configmaps",
+			Singular: "configmap",
+			Kind:     "ConfigMap",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.ConfigMap{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "secrets",
+			Singular: "secret",
+			Kind:     "Secret",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.Secret{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+	{
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Plural:   "serviceaccounts",
+			Singular: "serviceaccount",
+			Kind:     "ServiceAccount",
+		},
+		GroupVersion:  schema.GroupVersion{Group: "", Version: "v1"},
+		Instance:      &corev1.ServiceAccount{},
+		ResourceScope: apiextensionsv1.NamespaceScoped,
+	},
+}

--- a/pkg/virtual/syncer/schemas/builtin/builtin_test.go
+++ b/pkg/virtual/syncer/schemas/builtin/builtin_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builtin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "k8s.io/kubernetes/pkg/apis/core/install"
+)
+
+func TestInit(t *testing.T) {
+	require.Equal(t, len(syncerInternalAPIs), len(SyncerSchemas))
+}

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -54,7 +54,7 @@ import (
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
-	"github.com/kcp-dev/kcp/pkg/virtual/apiexport/controllers/apireconciler"
+	apiexportbuiltin "github.com/kcp-dev/kcp/pkg/virtual/apiexport/schemas/builtin"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/internalapis"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest"
@@ -568,9 +568,9 @@ func TestAPIExportInternalAPIsDrift(t *testing.T) {
 	apis, err := gatherInternalAPIs(discoveryClient.WithCluster(anyWorkspace), t)
 	require.NoError(t, err, "failed to gather built-in apis for server")
 
-	require.Equal(t, len(apis), len(apireconciler.InternalAPIs))
+	require.Equal(t, len(apis), len(apiexportbuiltin.BuiltInAPIs))
 
-	require.ElementsMatch(t, apis, apireconciler.InternalAPIs)
+	require.ElementsMatch(t, apis, apiexportbuiltin.BuiltInAPIs)
 }
 
 func gatherInternalAPIs(discoveryClient discovery.DiscoveryInterface, t *testing.T) ([]internalapis.InternalAPI, error) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This patch set includes two primary changes:

Update the APIResourceSchema generation to consider multiple versions of
an API and append the schemas to one ARS rather than generating a
separate ARS for each.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Adds an APIExport admission plugin that, for the time-being, only
validates that any permissionClaims for types that are not built-in
include an identityHash.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

The first can be observed when creating an `APIExport` with `permissionClaims` on `FlowSchemas` or `PriorityLevelConfigurations`.

Before:
```
🤖 (kxp) k -s https://192.168.1.189:6443/services/apiexport/root/kxp.crossplane.io/clusters/* api-versions
apiextensions.crossplane.io/v1
apiextensions.crossplane.io/v1alpha1
flowcontrol.apiserver.k8s.io/v1beta1
pkg.crossplane.io/v1
pkg.crossplane.io/v1alpha1
pkg.crossplane.io/v1beta1
secrets.crossplane.io/v1alpha1
v1
```

After:
```
🤖 (kxp) k -s https://192.168.1.189:6443/services/apiexport/root/kxp.crossplane.io/clusters/* api-versions
apiextensions.crossplane.io/v1
apiextensions.crossplane.io/v1alpha1
flowcontrol.apiserver.k8s.io/v1beta1
flowcontrol.apiserver.k8s.io/v1beta2
pkg.crossplane.io/v1
pkg.crossplane.io/v1alpha1
pkg.crossplane.io/v1beta1
secrets.crossplane.io/v1alpha1
v1
```

The second can be observed by trying to include a `permissionClaim` for something like `Deployment` (not built-in) without an `identityHash`:
```
🤖 (kxp) cat bad-export.yaml 
apiVersion: apis.kcp.dev/v1alpha1
kind: APIExport
metadata:
  name: data.my.domain
spec:
  latestResourceSchemas:
    - today.widgets.data.my.domain
  permissionClaims:
    - group: ""
      resource: "secrets"
    - group: ""
      resource: "configmaps"
    - group: ""
      resource: "namespaces"
    - group: "apps"
      resource: "deployments"
🤖 (kxp) k apply -f bad-export.yaml 
Error from server (Forbidden): error when creating "bad-export.yaml": apiexports.apis.kcp.dev "data.my.domain" is forbidden: spec.permissionClaims.[3].identityHash: Invalid value: "": identityHash is required for API types that are not built-in
```

## Related issue(s)

Fixes #2161 
xref #2152 (more work to be done on exposing conditions for other failure modes)
