### PR TITLE
🐛 types_apibinding,types_apiexport: revert applied/export permission claims

### DIFF
--- a/config/crds/apis.kcp.dev_apibindings.yaml
+++ b/config/crds/apis.kcp.dev_apibindings.yaml
@@ -53,7 +53,6 @@ spec:
                     records if the user accepts or rejects it.
                   properties:
                     group:
-                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
@@ -126,7 +125,6 @@ spec:
                     allow the service provider access to.
                   properties:
                     group:
-                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
@@ -148,10 +146,6 @@ spec:
                   - resource
                   type: object
                 type: array
-                x-kubernetes-list-map-keys:
-                - group
-                - resource
-                x-kubernetes-list-type: map
               boundExport:
                 description: "boundExport records the export this binding is bound
                   to currently. It can differ from the export that was specified in
@@ -297,7 +291,6 @@ spec:
                     allow the service provider access to.
                   properties:
                     group:
-                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$
@@ -319,10 +312,6 @@ spec:
                   - resource
                   type: object
                 type: array
-                x-kubernetes-list-map-keys:
-                - group
-                - resource
-                x-kubernetes-list-type: map
               phase:
                 description: 'phase is the current phase of the APIBinding: - "":
                   the APIBinding has just been created, waiting to be bound. - Binding:

--- a/config/crds/workload.kcp.dev_synctargets.yaml
+++ b/config/crds/workload.kcp.dev_synctargets.yaml
@@ -195,7 +195,6 @@ spec:
                 items:
                   properties:
                     group:
-                      default: ""
                       description: group is the name of an API group. For core groups
                         this is the empty string '""'.
                       pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$

--- a/config/root-phase0/apiexport-workload.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.dev.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.dev
 spec:
   latestResourceSchemas:
-  - v221011-1af9d713.synctargets.workload.kcp.dev
+  - v220923-836dfac8.synctargets.workload.kcp.dev
 status: {}

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v221011-1af9d713.synctargets.workload.kcp.dev
+  name: v220923-836dfac8.synctargets.workload.kcp.dev
 spec:
   group: workload.kcp.dev
   names:
@@ -189,7 +189,6 @@ spec:
               items:
                 properties:
                   group:
-                    default: ""
                     description: group is the name of an API group. For core groups
                       this is the empty string '""'.
                     pattern: ^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -174,17 +174,11 @@ type APIBindingStatus struct {
 	// state in spec.permissionClaims.
 	//
 	// +optional
-	// +listType=map
-	// +listMapKey=group
-	// +listMapKey=resource
 	AppliedPermissionClaims []PermissionClaim `json:"appliedPermissionClaims,omitempty"`
 
 	// exportPermissionClaims records the permissions that the export provider is asking for
 	// the binding to grant.
 	// +optional
-	// +listType=map
-	// +listMapKey=group
-	// +listMapKey=resource
 	ExportPermissionClaims []PermissionClaim `json:"exportPermissionClaims,omitempty"`
 }
 

--- a/pkg/apis/apis/v1alpha1/types_apiexport.go
+++ b/pkg/apis/apis/v1alpha1/types_apiexport.go
@@ -220,7 +220,6 @@ type GroupResource struct {
 	//
 	// +kubebuilder:validation:Pattern=`^(|[a-z0-9]([-a-z0-9]*[a-z0-9](\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?)$`
 	// +optional
-	// +kubebuilder:default=""
 	Group string `json:"group,omitempty"`
 
 	// resource is the name of the resource.

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1251,15 +1251,6 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 						},
 					},
 					"appliedPermissionClaims": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"group",
-									"resource",
-								},
-								"x-kubernetes-list-type": "map",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "appliedPermissionClaims is a list of the permission claims the system has seen and applied, according to the requests of the API service provider in the APIExport and the acceptance state in spec.permissionClaims.",
 							Type:        []string{"array"},
@@ -1274,15 +1265,6 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 						},
 					},
 					"exportPermissionClaims": {
-						VendorExtensible: spec.VendorExtensible{
-							Extensions: spec.Extensions{
-								"x-kubernetes-list-map-keys": []interface{}{
-									"group",
-									"resource",
-								},
-								"x-kubernetes-list-type": "map",
-							},
-						},
 						SchemaProps: spec.SchemaProps{
 							Description: "exportPermissionClaims records the permissions that the export provider is asking for the binding to grant.",
 							Type:        []string{"array"},


### PR DESCRIPTION
## Summary

This partially reverts commit f0bb055536a435aa13381e7ee1c878df4b5e522c.

Setting the list-type to map won't work semantically as we plan to add additional fields into permission claims which would need to be part of the key.

The types need to stay atomic.

## Related issue(s)

Partially reverts #2174
