### PR TITLE
🐛 Fix incorrect cleaning of deletion annotations

### DIFF
--- a/pkg/reconciler/workload/resource/resource_reconcile.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile.go
@@ -248,6 +248,10 @@ func computePlacement(expectedSyncTargetKeys sets.String, expectedDeletedSynctar
 			if _, ok := currentSynctargetKeysDeleting[loc]; !ok {
 				annotationPatch[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc] = expectedTimestamp
 			}
+		} else {
+			if _, ok := currentSynctargetKeysDeleting[loc]; ok {
+				annotationPatch[workloadv1alpha1.InternalClusterDeletionTimestampAnnotationPrefix+loc] = nil
+			}
 		}
 	}
 

--- a/pkg/reconciler/workload/resource/resource_reconcile_test.go
+++ b/pkg/reconciler/workload/resource/resource_reconcile_test.go
@@ -188,6 +188,9 @@ func TestComputePlacement(t *testing.T) {
 			}, map[string]string{
 				"state.workload.kcp.dev/cluster-3": "Sync",
 			}, nil, nil, "ns"),
+			wantAnnotationPatch: map[string]interface{}{
+				"deletion.internal.workload.kcp.dev/cluster-3": nil,
+			},
 		},
 		{name: "multiple locations, added and removed on namespace and object",
 			ns: namespace(map[string]string{


### PR DESCRIPTION
## Summary

This PR fixes an incorrect cleaning of SyncTarget-related deletion annotations.

## Related issue(s)

Fixes #2287
