### PR TITLE
🌱 cache: add e2e scenarios for testing behaviour of the cache server

### DIFF
--- a/test/e2e/cache/cache_server_test.go
+++ b/test/e2e/cache/cache_server_test.go
@@ -110,7 +110,7 @@ func testSchemaIsNotEnforced(ctx context.Context, t *testing.T, cacheClientRT *r
 		}
 	}
 
-	t.Logf("Create abmer/%s/earth on the cache server without type information", cluster)
+	t.Logf("Create abmer|%s/earth (shard|cluster/name) on the cache server without type information", cluster)
 	earthRaw, err := toUnstructured(&earth)
 	require.NoError(t, err)
 	_, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, earthRaw, metav1.CreateOptions{})
@@ -129,7 +129,7 @@ func testSchemaIsNotEnforced(ctx context.Context, t *testing.T, cacheClientRT *r
 	}
 
 	earth.Name = "earth"
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, earth.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, earth.Name)
 	earthRaw, err = toUnstructured(&earth)
 	require.NoError(t, err)
 	cachedEarthRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, earthRaw, metav1.CreateOptions{})
@@ -137,7 +137,7 @@ func testSchemaIsNotEnforced(ctx context.Context, t *testing.T, cacheClientRT *r
 	validateFn(earth, cachedEarthRaw)
 
 	// do additional sanity check with GET
-	t.Logf("Get abmer/%s/%s from the cache server", cluster, earth.Name)
+	t.Logf("Get abmer|%s/%s (shard|cluster/name) from the cache server", cluster, earth.Name)
 	cachedEarthRaw, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Get(ctx, earth.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	validateFn(earth, cachedEarthRaw)
@@ -155,14 +155,14 @@ func testShardClusterNamesAssigned(ctx context.Context, t *testing.T, cacheClien
 		cachedComicDB := &fakeAPIExport{}
 		require.NoError(t, json.Unmarshal(cachedComicDBJson, cachedComicDB))
 		if cachedComicDB.Annotations["kcp.dev/shard"] != "amber" {
-			t.Fatalf("unexpected shard name %v assigned to cached amber/%s/%s, expected %s", cachedComicDB.Annotations["kcp.dev/shard"], cluster, cachedComicDB.Name, "amber")
+			t.Fatalf("unexpected shard name %v assigned to cached amber|%s/%s (shard|cluster/name) , expected %s", cachedComicDB.Annotations["kcp.dev/shard"], cluster, cachedComicDB.Name, "amber")
 		}
 		if cachedComicDB.Annotations["kcp.dev/cluster"] != cluster.String() {
-			t.Fatalf("unexpected cluster name %v assigned to cached amber/%s/%s, expected %s", cachedComicDB.Annotations["kcp.dev/cluster"], cluster, cachedComicDB.Name, cluster.String())
+			t.Fatalf("unexpected cluster name %v assigned to cached amber|%s/%s (shard|cluster/name), expected %s", cachedComicDB.Annotations["kcp.dev/cluster"], cluster, cachedComicDB.Name, cluster.String())
 		}
 	}
 
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialComicDB.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, initialComicDB.Name)
 	comicDBRaw, err := toUnstructured(&initialComicDB)
 	require.NoError(t, err)
 	cachedComicDBRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, comicDBRaw, metav1.CreateOptions{})
@@ -170,7 +170,7 @@ func testShardClusterNamesAssigned(ctx context.Context, t *testing.T, cacheClien
 	validateFn(cachedComicDBRaw)
 
 	// do additional sanity check with GET
-	t.Logf("Get abmer/%s/%s from the cache server", cluster, initialComicDB.Name)
+	t.Logf("Get abmer|%s/%s (shard|cluster/name) from the cache server", cluster, initialComicDB.Name)
 	cachedComicDBRaw, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Get(ctx, initialComicDB.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	validateFn(cachedComicDBRaw)
@@ -198,7 +198,7 @@ func testUIDGenerationCreationTime(ctx context.Context, t *testing.T, cacheClien
 		}
 	}
 
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialMangoDB.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, initialMangoDB.Name)
 	mangoDBRaw, err := toUnstructured(&initialMangoDB)
 	require.NoError(t, err)
 	cachedMangoDBRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, mangoDBRaw, metav1.CreateOptions{})
@@ -206,7 +206,7 @@ func testUIDGenerationCreationTime(ctx context.Context, t *testing.T, cacheClien
 	validateFn(initialMangoDB, cachedMangoDBRaw)
 
 	// do additional sanity check with GET
-	t.Logf("Get abmer/%s/%s from the cache server", cluster, initialMangoDB.Name)
+	t.Logf("Get abmer|%s/%s (shard|cluster/name) from the cache server", cluster, initialMangoDB.Name)
 	cachedMangoDBRaw, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Get(ctx, initialMangoDB.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	validateFn(initialMangoDB, cachedMangoDBRaw)
@@ -229,13 +229,13 @@ func testUIDGenerationCreationTimeNegative(ctx context.Context, t *testing.T, ca
 		require.NoError(t, json.Unmarshal(cachedMangoDBJson, cachedMangoDB))
 
 		if cachedMangoDB.UID == mangoDB.UID {
-			t.Fatalf("unexpected UID %v set on amber/%s/%s, an UID should be assinged by the server", cachedMangoDB.UID, cluster, mangoDB.Name)
+			t.Fatalf("unexpected UID %v set on amber|%s/%s (shard|cluster/name), an UID should be assinged by the server", cachedMangoDB.UID, cluster, mangoDB.Name)
 		}
 		if cachedMangoDB.Generation == mangoDB.Generation {
-			t.Fatalf("unexpected Generation %v set on amber/%s/%s, a Generation should be assinged by the server", cachedMangoDB.Generation, cluster, mangoDB.Name)
+			t.Fatalf("unexpected Generation %v set on amber|%s/%s (shard|cluster/name), a Generation should be assinged by the server", cachedMangoDB.Generation, cluster, mangoDB.Name)
 		}
 		if cachedMangoDB.CreationTimestamp == mangoDB.CreationTimestamp {
-			t.Fatalf("unexpected CreationTimestamp %v set on amber/%s/%s, a CreationTimestamp should be assinged by the server", cachedMangoDB.CreationTimestamp, cluster, mangoDB.Name)
+			t.Fatalf("unexpected CreationTimestamp %v set on amber|%s/%s (shard|cluster/name), a CreationTimestamp should be assinged by the server", cachedMangoDB.CreationTimestamp, cluster, mangoDB.Name)
 		}
 
 		mangoDB.UID = cachedMangoDB.UID
@@ -249,13 +249,13 @@ func testUIDGenerationCreationTimeNegative(ctx context.Context, t *testing.T, ca
 		}
 	}
 
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialMangoDB.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, initialMangoDB.Name)
 	cachedMangoDBRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, mangoDBRaw, metav1.CreateOptions{})
 	require.NoError(t, err)
 	validateFn(initialMangoDB, cachedMangoDBRaw)
 
 	// do additional sanity check with GET
-	t.Logf("Get abmer/%s/%s from the cache server", cluster, initialMangoDB.Name)
+	t.Logf("Get abmer|%s/%s (shard|cluster/name) from the cache server", cluster, initialMangoDB.Name)
 	cachedMangoDBRaw, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Get(ctx, initialMangoDB.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	validateFn(initialMangoDB, cachedMangoDBRaw)
@@ -267,7 +267,7 @@ func testGenerationOnSpecChanges(ctx context.Context, t *testing.T, cacheClientR
 	require.NoError(t, err)
 	initialCinnamonDB := newFakeAPIExport("cinnamondb")
 
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialCinnamonDB.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, initialCinnamonDB.Name)
 	cinnamonDBRaw, err := toUnstructured(&initialCinnamonDB)
 	require.NoError(t, err)
 	cachedCinnamonDBRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, cinnamonDBRaw, metav1.CreateOptions{})
@@ -277,7 +277,7 @@ func testGenerationOnSpecChanges(ctx context.Context, t *testing.T, cacheClientR
 	cachedCinnamonDB := &fakeAPIExport{}
 	require.NoError(t, json.Unmarshal(cachedCinnamonDBJson, cachedCinnamonDB))
 
-	t.Logf("Update amber/%s/%s on the cache server", cluster, initialCinnamonDB.Name)
+	t.Logf("Update amber|%s/%s (shard|cluster/name) on the cache server", cluster, initialCinnamonDB.Name)
 	generationBeforeUpdate := cachedCinnamonDB.Generation
 	cachedCinnamonDB.Spec.Size = 5
 	cachedCinnamonDBRaw, err = toUnstructured(cachedCinnamonDB)
@@ -289,11 +289,11 @@ func testGenerationOnSpecChanges(ctx context.Context, t *testing.T, cacheClientR
 	cachedCinnamonDB = &fakeAPIExport{}
 	require.NoError(t, json.Unmarshal(cachedCinnamonDBJson, cachedCinnamonDB))
 	if cachedCinnamonDB.Generation != generationBeforeUpdate {
-		t.Fatalf("generation musn't be updated after a spec update, generationBeforeUpdate %v, generateAfterUpdate %v, object amber/%s/%s", generationBeforeUpdate, cachedCinnamonDB.Generation, cluster, initialCinnamonDB.Name)
+		t.Fatalf("generation musn't be updated after a spec update, generationBeforeUpdate %v, generateAfterUpdate %v, object amber|%s/%s (shard|cluster/name)", generationBeforeUpdate, cachedCinnamonDB.Generation, cluster, initialCinnamonDB.Name)
 	}
 
 	// do additional sanity check with GET
-	t.Logf("Get abmer/%s/%s from the cache server", cluster, initialCinnamonDB.Name)
+	t.Logf("Get abmer|%s/%s (shard|cluster/name) from the cache server", cluster, initialCinnamonDB.Name)
 	cachedCinnamonDBRaw, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Get(ctx, initialCinnamonDB.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	cachedCinnamonDBJson, err = cachedCinnamonDBRaw.MarshalJSON()
@@ -301,7 +301,7 @@ func testGenerationOnSpecChanges(ctx context.Context, t *testing.T, cacheClientR
 	cachedCinnamonDB = &fakeAPIExport{}
 	require.NoError(t, json.Unmarshal(cachedCinnamonDBJson, cachedCinnamonDB))
 	if cachedCinnamonDB.Generation != generationBeforeUpdate {
-		t.Fatalf("generation musn't be updated after a spec update, generationBeforeUpdate %v, currentGeneration %v, object amber/%s/%s", generationBeforeUpdate, cachedCinnamonDB.Generation, cluster, initialCinnamonDB.Name)
+		t.Fatalf("generation musn't be updated after a spec update, generationBeforeUpdate %v, currentGeneration %v, object amber|%s/%s (shard|cluster/name)", generationBeforeUpdate, cachedCinnamonDB.Generation, cluster, initialCinnamonDB.Name)
 	}
 }
 
@@ -312,13 +312,13 @@ func testDeletionWithFinalizers(ctx context.Context, t *testing.T, cacheClientRT
 	initialGhostDB := newFakeAPIExport("ghostdb")
 	initialGhostDB.Finalizers = append(initialGhostDB.Finalizers, "doNotRemove")
 
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialGhostDB.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, initialGhostDB.Name)
 	ghostDBRaw, err := toUnstructured(&initialGhostDB)
 	require.NoError(t, err)
 	_, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, ghostDBRaw, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	t.Logf("Remove amber/%s/%s from the cache server", cluster, initialGhostDB.Name)
+	t.Logf("Remove amber|%s/%s (shard|cluster/name) from the cache server", cluster, initialGhostDB.Name)
 	err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Delete(ctx, initialGhostDB.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 
@@ -335,7 +335,7 @@ func testSpecStatusSimultaneously(ctx context.Context, t *testing.T, cacheClient
 	require.NoError(t, err)
 	initialCucumberDB := newFakeAPIExport("cucumberdb")
 
-	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialCucumberDB.Name)
+	t.Logf("Create abmer|%s/%s (shard|cluster/name) on the cache server", cluster, initialCucumberDB.Name)
 	cucumberDBRaw, err := toUnstructured(&initialCucumberDB)
 	require.NoError(t, err)
 	cachedCucumberDBRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, cucumberDBRaw, metav1.CreateOptions{})
@@ -345,7 +345,7 @@ func testSpecStatusSimultaneously(ctx context.Context, t *testing.T, cacheClient
 	cachedCucumberDB := &fakeAPIExport{}
 	require.NoError(t, json.Unmarshal(cachedCucumberDBJson, cachedCucumberDB))
 
-	t.Logf("Update amber/%s/%s on the cache server", cluster, initialCucumberDB.Name)
+	t.Logf("Update amber|%s/%s (shard|cluster/name) on the cache server", cluster, initialCucumberDB.Name)
 	cachedCucumberDB.Status.Condition = "run out"
 	cachedCucumberDB.Spec.Size = 1111
 	cachedCucumberDBRaw, err = toUnstructured(cachedCucumberDB)
@@ -357,10 +357,10 @@ func testSpecStatusSimultaneously(ctx context.Context, t *testing.T, cacheClient
 	cachedCucumberDB = &fakeAPIExport{}
 	require.NoError(t, json.Unmarshal(cachedCucumberDBJson, cachedCucumberDB))
 	if cachedCucumberDB.Spec.Size != 1111 {
-		t.Fatalf("unexpected spec.size %v after an update of amber/%s/%s, epxected %v", cachedCucumberDB.Spec.Size, cluster, initialCucumberDB.Name, 1111)
+		t.Fatalf("unexpected spec.size %v after an update of amber|%s/%s (shard|cluster/name), epxected %v", cachedCucumberDB.Spec.Size, cluster, initialCucumberDB.Name, 1111)
 	}
 	if cachedCucumberDB.Status.Condition != "run out" {
-		t.Fatalf("unexpected status.condition %v after an update of amber/%s/%s, epxected %v", cachedCucumberDB.Status.Condition, cluster, initialCucumberDB.Name, "run out")
+		t.Fatalf("unexpected status.condition %v after an update of amber|%s/%s (shard|cluster/name), epxected %v", cachedCucumberDB.Status.Condition, cluster, initialCucumberDB.Name, "run out")
 	}
 
 }

--- a/test/e2e/cache/cache_server_test.go
+++ b/test/e2e/cache/cache_server_test.go
@@ -41,37 +41,6 @@ import (
 	cache2e "github.com/kcp-dev/kcp/test/e2e/reconciler/cache"
 )
 
-type testScenario struct {
-	name string
-	work func(ctx context.Context, t *testing.T, cacheClientRT *rest.Config, cluster logicalcluster.Name, gvr schema.GroupVersionResource)
-}
-
-// scenarios holds all test scenarios
-var scenarios = []testScenario{
-	{"TestSchemaIsNotEnforced", testSchemaIsNotEnforced},
-	{"TestShardClusterNamesAssigned", testShardClusterNamesAssigned},
-	{"TestUIDGenerationCreationTimeOverwrite", testUIDGenerationCreationTime},
-	{"TestUIDGenerationCreationTimeNegativeOverwriteNegative", testUIDGenerationCreationTimeNegative},
-	{"TestGenerationOnSpecChanges", testGenerationOnSpecChanges},
-	{"TestDeletionWithFinalizers", testDeletionWithFinalizers},
-	{"TestUpdatingSpecStatusSimultaneously", testSpecStatusSimultaneously},
-}
-
-type fakeAPIExport struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              spec   `json:"spec,omitempty"`
-	Status            status `json:"status,omitempty"`
-}
-
-type spec struct {
-	Size int `json:"size,omitempty"`
-}
-
-type status struct {
-	Condition string `json:"condition,omitempty"`
-}
-
 // testSchemaIsNotEnforced checks if an object of any schema can be stored as "apis.kcp.dev.v1alpha1.apiexports"
 func testSchemaIsNotEnforced(ctx context.Context, t *testing.T, cacheClientRT *rest.Config, cluster logicalcluster.Name, gvr schema.GroupVersionResource) {
 	cacheDynamicClient, err := dynamic.NewClusterForConfig(cacheClientRT)
@@ -368,6 +337,21 @@ func newFakeAPIExport(name string) fakeAPIExport {
 	}
 }
 
+type fakeAPIExport struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              spec   `json:"spec,omitempty"`
+	Status            status `json:"status,omitempty"`
+}
+
+type spec struct {
+	Size int `json:"size,omitempty"`
+}
+
+type status struct {
+	Condition string `json:"condition,omitempty"`
+}
+
 func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	unstructured := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
@@ -400,4 +384,20 @@ func TestCacheServerAllScenarios(t *testing.T) {
 			scenario.work(ctx, tt, cacheClientRT, logicalcluster.New("acme"), schema.GroupVersionResource{Group: "apis.kcp.dev", Version: "v1alpha1", Resource: "apiexports"})
 		})
 	}
+}
+
+type testScenario struct {
+	name string
+	work func(ctx context.Context, t *testing.T, cacheClientRT *rest.Config, cluster logicalcluster.Name, gvr schema.GroupVersionResource)
+}
+
+// scenarios holds all test scenarios
+var scenarios = []testScenario{
+	{"TestSchemaIsNotEnforced", testSchemaIsNotEnforced},
+	{"TestShardClusterNamesAssigned", testShardClusterNamesAssigned},
+	{"TestUIDGenerationCreationTimeOverwrite", testUIDGenerationCreationTime},
+	{"TestUIDGenerationCreationTimeNegativeOverwriteNegative", testUIDGenerationCreationTimeNegative},
+	{"TestGenerationOnSpecChanges", testGenerationOnSpecChanges},
+	{"TestDeletionWithFinalizers", testDeletionWithFinalizers},
+	{"TestUpdatingSpecStatusSimultaneously", testSpecStatusSimultaneously},
 }

--- a/test/e2e/cache/cache_server_test.go
+++ b/test/e2e/cache/cache_server_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
-	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -105,8 +104,8 @@ func testSchemaIsNotEnforced(ctx context.Context, t *testing.T, cacheClientRT *r
 		earth.CreationTimestamp = cachedEarth.CreationTimestamp
 		earth.ResourceVersion = cachedEarth.ResourceVersion
 		earth.Annotations = cachedEarth.Annotations
-		if !reflect.DeepEqual(cachedEarth, &earth) {
-			t.Errorf("received object from the cache server differs from the expected one :\n%s", cmp.Diff(cachedEarth, &earth))
+		if !cmp.Equal(cachedEarth, &earth) {
+			t.Fatalf("received object from the cache server differs from the expected one:\n%s", cmp.Diff(cachedEarth, &earth))
 		}
 	}
 
@@ -160,8 +159,8 @@ func testUIDGenerationCreationTime(ctx context.Context, t *testing.T, cacheClien
 
 		mangoDB.ResourceVersion = cachedMangoDB.ResourceVersion
 		mangoDB.Annotations["kcp.dev/cluster"] = cluster.String()
-		if !reflect.DeepEqual(cachedMangoDB, &mangoDB) {
-			t.Errorf("received object from the cache server differs from the expected one :\n%s", cmp.Diff(cachedMangoDB, &mangoDB))
+		if !cmp.Equal(cachedMangoDB, &mangoDB) {
+			t.Fatalf("received object from the cache server differs from the expected one:\n%s", cmp.Diff(cachedMangoDB, &mangoDB))
 		}
 	}
 
@@ -211,8 +210,8 @@ func testUIDGenerationCreationTimeNegative(ctx context.Context, t *testing.T, ca
 		mangoDB.CreationTimestamp = cachedMangoDB.CreationTimestamp
 		mangoDB.Annotations["kcp.dev/cluster"] = cluster.String()
 		mangoDB.Annotations["kcp.dev/shard"] = "amber"
-		if !reflect.DeepEqual(cachedMangoDB, &mangoDB) {
-			t.Errorf("received object from the cache server differs from the expected one :\n%s", cmp.Diff(cachedMangoDB, &mangoDB))
+		if !cmp.Equal(cachedMangoDB, &mangoDB) {
+			t.Fatalf("received object from the cache server differs from the expected one:\n%s", cmp.Diff(cachedMangoDB, &mangoDB))
 		}
 	}
 

--- a/test/e2e/cache/cache_server_test.go
+++ b/test/e2e/cache/cache_server_test.go
@@ -384,6 +384,9 @@ func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 }
 
 func TestCacheServerAllScenarios(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
 	_, dataDir, err := framework.ScratchDirs(t)
 	require.NoError(t, err)
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/test/e2e/cache/cache_server_test.go
+++ b/test/e2e/cache/cache_server_test.go
@@ -380,8 +380,10 @@ func TestCacheServerAllScenarios(t *testing.T) {
 
 	cacheClientRT := cache2e.CacheClientRoundTrippersFor(cacheClientRestConfig)
 	for _, scenario := range scenarios {
-		t.Run(scenario.name, func(tt *testing.T) {
-			scenario.work(ctx, tt, cacheClientRT, logicalcluster.New("acme"), schema.GroupVersionResource{Group: "apis.kcp.dev", Version: "v1alpha1", Resource: "apiexports"})
+		scenario := scenario
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			scenario.work(ctx, t, cacheClientRT, logicalcluster.New("acme"), schema.GroupVersionResource{Group: "apis.kcp.dev", Version: "v1alpha1", Resource: "apiexports"})
 		})
 	}
 }

--- a/test/e2e/cache/cache_server_test.go
+++ b/test/e2e/cache/cache_server_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apimachineryerrors "k8s.io/apimachinery/pkg/util/errors"
+	genericrequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	cacheclient "github.com/kcp-dev/kcp/pkg/cache/client"
+	cacheserver "github.com/kcp-dev/kcp/pkg/cache/server"
+	cacheopitons "github.com/kcp-dev/kcp/pkg/cache/server/options"
+	"github.com/kcp-dev/kcp/pkg/embeddedetcd"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+type testScenario struct {
+	name string
+	work func(ctx context.Context, t *testing.T, cacheClientRT *rest.Config, cluster logicalcluster.Name, gvr schema.GroupVersionResource)
+}
+
+// scenarios holds all test scenarios
+var scenarios = []testScenario{
+	{"TestUIDGenerationCreationTimeOverwrite", testUIDGenerationCreationTime},
+	{"TestUIDGenerationCreationTimeNegativeOverwriteNegative", testUIDGenerationCreationTimeNegative},
+	// TODO: changing spec doesn't increase the Generation of a replicated object
+	// TODO: deleting an object with finalizers immediately removes the obj
+	// TODO: a shard name is assigned to a replicated obj
+	// TODO: schema is not enforced
+	// TODO: spec and status can be updated at the same time
+}
+
+type fakeAPIExport struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              spec   `json:"spec,omitempty"`
+	Status            status `json:"status,omitempty"`
+}
+
+type spec struct {
+	Size int `json:"size,omitempty"`
+}
+
+type status struct {
+	Condition string `json:"condition,omitempty"`
+}
+
+// testUIDGenerationCreationTime checks if overwriting UID, Generation, CreationTime when the shard annotation is set works
+func testUIDGenerationCreationTime(ctx context.Context, t *testing.T, cacheClientRT *rest.Config, cluster logicalcluster.Name, gvr schema.GroupVersionResource) {
+	cacheDynamicClient, err := dynamic.NewClusterForConfig(cacheClientRT)
+	require.NoError(t, err)
+	initialMangoDB := newFakeAPIExport("mangodb")
+	initialMangoDB.UID = "3"
+	initialMangoDB.Generation = 11
+	initialMangoDB.CreationTimestamp = metav1.Now().Rfc3339Copy()
+	initialMangoDB.Annotations = map[string]string{genericrequest.AnnotationKey: "amber"}
+	validateFn := func(mangoDB fakeAPIExport, cachedMangoDBRaw *unstructured.Unstructured) {
+		cachedMangoDBJson, err := cachedMangoDBRaw.MarshalJSON()
+		require.NoError(t, err)
+		cachedMangoDB := &fakeAPIExport{}
+		require.NoError(t, json.Unmarshal(cachedMangoDBJson, cachedMangoDB))
+
+		mangoDB.ResourceVersion = cachedMangoDB.ResourceVersion
+		mangoDB.Annotations["kcp.dev/cluster"] = cluster.String()
+		if !reflect.DeepEqual(cachedMangoDB, &mangoDB) {
+			t.Errorf("received object from the cache server differs from the expected one :\n%s", cmp.Diff(cachedMangoDB, &mangoDB))
+		}
+	}
+
+	t.Logf("Create abmer/%s/%s on the cache server", cluster, initialMangoDB.Name)
+	mangoDBRaw, err := toUnstructured(&initialMangoDB)
+	require.NoError(t, err)
+	cachedMangoDBRaw, err := cacheDynamicClient.Cluster(cluster).Resource(gvr).Create(ctx, mangoDBRaw, metav1.CreateOptions{})
+	require.NoError(t, err)
+	validateFn(initialMangoDB, cachedMangoDBRaw)
+
+	// do additional sanity check with GET
+	t.Logf("Get abmer/%s/%s from the cache server", cluster, initialMangoDB.Name)
+	cachedMangoDBRaw, err = cacheDynamicClient.Cluster(cluster).Resource(gvr).Get(ctx, initialMangoDB.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	validateFn(initialMangoDB, cachedMangoDBRaw)
+}
+
+func newFakeAPIExport(name string) fakeAPIExport {
+	return fakeAPIExport{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apis.kcp.dev/v1alpha1",
+			Kind:       "APIExport",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: map[string]string{},
+		},
+	}
+}
+
+func toUnstructured(obj *fakeAPIExport) (*unstructured.Unstructured, error) {
+	unstructured := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	unstructured.Object = raw
+	return unstructured, nil
+}
+
+// TODO: refactor with TestAllScenariosAgainstStandaloneCacheServer
+func TestAllScenarios(t *testing.T) {
+	_, dataDir, err := framework.ScratchDirs(t)
+	require.NoError(t, err)
+
+	cacheServerPortStr, err := framework.GetFreePort(t)
+	require.NoError(t, err)
+	cacheServerPort, err := strconv.Atoi(cacheServerPortStr)
+	require.NoError(t, err)
+	cacheServerOptions := cacheopitons.NewOptions(path.Join(dataDir, "cache"))
+	cacheServerOptions.SecureServing.BindPort = cacheServerPort
+	cacheServerEmbeddedEtcdClientPort, err := framework.GetFreePort(t)
+	require.NoError(t, err)
+	cacheServerEmbeddedEtcdPeerPort, err := framework.GetFreePort(t)
+	require.NoError(t, err)
+	cacheServerOptions.EmbeddedEtcd.ClientPort = cacheServerEmbeddedEtcdClientPort
+	cacheServerOptions.EmbeddedEtcd.PeerPort = cacheServerEmbeddedEtcdPeerPort
+	cacheServerCompletedOptions, err := cacheServerOptions.Complete()
+	require.NoError(t, err)
+	if errs := cacheServerCompletedOptions.Validate(); len(errs) > 0 {
+		require.NoError(t, apimachineryerrors.NewAggregate(errs))
+	}
+	cacheServerConfig, err := cacheserver.NewConfig(cacheServerCompletedOptions, nil)
+	require.NoError(t, err)
+	cacheServerCompletedConfig, err := cacheServerConfig.Complete()
+	require.NoError(t, err)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+	if cacheServerCompletedConfig.EmbeddedEtcd.Config != nil {
+		t.Logf("Starting embedded etcd for the cache server")
+		require.NoError(t, embeddedetcd.NewServer(cacheServerCompletedConfig.EmbeddedEtcd).Run(ctx))
+	}
+	cacheServer, err := cacheserver.NewServer(cacheServerCompletedConfig)
+	require.NoError(t, err)
+	preparedCachedServer, err := cacheServer.PrepareRun(ctx)
+	require.NoError(t, err)
+	t.Logf("Starting the cache server")
+	go func() {
+		// TODO (p0lyn0mial): check readiness of the cache server
+		require.NoError(t, preparedCachedServer.Run(ctx))
+	}()
+	t.Logf("Creating kubeconfig for the cache server at %s", dataDir)
+	cacheServerKubeConfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cache": {
+				Server:               fmt.Sprintf("https://localhost:%s", cacheServerPortStr),
+				CertificateAuthority: path.Join(dataDir, "cache", "apiserver.crt"),
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"cache": {
+				Cluster: "cache",
+			},
+		},
+		CurrentContext: "cache",
+	}
+
+	cacheClientConfig := clientcmd.NewNonInteractiveClientConfig(cacheServerKubeConfig, "cache", nil, nil)
+	cacheClientRestConfig, err := cacheClientConfig.ClientConfig()
+	require.NoError(t, err)
+	cacheClientRT := cacheClientRoundTrippersFor(cacheClientRestConfig)
+
+	// TODO (p0lyn0mial): check readiness of the cache server
+	time.Sleep(3 * time.Second)
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(tt *testing.T) {
+			scenario.work(ctx, tt, cacheClientRT, logicalcluster.New("acme"), schema.GroupVersionResource{Group: "apis.kcp.dev", Version: "v1alpha1", Resource: "apiexports"})
+		})
+	}
+}
+
+// TODO: refactor with TestAllScenariosAgainstStandaloneCacheServer
+func cacheClientRoundTrippersFor(cfg *rest.Config) *rest.Config {
+	cacheClientRT := cacheclient.WithCacheServiceRoundTripper(rest.CopyConfig(cfg))
+	cacheClientRT = cacheclient.WithShardNameFromContextRoundTripper(cacheClientRT)
+	cacheClientRT = cacheclient.WithDefaultShardRoundTripper(cacheClientRT, "amber")
+	return cacheClientRT
+}

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -274,8 +274,10 @@ func TestCacheServerInProcess(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, scenario := range scenarios {
-		t.Run(scenario.name, func(tt *testing.T) {
-			scenario.work(ctx, tt, server, kcpRootShardClient, cacheKcpClusterClient)
+		scenario := scenario
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			scenario.work(ctx, t, server, kcpRootShardClient, cacheKcpClusterClient)
 		})
 	}
 }
@@ -312,8 +314,10 @@ func TestCacheServerStandalone(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, scenario := range scenarios {
-		t.Run(scenario.name, func(tt *testing.T) {
-			scenario.work(ctx, tt, server, kcpRootShardClient, cacheKcpClusterClient)
+		scenario := scenario
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+			scenario.work(ctx, t, server, kcpRootShardClient, cacheKcpClusterClient)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
adds the following e2e scenarios for testing behaviour of the cache server:

1. `TestSchemaIsNotEnforced` - for making sure an obj with any schema can be created
2. `TestShardClusterNamesAssigned` - for making sure that a shard name and a cluster name are passed in the annotations
3. `TestUIDGenerationCreationTimeOverwrite` - for making sure that `UID, Genaration, CreationTime` can be overwritten 
4. `TestUIDGenerationCreationTimeOverwriteNegative`  - for making sure that `UID, Genaration, CreationTime` are assigned by the server if the shard annotation is not provided
5. `TestGenerationOnSpecChanges` - for making sure that the Generation is not increased after updating the spec
6. `TestDeletionWithFinalizers` - for making sure that an object with some `Finalizers` can be deleted immediately
7. `TestUpdatingSpecStatusSimultaneously` - for making sure that both spec and status can be updated at the same time (single request)

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
