### PR TITLE
🌱 Register workspace authz metrics

### DIFF
--- a/pkg/virtual/workspaces/builder/build.go
+++ b/pkg/virtual/workspaces/builder/build.go
@@ -49,11 +49,14 @@ import (
 	rbacwrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/rbac"
 	tenancywrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/tenancy"
 	workspaceauth "github.com/kcp-dev/kcp/pkg/virtual/workspaces/authorization"
+	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/authorization/metrics"
 	workspacecache "github.com/kcp-dev/kcp/pkg/virtual/workspaces/cache"
 	"github.com/kcp-dev/kcp/pkg/virtual/workspaces/registry"
 )
 
 func BuildVirtualWorkspace(cfg *clientrest.Config, rootPathPrefix string, wildcardsClusterWorkspaces tenancyinformers.ClusterWorkspaceInformer, wildcardsRbacInformers rbacinformers.Interface, kubeClusterClient kubernetesclient.ClusterInterface, kcpClusterClient kcpclient.ClusterInterface) framework.VirtualWorkspace {
+	metrics.Register()
+
 	crbInformer := wildcardsRbacInformers.ClusterRoleBindings()
 
 	if !strings.HasSuffix(rootPathPrefix, "/") {


### PR DESCRIPTION
## Summary

We added some metrics in #2246 but forgot to register them.

With this PR, we now see:
```
$ k --user shard-admin get --raw /metrics|grep workspace_authorizer
# HELP workspace_authorizer_caches [ALPHA] Number of caches
# TYPE workspace_authorizer_caches counter
workspace_authorizer_caches{type="org"} 1
workspace_authorizer_caches{type="root"} 1
# HELP workspace_authorizer_invalidations [ALPHA] Number of cache invalidations
# TYPE workspace_authorizer_invalidations counter
workspace_authorizer_invalidations{type="org"} 3
workspace_authorizer_invalidations{type="root"} 3
# HELP workspace_authorizer_sync_duration_seconds [ALPHA] Cache sync latency in seconds.
# TYPE workspace_authorizer_sync_duration_seconds histogram
workspace_authorizer_sync_duration_seconds_bucket{result="skip",type="org",le="0.0001"} 55
.....
```

## Related issue(s)

Fixes #
