### PR TITLE
🌱 types_apiexport: make all and resourceSelector/namespace optional

### DIFF
--- a/config/crds/apis.kcp.dev_apibindings.yaml
+++ b/config/crds/apis.kcp.dev_apibindings.yaml
@@ -53,7 +53,6 @@ spec:
                     records if the user accepts or rejects it.
                   properties:
                     all:
-                      default: false
                       description: all claims all resources for the given group/resource.
                         This is mutually exclusive with resourceSelector.
                       type: boolean
@@ -83,18 +82,22 @@ spec:
                           name:
                             description: name of an object within a claimed group/resource.
                               It matches the metadata.name field of the underlying
-                              object.
+                              object. If namespace is unset, all objects matching
+                              that name will be claimed.
                             maxLength: 253
+                            minLength: 1
                             pattern: ^([a-z0-9][-a-z0-9_.]*)?[a-z0-9]$
                             type: string
                           namespace:
                             description: namespace containing the named object. Matches
                               metadata.namespace field. If "name" is unset, all objects
                               from the namespace are being claimed.
+                            minLength: 1
                             type: string
-                        required:
-                        - namespace
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one field must be set
+                          rule: has(self.__namespace__) || has(self.name)
                       type: array
                     state:
                       enum:
@@ -102,13 +105,13 @@ spec:
                       - Rejected
                       type: string
                   required:
-                  - all
                   - resource
                   - state
                   type: object
                   x-kubernetes-validations:
                   - message: either "all" or "resourceSelector" must be set
-                    rule: self.all != has(self.resourceSelector)
+                    rule: (has(self.all) && self.all) != (has(self.resourceSelector)
+                      && size(self.resourceSelector) > 0)
                 type: array
               reference:
                 description: reference uniquely identifies an API to bind to.
@@ -158,7 +161,6 @@ spec:
                     allow the service provider access to.
                   properties:
                     all:
-                      default: false
                       description: all claims all resources for the given group/resource.
                         This is mutually exclusive with resourceSelector.
                       type: boolean
@@ -188,26 +190,30 @@ spec:
                           name:
                             description: name of an object within a claimed group/resource.
                               It matches the metadata.name field of the underlying
-                              object.
+                              object. If namespace is unset, all objects matching
+                              that name will be claimed.
                             maxLength: 253
+                            minLength: 1
                             pattern: ^([a-z0-9][-a-z0-9_.]*)?[a-z0-9]$
                             type: string
                           namespace:
                             description: namespace containing the named object. Matches
                               metadata.namespace field. If "name" is unset, all objects
                               from the namespace are being claimed.
+                            minLength: 1
                             type: string
-                        required:
-                        - namespace
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one field must be set
+                          rule: has(self.__namespace__) || has(self.name)
                       type: array
                   required:
-                  - all
                   - resource
                   type: object
                   x-kubernetes-validations:
                   - message: either "all" or "resourceSelector" must be set
-                    rule: self.all != has(self.resourceSelector)
+                    rule: (has(self.all) && self.all) != (has(self.resourceSelector)
+                      && size(self.resourceSelector) > 0)
                 type: array
               boundResources:
                 description: boundResources records the state of bound APIs.
@@ -329,7 +335,6 @@ spec:
                     allow the service provider access to.
                   properties:
                     all:
-                      default: false
                       description: all claims all resources for the given group/resource.
                         This is mutually exclusive with resourceSelector.
                       type: boolean
@@ -359,26 +364,30 @@ spec:
                           name:
                             description: name of an object within a claimed group/resource.
                               It matches the metadata.name field of the underlying
-                              object.
+                              object. If namespace is unset, all objects matching
+                              that name will be claimed.
                             maxLength: 253
+                            minLength: 1
                             pattern: ^([a-z0-9][-a-z0-9_.]*)?[a-z0-9]$
                             type: string
                           namespace:
                             description: namespace containing the named object. Matches
                               metadata.namespace field. If "name" is unset, all objects
                               from the namespace are being claimed.
+                            minLength: 1
                             type: string
-                        required:
-                        - namespace
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one field must be set
+                          rule: has(self.__namespace__) || has(self.name)
                       type: array
                   required:
-                  - all
                   - resource
                   type: object
                   x-kubernetes-validations:
                   - message: either "all" or "resourceSelector" must be set
-                    rule: self.all != has(self.resourceSelector)
+                    rule: (has(self.all) && self.all) != (has(self.resourceSelector)
+                      && size(self.resourceSelector) > 0)
                 type: array
               phase:
                 description: 'phase is the current phase of the APIBinding: - "":

--- a/config/crds/apis.kcp.dev_apiexports.yaml
+++ b/config/crds/apis.kcp.dev_apiexports.yaml
@@ -123,7 +123,6 @@ spec:
                     allow the service provider access to.
                   properties:
                     all:
-                      default: false
                       description: all claims all resources for the given group/resource.
                         This is mutually exclusive with resourceSelector.
                       type: boolean
@@ -154,26 +153,30 @@ spec:
                           name:
                             description: name of an object within a claimed group/resource.
                               It matches the metadata.name field of the underlying
-                              object.
+                              object. If namespace is unset, all objects matching
+                              that name will be claimed.
                             maxLength: 253
+                            minLength: 1
                             pattern: ^([a-z0-9][-a-z0-9_.]*)?[a-z0-9]$
                             type: string
                           namespace:
                             description: namespace containing the named object. Matches
                               metadata.namespace field. If "name" is unset, all objects
                               from the namespace are being claimed.
+                            minLength: 1
                             type: string
-                        required:
-                        - namespace
                         type: object
+                        x-kubernetes-validations:
+                        - message: at least one field must be set
+                          rule: has(self.__namespace__) || has(self.name)
                       type: array
                   required:
-                  - all
                   - resource
                   type: object
                   x-kubernetes-validations:
                   - message: either "all" or "resourceSelector" must be set
-                    rule: self.all != has(self.resourceSelector)
+                    rule: (has(self.all) && self.all) != (has(self.resourceSelector)
+                      && size(self.resourceSelector) > 0)
                 type: array
                 x-kubernetes-list-map-keys:
                 - group

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e // indirect
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -92,7 +92,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/cel-go v0.10.1 // indirect
+	github.com/google/cel-go v0.12.5 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,9 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e h1:GCzyKMDDjSGnlpl3clrdAK7I1AaVoaiKDOYkUzChZzg=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed h1:ue9pVfIcP+QMEjfgo/Ez4ZjNZfonGgR6NgjMaJMu1Cg=
+github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/aojea/rwconn v0.1.1 h1:vsYyhoQghQ5HH98QE+xmNwnKsTm8GxWjpvxGft6s7q8=
 github.com/aojea/rwconn v0.1.1/go.mod h1:LUO0QX1YNsA51BR48slR87GsvEMiTTOWNdC6aoG+BTA=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
@@ -340,8 +341,9 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/cadvisor v0.44.1/go.mod h1:GQ9KQfz0iNHQk3D6ftzJWK4TXabfIgM10Oy3FkR+Gzg=
-github.com/google/cel-go v0.10.1 h1:MQBGSZGnDwh7T/un+mzGKOMz3x+4E/GDPprWjDL+1Jg=
 github.com/google/cel-go v0.10.1/go.mod h1:U7ayypeSkw23szu4GaQTPJGx66c20mx8JklMSxrmI1w=
+github.com/google/cel-go v0.12.5 h1:DmzaiSgoaqGCjtpPQWl26/gND+yRpim56H1jCVev6d8=
+github.com/google/cel-go v0.12.5/go.mod h1:Jk7ljRzLBhkmiAwBoUxB1sZSCVBAzkqPF25olK/iRDw=
 github.com/google/cel-spec v0.6.0/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
 github.com/google/gnostic v0.5.7-v3refs h1:FhTMOKj2VhjpouxvWJAV1TL304uMlb9zcDqkl6cEI54=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1756,7 +1756,6 @@ func schema_pkg_apis_apis_v1alpha1_AcceptablePermissionClaim(ref common.Referenc
 					"all": {
 						SchemaProps: spec.SchemaProps{
 							Description: "all claims all resources for the given group/resource. This is mutually exclusive with resourceSelector.",
-							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -1790,7 +1789,7 @@ func schema_pkg_apis_apis_v1alpha1_AcceptablePermissionClaim(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"all", "state"},
+				Required: []string{"state"},
 			},
 		},
 		Dependencies: []string{
@@ -2008,7 +2007,6 @@ func schema_pkg_apis_apis_v1alpha1_PermissionClaim(ref common.ReferenceCallback)
 					"all": {
 						SchemaProps: spec.SchemaProps{
 							Description: "all claims all resources for the given group/resource. This is mutually exclusive with resourceSelector.",
-							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2035,7 +2033,6 @@ func schema_pkg_apis_apis_v1alpha1_PermissionClaim(ref common.ReferenceCallback)
 						},
 					},
 				},
-				Required: []string{"all"},
 			},
 		},
 		Dependencies: []string{
@@ -2051,7 +2048,7 @@ func schema_pkg_apis_apis_v1alpha1_ResourceSelector(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name of an object within a claimed group/resource. It matches the metadata.name field of the underlying object.",
+							Description: "name of an object within a claimed group/resource. It matches the metadata.name field of the underlying object. If namespace is unset, all objects matching that name will be claimed.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2059,13 +2056,11 @@ func schema_pkg_apis_apis_v1alpha1_ResourceSelector(ref common.ReferenceCallback
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
 							Description: "namespace containing the named object. Matches metadata.namespace field. If \"name\" is unset, all objects from the namespace are being claimed.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"namespace"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
This sets the fields `all` and `resourceSelector/namespace` optional.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/pull/2222#discussion_r1008530913
Fixes https://github.com/kcp-dev/kcp/pull/2222#discussion_r1008532082
