### PR TITLE
:bug: Fix Dockerfile by copying tmc directory into build directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY Makefile Makefile
 COPY config/ config/
 COPY pkg/ pkg/
 COPY cmd/ cmd/
+COPY tmc/ tmc/
 COPY third_party/ third_party/
 COPY hack/ hack/
 COPY .git/ .git/


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Since #2202, container image builds were broken (https://github.com/kcp-dev/kcp/actions/workflows/kcp-image.yaml) because it moved tmc-related logging constants into a directory that was previously not copied as part of the `Dockerfile` COPY directives:

```
pkg/syncer/namespace/namespace_downstream_process.go:33:2: no required module provides package github.com/kcp-dev/kcp/tmc/pkg/logging; to add it:
	go get github.com/kcp-dev/kcp/tmc/pkg/logging
```

This PR should fix that, re-enabling image builds (locally and via GitHub actions).
