### PR TITLE
🌱 cache: indroduce cache-server-kubeconfig-file flag

### DIFF
--- a/pkg/server/options/flags.go
+++ b/pkg/server/options/flags.go
@@ -179,8 +179,8 @@ var (
 		"sync-target-heartbeat-threshold",        // Amount of time to wait for a successful heartbeat before marking the cluster as not ready.
 
 		// KCP Cache Server flags
-		"cache-url",        // A URL address of a cache server associated with this instance (default https://localhost:6443)
-		"run-cache-server", // If set to true it runs the cache server with this instance (default false).
+		"cache-server-kubeconfig-file", // Kubeconfig for the cache server this instance connects to (defaults to loop back configuration).
+		"run-cache-server",             // If set to true it runs the cache server with this instance (default false).
 
 		// generic flags
 		"cors-allowed-origins",                 // List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -338,7 +338,7 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 	//  - we need to modify wildcardClusterNameRegex and crdWildcardPartialMetadataClusterNameRegex
 	o.Cache.Server.Etcd.EnableWatchCache = false
 	o.Cache.Server.SecureServing = completedGenericControlPlane.SecureServing
-	cacheCompletedOptions, err := o.Cache.Complete(completedGenericControlPlane.SecureServing)
+	cacheCompletedOptions, err := o.Cache.Complete()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
points to a kubeconfig file for the cache server.
the config will be used by a kcp instance to establish a secure connection with the cache server. when a kubeconfig wasn't specify and the "run-cache-server" was provided the kcp will use the loop back client. assuming the cache server runs in the same process as the kcp server.

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
will be used in https://github.com/kcp-dev/kcp/pull/2132
