### PR TITLE
📖 Fix grammar of kcp command help message

### DIFF
--- a/cmd/kcp/kcp.go
+++ b/cmd/kcp/kcp.go
@@ -51,10 +51,10 @@ func main() {
 			KCP is the easiest way to manage Kubernetes applications against one or
 			more clusters, by giving you a personal control plane that schedules your
 			workloads onto one or many clusters, and making it simple to pick up and
-			move. Advanced use cases including spreading your apps across clusters for
-			resiliency, scheduling batch workloads onto clusters with free capacity,
-			and enabling collaboration for individual teams without having access to
-			the underlying clusters.
+			move. It supports advanced use cases such as spreading your apps across
+			clusters for resiliency, scheduling batch workloads onto clusters with
+			free capacity, and enabling collaboration for individual teams without
+			having access to the underlying clusters.
 
 			To get started, launch a new cluster with 'kcp start', which will
 			initialize your personal control plane and write an admin kubeconfig file


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Before this PR, the help message contains the sentence

```
Advanced use cases including <list of advanced use cases>.
```

, which is incomplete. This PR fixes that.
