### PR TITLE
:bug: fix CLI tree not showing bottom leafs

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -804,19 +804,19 @@ func (o *TreeOptions) Run(ctx context.Context) error {
 }
 
 func (o *TreeOptions) populateBranch(ctx context.Context, tree treeprint.Tree, name logicalcluster.Name) error {
+	var b treeprint.Tree
+	if o.Full {
+		b = tree.AddBranch(name.String())
+	} else {
+		b = tree.AddBranch(name.Base())
+	}
+
 	results, err := o.kcpClusterClient.Cluster(name).TenancyV1beta1().Workspaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
 		return err
-	}
-
-	var b treeprint.Tree
-	if o.Full {
-		b = tree.AddBranch(name.String())
-	} else {
-		b = tree.AddBranch(name.Base())
 	}
 
 	for _, workspace := range results.Items {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Tree skips bottom if List returns notFound. Separate bug raised why it returns NotFound with custom Workspace type.
I understand this is not the fix, but more of patch. Root cause if 404 itself.

````
[mjudeikis@unknown kcp]$ go run ./cmd/kubectl-workspace/ tree
(interface {}) <nil>
(interface {}) <nil>
(interface {}) <nil>
(interface {}) <nil>
(*errors.StatusError)(0xc0008ca780)(the server could not find the requested resource (get clusterworkspaces.tenancy.kcp.dev))
(*errors.StatusError)(0xc0008cac80)(the server could not find the requested resource (get clusterworkspaces.tenancy.kcp.dev))
(interface {}) <nil>
(interface {}) <nil>
(interface {}) <nil>
(interface {}) <nil>
.
└── root
    ├── compute
    ├── faros
    │   └── default
    ├── faros-system
    │   ├── controllers
    │   └── tenants
    └── users
````
with fix:
````
[mjudeikis@unknown kcp]$ go run ./cmd/kubectl-workspace/ tree
.
└── root
    ├── compute
    ├── faros
    │   └── default
    │       ├── bob
    │       └── bob1
    ├── faros-system
    │   ├── controllers
    │   └── tenants
    └── users
````

## Related issue(s)

Fixes #
