### PR TITLE
🐛 Correctly serve APIBindings in the APIExport virtual workspace

### DIFF
--- a/test/e2e/virtual/apiexport/apibindings_access_binding1.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_binding1.yaml
@@ -1,0 +1,8 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: binding1
+spec:
+  reference:
+    workspace:
+      exportName: export1

--- a/test/e2e/virtual/apiexport/apibindings_access_binding2.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_binding2.yaml
@@ -1,0 +1,8 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: binding2
+spec:
+  reference:
+    workspace:
+      exportName: export2

--- a/test/e2e/virtual/apiexport/apibindings_access_binding3.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_binding3.yaml
@@ -1,0 +1,8 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: binding3
+spec:
+  reference:
+    workspace:
+      exportName: export3

--- a/test/e2e/virtual/apiexport/apibindings_access_export1.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_export1.yaml
@@ -1,0 +1,7 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: export1
+spec:
+  latestResourceSchemas:
+  - v1.widgets.example.io

--- a/test/e2e/virtual/apiexport/apibindings_access_export2.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_export2.yaml
@@ -1,0 +1,7 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: export2
+spec:
+  latestResourceSchemas:
+  - v1.widgets.anotherexample.io

--- a/test/e2e/virtual/apiexport/apibindings_access_export3.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_export3.yaml
@@ -1,0 +1,7 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: export3
+spec:
+  latestResourceSchemas:
+  - v1.widgets.yetanotherexample.io

--- a/test/e2e/virtual/apiexport/apibindings_access_schema1.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_schema1.yaml
@@ -1,0 +1,39 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: v1.widgets.example.io
+spec:
+  group: example.io
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            firstName:
+              type: string
+            lastName:
+              type: string
+          type: object
+        status:
+          properties:
+            phase:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/virtual/apiexport/apibindings_access_schema2.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_schema2.yaml
@@ -1,0 +1,39 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: v1.widgets.anotherexample.io
+spec:
+  group: anotherexample.io
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            firstName:
+              type: string
+            lastName:
+              type: string
+          type: object
+        status:
+          properties:
+            phase:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/e2e/virtual/apiexport/apibindings_access_schema3.yaml
+++ b/test/e2e/virtual/apiexport/apibindings_access_schema3.yaml
@@ -1,0 +1,39 @@
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIResourceSchema
+metadata:
+  name: v1.widgets.yetanotherexample.io
+spec:
+  group: yetanotherexample.io
+  names:
+    kind: Widget
+    listKind: WidgetList
+    plural: widgets
+    singular: widget
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            firstName:
+              type: string
+            lastName:
+              type: string
+          type: object
+        status:
+          properties:
+            phase:
+              type: string
+          type: object
+      type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

Fix bug in the APIExport virtual workspace that prevented it from including APIBindings for the APIExport when there wasn't a permission claim for APIBindings.

Switch from checking APIBinding phase for determining what actions to perform to instead always trying to resolve desired state.

Add e2e test for APIBindings with/without permission claims in the APIExport virtual workspace.

## Related issue(s)

Fixes #1421
Fixes: #2181