### PR TITLE
:seedling: pkg/authorization: rename apibinding_authorizer to maximal_permission_policy_authorizer

### DIFF
--- a/config/crds/apis.kcp.dev_apiexports.yaml
+++ b/config/crds/apis.kcp.dev_apiexports.yaml
@@ -103,8 +103,8 @@ spec:
                   - local
                 properties:
                   local:
-                    description: local is policy that is defined in same namespace
-                      as API Export.
+                    description: local is the policy that is defined in same workspace
+                      as the API Export.
                     type: object
                 type: object
               permissionClaims:

--- a/pkg/apis/apis/v1alpha1/types_apiexport.go
+++ b/pkg/apis/apis/v1alpha1/types_apiexport.go
@@ -169,13 +169,16 @@ type Identity struct {
 
 // MaximalPermissionPolicy is a wrapper type around the multiple options that would be allowed.
 type MaximalPermissionPolicy struct {
-	// local is policy that is defined in same namespace as API Export.
+	// local is the policy that is defined in same workspace as the API Export.
 	// +optional
 	Local *LocalAPIExportPolicy `json:"local,omitempty"`
 }
 
-// LocalAPIExportPolicy will tell the APIBinding authorizer to check policy in the local namespace
-// of the API Export
+// LocalAPIExportPolicy is a maximal permission policy
+// that checks RBAC in the workspace of the API Export.
+//
+// In order to avoid conflicts the user and group name will be prefixed
+// with "apis.kcp.dev:binding:".
 type LocalAPIExportPolicy struct{}
 
 const (

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1945,7 +1945,7 @@ func schema_pkg_apis_apis_v1alpha1_LocalAPIExportPolicy(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "LocalAPIExportPolicy will tell the APIBinding authorizer to check policy in the local namespace of the API Export",
+				Description: "LocalAPIExportPolicy is a maximal permission policy that checks RBAC in the workspace of the API Export.\n\nIn order to avoid conflicts the user and group name will be prefixed with \"apis.kcp.dev:binding:\".",
 				Type:        []string{"object"},
 			},
 		},
@@ -1961,7 +1961,7 @@ func schema_pkg_apis_apis_v1alpha1_MaximalPermissionPolicy(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"local": {
 						SchemaProps: spec.SchemaProps{
-							Description: "local is policy that is defined in same namespace as API Export.",
+							Description: "local is the policy that is defined in same workspace as the API Export.",
 							Ref:         ref("github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1.LocalAPIExportPolicy"),
 						},
 					},

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -103,7 +103,7 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, informer kubern
 	// kcp authorizers
 	bootstrapAuth, bootstrapRules := authorization.NewBootstrapPolicyAuthorizer(informer)
 	localAuth, localResolver := authorization.NewLocalAuthorizer(informer)
-	apiBindingAuth, err := authorization.NewAPIBindingAccessAuthorizer(informer, kcpinformer,
+	apiBindingAuth, err := authorization.NewMaximalPermissionPolicyAuthorizer(informer, kcpinformer,
 		union.New(bootstrapAuth, localAuth),
 	)
 	if err != nil {

--- a/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
+++ b/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
@@ -47,7 +47,7 @@ import (
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
-func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
+func TestMaximalPermissionPolicyAuthorizerSystemGroupProtection(t *testing.T) {
 	t.Parallel()
 
 	server := framework.SharedKcpServer(t)
@@ -143,7 +143,7 @@ func TestAPIBindingAuthorizerSystemGroupProtection(t *testing.T) {
 	}
 }
 
-func TestAPIBindingAuthorizer(t *testing.T) {
+func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 	t.Parallel()
 
 	server := framework.SharedKcpServer(t)


### PR DESCRIPTION
## Summary
In the advent of reverse permission claims the "API binding authorizer" name is too coarse grained. We're introducing a "reverse permission claim authorizer" which will also handle API bindings but we don't want to conflate the implementations of both.

## Related issue(s)

Relates to #2089
