### PR TITLE
🐛 cache: fix a datarace

### DIFF
--- a/pkg/cache/server/server.go
+++ b/pkg/cache/server/server.go
@@ -54,7 +54,7 @@ type preparedServer struct {
 func (s *Server) PrepareRun(ctx context.Context) (preparedServer, error) {
 	logger := klog.FromContext(ctx).WithValues("component", "cache-server")
 	if err := s.apiextensions.GenericAPIServer.AddPostStartHook("bootstrap-cache-server", func(hookContext genericapiserver.PostStartHookContext) error {
-		logger = logger.WithValues("postStartHook", "bootstrap-cache-server")
+		logger := logger.WithValues("postStartHook", "bootstrap-cache-server")
 		if err := bootstrap.Bootstrap(klog.NewContext(goContext(hookContext), logger), s.ApiExtensionsClusterClient); err != nil {
 			logger.Error(err, "failed creating the static CustomResourcesDefinitions")
 			return nil // don't klog.Fatal. This only happens when context is cancelled.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the logger object needs to be created when a webhook is created otherwise it can be accessed from multiple goroutines.
```
==================
WARNING: DATA RACE
Read at 0x00c000b59a28 by goroutine 212:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  k8s.io/apiserver/pkg/server.runPostStartHook.func1()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:198 +0xa1
  k8s.io/apiserver/pkg/server.runPostStartHook()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:199 +0xda
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks.func2()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:165 +0xb4

Previous write at 0x00c000b59a28 by goroutine 210:
  github.com/kcp-dev/kcp/pkg/cache/server.(*Server).PrepareRun.func1()
      /go/src/github.com/kcp-dev/kcp/pkg/cache/server/server.go:57 +0x196
  k8s.io/apiserver/pkg/server.runPostStartHook.func1()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:198 +0xa1
  k8s.io/apiserver/pkg/server.runPostStartHook()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:199 +0xda
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks.func2()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:165 +0xb4

Goroutine 212 (running) created at:
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:165 +0x167
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.NonBlockingRun()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/genericapiserver.go:572 +0x28a
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.Run()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/genericapiserver.go:497 +0x7c8
  github.com/kcp-dev/kcp/pkg/cache/server.preparedServer.Run()
      /go/src/github.com/kcp-dev/kcp/pkg/cache/server/server.go:84 +0x93
  github.com/kcp-dev/kcp/test/e2e/reconciler/cache.TestAllScenariosAgainstStandaloneCacheServer.func1()
      /go/src/github.com/kcp-dev/kcp/test/e2e/reconciler/cache/replication_test.go:230 +0x67

Goroutine 210 (running) created at:
  k8s.io/apiserver/pkg/server.(*GenericAPIServer).RunPostStartHooks()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/hooks.go:165 +0x167
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.NonBlockingRun()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/genericapiserver.go:572 +0x28a
  k8s.io/apiserver/pkg/server.preparedGenericAPIServer.Run()
      /go/pkg/mod/github.com/kcp-dev/kubernetes/staging/src/k8s.io/apiserver@v0.0.0-20221005071841-6cfb7d485cbf/pkg/server/genericapiserver.go:497 +0x7c8
  github.com/kcp-dev/kcp/pkg/cache/server.preparedServer.Run()
      /go/src/github.com/kcp-dev/kcp/pkg/cache/server/server.go:84 +0x93
  github.com/kcp-dev/kcp/test/e2e/reconciler/cache.TestAllScenariosAgainstStandaloneCacheServer.func1()
      /go/src/github.com/kcp-dev/kcp/test/e2e/reconciler/cache/replication_test.go:230 +0x67
==================
```

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
