### PR TITLE
:sparkles: *: migrate to use cluster-aware apiextensions-apiserver clients, listers and informers

### DIFF
--- a/cmd/cluster-controller/main.go
+++ b/cmd/cluster-controller/main.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
+	kcpapiextensionsinformers "github.com/kcp-dev/client-go/apiextensions/clients/informers"
 	"github.com/spf13/pflag"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	crdexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -87,7 +87,7 @@ func main() {
 	}
 	clusterConfig := kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(config))
 
-	crdClusterClient, err := apiextensionsclient.NewForConfig(clusterConfig)
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(clusterConfig)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -99,7 +99,7 @@ func main() {
 	}
 
 	kcpSharedInformerFactory := kcpinformers.NewSharedInformerFactoryWithOptions(kcpclient.NewForConfigOrDie(config), resyncPeriod)
-	crdSharedInformerFactory := crdexternalversions.NewSharedInformerFactoryWithOptions(apiextensionsclient.NewForConfigOrDie(config), resyncPeriod)
+	crdSharedInformerFactory := kcpapiextensionsinformers.NewSharedInformerFactoryWithOptions(kcpapiextensionsclientset.NewForConfigOrDie(config), resyncPeriod)
 
 	apiResource, err := apiresource.NewController(
 		crdClusterClient,

--- a/cmd/crd-puller/pull-crds.go
+++ b/cmd/crd-puller/pull-crds.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kcp-code-generator:skip
+
 package main
 
 import (

--- a/config/crds/bootstrap.go
+++ b/config/crds/bootstrap.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kcp-code-generator:skip
+
 package crds
 
 import (

--- a/config/rootcompute/bootstrap.go
+++ b/config/rootcompute/bootstrap.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"embed"
 
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	"github.com/kcp-dev/logicalcluster/v2"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	confighelpers "github.com/kcp-dev/kcp/config/helpers"
@@ -40,7 +40,7 @@ var RootComputeWorkspace = logicalcluster.New("root:compute")
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, apiExtensionClusterClient apiextensionsclient.ClusterInterface, dynamicClusterClient kcpdynamic.ClusterInterface, batteriesIncluded sets.String) error {
+func Bootstrap(ctx context.Context, apiExtensionClusterClient kcpapiextensionsclientset.ClusterInterface, dynamicClusterClient kcpdynamic.ClusterInterface, batteriesIncluded sets.String) error {
 	rootDiscoveryClient := apiExtensionClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery()
 	rootDynamicClient := dynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster)
 	if err := confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, batteriesIncluded, fs); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/kcp-dev/apimachinery v0.0.0-20221019133255-9e1e13940519
-	github.com/kcp-dev/client-go v0.0.0-20221019184858-60e56386a574
+	github.com/kcp-dev/client-go v0.0.0-20221023141420-aa2709fd364f
 	github.com/kcp-dev/kcp/pkg/apis v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster/v2 v2.0.0-alpha.3
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,9 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kcp-dev/apimachinery v0.0.0-20221019133255-9e1e13940519 h1:eU1HvmmP8TbzS2pB9IX2Spky20n6V79/KgX4ssiG/A8=
 github.com/kcp-dev/apimachinery v0.0.0-20221019133255-9e1e13940519/go.mod h1:qnvUHkdxOrNzX17yX+z8r81CZEBuFdveNzWqFlwZ55w=
-github.com/kcp-dev/client-go v0.0.0-20221019184858-60e56386a574 h1:M73BZSrOxfUkSJ58ckwuTebpQDNuX5UG5s16k2Xl4vY=
 github.com/kcp-dev/client-go v0.0.0-20221019184858-60e56386a574/go.mod h1:Qmq1OxUOSdVQ8YIGnjbya5Xt04KMJ5fN41QvErl/XnI=
+github.com/kcp-dev/client-go v0.0.0-20221023141420-aa2709fd364f h1:8fXuqk1fTBIQv0/k6OhrafVWddxEI8w26rHtsBup92I=
+github.com/kcp-dev/client-go v0.0.0-20221023141420-aa2709fd364f/go.mod h1:jo6aMHy7JglKs2YixRXr4DjVzQiqFSA7RPqHQCi3WNo=
 github.com/kcp-dev/kubernetes v0.0.0-20221021135508-401e4f0fc370 h1:J7IgeABi7HDOkF7DHm1RyeV3uKXdMrbdXoLz0JaTfr8=
 github.com/kcp-dev/kubernetes v0.0.0-20221021135508-401e4f0fc370/go.mod h1:2D6mZWHzz+u16P91KvbcSBrR2/6zwdp7mlkF4IH8fXU=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20221021135508-401e4f0fc370 h1:BTwFKxwRKzOr+/SgND/UuVRppcuITp2AYwaZxIQj/hM=

--- a/pkg/admission/kubequota/kubequota_admission.go
+++ b/pkg/admission/kubequota/kubequota_admission.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package kubequota
 
 import (

--- a/pkg/admission/limitranger/admission.go
+++ b/pkg/admission/limitranger/admission.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package limitranger
 
 import (

--- a/pkg/admission/mutatingwebhook/plugin.go
+++ b/pkg/admission/mutatingwebhook/plugin.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package mutatingwebhook
 
 import (

--- a/pkg/admission/namespacelifecycle/admission.go
+++ b/pkg/admission/namespacelifecycle/admission.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package namespacelifecycle
 
 import (

--- a/pkg/admission/validatingwebhook/plugin.go
+++ b/pkg/admission/validatingwebhook/plugin.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package validatingwebhook
 
 import (

--- a/pkg/cache/server/bootstrap/bootstrap.go
+++ b/pkg/cache/server/bootstrap/bootstrap.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"time"
 
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -41,7 +41,7 @@ var SystemCRDLogicalCluster = logicalcluster.New("system:system-crds")
 // SystemCacheServerShard holds a default shard name
 const SystemCacheServerShard = "system:cache:server"
 
-func Bootstrap(ctx context.Context, apiExtensionsClusterClient apiextensionsclient.ClusterInterface) error {
+func Bootstrap(ctx context.Context, apiExtensionsClusterClient kcpapiextensionsclientset.ClusterInterface) error {
 	crds := []*apiextensionsv1.CustomResourceDefinition{}
 	for _, resource := range []string{"apiresourceschemas", "apiexports"} {
 		crd := &apiextensionsv1.CustomResourceDefinition{}

--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -24,13 +24,12 @@ import (
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
-	"github.com/kcp-dev/logicalcluster/v2"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
+	kcpapiextensionsinformers "github.com/kcp-dev/client-go/apiextensions/clients/informers"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	apiextensionsoptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -68,9 +67,9 @@ type completedConfig struct {
 }
 
 type ExtraConfig struct {
-	ApiExtensionsClusterClient apiextensionsclient.ClusterInterface
+	ApiExtensionsClusterClient kcpapiextensionsclientset.ClusterInterface
 
-	ApiExtensionsSharedInformerFactory apiextensionsexternalversions.SharedInformerFactory
+	ApiExtensionsSharedInformerFactory kcpapiextensionsinformers.SharedInformerFactory
 }
 
 type CompletedConfig struct {
@@ -195,13 +194,13 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 	clientutils.EnableMultiCluster(rt, &serverConfig.Config, "namespaces", "apiservices", "customresourcedefinitions", "clusterroles", "clusterrolebindings", "roles", "rolebindings", "serviceaccounts", "secrets")
 
 	var err error
-	c.ApiExtensionsClusterClient, err = apiextensionsclient.NewClusterForConfig(rt)
+	c.ApiExtensionsClusterClient, err = kcpapiextensionsclientset.NewForConfig(rt)
 	if err != nil {
 		return nil, err
 	}
 
-	c.ApiExtensionsSharedInformerFactory = apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
-		c.ApiExtensionsClusterClient.Cluster(logicalcluster.Wildcard),
+	c.ApiExtensionsSharedInformerFactory = kcpapiextensionsinformers.NewSharedInformerFactoryWithOptions(
+		c.ApiExtensionsClusterClient,
 		resyncPeriod,
 	)
 

--- a/pkg/cache/server/crd_lister.go
+++ b/pkg/cache/server/crd_lister.go
@@ -20,21 +20,20 @@ import (
 	"context"
 	"fmt"
 
+	kcpapiextensionsv1listers "github.com/kcp-dev/client-go/apiextensions/clients/listers/apiextensions/v1"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/kcp"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 
 	"github.com/kcp-dev/kcp/pkg/cache/server/bootstrap"
-	"github.com/kcp-dev/kcp/pkg/client"
 )
 
 // crdClusterLister is a CRD lister
 type crdClusterLister struct {
-	lister apiextensionslisters.CustomResourceDefinitionLister
+	lister kcpapiextensionsv1listers.CustomResourceDefinitionClusterLister
 }
 
 func (c *crdClusterLister) Cluster(name logicalcluster.Name) kcp.ClusterAwareCRDLister {
@@ -70,5 +69,5 @@ func (c *crdLister) Refresh(crd *apiextensionsv1.CustomResourceDefinition) (*api
 // Get gets a CustomResourceDefinition
 func (c *crdLister) Get(ctx context.Context, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 	// TODO: make it shard and cluster aware, for now just return what we have in the system ws
-	return c.lister.Get(client.ToClusterAwareKey(c.cluster, name))
+	return c.lister.Cluster(c.cluster).Get(name)
 }

--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package plugin
 
 import (

--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package crdpuller
 
 // We import the generic control plane scheme to provide access to the KCP control plane scheme,

--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kcp-code-generator:skip
+
 package crdpuller
 
 // We import the generic control plane scheme to provide access to the KCP control plane scheme,

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	kcpapiextensionsv1informers "github.com/kcp-dev/client-go/apiextensions/clients/informers/apiextensions/v1"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	kcpdynamicinformer "github.com/kcp-dev/client-go/clients/dynamic/dynamicinformer"
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/clients/informers"
@@ -33,7 +34,6 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -87,7 +87,7 @@ type DynamicDiscoverySharedInformerFactory struct {
 func NewDynamicDiscoverySharedInformerFactory(
 	cfg *rest.Config,
 	filterFunc func(obj interface{}) bool,
-	crdInformer apiextensionsinformers.CustomResourceDefinitionInformer,
+	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
 	indexers cache.Indexers,
 ) (*DynamicDiscoverySharedInformerFactory, error) {
 	cfg = rest.AddUserAgent(rest.CopyConfig(cfg), "kcp-partial-metadata-informers")

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package informer
 
 import (

--- a/pkg/reconciler/apis/apiresource/controller.go
+++ b/pkg/reconciler/apis/apiresource/controller.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
+	kcpapiextensionsv1informers "github.com/kcp-dev/client-go/apiextensions/clients/informers/apiextensions/v1"
+	kcpapiextensionsv1listers "github.com/kcp-dev/client-go/apiextensions/clients/listers/apiextensions/v1"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
-	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -51,12 +51,12 @@ func GetClusterNameAndGVRIndexKey(clusterName logicalcluster.Name, gvr metav1.Gr
 }
 
 func NewController(
-	crdClusterClient apiextensionsclient.Interface,
+	crdClusterClient kcpapiextensionsclientset.ClusterInterface,
 	kcpClusterClient kcpclient.Interface,
 	autoPublishNegotiatedAPIResource bool,
 	negotiatedAPIResourceInformer apiresourceinformer.NegotiatedAPIResourceInformer,
 	apiResourceImportInformer apiresourceinformer.APIResourceImportInformer,
-	crdInformer apiextensionsinformers.CustomResourceDefinitionInformer,
+	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
 ) (*Controller, error) {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "kcp-apiresource")
 
@@ -130,7 +130,7 @@ func NewController(
 type Controller struct {
 	queue workqueue.RateLimitingInterface
 
-	crdClusterClient             apiextensionsclient.Interface
+	crdClusterClient             kcpapiextensionsclientset.ClusterInterface
 	kcpClusterClient             kcpclient.Interface
 	negotiatedApiResourceIndexer cache.Indexer
 	negotiatedApiResourceLister  apiresourcelisters.NegotiatedAPIResourceLister
@@ -139,7 +139,7 @@ type Controller struct {
 	apiResourceImportLister  apiresourcelisters.APIResourceImportLister
 
 	crdIndexer cache.Indexer
-	crdLister  apiextensionslisters.CustomResourceDefinitionLister
+	crdLister  kcpapiextensionsv1listers.CustomResourceDefinitionClusterLister
 
 	AutoPublishNegotiatedAPIResource bool
 }

--- a/pkg/reconciler/apis/apiresource/negotiation.go
+++ b/pkg/reconciler/apis/apiresource/negotiation.go
@@ -707,7 +707,7 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 			cr.ObjectMeta.Annotations["api-approved.kubernetes.io"] = "https://github.com/kcp-dev/kubernetes/pull/4"
 		}
 
-		if _, err := c.crdClusterClient.ApiextensionsV1().CustomResourceDefinitions().Create(logicalcluster.WithCluster(ctx, clusterName), cr, metav1.CreateOptions{}); err != nil {
+		if _, err := c.crdClusterClient.Cluster(clusterName).ApiextensionsV1().CustomResourceDefinitions().Create(ctx, cr, metav1.CreateOptions{}); err != nil {
 			logger.Error(err, "error", "caller", runtime.GetCaller())
 			return err
 		}
@@ -757,7 +757,7 @@ func (c *Controller) publishNegotiatedResource(ctx context.Context, clusterName 
 				NegotiatedAPIResourceAsOwnerReference(negotiatedApiResource))
 		}
 
-		if _, err := c.crdClusterClient.ApiextensionsV1().CustomResourceDefinitions().Update(logicalcluster.WithCluster(ctx, clusterName), crd, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.crdClusterClient.Cluster(clusterName).ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
 			logger.Error(err, "error", "caller", runtime.GetCaller())
 			return err
 		}
@@ -867,7 +867,7 @@ func (c *Controller) cleanupNegotiatedAPIResource(ctx context.Context, clusterNa
 		return nil
 	}
 	if len(cleanedVersions) == 0 {
-		if err := c.crdClusterClient.ApiextensionsV1().CustomResourceDefinitions().Delete(logicalcluster.WithCluster(ctx, clusterName), crd.Name, metav1.DeleteOptions{}); err != nil {
+		if err := c.crdClusterClient.Cluster(clusterName).ApiextensionsV1().CustomResourceDefinitions().Delete(ctx, crd.Name, metav1.DeleteOptions{}); err != nil {
 			logger.Error(err, "error", "caller", runtime.GetCaller())
 			return err
 		}
@@ -875,7 +875,7 @@ func (c *Controller) cleanupNegotiatedAPIResource(ctx context.Context, clusterNa
 		crd = crd.DeepCopy()
 		crd.Spec.Versions = cleanedVersions
 		crd.OwnerReferences = cleanedOwnerReferences
-		if _, err := c.crdClusterClient.ApiextensionsV1().CustomResourceDefinitions().Update(logicalcluster.WithCluster(ctx, clusterName), crd, metav1.UpdateOptions{}); err != nil {
+		if _, err := c.crdClusterClient.Cluster(clusterName).ApiextensionsV1().CustomResourceDefinitions().Update(ctx, crd, metav1.UpdateOptions{}); err != nil {
 			logger.Error(err, "error", "caller", runtime.GetCaller())
 			return err
 		}

--- a/pkg/reconciler/kubequota/kubequota_controller.go
+++ b/pkg/reconciler/kubequota/kubequota_controller.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	kcpapiextensionsv1informers "github.com/kcp-dev/client-go/apiextensions/clients/informers/apiextensions/v1"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/clients/informers"
 	kcpcorev1informers "github.com/kcp-dev/client-go/clients/informers/core/v1"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -90,7 +90,7 @@ func NewController(
 	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
 	kubeInformerFactory kcpkubernetesinformers.SharedInformerFactory,
 	dynamicDiscoverySharedInformerFactory *informer.DynamicDiscoverySharedInformerFactory,
-	crdInformer apiextensionsinformers.CustomResourceDefinitionInformer,
+	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
 	quotaRecalculationPeriod time.Duration,
 	fullResyncPeriod time.Duration,
 	workersPerLogicalCluster int,

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
@@ -24,10 +24,10 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	"github.com/kcp-dev/logicalcluster/v2"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +56,7 @@ const (
 func NewController(
 	baseConfig *rest.Config,
 	dynamicClusterClient kcpdynamic.ClusterInterface,
-	crdClusterClient apiextensionsclient.Interface,
+	crdClusterClient kcpapiextensionsclientset.ClusterInterface,
 	kcpClusterClient kcpclient.Interface,
 	workspaceInformer tenancyinformers.ClusterWorkspaceInformer,
 	workspaceType tenancyv1alpha1.ClusterWorkspaceTypeReference,
@@ -95,7 +95,7 @@ type controller struct {
 	queue          workqueue.RateLimitingInterface
 
 	dynamicClusterClient kcpdynamic.ClusterInterface
-	crdClusterClient     apiextensionsclient.Interface
+	crdClusterClient     kcpapiextensionsclientset.ClusterInterface
 	kcpClusterClient     kcpclient.Interface
 
 	workspaceLister tenancylisters.ClusterWorkspaceLister

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_controller.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package bootstrap
 
 import (

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
@@ -21,9 +21,9 @@ import (
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	"github.com/kcp-dev/logicalcluster/v2"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
@@ -50,7 +50,7 @@ func (c *controller) reconcile(ctx context.Context, workspace *tenancyv1alpha1.C
 	defer cancel()
 
 	clusterWsConfig := kcpclienthelper.SetCluster(rest.CopyConfig(c.baseConfig), wsClusterName)
-	crdWsClient, err := apiextensionsclient.NewForConfig(clusterWsConfig)
+	crdWsClient, err := kcpapiextensionsclientset.NewForConfig(clusterWsConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
+++ b/pkg/reconciler/tenancy/bootstrap/bootstrap_reconcile.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package bootstrap
 
 import (

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -22,11 +22,11 @@ import (
 	_ "net/http/pprof"
 	"strings"
 
+	kcpapiextensionsv1listers "github.com/kcp-dev/client-go/apiextensions/clients/listers/apiextensions/v1"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionshelpers "k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionslisters "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/kcp"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,7 +38,6 @@ import (
 	"k8s.io/klog/v2"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/client"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	apislisters "github.com/kcp-dev/kcp/pkg/client/listers/apis/v1alpha1"
 	tenancylisters "github.com/kcp-dev/kcp/pkg/client/listers/tenancy/v1alpha1"
@@ -53,7 +52,7 @@ var SystemCRDLogicalCluster = logicalcluster.New("system:system-crds")
 
 type apiBindingAwareCRDClusterLister struct {
 	kcpClusterClient     kcpclient.ClusterInterface
-	crdLister            apiextensionslisters.CustomResourceDefinitionLister
+	crdLister            kcpapiextensionsv1listers.CustomResourceDefinitionClusterLister
 	crdIndexer           cache.Indexer
 	workspaceLister      tenancylisters.ClusterWorkspaceLister
 	apiBindingLister     apislisters.APIBindingLister

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -23,14 +23,14 @@ import (
 	_ "net/http/pprof"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
+	kcpapiextensionsinformers "github.com/kcp-dev/client-go/apiextensions/clients/informers"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	kcpkubernetesinformers "github.com/kcp-dev/client-go/clients/informers"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsexternalversions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/endpoints/filters"
@@ -96,11 +96,11 @@ type ExtraConfig struct {
 	DynamicClusterClient                kcpdynamic.ClusterInterface
 	KubeClusterClient                   kcpkubernetesclientset.ClusterInterface
 	DeepSARClient                       kcpkubernetesclientset.ClusterInterface
-	ApiExtensionsClusterClient          apiextensionsclient.ClusterInterface
+	ApiExtensionsClusterClient          kcpapiextensionsclientset.ClusterInterface
 	KcpClusterClient                    kcpclient.ClusterInterface
 	RootShardKcpClusterClient           kcpclient.ClusterInterface
 	BootstrapDynamicClusterClient       kcpdynamic.ClusterInterface
-	BootstrapApiExtensionsClusterClient apiextensionsclient.ClusterInterface
+	BootstrapApiExtensionsClusterClient kcpapiextensionsclientset.ClusterInterface
 	BootstrapKcpClusterClient           kcpclient.ClusterInterface
 	CacheDynamicClient                  kcpdynamic.ClusterInterface
 
@@ -111,7 +111,7 @@ type ExtraConfig struct {
 	// informers
 	KcpSharedInformerFactory              kcpinformers.SharedInformerFactory
 	KubeSharedInformerFactory             kcpkubernetesinformers.SharedInformerFactory
-	ApiExtensionsSharedInformerFactory    apiextensionsexternalversions.SharedInformerFactory
+	ApiExtensionsSharedInformerFactory    kcpapiextensionsinformers.SharedInformerFactory
 	DynamicDiscoverySharedInformerFactory *informer.DynamicDiscoverySharedInformerFactory
 	CacheKcpSharedInformerFactory         kcpinformers.SharedInformerFactory
 	// TODO(p0lyn0mial):  get rid of TemporaryRootShardKcpSharedInformerFactory, in the future
@@ -269,15 +269,13 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	}
 
 	// Setup apiextensions * informers
-	c.ApiExtensionsClusterClient, err = apiextensionsclient.NewClusterForConfig(c.GenericConfig.LoopbackClientConfig)
+	c.ApiExtensionsClusterClient, err = kcpapiextensionsclientset.NewForConfig(c.GenericConfig.LoopbackClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	c.ApiExtensionsSharedInformerFactory = apiextensionsexternalversions.NewSharedInformerFactoryWithOptions(
-		c.ApiExtensionsClusterClient.Cluster(logicalcluster.Wildcard),
+	c.ApiExtensionsSharedInformerFactory = kcpapiextensionsinformers.NewSharedInformerFactoryWithOptions(
+		c.ApiExtensionsClusterClient,
 		resyncPeriod,
-		apiextensionsexternalversions.WithExtraClusterScopedIndexers(indexers.ClusterScoped()),
-		apiextensionsexternalversions.WithExtraNamespaceScopedIndexers(indexers.NamespaceScoped()),
 	)
 
 	// Setup dynamic client
@@ -312,7 +310,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	bootstrapConfig.Impersonate.Groups = []string{bootstrappolicy.SystemKcpWorkspaceBootstrapper}
 	bootstrapConfig = rest.AddUserAgent(bootstrapConfig, "kcp-bootstrapper")
 
-	c.BootstrapApiExtensionsClusterClient, err = apiextensionsclient.NewClusterForConfig(bootstrapConfig)
+	c.BootstrapApiExtensionsClusterClient, err = kcpapiextensionsclientset.NewForConfig(bootstrapConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package server
 
 import (

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -26,13 +26,13 @@ import (
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	kcpmetadata "github.com/kcp-dev/client-go/clients/metadata"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -473,7 +473,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 		return err
 	}
 
-	crdClusterClient, err := apiextensionsclient.NewForConfig(bootstrapConfig)
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(bootstrapConfig)
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func (s *Server) installApiResourceController(ctx context.Context, config *rest.
 	config = rest.CopyConfig(config)
 	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), apiresource.ControllerName)
 
-	crdClusterClient, err := apiextensionsclient.NewForConfig(config)
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(config)
 	if err != nil {
 		return err
 	}
@@ -590,7 +590,7 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		return err
 	}
 
-	crdClusterClient, err := apiextensionsclient.NewForConfig(apiBindingConfig)
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(apiBindingConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/apiimporter.go
+++ b/pkg/syncer/apiimporter.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kcp-code-generator:skip
+
 package syncer
 
 import (

--- a/pkg/syncer/namespace/namespace_downstream_controller.go
+++ b/pkg/syncer/namespace/namespace_downstream_controller.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package namespace
 
 import (

--- a/pkg/syncer/namespace/namespace_downstream_process.go
+++ b/pkg/syncer/namespace/namespace_downstream_process.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package namespace
 
 import (

--- a/pkg/syncer/namespace/namespace_downstream_process_test.go
+++ b/pkg/syncer/namespace/namespace_downstream_process_test.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package namespace
 
 import (

--- a/pkg/syncer/namespace/namespace_upstream_controller.go
+++ b/pkg/syncer/namespace/namespace_upstream_controller.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package namespace
 
 import (

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package spec
 
 import (

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package spec
 
 import (

--- a/pkg/syncer/status/status_controller.go
+++ b/pkg/syncer/status/status_controller.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package status
 
 import (

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package status
 
 import (

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package status
 
 import (

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package syncer
 
 import (

--- a/pkg/virtual/framework/client/dynamic/client.go
+++ b/pkg/virtual/framework/client/dynamic/client.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package dynamic
 
 import (

--- a/pkg/virtual/framework/forwardingregistry/store.go
+++ b/pkg/virtual/framework/forwardingregistry/store.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package forwardingregistry
 
 import (

--- a/pkg/virtual/framework/wrappers/rbac/cluster_filtering.go
+++ b/pkg/virtual/framework/wrappers/rbac/cluster_filtering.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package rbac
 
 import (

--- a/pkg/virtual/framework/wrappers/rbac/merging.go
+++ b/pkg/virtual/framework/wrappers/rbac/merging.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package rbac
 
 import (

--- a/pkg/virtual/workspaces/authorization/cache.go
+++ b/pkg/virtual/workspaces/authorization/cache.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package authorization
 
 import (

--- a/test/e2e/conformance/metadata_test.go
+++ b/test/e2e/conformance/metadata_test.go
@@ -23,12 +23,12 @@ import (
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -54,11 +54,10 @@ func TestMetadataMutations(t *testing.T) {
 
 	workspaceName := framework.NewOrganizationFixture(t, server)
 
-	workspaceCfg := kcpclienthelper.SetCluster(rest.CopyConfig(cfg), workspaceName)
-	workspaceCRDClient, err := apiextensionclientset.NewForConfig(workspaceCfg)
+	workspaceCRDClient, err := kcpapiextensionsclientset.NewForConfig(cfg)
 	require.NoError(t, err, "error creating crd cluster client")
 
-	kube.Create(t, workspaceCRDClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: "apps.k8s.io", Resource: "deployments"})
+	kube.Create(t, workspaceCRDClient.ApiextensionsV1().CustomResourceDefinitions().Cluster(workspaceName), metav1.GroupResource{Group: "apps.k8s.io", Resource: "deployments"})
 
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(kcpclienthelper.SetMultiClusterRoundTripper(rest.CopyConfig(cfg)))
 	require.NoError(t, err, "error creating kube cluster client")

--- a/test/e2e/conformance/webhook_test.go
+++ b/test/e2e/conformance/webhook_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/admission/v1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -92,7 +92,7 @@ func TestMutatingWebhookInWorkspace(t *testing.T) {
 	require.NoError(t, err, "failed to construct client for server")
 	cowbyClusterClient, err := client.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct cowboy client for server")
-	apiExtensionsClients, err := apiextensionsclient.NewForConfig(cfg)
+	apiExtensionsClients, err := kcpapiextensionsclientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct apiextensions client for server")
 
 	t.Logf("Install the Cowboy resources into logical clusters")
@@ -211,7 +211,7 @@ func TestValidatingWebhookInWorkspace(t *testing.T) {
 	require.NoError(t, err, "failed to construct client for server")
 	cowbyClusterClient, err := client.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct cowboy client for server")
-	apiExtensionsClients, err := apiextensionsclient.NewForConfig(cfg)
+	apiExtensionsClients, err := kcpapiextensionsclientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct apiextensions client for server")
 
 	t.Logf("Install the Cowboy resources into logical clusters")

--- a/test/e2e/customresourcedefinition/customresourcedefinition_test.go
+++ b/test/e2e/customresourcedefinition/customresourcedefinition_test.go
@@ -21,10 +21,10 @@ import (
 	"embed"
 	"testing"
 
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	"github.com/stretchr/testify/require"
 
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/restmapper"
 
@@ -48,7 +48,7 @@ func TestCustomResourceCreation(t *testing.T) {
 
 	cfg := server.BaseConfig(t)
 
-	kcpClients, err := clientset.NewClusterForConfig(cfg)
+	kcpClients, err := kcpapiextensionsclientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")
 
 	dynamicClients, err := kcpdynamic.NewForConfig(cfg)

--- a/test/e2e/fixtures/kcp-test-image/icc-test.go
+++ b/test/e2e/fixtures/kcp-test-image/icc-test.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package main
 
 import (

--- a/test/e2e/fixtures/kube/bootstrap.go
+++ b/test/e2e/fixtures/kube/bootstrap.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kcp-code-generator:skip
+
 package kube
 
 import (

--- a/test/e2e/fixtures/wildwest/bootstrap.go
+++ b/test/e2e/fixtures/wildwest/bootstrap.go
@@ -38,6 +38,14 @@ func Create(t *testing.T, clustername logicalcluster.Name, client apiextensionsv
 	ctx, cancelFunc := context.WithTimeout(logicalcluster.WithCluster(context.Background(), clustername), wait.ForeverTestTimeout)
 	t.Cleanup(cancelFunc)
 
-	err := configcrds.CreateFromFS(logicalcluster.WithCluster(ctx, clustername), client, rawCustomResourceDefinitions, grs...)
+	err := configcrds.CreateFromFS(ctx, client.Cluster(clustername), rawCustomResourceDefinitions, grs...)
+	require.NoError(t, err)
+}
+
+func FakePClusterCreate(t *testing.T, client apiextensionsv1client.CustomResourceDefinitionInterface, grs ...metav1.GroupResource) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), wait.ForeverTestTimeout)
+	t.Cleanup(cancelFunc)
+
+	err := configcrds.CreateFromFS(ctx, client, rawCustomResourceDefinitions, grs...)
 	require.NoError(t, err)
 }

--- a/test/e2e/fixtures/wildwest/bootstrap.go
+++ b/test/e2e/fixtures/wildwest/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"embed"
 	"testing"
 
+	kcpapiextensionsv1client "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned/typed/apiextensions/v1"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
@@ -34,7 +35,7 @@ import (
 //go:embed *.yaml
 var rawCustomResourceDefinitions embed.FS
 
-func Create(t *testing.T, clustername logicalcluster.Name, client apiextensionsv1client.CustomResourceDefinitionInterface, grs ...metav1.GroupResource) {
+func Create(t *testing.T, clustername logicalcluster.Name, client kcpapiextensionsv1client.CustomResourceDefinitionClusterInterface, grs ...metav1.GroupResource) {
 	ctx, cancelFunc := context.WithTimeout(logicalcluster.WithCluster(context.Background(), clustername), wait.ForeverTestTimeout)
 	t.Cleanup(cancelFunc)
 

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package framework
 
 import (

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +kcp-code-generator:skip
+
 package framework
 
 import (

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +kcp-code-generator:skip
-
 package framework
 
 import (

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -191,7 +191,7 @@ func TestClusterController(t *testing.T) {
 					sinkCrdClient, err := apiextensionsclientset.NewForConfig(config)
 					require.NoError(t, err)
 					t.Log("Installing test CRDs into sink cluster...")
-					fixturewildwest.Create(t, logicalcluster.Name{}, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
+					fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 
 					if isFakePCluster {
 						// Only need to install services in a non-logical cluster

--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -25,6 +25,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	"github.com/kcp-dev/logicalcluster/v2"
@@ -32,7 +33,6 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -212,10 +212,10 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	err = helpers.CreateResourceFromFS(ctx, user3DynamicClusterClient.Cluster(tenantShadowCRDWorkspace), mapper, nil, "crd_cowboys.yaml", testFiles)
 	require.NoError(t, err)
 
-	user3APIExtensionsClient, err := apiextensionsclient.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
+	user3APIExtensionsClient, err := kcpapiextensionsclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err)
 	framework.Eventually(t, func() (bool, string) {
-		cowboysCRD, err := user3APIExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(logicalcluster.WithCluster(ctx, tenantShadowCRDWorkspace), "cowboys.wildwest.dev", metav1.GetOptions{})
+		cowboysCRD, err := user3APIExtensionsClient.Cluster(tenantShadowCRDWorkspace).ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "cowboys.wildwest.dev", metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Sprintf("error creating API binding: %v", err)
 		}

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
@@ -621,7 +622,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 			unrelatedWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
-			sourceCrdClient, err := apiextensionsclientset.NewForConfig(server.BaseConfig(t))
+			sourceCrdClient, err := kcpapiextensionsclientset.NewForConfig(server.BaseConfig(t))
 			require.NoError(t, err)
 
 			fixturewildwest.Create(t, unrelatedWorkspace, sourceCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
@@ -662,7 +663,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 					sinkCrdClient, err := apiextensionsclientset.NewForConfig(config)
 					require.NoError(t, err)
 					t.Log("Installing test CRDs into sink cluster...")
-					fixturewildwest.Create(t, logicalcluster.Name{}, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
+					fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					if isFakePCluster {
 						// Only need to install services in a non-logical cluster
 						kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: "core.k8s.io", Resource: "services"})

--- a/test/e2e/watchcache/watchcache_enabled_test.go
+++ b/test/e2e/watchcache/watchcache_enabled_test.go
@@ -26,13 +26,13 @@ import (
 	"testing"
 	"time"
 
+	kcpapiextensionsclientset "github.com/kcp-dev/client-go/apiextensions/clients/clientset/versioned"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/clients/clientset/versioned"
 	kcpdynamic "github.com/kcp-dev/client-go/clients/dynamic"
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -58,7 +58,7 @@ func TestWatchCacheEnabledForCRD(t *testing.T) {
 	cowBoysGR := metav1.GroupResource{Group: "wildwest.dev", Resource: "cowboys"}
 
 	t.Log("Creating wildwest.dev CRD")
-	rootCRDClusterClient, err := apiextensionsclient.NewForConfig(rootShardConfig)
+	rootCRDClusterClient, err := kcpapiextensionsclientset.NewForConfig(rootShardConfig)
 	require.NoError(t, err)
 	rootShardCRDWildcardClient := rootCRDClusterClient.ApiextensionsV1().CustomResourceDefinitions()
 


### PR DESCRIPTION
*: remove old skip annotations for the automated refactor

---

go.mod: bump to newer kcp-dev/client-go

---

*: manual edits to use cluster-aware apiextensions client

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: autogenerated changes to use cluster-aware apiextensions client

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @ncdc @sttts @p0lyn0mial 