### PR TITLE
🌱 cache: add replicateAPIResourceSchema test scenario 

### DIFF
--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -82,63 +82,39 @@ type baseScenario struct {
 // replicateAPIExportScenario tests if an APIExport is propagated to the cache server.
 // The test exercises creation, modification and removal of the APIExport object.
 func replicateAPIExportScenario(ctx context.Context, t *testing.T, server framework.RunningServer, kcpShardClusterClient clientset.ClusterInterface, cacheKcpClusterClient clientset.ClusterInterface) {
-	org := framework.NewOrganizationFixture(t, server)
-	cluster := framework.NewWorkspaceFixture(t, server, org, framework.WithShardConstraints(tenancyv1alpha1.ShardConstraints{Name: "root"}))
-
-	t.Logf("Create an APIExport in %s workspace on the root shard", cluster)
-	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, cluster, kcpShardClusterClient.Cluster(cluster), "wild.wild.west", "testing replication to the cache server")
-	var cachedWildAPIExport *apisv1alpha1.APIExport
-	var wildAPIExport *apisv1alpha1.APIExport
-	var err error
-	t.Logf("Get %s/%s APIExport from the root shard and the cache server for comparison", cluster, "wild.wild.west")
-	framework.Eventually(t, func() (bool, string) {
-		wildAPIExport, err = kcpShardClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(ctx, "wild.wild.west", metav1.GetOptions{})
-		if err != nil {
-			return false, err.Error()
-		}
-		cachedWildAPIExport, err = cacheKcpClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(cacheclient.WithShardInContext(ctx, shard.New("root")), wildAPIExport.Name, metav1.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				return false, err.Error()
+	replicateResourceScenario(t, baseScenario{
+		server:       server,
+		resourceName: "wild.wild.west",
+		resourceKind: "APIExport",
+		createSourceResource: func(cluster logicalcluster.Name) error {
+			apifixtures.CreateSheriffsSchemaAndExport(ctx, t, cluster, kcpShardClusterClient.Cluster(cluster), "wild.wild.west", "testing replication to the cache server")
+			return nil
+		},
+		getSourceResource: func(cluster logicalcluster.Name) (interface{}, error) {
+			return kcpShardClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(ctx, "wild.wild.west", metav1.GetOptions{})
+		},
+		updateSourceResource: func(cluster logicalcluster.Name, res interface{}) (interface{}, error) {
+			apiExport, ok := res.(*apisv1alpha1.APIExport)
+			if !ok {
+				return nil, fmt.Errorf("%T is not *APIExport", res)
 			}
-			return false, err.Error()
-		}
-		t.Logf("Verify if both the orignal APIExport and replicated are the same except %s annotation and ResourceVersion after creation", genericapirequest.AnnotationKey)
-		if _, found := cachedWildAPIExport.Annotations[genericapirequest.AnnotationKey]; !found {
-			t.Fatalf("replicated APIExport root/%s/%s, doesn't have %s annotation", cluster, cachedWildAPIExport.Name, genericapirequest.AnnotationKey)
-		}
-		delete(cachedWildAPIExport.Annotations, genericapirequest.AnnotationKey)
-		if diff := cmp.Diff(cachedWildAPIExport, wildAPIExport, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); len(diff) > 0 {
-			return false, fmt.Sprintf("replicated APIExport root/%s/%s is different that the original", cluster, wildAPIExport.Name)
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, 400*time.Millisecond)
-
-	t.Logf("Verify that a spec update on %s/%s APIExport is propagated to the cached object", cluster, "wild.wild.west")
-	verifyAPIExportUpdate(ctx, t, cluster, kcpShardClusterClient, cacheKcpClusterClient, func(apiExport *apisv1alpha1.APIExport) {
-		apiExport.Spec.LatestResourceSchemas = append(apiExport.Spec.LatestResourceSchemas, "foo.bar")
+			return kcpShardClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Update(ctx, apiExport, metav1.UpdateOptions{})
+		},
+		updateSpecForSourceResource: func(res interface{}) error {
+			apiExport, ok := res.(*apisv1alpha1.APIExport)
+			if !ok {
+				return fmt.Errorf("%T is not *APIExport", res)
+			}
+			apiExport.Spec.LatestResourceSchemas = append(apiExport.Spec.LatestResourceSchemas, "foo.bar")
+			return nil
+		},
+		deleteSourceResource: func(cluster logicalcluster.Name) error {
+			return kcpShardClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Delete(ctx, "wild.wild.west", metav1.DeleteOptions{})
+		},
+		getCachedResource: func(cluster logicalcluster.Name) (interface{}, error) {
+			return cacheKcpClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(cacheclient.WithShardInContext(ctx, shard.New("root")), "wild.wild.west", metav1.GetOptions{})
+		},
 	})
-	t.Logf("Verify that a metadata update on %s/%s APIExport is propagated ot the cached object", cluster, "wild.wild.west")
-	verifyAPIExportUpdate(ctx, t, cluster, kcpShardClusterClient, cacheKcpClusterClient, func(apiExport *apisv1alpha1.APIExport) {
-		if apiExport.Annotations == nil {
-			apiExport.Annotations = map[string]string{}
-		}
-		apiExport.Annotations["testAnnotation"] = "testAnnotationValue"
-	})
-
-	t.Logf("Verify that deleting %s/%s APIExport leads to removal of the cached object", cluster, "wild.wild.west")
-	err = kcpShardClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Delete(ctx, "wild.wild.west", metav1.DeleteOptions{})
-	require.NoError(t, err)
-	framework.Eventually(t, func() (bool, string) {
-		_, err := cacheKcpClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(cacheclient.WithShardInContext(ctx, shard.New("root")), wildAPIExport.Name, metav1.GetOptions{})
-		if errors.IsNotFound(err) {
-			return true, ""
-		}
-		if err != nil {
-			return false, err.Error()
-		}
-		return false, fmt.Sprintf("replicated APIExport root/%s/%s wasn't removed", cluster, cachedWildAPIExport.Name)
-	}, wait.ForeverTestTimeout, 400*time.Millisecond)
 }
 
 // replicateResourceScenario tests if a given resource is propagated to the cache server.
@@ -249,43 +225,6 @@ func verifyResourceUpdate(t *testing.T, scenario baseScenario, cluster logicalcl
 		delete(cachedResourceMeta.GetAnnotations(), genericapirequest.AnnotationKey)
 		if diff := cmp.Diff(cachedResource, originalResource, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); len(diff) > 0 {
 			return false, fmt.Sprintf("replicated %s root/%s/%s is different that the original", scenario.resourceKind, cluster, cachedResourceMeta.GetName())
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, 400*time.Millisecond)
-}
-
-func verifyAPIExportUpdate(ctx context.Context, t *testing.T, cluster logicalcluster.Name, kcpRootShardClient clientset.ClusterInterface, cacheKcpClusterClient clientset.ClusterInterface, changeApiExportFn func(*apisv1alpha1.APIExport)) {
-	var wildAPIExport *apisv1alpha1.APIExport
-	var updatedWildAPIExport *apisv1alpha1.APIExport
-	var err error
-	framework.Eventually(t, func() (bool, string) {
-		wildAPIExport, err = kcpRootShardClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(ctx, "wild.wild.west", metav1.GetOptions{})
-		if err != nil {
-			return false, err.Error()
-		}
-		changeApiExportFn(wildAPIExport)
-		updatedWildAPIExport, err = kcpRootShardClient.Cluster(cluster).ApisV1alpha1().APIExports().Update(ctx, wildAPIExport, metav1.UpdateOptions{})
-		if err != nil {
-			if !errors.IsConflict(err) {
-				return false, fmt.Sprintf("unknow error while updating the cached %s/%s/%s APIExport, err: %s", "root", cluster, "wild.wild.west", err.Error())
-			}
-			return false, err.Error() // try again
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, 400*time.Millisecond)
-	t.Logf("Get root/%s/%s APIExport from the cache server", cluster, "wild.wild.west")
-	framework.Eventually(t, func() (bool, string) {
-		cachedWildAPIExport, err := cacheKcpClusterClient.Cluster(cluster).ApisV1alpha1().APIExports().Get(cacheclient.WithShardInContext(ctx, shard.New("root")), wildAPIExport.Name, metav1.GetOptions{})
-		if err != nil {
-			return false, err.Error()
-		}
-		t.Logf("Verify if both the orignal APIExport and replicated are the same except %s annotation and ResourceVersion after an update to the spec", genericapirequest.AnnotationKey)
-		if _, found := cachedWildAPIExport.Annotations[genericapirequest.AnnotationKey]; !found {
-			return false, fmt.Sprintf("replicated APIExport root/%s/%s, doesn't have %s annotation", cluster, cachedWildAPIExport.Name, genericapirequest.AnnotationKey)
-		}
-		delete(cachedWildAPIExport.Annotations, genericapirequest.AnnotationKey)
-		if diff := cmp.Diff(cachedWildAPIExport, updatedWildAPIExport, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); len(diff) > 0 {
-			return false, fmt.Sprintf("replicated APIExport root/%s/%s is different that the original, diff: %s", cluster, wildAPIExport.Name, diff)
 		}
 		return true, ""
 	}, wait.ForeverTestTimeout, 400*time.Millisecond)

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -266,8 +266,8 @@ func verifyResourceUpdate(t *testing.T, scenario baseScenario, cluster logicalcl
 	}, wait.ForeverTestTimeout, 400*time.Millisecond)
 }
 
-// TestAllAgainstInProcessCacheServer runs all test scenarios against a cache server that runs with a kcp server
-func TestAllAgainstInProcessCacheServer(t *testing.T) {
+// TestAllReplicationScenariosAgainstInProcessCacheServer runs all test scenarios against a cache server that runs with a kcp server
+func TestAllReplicationScenariosAgainstInProcessCacheServer(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
@@ -296,8 +296,8 @@ func TestAllAgainstInProcessCacheServer(t *testing.T) {
 	}
 }
 
-// TestAllScenariosAgainstStandaloneCacheServer runs all test scenarios against a standalone cache server
-func TestAllScenariosAgainstStandaloneCacheServer(t *testing.T) {
+// TestAllReplicationScenariosAgainstStandaloneCacheServer runs all test scenarios against a standalone cache server
+func TestAllReplicationScenariosAgainstStandaloneCacheServer(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The new test checks if an APIResourceSchema is propagated to the cache server.
The test exercises a creation, modification and removal of the APIExport object.

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
