### PR TITLE
🌱 e2e framework:  introduce KcpConfigOption function

### DIFF
--- a/test/e2e/audit/audit_log_test.go
+++ b/test/e2e/audit/audit_log_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestAuditLogs(t *testing.T) {
-	server := framework.PrivateKcpServer(t, []string{"--audit-log-path", "./audit-log", "--audit-policy-file", "./policy.yaml"}...)
+	server := framework.PrivateKcpServer(t, framework.WithCustomArguments([]string{"--audit-log-path", "./audit-log", "--audit-policy-file", "./policy.yaml"}...))
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 

--- a/test/e2e/homeworkspaces/home_workspaces_test.go
+++ b/test/e2e/homeworkspaces/home_workspaces_test.go
@@ -148,7 +148,7 @@ func TestUserHomeWorkspaces(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			tokenAuthFile := framework.WriteTokenAuthFile(t)
-			server := framework.PrivateKcpServer(t, append(framework.TestServerArgsWithTokenAuthFile(tokenAuthFile), testCase.kcpArgs...)...)
+			server := framework.PrivateKcpServer(t, framework.WithCustomArguments(append(framework.TestServerArgsWithTokenAuthFile(tokenAuthFile), testCase.kcpArgs...)...))
 			ctx, cancelFunc := context.WithCancel(context.Background())
 			t.Cleanup(cancelFunc)
 

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -600,11 +600,11 @@ func testWorkspacesVirtualWorkspaces(t *testing.T, standalone bool) {
 
 		tokenAuthFile := framework.WriteTokenAuthFile(t)
 		server = framework.PrivateKcpServer(t,
-			append(framework.TestServerArgsWithTokenAuthFile(tokenAuthFile),
+			framework.WithCustomArguments(append(framework.TestServerArgsWithTokenAuthFile(tokenAuthFile),
 				"--run-virtual-workspaces=false",
 				fmt.Sprintf("--shard-virtual-workspace-url=https://localhost:%s", portStr),
 			)...,
-		)
+			))
 
 		// write kubeconfig to disk, next to kcp kubeconfig
 		kcpAdminConfig, _ := server.RawConfig()


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Allows for providing a custom configuration when creating a `PrivateKcpServer`. Could be extended in the future to `SharedKcpServer`

It will be used in https://github.com/kcp-dev/kcp/pull/2132. The `PrivateKcpServer` will be created with `WithScratchDirectories`. The scratch directories will be shared with an instance of `the cache server`

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
