### PR TITLE
🐛 kcp: run the embeeded cache server only when a kubeconfig was provided

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -486,7 +486,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}
 
-	if s.Options.Cache.Enabled {
+	if s.Options.Cache.Enabled && len(s.Options.Cache.KubeconfigFile) == 0 {
 		if err := s.installCacheServer(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
