### PR TITLE
:bug: Remove leftover comment

### DIFF
--- a/config/crds/apis.kcp.dev_apiexports.yaml
+++ b/config/crds/apis.kcp.dev_apiexports.yaml
@@ -23,9 +23,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: "APIExport registers an API and implementation to allow consumption
-          by others through APIBindings. \n APIExports cannot be deleted until status.resourceSchemasInUse
-          is empty."
+        description: APIExport registers an API and implementation to allow consumption
+          by others through APIBindings.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/pkg/apis/apis/v1alpha1/types_apiexport.go
+++ b/pkg/apis/apis/v1alpha1/types_apiexport.go
@@ -46,8 +46,6 @@ const (
 // APIExport registers an API and implementation to allow consumption by others
 // through APIBindings.
 //
-// APIExports cannot be deleted until status.resourceSchemasInUse is empty.
-//
 // +crd
 // +genclient
 // +genclient:nonNamespaced

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1284,7 +1284,7 @@ func schema_pkg_apis_apis_v1alpha1_APIExport(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "APIExport registers an API and implementation to allow consumption by others through APIBindings.\n\nAPIExports cannot be deleted until status.resourceSchemasInUse is empty.",
+				Description: "APIExport registers an API and implementation to allow consumption by others through APIBindings.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {


### PR DESCRIPTION
## Summary

Remove a comment referencing a field `status.resourceSchemasInUse`, which does not exist. I also verified that there is no finalizer based mechanism in place that would match the behavior described in the comment.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>