### PR TITLE
:sparkles: Add command for fetching permission claims

### DIFF
--- a/cmd/kubectl-kcp/cmd/kubectlKcp.go
+++ b/cmd/kubectl-kcp/cmd/kubectlKcp.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/klog/v2"
 
 	bindcmd "github.com/kcp-dev/kcp/pkg/cliplugins/bind/cmd"
+	claimscmd "github.com/kcp-dev/kcp/pkg/cliplugins/claims/cmd"
 	crdcmd "github.com/kcp-dev/kcp/pkg/cliplugins/crd/cmd"
 	workloadcmd "github.com/kcp-dev/kcp/pkg/cliplugins/workload/cmd"
 	workspacecmd "github.com/kcp-dev/kcp/pkg/cliplugins/workspace/cmd"
@@ -83,6 +84,9 @@ func KubectlKcpCommand() *cobra.Command {
 
 	bindCmd := bindcmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	root.AddCommand(bindCmd)
+
+	claimsCmd := claimscmd.New(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root.AddCommand(claimsCmd)
 
 	return root
 }

--- a/pkg/cliplugins/claims/cmd/cmd.go
+++ b/pkg/cliplugins/claims/cmd/cmd.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/kcp-dev/kcp/pkg/cliplugins/claims/plugin"
+)
+
+// TODO: Add examples for edit and update claims
+var (
+	claimsExample = `
+	# Lists the permission claims and their respective status related to a specific APIBinding.
+	%[1]s claims get apibinding cert-manager
+
+	# List permission claims and their respective status for all APIBindings in current workspace.
+	%[1]s claims get apibinding
+	`
+)
+
+// New returns a cobra.Command for claims related actions.
+func New(streams genericclioptions.IOStreams) *cobra.Command {
+
+	cliName := "kubectl"
+	if pflag.CommandLine.Name() == "kubectl-kcp" {
+		cliName = "kubectl kcp"
+	}
+
+	claimsCmd := &cobra.Command{
+		Use:              "claims",
+		Short:            "Operations related to viewing or updating permission claims",
+		SilenceUsage:     true,
+		Example:          fmt.Sprintf(claimsExample, cliName),
+		TraverseChildren: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	getcmd := &cobra.Command{
+		Use:              "get",
+		Short:            "Operations related to fetching APIs with respect to permission claims",
+		SilenceUsage:     true,
+		TraverseChildren: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	apibindingGetOpts := plugin.NewGetAPIBindingOptions(streams)
+	apibindingGetCmd := &cobra.Command{
+		Use:          "apibinding <apibinding_name>",
+		Short:        "Get claims related to apibinding",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := apibindingGetOpts.Complete(args); err != nil {
+				return err
+			}
+			if err := apibindingGetOpts.Validate(); err != nil {
+				return err
+			}
+			return apibindingGetOpts.Run(cmd.Context())
+		},
+	}
+	apibindingGetOpts.BindFlags(apibindingGetCmd)
+	getcmd.AddCommand(apibindingGetCmd)
+	claimsCmd.AddCommand(getcmd)
+	return claimsCmd
+}

--- a/pkg/cliplugins/claims/plugin/claims.go
+++ b/pkg/cliplugins/claims/plugin/claims.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	apiv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/pkg/cliplugins/base"
+	pluginhelpers "github.com/kcp-dev/kcp/pkg/cliplugins/helpers"
+)
+
+// GetAPIBindingOptions contains the options for fetching claims
+// and their status corresponding to a specific API Binding.
+type GetAPIBindingOptions struct {
+	*base.Options
+
+	// Name of the APIbinding whose claims we need to list.
+	APIBindingName string
+
+	// If allBindings is true, then get permission claims for all
+	// APIBindings in a workspace.
+	allBindings bool
+}
+
+func NewGetAPIBindingOptions(streams genericclioptions.IOStreams) *GetAPIBindingOptions {
+	return &GetAPIBindingOptions{
+		Options: base.NewOptions(streams),
+	}
+}
+
+func (g *GetAPIBindingOptions) Complete(args []string) error {
+	if err := g.Options.Complete(); err != nil {
+		return err
+	}
+
+	if len(args) > 0 {
+		g.APIBindingName = args[0]
+	}
+	return nil
+}
+
+func (g *GetAPIBindingOptions) Validate() error {
+	if g.APIBindingName == "" {
+		g.allBindings = true
+	}
+	return g.Options.Validate()
+}
+
+func (g *GetAPIBindingOptions) BindFlags(cmd *cobra.Command) {
+	g.Options.BindFlags(cmd)
+}
+
+func (g *GetAPIBindingOptions) Run(ctx context.Context) error {
+	cfg, err := g.ClientConfig.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	_, currentClusterName, err := pluginhelpers.ParseClusterURL(cfg.Host)
+	if err != nil {
+		return fmt.Errorf("current URL %q does not point to cluster workspace", cfg.Host)
+	}
+
+	kcpClusterClient, err := newKCPClusterClient(g.ClientConfig)
+	if err != nil {
+		return fmt.Errorf("error while creating kcp client %w", err)
+	}
+
+	out := printers.GetNewTabWriter(g.Out)
+	defer out.Flush()
+
+	err = printHeaders(out)
+	if err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+
+	allErrors := []error{}
+	apibindings := []apiv1alpha1.APIBinding{}
+	// List permission claims for all bindings in current workspace.
+	if g.allBindings {
+		bindings, err := kcpClusterClient.Cluster(currentClusterName).ApisV1alpha1().APIBindings().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("error listing apibindings in %q workspace: %w", currentClusterName, err)
+		}
+		apibindings = append(apibindings, bindings.Items...)
+	} else {
+		binding, err := kcpClusterClient.Cluster(currentClusterName).ApisV1alpha1().APIBindings().Get(ctx, g.APIBindingName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error finding apibinding: %w", err)
+		}
+		apibindings = append(apibindings, *binding)
+	}
+
+	for _, b := range apibindings {
+		for _, claim := range b.Spec.PermissionClaims {
+			err := printDetails(out, b.Name, claim.Group+"-"+claim.Resource, string(claim.State))
+			if err != nil {
+				allErrors = append(allErrors, err)
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(allErrors)
+}
+
+func newKCPClusterClient(clientConfig clientcmd.ClientConfig) (kcpclient.ClusterInterface, error) {
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	clusterConfig := rest.CopyConfig(config)
+	u, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = ""
+	clusterConfig.Host = u.String()
+	clusterConfig.UserAgent = rest.DefaultKubernetesUserAgent()
+	return kcpclient.NewClusterForConfig(clusterConfig)
+}
+
+func printHeaders(out io.Writer) error {
+	columnNames := []string{"APIBINDING", "RESOURCE GROUP-VERSION", "STATUS"}
+	_, err := fmt.Fprintf(out, "%s\n", strings.Join(columnNames, "\t"))
+	return err
+}
+
+func printDetails(w io.Writer, name, binding, status string) error {
+	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", name, binding, status)
+	return err
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR adds command to get permission claims related to an APIBinding.
Example:

```
➜  kcp git:(cmd/permission-claim-get) ✗ kubectl-kcp claims get apibinding cert-manager
NAME                       BINDING            STATUS
group1-resource1    cert-manager   Rejected
group2-resource2   cert-manager   Rejected
```

```
➜  kcp git:(cmd/permission-claim-get) ✗ kubectl-kcp claims get apibinding
NAME                       BINDING            STATUS
group1-resource1    cert-manager   Rejected
group2-resource2   cert-manager   Rejected
group3-resource3   solo                   Accepted
```

Related design doc: https://docs.google.com/document/d/1J31wXY1-2aCyyGFjUlusKoHDzV-zktAmRdIMjMf4OR0/edit

