### PR TITLE
🐛 Isolate tmc-related logging constants in a dedicated package

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -45,7 +45,7 @@
 /pkg/admission/kubequota/kubequota_admission.go:221:2: function "V" should not be used, convert to contextual logging
 /pkg/admission/kubequota/kubequota_clusterworkspace_monitor.go:76:2: function "Infof" should not be used, convert to contextual logging
 /pkg/admission/kubequota/kubequota_clusterworkspace_monitor.go:77:8: function "Infof" should not be used, convert to contextual logging
-/pkg/admission/webhook/generic_webhook.go:101:5: function "Errorf" should not be used, convert to contextual logging
+/pkg/admission/webhook/generic_webhook.go:102:5: function "Errorf" should not be used, convert to contextual logging
 /pkg/admission/webhook/generic_webhook.go:139:4: function "Errorf" should not be used, convert to contextual logging
 /pkg/admission/webhook/generic_webhook.go:82:3: function "Infof" should not be used, convert to contextual logging
 /pkg/admission/webhook/generic_webhook.go:82:3: function "V" should not be used, convert to contextual logging
@@ -112,32 +112,32 @@
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:331:2: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:333:3: function "Errorf" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_reconcile.go:58:5: function "Warningf" should not be used, convert to contextual logging
-/pkg/server/controllers.go:997:4: function "Errorf" should not be used, convert to contextual logging
+/pkg/server/controllers.go:998:4: function "Errorf" should not be used, convert to contextual logging
 /pkg/server/home_workspaces.go:352:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/home_workspaces.go:638:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
-/pkg/syncer/namespace/namespace_downstream_process.go:43:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_downstream_process.go:74:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_downstream_process.go:74:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_upstream_process.go:40:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/namespace/namespace_upstream_process.go:40:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_upstream_process.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
-/pkg/syncer/spec/spec_controller.go:141:16: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/spec/spec_controller.go:141:16: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:116:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:134:4: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:152:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:366:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/status/status_process.go:138:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/status/status_process.go:138:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:138:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:68:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNameKey} provided with string value.
-/pkg/syncer/status/status_process.go:68:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging DownstreamNamespaceKey} provided with string value.
-/pkg/syncer/syncer.go:166:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetNameKey} provided with string value.
-/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetNameKey} provided with string value.
-/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging SyncTargetWorkspaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:44:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:75:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:75:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_upstream_process.go:41:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/namespace/namespace_upstream_process.go:41:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_upstream_process.go:79:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/spec/spec_controller.go:142:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/spec/spec_controller.go:142:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/spec/spec_process.go:135:4: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/spec/spec_process.go:153:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/spec/spec_process.go:368:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/status/status_process.go:139:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/status/status_process.go:139:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:139:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:69:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/status/status_process.go:69:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/syncer.go:166:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetKey provided with string value.
+/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetName provided with string value.
+/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetWorkspace provided with string value.
 /pkg/tunneler/dialer.go:148:8: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/dialer.go:148:8: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:157:3: function "Infof" should not be used, convert to contextual logging

--- a/pkg/syncer/namespace/namespace_downstream_process.go
+++ b/pkg/syncer/namespace/namespace_downstream_process.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/dns/plugin/nsmap"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
 func (c *DownstreamController) process(ctx context.Context, key string) error {
@@ -40,7 +41,7 @@ func (c *DownstreamController) process(ctx context.Context, key string) error {
 		return nil
 	}
 
-	logger = logger.WithValues(logging.DownstreamNamespaceKey, namespaceName)
+	logger = logger.WithValues(DownstreamNamespace, namespaceName)
 
 	// Always refresh the DNS ConfigMap
 	err = c.updateDNSConfigMap(ctx)

--- a/pkg/syncer/namespace/namespace_upstream_process.go
+++ b/pkg/syncer/namespace/namespace_upstream_process.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
 func (c *UpstreamController) process(ctx context.Context, key string) error {
@@ -75,7 +76,7 @@ func (c *UpstreamController) process(ctx context.Context, key string) error {
 	}
 
 	downstreamNamespaceName := downstreamNamespace.(*unstructured.Unstructured).GetName()
-	logger = logger.WithValues(logging.DownstreamNamespaceKey, downstreamNamespaceName)
+	logger = logger.WithValues(DownstreamNamespace, downstreamNamespaceName)
 	logger.V(2).Info("deleting downstream namespace because the upstream namespace doesn't exist")
 	return c.deleteDownstreamNamespace(ctx, downstreamNamespaceName)
 }

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -45,6 +45,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 	specmutators "github.com/kcp-dev/kcp/pkg/syncer/spec/mutators"
 	"github.com/kcp-dev/kcp/third_party/keyfunctions"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
 const (
@@ -138,7 +139,7 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetWorkspace logicalcluster.
 					if err != nil {
 						utilruntime.HandleError(fmt.Errorf("error splitting key %q: %w", key, err))
 					}
-					logger := logging.WithQueueKey(logger, key).WithValues("gvr", gvr, logging.DownstreamNamespaceKey, namespace, logging.DownstreamNameKey, name)
+					logger := logging.WithQueueKey(logger, key).WithValues("gvr", gvr, DownstreamNamespace, namespace, DownstreamName, name)
 					logger.V(3).Info("processing delete event")
 
 					var nsLocatorHolder *unstructured.Unstructured

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -42,6 +42,7 @@ import (
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
 const (
@@ -131,7 +132,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 
 		if len(downstreamNamespaces) == 1 {
 			namespace := downstreamNamespaces[0].(*unstructured.Unstructured)
-			logger.WithValues(logging.DownstreamNameKey, namespace.GetName()).V(4).Info("Found downstream namespace for upstream namespace")
+			logger.WithValues(DownstreamName, namespace.GetName()).V(4).Info("Found downstream namespace for upstream namespace")
 			downstreamNamespace = namespace.GetName()
 		} else if len(downstreamNamespaces) > 1 {
 			// This should never happen unless there's some namespace collision.
@@ -149,7 +150,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 			}
 		}
 	}
-	logger = logger.WithValues(logging.DownstreamNamespaceKey, downstreamNamespace)
+	logger = logger.WithValues(DownstreamNamespace, downstreamNamespace)
 
 	// TODO(skuznets): can we figure out how to not leak this detail up to this code?
 	// I guess once the indexer is using kcpcache.MetaClusterNamespaceKeyFunc, we can just use that formatter ...
@@ -364,7 +365,7 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 		return nil
 	}
 
-	logger = logger.WithValues(logging.DownstreamNameKey, transformedName)
+	logger = logger.WithValues(DownstreamName, transformedName)
 	ctx = klog.NewContext(ctx, logger)
 
 	logger.V(4).Info("Upstream object is intended to be removed", "intendedToBeRemovedFromLocation", intendedToBeRemovedFromLocation, "stillOwnedByExternalActorForLocation", stillOwnedByExternalActorForLocation)

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -38,6 +38,7 @@ import (
 	workloadcliplugin "github.com/kcp-dev/kcp/pkg/cliplugins/workload/plugin"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
 func deepEqualFinalizersAndStatus(oldUnstrob, newUnstrob *unstructured.Unstructured) bool {
@@ -65,7 +66,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		return nil
 	}
 
-	logger = logger.WithValues(logging.DownstreamNamespaceKey, downstreamNamespace, logging.DownstreamNameKey, downstreamName)
+	logger = logger.WithValues(DownstreamNamespace, downstreamNamespace, DownstreamName, downstreamName)
 
 	// to upstream
 	var namespaceLocator *shared.NamespaceLocator

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -43,12 +43,12 @@ import (
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
-	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/syncer/namespace"
 	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
 	"github.com/kcp-dev/kcp/pkg/syncer/spec"
 	"github.com/kcp-dev/kcp/pkg/syncer/status"
 	"github.com/kcp-dev/kcp/third_party/keyfunctions"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
 const (
@@ -75,7 +75,7 @@ type SyncerConfig struct {
 
 func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, importPollInterval time.Duration) error {
 	logger := klog.FromContext(ctx)
-	logger = logger.WithValues(logging.SyncTargetWorkspaceKey, cfg.SyncTargetWorkspace, logging.SyncTargetNameKey, cfg.SyncTargetName)
+	logger = logger.WithValues(SyncTargetWorkspace, cfg.SyncTargetWorkspace, SyncTargetName, cfg.SyncTargetName)
 	logger.V(2).Info("starting syncer")
 
 	kcpVersion := version.Get().GitVersion
@@ -163,7 +163,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	}
 
 	syncTargetKey := workloadv1alpha1.ToSyncTargetKey(cfg.SyncTargetWorkspace, cfg.SyncTargetName)
-	logger = logger.WithValues(logging.SyncTargetNameKey, syncTargetKey)
+	logger = logger.WithValues(SyncTargetKey, syncTargetKey)
 	ctx = klog.NewContext(ctx, logger)
 
 	upstreamInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(upstreamDynamicClusterClient.Cluster(logicalcluster.Wildcard), resyncPeriod, metav1.NamespaceAll, func(o *metav1.ListOptions) {

--- a/tmc/pkg/logging/constants.go
+++ b/tmc/pkg/logging/constants.go
@@ -21,18 +21,20 @@ const (
 	// SyncTargetKeyPrefix is the prefix used for all the keys related to a SyncTarget.
 	SyncTargetKeyPrefix = "syncTarget."
 
-	// SyncTargetWorkspaceKey is used to specify a workspace when a log is related to a SyncTarget.
-	SyncTargetWorkspaceKey = SyncTargetKeyPrefix + "workspace"
-	// SyncTargetNamespaceKey is used to specify a namespace when a log is related to a SyncTarget.
-	SyncTargetNamespaceKey = SyncTargetKeyPrefix + "namespace"
-	// SyncTargetNameKey is used to specify a name when a log is related to a SyncTarget.
-	SyncTargetNameKey = SyncTargetKeyPrefix + "name"
+	// SyncTargetWorkspace is used to specify a workspace when a log is related to a SyncTarget.
+	SyncTargetWorkspace = SyncTargetKeyPrefix + "workspace"
+	// SyncTargetNamespace is used to specify a namespace when a log is related to a SyncTarget.
+	SyncTargetNamespace = SyncTargetKeyPrefix + "namespace"
+	// SyncTargetName is used to specify a name when a log is related to a SyncTarget.
+	SyncTargetName = SyncTargetKeyPrefix + "name"
+	// SyncTargetKey is used to specify the obfuscated key of a SyncTarget as used in the Syncer labels and annotations.
+	SyncTargetKey = SyncTargetKeyPrefix + "key"
 
 	// DownstreamKeyPrefix is the prefix used for all the keys related to a downstream object.
 	DownstreamKeyPrefix = "downstream."
 
-	// DownstreamNamespaceKey is used to specify a namespace when a log is related to a downstream object.
-	DownstreamNamespaceKey = DownstreamKeyPrefix + "namespace"
-	// DownstreamNameKey is used to specify a name when a log is related to a downstream object.
-	DownstreamNameKey = DownstreamKeyPrefix + "name"
+	// DownstreamNamespace is used to specify a namespace when a log is related to a downstream object.
+	DownstreamNamespace = DownstreamKeyPrefix + "namespace"
+	// DownstreamName is used to specify a name when a log is related to a downstream object.
+	DownstreamName = DownstreamKeyPrefix + "name"
 )


### PR DESCRIPTION
## Summary

This PR fixes a small structured logging bug in the Syncer that was overriding the SyncTargetName structured logging value.
But most importantly, it isolates the tmc-related logging constants in a dedicated tmc-specific package, and . imports them so that code is more readable (see the discussion [here](https://kubernetes.slack.com/archives/C021U8WSAFK/p1666022954832189))
