### PR TITLE
:bug: Fix url double decoration

### DIFF
--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -282,7 +282,11 @@ func decorateWildcardPathsWithResourceIdentities(urlPath string, ids *identities
 		if len(id) == 0 {
 			return "", fmt.Errorf("identity for %s is unknown", gr)
 		}
-		comps[5] += ":" + id
+
+		// Check if identity already exists in the URL path before appending it.
+		if !strings.Contains(comps[5], ":") {
+			comps[5] += ":" + id
+		}
 
 		return "/" + path.Join(comps...), nil
 	}

--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -277,16 +277,17 @@ func decorateWildcardPathsWithResourceIdentities(urlPath string, ids *identities
 		return urlPath, nil
 	}
 
+	if strings.Contains(comps[5], ":") {
+		return urlPath, nil
+	}
+
 	gr := schema.GroupResource{Group: comps[3], Resource: comps[5]}
 	if id, found := ids.grIdentity(gr); found {
 		if len(id) == 0 {
 			return "", fmt.Errorf("identity for %s is unknown", gr)
 		}
 
-		// Check if identity already exists in the URL path before appending it.
-		if !strings.Contains(comps[5], ":") {
-			comps[5] += ":" + id
-		}
+		comps[5] += ":" + id
 
 		return "/" + path.Join(comps...), nil
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes Double URL decoration. 
If you think fix should be somewhere else, let me know.

## Related issue(s)

Fixes #2184
