### PR TITLE
:bug: permissionclaim_labeler: use accepted claims in spec to drive labels

### DIFF
--- a/pkg/permissionclaim/permissionclaim_labeler.go
+++ b/pkg/permissionclaim/permissionclaim_labeler.go
@@ -77,12 +77,12 @@ func (l *Labeler) LabelsFor(ctx context.Context, cluster logicalcluster.Name, gr
 		}
 		boundAPIExportWorkspace := binding.Spec.Reference.Workspace
 
-		for _, claim := range binding.Status.ExportPermissionClaims {
-			if claim.Group != groupResource.Group || claim.Resource != groupResource.Resource {
+		for _, claim := range binding.Spec.PermissionClaims {
+			if claim.State != apisv1alpha1.ClaimAccepted || claim.Group != groupResource.Group || claim.Resource != groupResource.Resource {
 				continue
 			}
 
-			k, v, err := permissionclaims.ToLabelKeyAndValue(logicalcluster.New(boundAPIExportWorkspace.Path), boundAPIExportWorkspace.ExportName, claim)
+			k, v, err := permissionclaims.ToLabelKeyAndValue(logicalcluster.New(boundAPIExportWorkspace.Path), boundAPIExportWorkspace.ExportName, claim.PermissionClaim)
 			if err != nil {
 				// extremely unlikely to get an error here - it means the json marshaling failed
 				logger.Error(err, "error calculating permission claim label key and value",

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
@@ -87,7 +87,7 @@ func (c *controller) reconcile(ctx context.Context, apiBinding *apisv1alpha1.API
 	needToRemove := appliedClaims.Difference(acceptedClaims)
 	allChanges := needToApply.Union(needToRemove)
 
-	logger.V(6).Info("claim set details",
+	logger.V(4).Info("claim set details",
 		"expected", expectedClaims,
 		"unexpected", unexpectedClaims,
 		"toApply", needToApply,


### PR DESCRIPTION
permissionclaim_labeler: use accepted claims in spec to drive labels

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

reconciler/permissionclaim: bump log level higher

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @ncdc 