### PR TITLE
🐛 Fix permissionclaim patch thrashing

### DIFF
--- a/config/crds/apis.kcp.dev_apibindings.yaml
+++ b/config/crds/apis.kcp.dev_apibindings.yaml
@@ -53,6 +53,7 @@ spec:
                     records if the user accepts or rejects it.
                   properties:
                     group:
+                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
@@ -125,6 +126,7 @@ spec:
                     allow the service provider access to.
                   properties:
                     group:
+                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
@@ -146,6 +148,10 @@ spec:
                   - resource
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                x-kubernetes-list-type: map
               boundExport:
                 description: "boundExport records the export this binding is bound
                   to currently. It can differ from the export that was specified in
@@ -291,6 +297,7 @@ spec:
                     allow the service provider access to.
                   properties:
                     group:
+                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
@@ -312,6 +319,10 @@ spec:
                   - resource
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                x-kubernetes-list-type: map
               phase:
                 description: 'phase is the current phase of the APIBinding: - "":
                   the APIBinding has just been created, waiting to be bound. - Binding:

--- a/config/crds/workload.kcp.dev_synctargets.yaml
+++ b/config/crds/workload.kcp.dev_synctargets.yaml
@@ -195,6 +195,7 @@ spec:
                 items:
                   properties:
                     group:
+                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$

--- a/config/root-phase0/apiexport-workload.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.dev.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220923-836dfac8.synctargets.workload.kcp.dev
+  - v221011-1af9d713.synctargets.workload.kcp.dev
 status: {}

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220923-836dfac8.synctargets.workload.kcp.dev
+  name: v221011-1af9d713.synctargets.workload.kcp.dev
 spec:
   group: workload.kcp.dev
   names:
@@ -189,6 +189,7 @@ spec:
               items:
                 properties:
                   group:
+                    default: ""
                     description: group is the name of an API group. For core groups
                       this is the empty string '""'.
                     pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -174,11 +174,17 @@ type APIBindingStatus struct {
 	// state in spec.permissionClaims.
 	//
 	// +optional
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=resource
 	AppliedPermissionClaims []PermissionClaim `json:"appliedPermissionClaims,omitempty"`
 
 	// exportPermissionClaims records the permissions that the export provider is asking for
 	// the binding to grant.
 	// +optional
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=resource
 	ExportPermissionClaims []PermissionClaim `json:"exportPermissionClaims,omitempty"`
 }
 

--- a/pkg/apis/apis/v1alpha1/types_apiexport.go
+++ b/pkg/apis/apis/v1alpha1/types_apiexport.go
@@ -220,6 +220,7 @@ type GroupResource struct {
 	//
 	// +kubebuilder:validation:Pattern=`^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$`
 	// +optional
+	// +kubebuilder:default=""
 	Group string `json:"group,omitempty"`
 
 	// resource is the name of the resource.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1251,6 +1251,15 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 						},
 					},
 					"appliedPermissionClaims": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "appliedPermissionClaims is a list of the permission claims the system has seen and applied, according to the requests of the API service provider in the APIExport and the acceptance state in spec.permissionClaims.",
 							Type:        []string{"array"},
@@ -1265,6 +1274,15 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 						},
 					},
 					"exportPermissionClaims": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "exportPermissionClaims records the permissions that the export provider is asking for the binding to grant.",
 							Type:        []string{"array"},

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
@@ -132,6 +132,14 @@ func (c *controller) reconcile(ctx context.Context, apiBinding *apisv1alpha1.API
 			}
 
 			logger := logging.WithObject(logger, u)
+
+			if gvr == apisv1alpha1.SchemeGroupVersion.WithResource("apibindings") && logicalcluster.From(u) == clusterName && u.GetName() == apiBinding.Name {
+				// Don't issue a generic patch when obj == the APIBinding being reconciled. That will be covered when
+				// this call to reconcile exits and the controller patches this APIBinding. Otherwise, the generic patch
+				// here will conflict with the controller's attempt to update the APIBinding's status.
+				continue
+			}
+
 			logger.V(4).Info("patching to get claim labels updated")
 
 			// Empty patch, allowing the admission plugin to update the resource to the correct labels
@@ -180,7 +188,7 @@ func (c *controller) reconcile(ctx context.Context, apiBinding *apisv1alpha1.API
 
 	fullyApplied := expectedClaims.Difference(applyErrors)
 	apiBinding.Status.AppliedPermissionClaims = []apisv1alpha1.PermissionClaim{}
-	for _, s := range fullyApplied.UnsortedList() {
+	for _, s := range fullyApplied.List() {
 		claim := claimFromSetKey(s)
 		apiBinding.Status.AppliedPermissionClaims = append(apiBinding.Status.AppliedPermissionClaims, claim)
 	}


### PR DESCRIPTION
## Summary
- Add map keys to APIBinding.Status.AppliedPermissionClaims and .ExportPermissionClaims
- Switched to using a sorted list when calculating applied permission claims so it doesn't keep generating new patches because of different ordering in the list.

## Related issue(s)

Fixes #
