### PR TITLE
:bug: Revert additional proxy auth methods in e2e-sharded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ test-e2e-sharded: require-kind build-all build-kind-images
 	mkdir -p "$(LOG_DIR)" "$(WORK_DIR)/.kcp"
 	kind get kubeconfig > "$(WORK_DIR)/.kcp/kind.kubeconfig"
 	rm -f "$(WORK_DIR)/.kcp/admin.kubeconfig"
-	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/sharded-test-server --v=2 --proxy-token-auth-file=./test/e2e/framework/auth-tokens.csv --proxy-service-account-key-file=.kcp/service-account.crt --log-dir-path="$(LOG_DIR)" --work-dir-path="$(WORK_DIR)" $(TEST_SERVER_ARGS) --number-of-shards=2 2>&1 & PID=$$!; echo "PID $$PID" && \
+	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/sharded-test-server --v=2 --log-dir-path="$(LOG_DIR)" --work-dir-path="$(WORK_DIR)" $(TEST_SERVER_ARGS) --number-of-shards=2 2>&1 & PID=$$!; echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; done && \
 	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS) \


### PR DESCRIPTION
## Summary
This is a partial revert of #2178 - which passed e2e-sharded, but there are reports of that job now taking twice as long with these new auth methods enabled.

I'm reverting the Makefile changes to restore the CI job to the previous behavior, and will investigate locally why performance is impacted.

## Related issue(s)
Related to changes in #2178 but since we can hopefully restore the default behavior by removing the new optional proxy auth flags, I've not proposed a full revert (if that proves to be wrong we can of course revert the entire change)
