### PR TITLE
:seedling: make: add non-kind shared and sharded e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           go install github.com/google/ko@latest
 
       - run: |-
-          LOG_DIR=/tmp/e2e/shared-server/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 E2E_PARALLELISM=2 \
+          LOG_DIR=/tmp/e2e/shared-server/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 \
           make test-e2e-shared
 
       - uses: cytopia/upload-artifact-retry-action@v0.1.2
@@ -76,7 +76,7 @@ jobs:
         go install github.com/google/ko@latest
 
     - run: |-
-        LOG_DIR=/tmp/e2e/sharded/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 E2E_PARALLELISM=2 \
+        LOG_DIR=/tmp/e2e/sharded/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 \
         make test-e2e-sharded
 
     - uses: cytopia/upload-artifact-retry-action@v0.1.2

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,15 @@ ifdef USE_GOTESTSUM
 GO_TEST = $(GOTESTSUM) $(GOTESTSUM_ARGS) --
 endif
 
-COUNT ?= 1
-E2E_PARALLELISM ?= 1
+COUNT ?=
+COUNT_ARG =
+ifdef COUNT
+COUNT_ARG = -count $(COUNT)
+endif
+E2E_PARALLELISM ?=
+ifdef E2E_PARALLELISM
+PARALLELISM_ARG = -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM)
+endif
 
 .PHONY: test-e2e
 ifdef USE_GOTESTSUM
@@ -217,7 +224,7 @@ endif
 test-e2e: TEST_ARGS ?=
 test-e2e: WHAT ?= ./test/e2e...
 test-e2e: build-all
-	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS)
+	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS)
 
 .PHONY: test-e2e-shared
 ifdef USE_GOTESTSUM
@@ -238,7 +245,7 @@ test-e2e-shared: require-kind build-all build-kind-images
 	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/test-server --log-file-path="$(LOG_DIR)/kcp.log" $(TEST_SERVER_ARGS) 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; done && \
-	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS) \
+	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
 		-args --use-default-kcp-server --syncer-image="$(SYNCER_IMAGE)" --kcp-test-image="$(TEST_IMAGE)" --pcluster-kubeconfig="$(abspath $(WORK_DIR)/.kcp/kind.kubeconfig)" \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
@@ -260,7 +267,7 @@ test-e2e-shared-minimal: build-all
 	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/test-server --log-file-path="$(LOG_DIR)/kcp.log" $(TEST_SERVER_ARGS) 2>&1 & PID=$$! && echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; done && \
-	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(WHAT) $(TEST_ARGS) \
+	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
 		-args --use-default-kcp-server \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
@@ -283,7 +290,7 @@ test-e2e-sharded: require-kind build-all build-kind-images
 	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/sharded-test-server --v=2 --log-dir-path="$(LOG_DIR)" --work-dir-path="$(WORK_DIR)" $(TEST_SERVER_ARGS) --number-of-shards=2 2>&1 & PID=$$!; echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; done && \
-	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS) \
+	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
 		-args --use-default-kcp-server --root-shard-kubeconfig=$(PWD)/.kcp-0/admin.kubeconfig \
 		--syncer-image="$(SYNCER_IMAGE)" --kcp-test-image="$(TEST_IMAGE)" --pcluster-kubeconfig="$(abspath $(WORK_DIR)/.kcp/kind.kubeconfig)" \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
@@ -306,7 +313,7 @@ test-e2e-sharded-minimal: build-all
 	UNSAFE_E2E_HACK_DISABLE_ETCD_FSYNC=true NO_GORUN=1 ./bin/sharded-test-server --v=2 --log-dir-path="$(LOG_DIR)" --work-dir-path="$(WORK_DIR)" $(TEST_SERVER_ARGS) --number-of-shards=2 2>&1 & PID=$$!; echo "PID $$PID" && \
 	trap 'kill -TERM $$PID' TERM INT EXIT && \
 	while [ ! -f "$(WORK_DIR)/.kcp/admin.kubeconfig" ]; do sleep 1; done && \
-	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race -count $(COUNT) -p $(E2E_PARALLELISM) -parallel $(E2E_PARALLELISM) $(WHAT) $(TEST_ARGS) \
+	NO_GORUN=1 GOOS=$(OS) GOARCH=$(ARCH) $(GO_TEST) -race $(COUNT_ARG) $(PARALLELISM_ARG) $(WHAT) $(TEST_ARGS) \
 		-args --use-default-kcp-server --root-shard-kubeconfig=$(PWD)/.kcp-0/admin.kubeconfig \
 	$(if $(value WAIT),|| { echo "Terminated with $$?"; wait "$$PID"; },)
 
@@ -317,8 +324,8 @@ endif
 test: WHAT ?= ./...
 # We will need to move into the sub package, of pkg/apis to run those tests.
 test:
-	$(GO_TEST) -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic $(TEST_ARGS) $$(go list "$(WHAT)" | grep -v ./test/e2e/)
-	cd pkg/apis && $(GO_TEST) -race -count $(COUNT) -coverprofile=coverage.txt -covermode=atomic $(TEST_ARGS) $(WHAT)
+	$(GO_TEST) -race $(COUNT_ARG) -coverprofile=coverage.txt -covermode=atomic $(TEST_ARGS) $$(go list "$(WHAT)" | grep -v ./test/e2e/)
+	cd pkg/apis && $(GO_TEST) -race $(COUNT_ARG) -coverprofile=coverage.txt -covermode=atomic $(TEST_ARGS) $(WHAT)
 
 .PHONY: verify-k8s-deps
 verify-k8s-deps:

--- a/test/e2e/audit/audit_log_test.go
+++ b/test/e2e/audit/audit_log_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestAuditLogs(t *testing.T) {
+	t.Parallel()
 	server := framework.PrivateKcpServer(t, framework.WithCustomArguments([]string{"--audit-log-path", "./audit-log", "--audit-policy-file", "./policy.yaml"}...))
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -90,7 +90,7 @@ func TestAuthorizer(t *testing.T) {
 	require.Eventually(t, func() bool {
 		_, err := user1KubeClusterClient.Cluster(org1.Join("workspace1")).CoreV1().ConfigMaps("default").List(ctx, metav1.ListOptions{})
 		return err == nil
-	}, time.Minute, time.Second)
+	}, 2*wait.ForeverTestTimeout, 100*time.Millisecond)
 
 	tests := map[string]func(t *testing.T){
 		"as org member, workspace admin user-1 can access everything": func(t *testing.T) {

--- a/test/e2e/authorizer/serviceaccounts_test.go
+++ b/test/e2e/authorizer/serviceaccounts_test.go
@@ -150,6 +150,7 @@ func TestServiceAccounts(t *testing.T) {
 	}
 	for _, ttc := range testCases {
 		t.Run(ttc.name, func(t *testing.T) {
+			t.Parallel()
 			saRestConfig := framework.ConfigWithToken(ttc.token(t), server.BaseConfig(t))
 			saKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(saRestConfig)
 			require.NoError(t, err)

--- a/test/e2e/framework/accessory.go
+++ b/test/e2e/framework/accessory.go
@@ -119,7 +119,7 @@ func Ready(ctx context.Context, t *testing.T, port string) bool {
 
 func waitForEndpoint(ctx context.Context, t *testing.T, port, endpoint string) {
 	var lastError error
-	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, 30*time.Second, func(ctx context.Context) (bool, error) {
+	if err := wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(ctx context.Context) (bool, error) {
 		url := fmt.Sprintf("http://[::1]:%s%s", port, endpoint)
 		resp, err := http.Get(url)
 		if err != nil {

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -29,6 +29,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
@@ -223,7 +224,7 @@ func ExpectClusterWorkspaces(ctx context.Context, t *testing.T, client kcpclient
 			}
 			expectErr := expectation(current.DeepCopy())
 			return expectErr == nil, expectErr
-		}, 30*time.Second)
+		}, wait.ForeverTestTimeout)
 	}, nil
 }
 
@@ -254,6 +255,6 @@ func ExpectWorkspaceShards(ctx context.Context, t *testing.T, client kcpclient.I
 			}
 			expectErr := expectation(current.DeepCopy())
 			return expectErr == nil, expectErr
-		}, 30*time.Second)
+		}, wait.ForeverTestTimeout)
 	}, nil
 }

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -757,7 +757,7 @@ func (c *kcpServer) monitorEndpoint(client *rest.RESTClient, endpoint string) {
 		if errs.Len() > 0 {
 			errs = sets.NewString()
 		}
-	}, 1*time.Second)
+	}, 100*time.Millisecond)
 }
 
 // there doesn't seem to be any simple way to get a metav1.Status from the Go client, so we get

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -186,7 +186,7 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 
 	// collect both in deployed and in-process mode
 	t.Cleanup(func() {
-		ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
+		ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(wait.ForeverTestTimeout))
 		defer cancelFn()
 
 		t.Logf("Collecting imported resource info: %s", artifactDir)
@@ -251,7 +251,7 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 
 	if useDeployedSyncer {
 		t.Cleanup(func() {
-			ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
+			ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(wait.ForeverTestTimeout))
 			defer cancelFn()
 
 			// collect syncer logs

--- a/test/e2e/homeworkspaces/home_workspaces_test.go
+++ b/test/e2e/homeworkspaces/home_workspaces_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestUserHomeWorkspaces(t *testing.T) {
+	t.Parallel()
 	type clientInfo struct {
 		Token string
 	}

--- a/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspacedeletion/controller_test.go
@@ -83,7 +83,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					}
 
 					return conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceScheduled)
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				workspaceCluster := orgClusterName.Join(workspace.Name)
 
@@ -134,7 +134,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					}
 
 					return conditions.IsTrue(workspace, tenancyv1alpha1.WorkspaceDeletionContentSuccess) && conditions.IsFalse(workspace, tenancyv1alpha1.WorkspaceContentDeleted)
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Clean finalizer to remove the configmap")
 				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -152,7 +152,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 				require.Eventually(t, func() bool {
 					_, err := server.kcpClusterClient.TenancyV1alpha1().ClusterWorkspaces().Get(logicalcluster.WithCluster(ctx, orgClusterName), workspace.Name, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Finally check if all resources has been removed")
 
@@ -190,7 +190,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					workspace, err := server.kcpClusterClient.TenancyV1alpha1().ClusterWorkspaces().Get(logicalcluster.WithCluster(ctx, orgClusterName), workspaceName, metav1.GetOptions{})
 					require.NoError(t, err, "failed to get workspace %s", workspaceName)
 					return len(workspace.Finalizers) > 0
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Create namespace in both the workspace and org workspace")
 				ns := &corev1.Namespace{
@@ -224,7 +224,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					}
 
 					return len(nslist.Items) == 0
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Ensure namespace in the org workspace is deleted")
 				require.Eventually(t, func() bool {
@@ -233,7 +233,7 @@ func TestWorkspaceDeletionController(t *testing.T) {
 						return false
 					}
 					return len(nslist.Items) == 0
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Ensure workspace in the org workspace is deleted")
 				require.Eventually(t, func() bool {
@@ -244,13 +244,13 @@ func TestWorkspaceDeletionController(t *testing.T) {
 					}
 					require.NoError(t, err, "failed to list workspaces in org workspace")
 					return len(wslist.Items) == 0
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Logf("Ensure the org workspace is deleted")
 				require.Eventually(t, func() bool {
 					_, err := rootShardKcpClusterClient.TenancyV1alpha1().ClusterWorkspaces().Get(logicalcluster.WithCluster(ctx, tenancyv1alpha1.RootCluster), orgWorkspaceName, metav1.GetOptions{})
 					return apierrors.IsNotFound(err)
-				}, wait.ForeverTestTimeout, 1*time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 			},
 		},
 	}

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -133,7 +133,7 @@ func TestNamespaceScheduler(t *testing.T) {
 						return false
 					}
 					return scheduledMatcher(syncTargetKey)(ns) == nil
-				}, wait.ForeverTestTimeout, time.Second)
+				}, wait.ForeverTestTimeout, 100*time.Millisecond)
 
 				t.Log("Cordon the cluster and expect the namespace to end up unschedulable")
 				err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -182,7 +182,7 @@ func TestNamespaceScheduler(t *testing.T) {
 						t.Logf("failed to set status.lastSyncerHeartbeatTime: %v", err)
 						return
 					}
-				}, time.Second*10)
+				}, 100*time.Millisecond)
 
 				t.Log("Create a new unique sheriff CRD")
 				group := framework.UniqueGroup(".io")
@@ -341,7 +341,7 @@ func expectNamespaces(ctx context.Context, t *testing.T, client kcpkubernetescli
 			}
 			expectErr := expectation(current.DeepCopy())
 			return expectErr == nil, expectErr
-		}, 30*time.Second)
+		}, wait.ForeverTestTimeout)
 	}, nil
 }
 

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -47,6 +47,7 @@ import (
 )
 
 func TestSyncerTunnel(t *testing.T) {
+	t.Parallel()
 	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
 		t.Skip("Test requires a pcluster")
 	}

--- a/test/e2e/virtual/workspaces/virtual_workspace_test.go
+++ b/test/e2e/virtual/workspaces/virtual_workspace_test.go
@@ -154,6 +154,7 @@ func createWorkspaceRoleForGroup(t *testing.T, ctx context.Context, kubeClusterC
 }
 
 func TestStandaloneWorkspacesVirtualWorkspaces(t *testing.T) {
+	t.Parallel()
 	if len(framework.TestConfig.KCPKubeconfig()) != 0 {
 		t.Skip("Skip testing standalone when running against persistent fixture to minimize test execution cost for development")
 	}
@@ -167,6 +168,7 @@ func TestStandaloneWorkspacesVirtualWorkspaces(t *testing.T) {
 }
 
 func TestInProcessWorkspacesVirtualWorkspaces(t *testing.T) {
+	t.Parallel()
 	t.Run("In-process virtual workspace apiserver", func(t *testing.T) {
 		t.Parallel()
 		testWorkspacesVirtualWorkspaces(t, false)


### PR DESCRIPTION
test/e2e: make sure tests actually run in parallel

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test/e2e: be consistent about timeouts and poll intervals

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test/e2e/workspacetype: poll, don't blindly wait for 5s

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test/e2e/syncer: send one request, not many

You can't prove a negative, and eventually consistent systems don't like
to conform to your idea of "long enough" before synchronizing. We can't
assume that "nothing will happen" within 5s here. If we wanted to make
sure that the controller had seen & acknowledged the object, we should
have it post some observed generation.

Since these polls were not effective at best, and flaky at worst, we can
save 10s by just making one call.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

make: add non-kind variants of shared & sharded e2e

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

make: be more intelligent with parallelism, count
    
First, we don't want to pass `-count 1` to `go test` unless someone
explicitly opts into this behavior, as this explicitly invalidates the
test cache. When re-running tests locally, being able to run the full
suite every time and use the cache is incredibly useful.
    
Second, we should only bother with limiting parallelism when we're
starting up a full `kcp` and `etcd` server per test case.
    
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/cc @jmprusi @davidfestal 
/assign @ncdc @sttts 