### PR TITLE
🌱 cmd/syncer: switch to contextual logging

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -53,7 +53,7 @@ func NewSyncerCommand() *cobra.Command {
 			}
 
 			ctx := genericapiserver.SetupSignalContext()
-			if err := Run(options, ctx); err != nil {
+			if err := Run(ctx, options); err != nil {
 				return err
 			}
 
@@ -76,8 +76,9 @@ func NewSyncerCommand() *cobra.Command {
 	return syncerCommand
 }
 
-func Run(options *synceroptions.Options, ctx context.Context) error {
-	klog.Infof("Syncing the following resource types: %s", options.SyncedResourceTypes)
+func Run(ctx context.Context, options *synceroptions.Options) error {
+	logger := klog.FromContext(ctx)
+	logger.Info("syncing", "resource-types", options.SyncedResourceTypes)
 
 	kcpConfigOverrides := &clientcmd.ConfigOverrides{
 		CurrentContext: options.FromContext,

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -1,4 +1,4 @@
-/cmd/kubectl-kcp/cmd/kubectlKcp.go:58:2: function "InitFlags" should not be used, convert to contextual logging
+/cmd/kubectl-kcp/cmd/kubectlKcp.go:57:2: function "InitFlags" should not be used, convert to contextual logging
 /cmd/kubectl-workspace/main.go:44:2: function "InitFlags" should not be used, convert to contextual logging
 /cmd/sharded-test-server/shard.go:34:2: function "Infof" should not be used, convert to contextual logging
 /cmd/sharded-test-server/shard.go:43:2: function "Infof" should not be used, convert to contextual logging
@@ -10,7 +10,6 @@
 /cmd/sharded-test-server/third_party/library-go/crypto/crypto.go:740:2: function "V" should not be used, convert to contextual logging
 /cmd/sharded-test-server/third_party/library-go/crypto/crypto.go:809:2: function "Infof" should not be used, convert to contextual logging
 /cmd/sharded-test-server/third_party/library-go/crypto/crypto.go:809:2: function "V" should not be used, convert to contextual logging
-/cmd/syncer/cmd/syncer.go:80:2: function "Infof" should not be used, convert to contextual logging
 /cmd/test-server/kcp/shard.go:121:2: function "Infof" should not be used, convert to contextual logging
 /cmd/test-server/kcp/shard.go:141:2: function "Infof" should not be used, convert to contextual logging
 /cmd/test-server/kcp/shard.go:144:2: function "Infof" should not be used, convert to contextual logging


### PR DESCRIPTION
## Summary
cmd/syncer: switch to contextual logging

## Related issue(s)

Part of #1694