### PR TITLE
🌱 Exclude warnings about inlined strings for logs

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -68,14 +68,11 @@
 /pkg/informer/informer.go:530:4: function "InfoS" should not be used, convert to contextual logging
 /pkg/informer/informer.go:530:4: function "V" should not be used, convert to contextual logging
 /pkg/logging/constants.go:100:9: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
-/pkg/logging/constants.go:52:9: Key positional arguments are expected to be inlined constant strings. Please replace ReconcilerKey provided with string value.
-/pkg/logging/constants.go:57:9: Key positional arguments are expected to be inlined constant strings. Please replace QueueKeyKey provided with string value.
 /pkg/logging/constants.go:67:9: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/reconciler/apis/apiresource/controller.go:229:4: function "Errorf" should not be used, convert to contextual logging
 /pkg/reconciler/apis/apiresource/startup.go:51:3: function "Warningf" should not be used, convert to contextual logging
 /pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go:67:4: function "Info" should not be used, convert to contextual logging
 /pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go:67:4: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/tenancy/clusterworkspace/clusterworkspace_reconcile_metadata.go:70:5: Key positional arguments are expected to be inlined constant strings. Please replace &{tenancyv1alpha1 ExperimentalClusterWorkspaceOwnerAnnotationKey} provided with string value.
 /pkg/reconciler/workload/resource/resource_controller.go:403:32: function "Enabled" should not be used, convert to contextual logging
 /pkg/reconciler/workload/resource/resource_controller.go:403:32: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/workload/resource/resource_controller.go:403:8: function "Enabled" should not be used, convert to contextual logging
@@ -97,28 +94,6 @@
 /pkg/server/home_workspaces.go:352:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/home_workspaces.go:638:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
-/pkg/syncer/namespace/namespace_downstream_process.go:44:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/namespace/namespace_downstream_process.go:75:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_downstream_process.go:75:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_upstream_process.go:41:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/namespace/namespace_upstream_process.go:41:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_upstream_process.go:79:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/spec/spec_controller.go:145:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/spec/spec_controller.go:145:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/spec/spec_process.go:135:4: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/spec/spec_process.go:153:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/spec/spec_process.go:358:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/syncer.go:168:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetKey provided with string value.
-/pkg/syncer/syncer.go:80:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetName provided with string value.
-/pkg/syncer/syncer.go:80:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetWorkspace provided with string value.
 /pkg/tunneler/dialer.go:148:8: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/dialer.go:148:8: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:157:3: function "Infof" should not be used, convert to contextual logging

--- a/hack/verify-contextual-logging.sh
+++ b/hack/verify-contextual-logging.sh
@@ -43,7 +43,8 @@ else
 fi
 
 # Normalize paths so we don't generate diffs based only on user directory mismatches
-${SED} -e "s,${REPO_ROOT},,g" "${work_file}"
+# Also remove warning about not using inlined strings.
+${SED} -e "s,${REPO_ROOT},,g" -e "/Key positional arguments are expected to be inlined constant strings./d" "${work_file}"
 LC_COLLATE=C sort "${work_file}" -o "${work_file}"
 
 # Copy the current set to the known set, but keep temp file in place for diffing


### PR DESCRIPTION
## Summary

We're actually adding our log messages to constants for consistency, so ignore this particular check.

This is something that may change upstream, see [Slack discussion](https://kubernetes.slack.com/archives/C020CCMUEAX/p1665065309248589).

/cc @stevekuznetsov 
