### PR TITLE
:bug: Avoid syncers deleting namespace from other synctargets. 

### DIFF
--- a/pkg/syncer/namespace/namespace_downstream_process.go
+++ b/pkg/syncer/namespace/namespace_downstream_process.go
@@ -72,6 +72,14 @@ func (c *DownstreamController) process(ctx context.Context, key string) error {
 		logger.Error(err, "failed to unmarshal namespace locator", "namespaceLocator", namespaceLocatorJSON)
 		return nil
 	}
+
+	// Check if the nsLocator SyncTarget UID is the same as ours. If not, we should ignore this namespace as it could be
+	// managed by different syncer.
+	if nsLocator.SyncTarget.UID != c.syncTargetUID {
+		logger.V(4).Info("downstream namespace is not handled by this sync target, ignoring")
+		return nil
+	}
+
 	logger = logger.WithValues(logging.WorkspaceKey, nsLocator.Workspace, logging.NamespaceKey, nsLocator.Namespace)
 	exists, err := c.upstreamNamespaceExists(nsLocator.Workspace, nsLocator.Namespace)
 	if err != nil {

--- a/pkg/syncer/namespace/namespace_downstream_process_test.go
+++ b/pkg/syncer/namespace/namespace_downstream_process_test.go
@@ -41,6 +41,7 @@ func TestSyncerNamespaceProcess(t *testing.T) {
 	tests := map[string]struct {
 		upstreamNamespaceExists bool
 		deletedNamespace        string
+		syncTargetUID           types.UID
 
 		upstreamNamespaceExistsError                    error
 		getDownstreamNamespaceError                     error
@@ -52,6 +53,12 @@ func TestSyncerNamespaceProcess(t *testing.T) {
 			upstreamNamespaceExists: false,
 			deletedNamespace:        "kcp-hcbsa8z6c2er",
 			eventOrigin:             "downstream",
+		},
+		"NamespaceSyncer doesn't remove downstream namespace when nsLocator synctarget UID is different, expect no namespace deletion": {
+			upstreamNamespaceExists: false,
+			deletedNamespace:        "",
+			eventOrigin:             "downstream",
+			syncTargetUID:           "1234",
 		},
 		"NamespaceSyncer, downstream event, no deletion as there is a matching upstream namespace, expect no namespace deletion": {
 			upstreamNamespaceExists: true,
@@ -89,7 +96,10 @@ func TestSyncerNamespaceProcess(t *testing.T) {
 			syncTargetName := "us-west1"
 			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(syncTargetWorkspace, syncTargetName)
 			deletedNamespace := ""
-
+			syncTargetUID := types.UID("syncTargetUID")
+			if tc.syncTargetUID != "" {
+				syncTargetUID = tc.syncTargetUID
+			}
 			nsController := DownstreamController{
 				deleteDownstreamNamespace: func(ctx context.Context, downstreamNamespaceName string) error {
 					deletedNamespace = downstreamNamespaceName
@@ -115,7 +125,7 @@ func TestSyncerNamespaceProcess(t *testing.T) {
 				},
 				syncTargetName:      syncTargetName,
 				syncTargetWorkspace: syncTargetWorkspace,
-				syncTargetUID:       types.UID("syncTargetUID"),
+				syncTargetUID:       syncTargetUID,
 				syncTargetKey:       syncTargetKey,
 			}
 


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR adds an additional check (synctarget UID) when deleting downstream namespaces to avoid a reconciliation loop between different syncers from different kcp instances. (or for example, an old syncer from a previous KCP deployment)

## Related issue(s)

related to: https://github.com/kcp-dev/kcp/issues/2041 (doesn't fix it as there are multiple root causes for that issue)

