### PR TITLE
:bug: test/e2e/framework: Don't try to pull logs from a non-ready POD

### DIFF
--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -275,8 +275,14 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 					}
 					artifactPath := filepath.Join(artifactDir, fmt.Sprintf("syncer-%s-%s.log", syncerID, pod.Name))
 
+					// if the log is stopped or has crashed we will try to get --previous logs.
+					extraArg := ""
+					if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+						extraArg = "--previous"
+					}
+
 					t.Logf("Collecting downstream logs for pod %s/%s: %s", syncerID, pod.Name, artifactPath)
-					logs := Kubectl(t, downstreamKubeconfigPath, "-n", syncerID, "logs", pod.Name)
+					logs := Kubectl(t, downstreamKubeconfigPath, "-n", syncerID, "logs", pod.Name, extraArg)
 
 					err = ioutil.WriteFile(artifactPath, logs, 0644)
 					if err != nil {

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -268,6 +268,11 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 				}
 
 				for _, pod := range pods.Items {
+					//Check if the POD is ready before trying to get the logs, ignore if not to avoid the test failing.
+					if pod.Status.Phase != corev1.PodRunning {
+						t.Logf("Pod %s is not running", pod.Name)
+						continue
+					}
 					artifactPath := filepath.Join(artifactDir, fmt.Sprintf("syncer-%s-%s.log", syncerID, pod.Name))
 
 					t.Logf("Collecting downstream logs for pod %s/%s: %s", syncerID, pod.Name, artifactPath)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Fixes some flaky tests due to the syncer-dns pod not being in "running" state (synctarget heartbeat is sent by the syncer pod, and doesn't take into account the syncer-dns POD state.)

This is causing some e2e-shared tests to fail, due to the collecting of logs failing as the syncer-dns pod is not ready.

related to: https://github.com/kcp-dev/kcp/issues/2284