### PR TITLE
:sparkles: Create one DNS nameserver per workspace

### DIFF
--- a/cmd/syncer/cmd/dns.go
+++ b/cmd/syncer/cmd/dns.go
@@ -19,10 +19,13 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	synceroptions "github.com/kcp-dev/kcp/cmd/syncer/options"
+	"github.com/kcp-dev/kcp/pkg/dns/plugin/nsmap"
 	"github.com/kcp-dev/kcp/third_party/coredns/coremain"
 )
 
 func NewDNSCommand() *cobra.Command {
+	options := synceroptions.NewDNSOptions()
 	dnsCommand := &cobra.Command{
 		Use:   "dns",
 		Short: "Manage kcp dns server",
@@ -33,10 +36,20 @@ func NewDNSCommand() *cobra.Command {
 		Short: "Start the kcp dns server",
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := options.Complete(); err != nil {
+				return err
+			}
+			if err := options.Validate(); err != nil {
+				return err
+			}
+
+			nsmap.ConfigMapName = options.ConfigMapName
+
 			coremain.Start()
 			return nil
 		},
 	}
+	options.AddFlags(startCmd.Flags())
 
 	dnsCommand.AddCommand(startCmd)
 

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -108,6 +108,7 @@ func Run(ctx context.Context, options *synceroptions.Options) error {
 	if err := syncer.StartSyncer(
 		ctx,
 		&syncer.SyncerConfig{
+<<<<<<< HEAD
 			UpstreamConfig:                upstreamConfig,
 			DownstreamConfig:              downstreamConfig,
 			ResourcesToSync:               sets.NewString(options.SyncedResourceTypes...),
@@ -116,6 +117,15 @@ func Run(ctx context.Context, options *synceroptions.Options) error {
 			SyncTargetUID:                 options.SyncTargetUID,
 			DNSServer:                     options.DNSServer,
 			DownstreamNamespaceCleanDelay: options.DownstreamNamespaceCleanDelay,
+=======
+			UpstreamConfig:      upstreamConfig,
+			DownstreamConfig:    downstreamConfig,
+			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
+			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),
+			SyncTargetName:      options.SyncTargetName,
+			SyncTargetUID:       options.SyncTargetUID,
+			DNSImage:            options.DNSImage,
+>>>>>>> ef48ca9b (Create one DNS nameserver per workspace)
 		},
 		numThreads,
 		options.APIImportPollInterval,

--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -108,24 +108,14 @@ func Run(ctx context.Context, options *synceroptions.Options) error {
 	if err := syncer.StartSyncer(
 		ctx,
 		&syncer.SyncerConfig{
-<<<<<<< HEAD
 			UpstreamConfig:                upstreamConfig,
 			DownstreamConfig:              downstreamConfig,
 			ResourcesToSync:               sets.NewString(options.SyncedResourceTypes...),
 			SyncTargetWorkspace:           logicalcluster.New(options.FromClusterName),
 			SyncTargetName:                options.SyncTargetName,
 			SyncTargetUID:                 options.SyncTargetUID,
-			DNSServer:                     options.DNSServer,
+			DNSImage:                      options.DNSImage,
 			DownstreamNamespaceCleanDelay: options.DownstreamNamespaceCleanDelay,
-=======
-			UpstreamConfig:      upstreamConfig,
-			DownstreamConfig:    downstreamConfig,
-			ResourcesToSync:     sets.NewString(options.SyncedResourceTypes...),
-			SyncTargetWorkspace: logicalcluster.New(options.FromClusterName),
-			SyncTargetName:      options.SyncTargetName,
-			SyncTargetUID:       options.SyncTargetUID,
-			DNSImage:            options.DNSImage,
->>>>>>> ef48ca9b (Create one DNS nameserver per workspace)
 		},
 		numThreads,
 		options.APIImportPollInterval,

--- a/cmd/syncer/options/dnsoptions.go
+++ b/cmd/syncer/options/dnsoptions.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+)
+
+type DNSOptions struct {
+	ConfigMapName string
+}
+
+func NewDNSOptions() *DNSOptions {
+	return &DNSOptions{}
+}
+
+func (options *DNSOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&options.ConfigMapName, "configmap-name", options.ConfigMapName, "name of the ConfigMap containing namespace mappings")
+}
+
+func (options *DNSOptions) Complete() error {
+	return nil
+}
+
+func (options *DNSOptions) Validate() error {
+	if options.ConfigMapName == "" {
+		return errors.New("--configmap-name is required")
+	}
+
+	return nil
+}

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -43,7 +43,7 @@ type Options struct {
 	SyncTargetUID                 string
 	Logs                          *logs.Options
 	SyncedResourceTypes           []string
-	DNSServer                     string
+	DNSImage                      string
 	DownstreamNamespaceCleanDelay time.Duration
 
 	APIImportPollInterval time.Duration
@@ -80,8 +80,9 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(kcpfeatures.NewFlagValue(), "feature-gates", ""+
 		"A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(kcpfeatures.KnownFeatures(), "\n")) // hide kube-only gates
-	fs.StringVar(&options.DNSServer, "dns", options.DNSServer, "kcp DNS server name.")
+	fs.StringVar(&options.DNSImage, "dns-image", options.DNSImage, "kcp DNS server image.")
 	fs.DurationVar(&options.DownstreamNamespaceCleanDelay, "downstream-namespace-clean-delay", options.DownstreamNamespaceCleanDelay, "Time to wait before deleting of a downstream namespace.")
+
 	options.Logs.AddFlags(fs)
 }
 

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -29,8 +29,8 @@
 /pkg/admission/webhook/generic_webhook.go:142:5: function "Errorf" should not be used, convert to contextual logging
 /pkg/admission/webhook/generic_webhook.go:172:4: function "Errorf" should not be used, convert to contextual logging
 /pkg/authorization/delegated/authorizer.go:45:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/cliplugins/workload/plugin/sync.go:592:4: function "Infof" should not be used, convert to contextual logging
-/pkg/cliplugins/workload/plugin/sync.go:592:4: function "V" should not be used, convert to contextual logging
+/pkg/cliplugins/workload/plugin/sync.go:594:4: function "Infof" should not be used, convert to contextual logging
+/pkg/cliplugins/workload/plugin/sync.go:594:4: function "V" should not be used, convert to contextual logging
 /pkg/dns/plugin/nsmap/namespace.go:68:2: function "Info" should not be used, convert to contextual logging
 /pkg/dns/plugin/nsmap/namespace.go:68:2: function "V" should not be used, convert to contextual logging
 /pkg/embeddedetcd/server.go:44:2: function "Info" should not be used, convert to contextual logging
@@ -93,20 +93,20 @@
 /pkg/server/home_workspaces.go:352:5: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/home_workspaces.go:638:6: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
-/pkg/syncer/namespace/namespace_downstream_process.go:44:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/namespace/namespace_downstream_process.go:83:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/namespace/namespace_downstream_process.go:83:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:45:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:90:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/namespace/namespace_downstream_process.go:90:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
 /pkg/syncer/namespace/namespace_upstream_process.go:41:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
 /pkg/syncer/namespace/namespace_upstream_process.go:41:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
 /pkg/syncer/namespace/namespace_upstream_process.go:79:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/spec/spec_controller.go:145:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/spec/spec_controller.go:145:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/spec/spec_controller.go:161:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/spec/spec_controller.go:161:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
 /pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:117:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:135:4: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
 /pkg/syncer/spec/spec_process.go:153:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/spec/spec_process.go:358:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/spec/spec_process.go:364:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
 /pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
 /pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -37,12 +37,6 @@ metadata:
   namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-  namespace: kcp-syncer-sync-target-name-34b23c4k
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: kcp-syncer-sync-target-name-34b23c4k-token
@@ -82,20 +76,6 @@ rules:
   - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kcp-syncer-sync-target-name-34b23c4k
@@ -109,16 +89,67 @@ subjects:
   namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
   name: kcp-dns-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kcp-dns-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: kcp-dns-sync-target-name-34b23c4k
 subjects:
   - kind: ServiceAccount
-    name: kcp-dns-sync-target-name-34b23c4k
+    name: kcp-syncer-sync-target-name-34b23c4k
     namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
@@ -178,7 +209,7 @@ spec:
         - --resources=resource2
         - --qps=123.4
         - --burst=456
-        - --dns=kcp-dns-sync-target-name-34b23c4k.kcp-syncer-sync-target-name-34b23c4k.svc.cluster.local
+        - --dns-image=image
         env:
         - name: NAMESPACE
           valueFrom:
@@ -197,62 +228,6 @@ spec:
           secret:
             secretName: kcp-syncer-sync-target-name-34b23c4k
             optional: false
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-  namespace: kcp-syncer-sync-target-name-34b23c4k
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: kcp-dns-sync-target-name-34b23c4k
-  template:
-    metadata:
-      labels:
-        app: kcp-dns-sync-target-name-34b23c4k
-    spec:
-      containers:
-      - name: kcp-dns
-        command:
-        - /ko-app/syncer
-        args:
-        - dns
-        - start
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: image
-        imagePullPolicy: IfNotPresent
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccountName: kcp-dns-sync-target-name-34b23c4k
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-  namespace: kcp-syncer-sync-target-name-34b23c4k
-  labels:
-    app: kcp-dns-sync-target-name-34b23c4k
-spec:
-  type: ClusterIP
-  selector:
-    app: kcp-dns-sync-target-name-34b23c4k
-  ports:
-    - name: dns
-      port: 53
-      protocol: UDP
-      targetPort: 5353
-    - name: dns-tcp
-      port: 53
-      protocol: TCP
-      targetPort: 5353
-
 `
 
 	actualYAML, err := renderSyncerResources(templateInput{
@@ -286,12 +261,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kcp-syncer-sync-target-name-34b23c4k
-  namespace: kcp-syncer-sync-target-name-34b23c4k
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
   namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
@@ -334,20 +303,6 @@ rules:
   - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kcp-syncer-sync-target-name-34b23c4k
@@ -361,16 +316,67 @@ subjects:
   namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
   name: kcp-dns-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kcp-dns-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: kcp-dns-sync-target-name-34b23c4k
 subjects:
   - kind: ServiceAccount
-    name: kcp-dns-sync-target-name-34b23c4k
+    name: kcp-syncer-sync-target-name-34b23c4k
     namespace: kcp-syncer-sync-target-name-34b23c4k
 ---
 apiVersion: v1
@@ -431,7 +437,7 @@ spec:
         - --qps=123.4
         - --burst=456
         - --feature-gates=myfeature=true
-        - --dns=kcp-dns-sync-target-name-34b23c4k.kcp-syncer-sync-target-name-34b23c4k.svc.cluster.local
+        - --dns-image=image
         env:
         - name: NAMESPACE
           valueFrom:
@@ -450,62 +456,6 @@ spec:
           secret:
             secretName: kcp-syncer-sync-target-name-34b23c4k
             optional: false
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-  namespace: kcp-syncer-sync-target-name-34b23c4k
-spec:
-  replicas: 1
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: kcp-dns-sync-target-name-34b23c4k
-  template:
-    metadata:
-      labels:
-        app: kcp-dns-sync-target-name-34b23c4k
-    spec:
-      containers:
-      - name: kcp-dns
-        command:
-        - /ko-app/syncer
-        args:
-        - dns
-        - start
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: image
-        imagePullPolicy: IfNotPresent
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccountName: kcp-dns-sync-target-name-34b23c4k
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: kcp-dns-sync-target-name-34b23c4k
-  namespace: kcp-syncer-sync-target-name-34b23c4k
-  labels:
-    app: kcp-dns-sync-target-name-34b23c4k
-spec:
-  type: ClusterIP
-  selector:
-    app: kcp-dns-sync-target-name-34b23c4k
-  ports:
-    - name: dns
-      port: 53
-      protocol: UDP
-      targetPort: 5353
-    - name: dns-tcp
-      port: 53
-      protocol: TCP
-      targetPort: 5353
-
 `
 	actualYAML, err := renderSyncerResources(templateInput{
 		ServerURL:                   "server-url",

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -11,12 +11,6 @@ metadata:
   namespace: {{.Namespace}}
 ---
 apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{.DNSServiceAccount}}
-  namespace: {{.Namespace}}
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: {{.ServiceAccount}}-token
@@ -59,20 +53,6 @@ rules:
 {{- end}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{.DNSClusterRole}}
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - "get"
-      - "list"
-      - "watch"
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{.ClusterRoleBinding}}
@@ -86,16 +66,67 @@ subjects:
   namespace: {{.Namespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
-  name: {{.DNSClusterRoleBinding}}
+  name: {{.DNSRole}}
+  namespace: {{.Namespace}}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.DNSRoleBinding}}
+  namespace: {{.Namespace}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{.DNSClusterRole}}
+  kind: Role
+  name: {{.DNSRole}}
 subjects:
   - kind: ServiceAccount
-    name: {{.DNSServiceAccount}}
+    name: {{.ServiceAccount}}
     namespace: {{.Namespace}}
 ---
 apiVersion: v1
@@ -159,7 +190,7 @@ spec:
 {{- if .FeatureGatesString }}
         - --feature-gates={{ .FeatureGatesString }}
 {{- end}}
-        - --dns={{.DNSAppName}}.{{.Namespace}}.svc.cluster.local
+        - --dns-image={{.Image}}
         env:
         - name: NAMESPACE
           valueFrom:
@@ -178,59 +209,3 @@ spec:
           secret:
             secretName: {{.Secret}}
             optional: false
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{.DNSAppName}}
-  namespace: {{.Namespace}}
-spec:
-  replicas: {{.Replicas}}
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: {{.DNSAppName}}
-  template:
-    metadata:
-      labels:
-        app: {{.DNSAppName}}
-    spec:
-      containers:
-      - name: kcp-dns
-        command:
-        - /ko-app/syncer
-        args:
-        - dns
-        - start
-        env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        image: {{.Image}}
-        imagePullPolicy: IfNotPresent
-        terminationMessagePolicy: FallbackToLogsOnError
-      serviceAccountName: {{.DNSServiceAccount}}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{.DNSAppName}}
-  namespace: {{.Namespace}}
-  labels:
-    app: {{.DNSAppName}}
-spec:
-  type: ClusterIP
-  selector:
-    app: {{.DNSAppName}}
-  ports:
-    - name: dns
-      port: 53
-      protocol: UDP
-      targetPort: 5353
-    - name: dns-tcp
-      port: 53
-      protocol: TCP
-      targetPort: 5353
-

--- a/pkg/dns/plugin/nsmap/config.go
+++ b/pkg/dns/plugin/nsmap/config.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
+var (
 	// ConfigMapName is the name of the configmap containing logical to physical namespace mappings
 	ConfigMapName = "config-nsmap"
 )

--- a/pkg/syncer/namespace/namespace_downstream_process_test.go
+++ b/pkg/syncer/namespace/namespace_downstream_process_test.go
@@ -132,6 +132,7 @@ func TestSyncerNamespaceProcess(t *testing.T) {
 				syncTargetWorkspace: syncTargetWorkspace,
 				syncTargetUID:       syncTargetUID,
 				syncTargetKey:       syncTargetKey,
+				dnsNamespace:        "kcp-hcbsa8z6c2er",
 			}
 
 			var key string

--- a/pkg/syncer/spec/dns/deployment_dns.yaml
+++ b/pkg/syncer/spec/dns/deployment_dns.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: Name
+  namespace: Namespace
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: Name
+  template:
+    metadata:
+      labels:
+        app: Name
+    spec:
+      containers:
+        - name: kcp-dns
+          command:
+            - /ko-app/syncer
+          args:
+            - dns
+            - start
+            - --configmap-name
+            - ConfigMapName
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          image: Image
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: Name

--- a/pkg/syncer/spec/dns/dns_process.go
+++ b/pkg/syncer/spec/dns/dns_process.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"context"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	listersappsv1 "k8s.io/client-go/listers/apps/v1"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	listersrbacv1 "k8s.io/client-go/listers/rbac/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+type DNSProcessor struct {
+	downstreamKubeClient kubernetes.Interface
+
+	serviceAccountLister listerscorev1.ServiceAccountLister
+	roleLister           listersrbacv1.RoleLister
+	roleBindingLister    listersrbacv1.RoleBindingLister
+	deploymentLister     listersappsv1.DeploymentLister
+	serviceLister        listerscorev1.ServiceLister
+	endpointLister       listerscorev1.EndpointsLister
+
+	syncTargetName string
+	syncTargetUID  types.UID
+	dnsNamespace   string // namespace containing all DNS objects
+	dnsImage       string
+}
+
+func NewDNSProcessor(
+	downstreamKubeClient kubernetes.Interface,
+	serviceAccountLister listerscorev1.ServiceAccountLister,
+	roleLister listersrbacv1.RoleLister,
+	roleBindingLister listersrbacv1.RoleBindingLister,
+	deploymentLister listersappsv1.DeploymentLister,
+	serviceLister listerscorev1.ServiceLister,
+	endpointLister listerscorev1.EndpointsLister,
+	syncTargetName string,
+	syncTargetUID types.UID,
+	dnsNamespace string,
+	dnsImage string) *DNSProcessor {
+
+	return &DNSProcessor{
+		downstreamKubeClient: downstreamKubeClient,
+		serviceAccountLister: serviceAccountLister,
+		roleLister:           roleLister,
+		roleBindingLister:    roleBindingLister,
+		deploymentLister:     deploymentLister,
+		serviceLister:        serviceLister,
+		endpointLister:       endpointLister,
+		syncTargetName:       syncTargetName,
+		syncTargetUID:        syncTargetUID,
+		dnsNamespace:         dnsNamespace,
+		dnsImage:             dnsImage,
+	}
+}
+
+// Process reconciles all DNS objects: it checks they exist and are up-to-date.
+func (d *DNSProcessor) Process(ctx context.Context, workspace logicalcluster.Name) error {
+	logger := klog.FromContext(ctx)
+	logger.WithName("dns")
+
+	dnsID := shared.GetDNSID(workspace, d.syncTargetUID, d.syncTargetName)
+	logger.WithValues("name", dnsID, "namespace", d.dnsNamespace)
+
+	logger.Info("checking if all dns objects exist and are up-to-date")
+	ctx = klog.NewContext(ctx, logger)
+
+	if err := d.processServiceAccount(ctx, dnsID); err != nil {
+		return err
+	}
+	if err := d.processRole(ctx, dnsID); err != nil {
+		return err
+	}
+	if err := d.processRoleBinding(ctx, dnsID); err != nil {
+		return err
+	}
+	if err := d.processDeployment(ctx, dnsID); err != nil {
+		return err
+	}
+	if err := d.processService(ctx, dnsID); err != nil {
+		return err
+	}
+
+	// TODO: check endpoints. It's disabled until we figure out how to update e2e tests.
+	//endpoints, err := d.endpointLister.Endpoints(d.dnsNamespace).Get(dnsID)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//if hasAtLeastOneReadyAddress(endpoints) {
+	//	return nil
+	//}
+
+	return nil
+}
+
+func (d *DNSProcessor) processServiceAccount(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	expected := MakeServiceAccount(name, d.dnsNamespace)
+	_, err := d.serviceAccountLister.ServiceAccounts(d.dnsNamespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err := d.downstreamKubeClient.CoreV1().ServiceAccounts(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to create ServiceAccount (retrying)")
+				return err // retry
+			}
+			logger.Info("ServiceAccount created")
+		}
+		logger.Error(err, "failed to get ServiceAccount (retrying)")
+		return err
+	}
+
+	// TODO: check object has the expected content (eg. after an upgrade)
+
+	return nil
+}
+
+func (d *DNSProcessor) processRole(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	expected := MakeRole(name, d.dnsNamespace)
+	_, err := d.roleLister.Roles(d.dnsNamespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err := d.downstreamKubeClient.RbacV1().Roles(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to create Role (retrying)")
+				return err // retry
+			}
+			logger.Info("Role created")
+		}
+		logger.Error(err, "failed to get Role (retrying)")
+		return err
+	}
+
+	// TODO: check object has the expected content (eg. after an upgrade)
+
+	return nil
+}
+
+func (d *DNSProcessor) processRoleBinding(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	expected := MakeRoleBinding(name, d.dnsNamespace)
+	_, err := d.roleBindingLister.RoleBindings(d.dnsNamespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err := d.downstreamKubeClient.RbacV1().RoleBindings(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to create RoleBinding (retrying)")
+				return err // retry
+			}
+			logger.Info("RoleBinding created")
+		}
+		logger.Error(err, "failed to get RoleBinding (retrying)")
+		return err
+	}
+
+	// TODO: check object has the expected content (eg. after an upgrade)
+
+	return nil
+}
+
+func (d *DNSProcessor) processDeployment(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	expected := MakeDeployment(name, d.dnsNamespace, d.dnsImage)
+	_, err := d.deploymentLister.Deployments(d.dnsNamespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err := d.downstreamKubeClient.AppsV1().Deployments(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to create Deployment (retrying)")
+				return err // retry
+			}
+			logger.Info("Deployment created")
+		}
+		logger.Error(err, "failed to get Deployment (retrying)")
+		return err
+	}
+
+	// TODO: check object has the expected content (eg. after an upgrade)
+
+	return nil
+}
+
+func (d *DNSProcessor) processService(ctx context.Context, name string) error {
+	logger := klog.FromContext(ctx)
+
+	expected := MakeService(name, d.dnsNamespace)
+	_, err := d.serviceLister.Services(d.dnsNamespace).Get(name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err := d.downstreamKubeClient.CoreV1().Services(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+			if err != nil {
+				logger.Error(err, "failed to create Service (retrying)")
+				return err // retry
+			}
+			logger.Info("Service created")
+		}
+		logger.Error(err, "failed to get Service (retrying)")
+		return err
+	}
+
+	// TODO: check object has the expected content (eg. after an upgrade)
+
+	return nil
+}
+
+//
+//func hasAtLeastOneReadyAddress(endpoints *corev1.Endpoints) bool {
+//	for _, s := range endpoints.Subsets {
+//		if len(s.Addresses) > 0 {
+//			return true
+//		}
+//	}
+//	return false
+//}

--- a/pkg/syncer/spec/dns/resources.go
+++ b/pkg/syncer/spec/dns/resources.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+	"log"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+//go:embed *.yaml
+var dnsFiles embed.FS
+
+var (
+	serviceAccountTemplate corev1.ServiceAccount
+	roleTemplate           rbacv1.Role
+	roleBindingTemplate    rbacv1.RoleBinding
+	deploymentTemplate     appsv1.Deployment
+	serviceTemplate        corev1.Service
+)
+
+func init() {
+	loadTemplateOrDie("serviceaccount_dns.yaml", &serviceAccountTemplate)
+	loadTemplateOrDie("role_dns.yaml", &roleTemplate)
+	loadTemplateOrDie("rolebinding_dns.yaml", &roleBindingTemplate)
+	loadTemplateOrDie("deployment_dns.yaml", &deploymentTemplate)
+	loadTemplateOrDie("service_dns.yaml", &serviceTemplate)
+}
+
+func MakeServiceAccount(name, namespace string) *corev1.ServiceAccount {
+	sa := serviceAccountTemplate.DeepCopy()
+
+	sa.Name = name
+	sa.Namespace = namespace
+
+	return sa
+}
+
+func MakeRole(name, namespace string) *rbacv1.Role {
+	role := roleTemplate.DeepCopy()
+
+	role.Name = name
+	role.Namespace = namespace
+	role.Rules[0].ResourceNames[0] = name
+
+	return role
+}
+
+func MakeRoleBinding(name, namespace string) *rbacv1.RoleBinding {
+	roleBinding := roleBindingTemplate.DeepCopy()
+
+	roleBinding.Name = name
+	roleBinding.Namespace = namespace
+	roleBinding.RoleRef.Name = name
+	roleBinding.Subjects[0].Name = name
+	roleBinding.Subjects[0].Namespace = namespace
+
+	return roleBinding
+}
+
+func MakeDeployment(name, namespace, image string) *appsv1.Deployment {
+	deploymentTemplate := deploymentTemplate.DeepCopy()
+
+	deploymentTemplate.Name = name
+	deploymentTemplate.Namespace = namespace
+	deploymentTemplate.Spec.Selector.MatchLabels["app"] = name
+	deploymentTemplate.Spec.Template.Labels["app"] = name
+	deploymentTemplate.Spec.Template.Spec.Containers[0].Image = image
+	deploymentTemplate.Spec.Template.Spec.Containers[0].Args[3] = name
+	deploymentTemplate.Spec.Template.Spec.ServiceAccountName = name
+
+	return deploymentTemplate
+}
+
+func MakeService(name, namespace string) *corev1.Service {
+	service := serviceTemplate.DeepCopy()
+
+	service.Name = name
+	service.Namespace = namespace
+	service.Labels["app"] = name
+	service.Spec.Selector["app"] = name
+
+	return service
+}
+
+// load a YAML resource into a typed kubernetes object.
+func loadTemplateOrDie(filename string, obj interface{}) {
+	raw, err := dnsFiles.ReadFile(filename)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read file: %v", err))
+	}
+	decoder := yaml.NewYAMLToJSONDecoder(bytes.NewReader(raw))
+
+	var u unstructured.Unstructured
+	err = decoder.Decode(&u)
+	if err != nil {
+		log.Fatalf("failed to decode file: %v", err)
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, obj)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert object: %v", err))
+	}
+}

--- a/pkg/syncer/spec/dns/role_dns.yaml
+++ b/pkg/syncer/spec/dns/role_dns.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: Name
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - ConfigMapName
+    verbs:
+      - "get"
+      - "list"
+      - "watch"

--- a/pkg/syncer/spec/dns/rolebinding_dns.yaml
+++ b/pkg/syncer/spec/dns/rolebinding_dns.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: Name
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: Name
+subjects:
+  - kind: ServiceAccount
+    name: Name
+    namespace: Name

--- a/pkg/syncer/spec/dns/service_dns.yaml
+++ b/pkg/syncer/spec/dns/service_dns.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: Name
+  namespace: Namespace
+  labels:
+    app: Name
+spec:
+  type: ClusterIP
+  selector:
+    app: Name
+  ports:
+    - name: dns
+      port: 53
+      protocol: UDP
+      targetPort: 5353
+    - name: dns-tcp
+      port: 53
+      protocol: TCP
+      targetPort: 5353

--- a/pkg/syncer/spec/dns/serviceaccount_dns.yaml
+++ b/pkg/syncer/spec/dns/serviceaccount_dns.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: Name
+  namespace: Namespace

--- a/pkg/syncer/spec/mutators/deployment.go
+++ b/pkg/syncer/spec/mutators/deployment.go
@@ -18,6 +18,7 @@ package mutators
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"sort"
 
@@ -28,7 +29,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilspointer "k8s.io/utils/pointer"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+var (
+	// DefaultLookupIPFn is the IP lookup function used by the deployment mutator.
+	// Override for testing only
+	DefaultLookupIPFn = net.LookupIP
 )
 
 type ListSecretFunc func(clusterName logicalcluster.Name, namespace string) ([]runtime.Object, error)
@@ -37,7 +47,10 @@ type DeploymentMutator struct {
 	upstreamURL                  *url.URL
 	listSecrets                  ListSecretFunc
 	syncTargetLogicalClusterName logicalcluster.Name
-	dnsIP                        string
+	syncTargetUID                types.UID
+	syncTargetName               string
+	dnsNamespace                 string
+	dnsIPs                       map[string]string
 }
 
 func (dm *DeploymentMutator) GVR() schema.GroupVersionResource {
@@ -48,12 +61,18 @@ func (dm *DeploymentMutator) GVR() schema.GroupVersionResource {
 	}
 }
 
-func NewDeploymentMutator(upstreamURL *url.URL, secretLister ListSecretFunc, syncTargetLogicalClusterName logicalcluster.Name, dnsIP string) *DeploymentMutator {
+func NewDeploymentMutator(upstreamURL *url.URL, secretLister ListSecretFunc, syncTargetLogicalClusterName logicalcluster.Name,
+	syncTargetUID types.UID, syncTargetName, dnsNamespace string) *DeploymentMutator {
+
 	return &DeploymentMutator{
 		upstreamURL:                  upstreamURL,
 		listSecrets:                  secretLister,
 		syncTargetLogicalClusterName: syncTargetLogicalClusterName,
-		dnsIP:                        dnsIP,
+		syncTargetUID:                syncTargetUID,
+		syncTargetName:               syncTargetName,
+
+		dnsNamespace: dnsNamespace,
+		dnsIPs:       map[string]string{}, // map workspace ID to DNS IP
 	}
 }
 
@@ -216,24 +235,27 @@ func (dm *DeploymentMutator) Mutate(obj *unstructured.Unstructured) error {
 		templateSpec.Volumes = append(templateSpec.Volumes, serviceAccountVolume)
 	}
 
-	// TODO: multiple worskpaces support. See https://github.com/kcp-dev/kcp/issues/1987
-	if dm.syncTargetLogicalClusterName == upstreamLogicalName {
-		// Overrides DNS to point to the workspace DNS
-		deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
-		deployment.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
-			Nameservers: []string{dm.dnsIP},
-			Searches: []string{ // TODO(LV): from /etc/resolv.conf
-				obj.GetNamespace() + ".svc.cluster.local",
-				"svc.cluster.local",
-				"cluster.local",
+	// Overrides DNS to point to the workspace DNS
+	dnsIP, err := dm.getDNSIPForWorkspace(upstreamLogicalName)
+	if err != nil {
+		// the DNS nameserver is not ready yet or other transient failure
+		return err // retry
+	}
+
+	deployment.Spec.Template.Spec.DNSPolicy = corev1.DNSNone
+	deployment.Spec.Template.Spec.DNSConfig = &corev1.PodDNSConfig{
+		Nameservers: []string{dnsIP},
+		Searches: []string{ // TODO(LV): from /etc/resolv.conf
+			obj.GetNamespace() + ".svc.cluster.local",
+			"svc.cluster.local",
+			"cluster.local",
+		},
+		Options: []corev1.PodDNSConfigOption{
+			{
+				Name:  "ndots",
+				Value: utilspointer.String("5"),
 			},
-			Options: []corev1.PodDNSConfigOption{
-				{
-					Name:  "ndots",
-					Value: utilspointer.String("5"),
-				},
-			},
-		}
+		},
 	}
 
 	unstructured, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&deployment)
@@ -245,6 +267,27 @@ func (dm *DeploymentMutator) Mutate(obj *unstructured.Unstructured) error {
 	obj.SetUnstructuredContent(unstructured)
 
 	return nil
+}
+
+func (dm *DeploymentMutator) getDNSIPForWorkspace(workspace logicalcluster.Name) (string, error) {
+	// Retrieve the DNS IP associated to the workspace
+	dnsServiceName := shared.GetDNSID(workspace, dm.syncTargetUID, dm.syncTargetName)
+
+	// cached?
+	if ip, ok := dm.dnsIPs[dnsServiceName]; ok {
+		return ip, nil
+	}
+
+	// Not cached: do actual lookup
+	qname := fmt.Sprintf("%s.%s.svc.cluster.local", dnsServiceName, dm.dnsNamespace)
+
+	ips, err := DefaultLookupIPFn(qname)
+	if len(ips) == 0 || err != nil {
+		// not available (yet)
+		return "", fmt.Errorf("failed to get DNS nameserver IP address: %w", err)
+	}
+
+	return ips[0].String(), nil
 }
 
 // resolveDownwardAPIFieldRefEnv replaces the downwardAPI FieldRef EnvVars with the value from the deployment, right now it only replaces the metadata.namespace

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -194,6 +194,12 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		}
 	}
 
+	// Make sure the DNS nameserver for the spec workspace is up and running
+	if err := c.dnsProcessor.Process(ctx, clusterName); err != nil {
+		logger.Error(err, "failed to check DNS nameserver is up and running (retrying)")
+		return err
+	}
+
 	if added, err := c.ensureSyncerFinalizer(ctx, gvr, upstreamObj); added {
 		// The successful update of the upstream resource finalizer will trigger a new reconcile
 		return nil

--- a/test/e2e/fixtures/kube/core.k8s.io_endpoints.yaml
+++ b/test/e2e/fixtures/kube/core.k8s.io_endpoints.yaml
@@ -1,0 +1,154 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: endpoints.core
+spec:
+  group: ""
+  names:
+    kind: Endpoints
+    listKind: EndpointsList
+    plural: endpoints
+    singular: endpoints
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'Endpoints is a collection of endpoints that implement the actual service. Example:   Name: "mysvc",   Subsets: [     {       Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],       Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]     },     {       Addresses: [{"ip": "10.10.3.3"}],       Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]     },  ]'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          subsets:
+            description: The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
+            items:
+              description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+              properties:
+                addresses:
+                  description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+                  items:
+                    description: EndpointAddress is a tuple that describes single IP address.
+                    properties:
+                      hostname:
+                        description: The Hostname of this endpoint
+                        type: string
+                      ip:
+                        description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                        type: string
+                      nodeName:
+                        description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                        type: string
+                      targetRef:
+                        description: Reference to object providing the endpoint.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                notReadyAddresses:
+                  description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+                  items:
+                    description: EndpointAddress is a tuple that describes single IP address.
+                    properties:
+                      hostname:
+                        description: The Hostname of this endpoint
+                        type: string
+                      ip:
+                        description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                        type: string
+                      nodeName:
+                        description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                        type: string
+                      targetRef:
+                        description: Reference to object providing the endpoint.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ip
+                    type: object
+                  type: array
+                ports:
+                  description: Port numbers available on the related IP addresses.
+                  items:
+                    description: EndpointPort is a tuple that describes a single port.
+                    properties:
+                      appProtocol:
+                        description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                        type: string
+                      name:
+                        description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+                        type: string
+                      port:
+                        description: The port number of the endpoint.
+                        format: int32
+                        type: integer
+                      protocol:
+                        default: TCP
+                        description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  type: array
+              type: object
+            type: array
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -351,6 +352,11 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 				return []net.IP{net.ParseIP("8.8.8.8")}, nil
 			}
 		})
+
+		// Manually create the DNS Endpoints for the main workspace
+		dnsID := shared.GetDNSID(sf.workspaceClusterName, types.UID(syncerConfig.SyncTargetUID), sf.syncTargetName)
+		_, err = downstreamKubeClient.CoreV1().Endpoints(syncerID).Create(ctx, endpoints(dnsID, syncerID), metav1.CreateOptions{})
+		require.NoError(t, err)
 	}
 
 	startedSyncer := &StartedSyncerFixture{
@@ -358,6 +364,7 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 		SyncerID:             syncerID,
 		DownstreamConfig:     downstreamConfig,
 		DownstreamKubeClient: downstreamKubeClient,
+		useDeployedSyncer:    useDeployedSyncer,
 	}
 
 	// The sync target becoming ready indicates the syncer is healthy and has
@@ -376,6 +383,7 @@ type StartedSyncerFixture struct {
 	// SyncerConfig will be less privileged.
 	DownstreamConfig     *rest.Config
 	DownstreamKubeClient kubernetesclient.Interface
+	useDeployedSyncer    bool
 }
 
 // WaitForClusterReady waits for the cluster to be ready with the given reason.
@@ -388,6 +396,15 @@ func (sf *StartedSyncerFixture) WaitForClusterReady(t *testing.T, ctx context.Co
 		return kcpClusterClient.WorkloadV1alpha1().SyncTargets().Get(logicalcluster.WithCluster(ctx, cfg.SyncTargetWorkspace), cfg.SyncTargetName, metav1.GetOptions{})
 	}, "Waiting for cluster %q condition %q", cfg.SyncTargetName, conditionsv1alpha1.ReadyCondition)
 	t.Logf("Cluster %q is %s", cfg.SyncTargetName, conditionsv1alpha1.ReadyCondition)
+}
+
+// BoundWorkspace is called when a new workspace is bound to this workload workspace
+func (sf *StartedSyncerFixture) BoundWorkspace(t *testing.T, ctx context.Context, workspace logicalcluster.Name) {
+	if !sf.useDeployedSyncer {
+		dnsID := shared.GetDNSID(workspace, types.UID(sf.SyncerConfig.SyncTargetUID), sf.SyncerConfig.SyncTargetName)
+		_, err := sf.DownstreamKubeClient.CoreV1().Endpoints(sf.SyncerID).Create(ctx, endpoints(dnsID, sf.SyncerID), metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
 }
 
 // syncerConfigFromCluster reads the configuration needed to start an in-process
@@ -483,4 +500,19 @@ func syncerArgsToMap(args []string) (map[string][]string, error) {
 		}
 	}
 	return argMap, nil
+}
+
+func endpoints(name, namespace string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{Addresses: []corev1.EndpointAddress{
+				{
+					IP: "8.8.8.8",
+				}}},
+		},
+	}
 }

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -184,7 +184,7 @@ func TestClusterController(t *testing.T) {
 			require.NoError(t, err)
 
 			syncerFixture := framework.NewSyncerFixture(t, source, wsClusterName,
-				framework.WithExtraResources("cowboys.wildwest.dev", "services"),
+				framework.WithExtraResources("cowboys.wildwest.dev", "services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 				framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 					// Always install the crd regardless of whether the target is
 					// logical or not since cowboys is not a native type.
@@ -197,6 +197,7 @@ func TestClusterController(t *testing.T) {
 						// Only need to install services in a non-logical cluster
 						kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 							metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+							metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 						)
 					}
 				})).Start(t)

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -69,7 +69,7 @@ func TestSyncTargetLocalExport(t *testing.T) {
 	t.Logf("Creating a SyncTarget and syncer in %s", computeClusterName)
 	syncTarget := framework.NewSyncerFixture(t, source, computeClusterName,
 		framework.WithAPIExports(""),
-		framework.WithExtraResources("services"),
+		framework.WithExtraResources("services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithSyncTarget(computeClusterName, syncTargetName),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
@@ -81,6 +81,7 @@ func TestSyncTargetLocalExport(t *testing.T) {
 			t.Logf("Installing test CRDs into sink cluster...")
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
+++ b/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
@@ -120,6 +120,7 @@ func TestMultipleExports(t *testing.T) {
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
 				metav1.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/reconciler/locationworkspace/rootcompute_test.go
+++ b/test/e2e/reconciler/locationworkspace/rootcompute_test.go
@@ -66,6 +66,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 	syncTargetName := fmt.Sprintf("synctarget-%d", +rand.Intn(1000000))
 	t.Logf("Creating a SyncTarget and syncer in %s", computeClusterName)
 	syncerFixture := framework.NewSyncerFixture(t, source, computeClusterName,
+		framework.WithExtraResources("roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithSyncTarget(computeClusterName, syncTargetName),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
@@ -79,6 +80,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
 				metav1.GroupResource{Group: "apps.k8s.io", Resource: "deployments"},
 				metav1.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/reconciler/locationworkspace/rootcompute_test.go
+++ b/test/e2e/reconciler/locationworkspace/rootcompute_test.go
@@ -117,6 +117,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 		framework.WithAPIExportsWorkloadBindOption("root:compute:kubernetes"),
 		framework.WithLocationWorkspaceWorkloadBindOption(computeClusterName),
 	).Bind(t)
+	syncerFixture.BoundWorkspace(t, ctx, consumerWorkspace)
 
 	t.Logf("Wait for being able to list Services in the user workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/locationworkspace/synctarget_test.go
+++ b/test/e2e/reconciler/locationworkspace/synctarget_test.go
@@ -108,6 +108,7 @@ func TestSyncTargetExport(t *testing.T) {
 			t.Logf("Installing test CRDs into sink cluster...")
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -105,6 +105,7 @@ func TestNamespaceScheduler(t *testing.T) {
 						require.NoError(t, err, "failed to construct apiextensions client for server")
 						kubefixtures.Create(t, crdClusterClient.ApiextensionsV1().CustomResourceDefinitions(),
 							metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+							metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 						)
 					})).Start(t)
 				syncTargetName := syncerFixture.SyncerConfig.SyncTargetName

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -74,7 +74,7 @@ func TestScheduling(t *testing.T) {
 	syncTargetName := fmt.Sprintf("synctarget-%d", +rand.Intn(1000000))
 	t.Logf("Creating a SyncTarget and syncer in %s", negotiationClusterName)
 	syncerFixture := framework.NewSyncerFixture(t, source, negotiationClusterName,
-		framework.WithExtraResources("services"),
+		framework.WithExtraResources("services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithSyncTarget(negotiationClusterName, syncTargetName),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
@@ -86,6 +86,7 @@ func TestScheduling(t *testing.T) {
 			t.Logf("Installing test CRDs into sink cluster...")
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -167,6 +167,7 @@ func TestScheduling(t *testing.T) {
 	framework.NewBindCompute(t, userClusterName, source,
 		framework.WithLocationWorkspaceWorkloadBindOption(negotiationClusterName),
 	).Bind(t)
+	syncerFixture.BoundWorkspace(t, ctx, userClusterName)
 
 	t.Logf("Wait for being able to list Services in the user workspace")
 	require.Eventually(t, func() bool {
@@ -184,6 +185,7 @@ func TestScheduling(t *testing.T) {
 	framework.NewBindCompute(t, secondUserClusterName, source,
 		framework.WithLocationWorkspaceWorkloadBindOption(negotiationClusterName),
 	).Bind(t)
+	syncerFixture.BoundWorkspace(t, ctx, secondUserClusterName)
 
 	t.Logf("Wait for being able to list Services in the user workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -158,12 +158,14 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithLocationWorkspaceWorkloadBindOption(locationClusterName),
 		framework.WithLocationSelectorWorkloadBindOption(metav1.LabelSelector{MatchLabels: map[string]string{"loc": "loc1"}}),
 	).Bind(t)
+	firstSyncerFixture.BoundWorkspace(t, ctx, userClusterName)
 
 	t.Logf("Bind user workspace to location workspace with loc 2")
 	framework.NewBindCompute(t, userClusterName, source,
 		framework.WithLocationWorkspaceWorkloadBindOption(locationClusterName),
 		framework.WithLocationSelectorWorkloadBindOption(metav1.LabelSelector{MatchLabels: map[string]string{"loc": "loc2"}}),
 	).Bind(t)
+	secondSyncerFixture.BoundWorkspace(t, ctx, userClusterName)
 
 	t.Logf("Wait for being able to list Services in the user workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -68,7 +68,7 @@ func TestMultiPlacement(t *testing.T) {
 	t.Logf("Creating a SyncTarget and syncer in %s", locationClusterName)
 	firstSyncerFixture := framework.NewSyncerFixture(t, source, locationClusterName,
 		framework.WithSyncTarget(locationClusterName, firstSyncTargetName),
-		framework.WithExtraResources("services"),
+		framework.WithExtraResources("services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
 				// Only need to install services and ingresses in a logical cluster
@@ -79,6 +79,7 @@ func TestMultiPlacement(t *testing.T) {
 			t.Logf("Installing test CRDs into sink cluster...")
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),
@@ -87,7 +88,7 @@ func TestMultiPlacement(t *testing.T) {
 	secondSyncTargetName := fmt.Sprintf("synctarget-%d", +rand.Intn(1000000))
 	t.Logf("Creating a SyncTarget and syncer in %s", locationClusterName)
 	secondSyncerFixture := framework.NewSyncerFixture(t, source, locationClusterName,
-		framework.WithExtraResources("services"),
+		framework.WithExtraResources("services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithSyncTarget(locationClusterName, secondSyncTargetName),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
@@ -99,6 +100,7 @@ func TestMultiPlacement(t *testing.T) {
 			t.Logf("Installing test CRDs into sink cluster...")
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -99,6 +99,7 @@ func TestPlacementUpdate(t *testing.T) {
 		framework.WithLocationWorkspaceWorkloadBindOption(locationClusterName),
 		framework.WithPlacementNameBindOption(placementName),
 	).Bind(t)
+	syncerFixture.BoundWorkspace(t, ctx, userClusterName)
 
 	t.Logf("Wait for being able to list Services in the user workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -69,7 +69,7 @@ func TestPlacementUpdate(t *testing.T) {
 	t.Logf("Creating a SyncTarget and syncer in %s", locationClusterName)
 	syncerFixture := framework.NewSyncerFixture(t, source, locationClusterName,
 		framework.WithSyncTarget(locationClusterName, firstSyncTargetName),
-		framework.WithExtraResources("services"),
+		framework.WithExtraResources("services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
 				// Only need to install services and ingresses in a logical cluster
@@ -81,6 +81,7 @@ func TestPlacementUpdate(t *testing.T) {
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
 				metav1.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		}),

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -71,7 +71,7 @@ func TestSyncerLifecycle(t *testing.T) {
 	// heartbeating and the heartbeat controller setting the sync target ready in
 	// response.
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsClusterName,
-		framework.WithExtraResources("persistentvolumes"),
+		framework.WithExtraResources("persistentvolumes", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 		framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 			if !isFakePCluster {
 				// Only need to install services and ingresses in a logical cluster
@@ -83,6 +83,7 @@ func TestSyncerLifecycle(t *testing.T) {
 			kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "persistentvolumes"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 			require.NoError(t, err)
 		})).Start(t)
@@ -618,6 +619,7 @@ func TestCordonUncordonDrain(t *testing.T) {
 			require.NoError(t, err, "failed to construct apiextensions client for server")
 			kubefixtures.Create(t, crdClusterClient.ApiextensionsV1().CustomResourceDefinitions(),
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+				metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 			)
 		})).Start(t)
 	syncTargetName := syncerFixture.SyncerConfig.SyncTargetName

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -207,11 +207,13 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 	var testCases = []struct {
 		name string
-		work func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string)
+		work func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+			wildwestSyncer *framework.StartedSyncerFixture)
 	}{
 		{
 			name: "isolated API domains per syncer",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				kubelikeVWDiscoverClusterClient, err := clientgodiscovery.NewDiscoveryClientForConfig(kubelikeSyncerVWConfig)
 				require.NoError(t, err)
 
@@ -266,7 +268,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "access is authorized",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -364,7 +367,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "access kcp resources through syncer virtual workspace",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -477,7 +481,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "access kcp resources through syncer virtual workspace, from a other workspace to the wildwest resources through an APIBinding",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -488,6 +493,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 					framework.WithAPIExportsWorkloadBindOption(wildwestClusterName.String()+":kubernetes"),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestClusterName),
 				).Bind(t)
+				wildwestSyncer.BoundWorkspace(t, ctx, otherWorkspace)
 
 				wildwestClusterClient, err := wildwestclientset.NewForConfig(server.BaseConfig(t))
 				require.NoError(t, err)
@@ -582,7 +588,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "Never promote overridden syncer view status to upstream when scheduled on 2 synctargets",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -682,6 +689,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						},
 					}),
 				).Bind(t)
+				wildwestSyncer.BoundWorkspace(t, ctx, otherWorkspace)
 
 				framework.NewBindCompute(t, otherWorkspace, server,
 					framework.WithPlacementNameBindOption("secondplacement"),
@@ -693,6 +701,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						},
 					}),
 				).Bind(t)
+				wildwestSecondSyncer.BoundWorkspace(t, ctx, otherWorkspace)
 
 				wildwestClusterClient, err := wildwestclientset.NewForConfig(server.BaseConfig(t))
 				require.NoError(t, err)
@@ -806,7 +815,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "Correctly manage status, with promote and unpromote, when moving a cowboy from one synctarget to the other",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -815,6 +825,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 				_, err = kcpClusterClient.WorkloadV1alpha1().SyncTargets().Patch(logicalcluster.WithCluster(ctx, wildwestClusterName), wildwestSyncTargetName, types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/name","value":"`+wildwestSyncTargetName+`"}]`), metav1.PatchOptions{})
 				require.NoError(t, err)
+
+				otherWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 				t.Logf("Deploying second syncer into workspace %s", wildwestClusterName)
 				wildwestSecondSyncTargetName := wildwestSyncTargetName + "second"
@@ -899,7 +911,6 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				}, metav1.CreateOptions{})
 				require.NoError(t, err)
 
-				otherWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 				t.Logf("Using User workspace: %s", otherWorkspace.String())
 
 				logWithTimestamp := func(format string, args ...interface{}) {
@@ -917,6 +928,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						},
 					}),
 				).Bind(t)
+				wildwestSyncer.BoundWorkspace(t, ctx, otherWorkspace)
 
 				logWithTimestamp("Wait for being able to list cowboys in the other workspace (kubelike) through the virtual workspace")
 				require.Eventually(t, func() bool {
@@ -1021,6 +1033,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						},
 					}),
 				).Bind(t)
+				wildwestSecondSyncer.BoundWorkspace(t, ctx, otherWorkspace)
 
 				logWithTimestamp("Wait for resource controller to schedule cowboy on the 2 synctargets, and for both syncers to own it")
 				require.Eventually(t, func() bool {
@@ -1118,7 +1131,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "Transform spec through spec-diff annotation",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -1181,7 +1195,8 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 		},
 		{
 			name: "Override summarizing rules to disable status promotion",
-			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string) {
+			work: func(t *testing.T, kubelikeSyncerVWConfig, wildwestSyncerVWConfig *rest.Config, kubelikeClusterName, wildwestClusterName logicalcluster.Name, wildwestSyncTargetName string,
+				wildwestSyncer *framework.StartedSyncerFixture) {
 				ctx, cancelFunc := context.WithCancel(context.Background())
 				t.Cleanup(cancelFunc)
 
@@ -1353,7 +1368,6 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			}, wait.ForeverTestTimeout, time.Millisecond*100)
 
 			t.Log("Setting up an unrelated workspace with cowboys...")
-
 			unrelatedWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 
 			sourceCrdClient, err := kcpapiextensionsclientset.NewForConfig(server.BaseConfig(t))
@@ -1382,10 +1396,11 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			}, metav1.CreateOptions{})
 			require.NoError(t, err)
 
-			wildwestWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 			wildwestSyncTargetName := fmt.Sprintf("wildwest-%d", +rand.Intn(1000000))
 
+			wildwestWorkspace := framework.NewWorkspaceFixture(t, server, orgClusterName)
 			t.Logf("Deploying syncer into workspace %s", wildwestWorkspace)
+
 			wildwestSyncer := framework.NewSyncerFixture(t, server, wildwestWorkspace,
 				framework.WithExtraResources("cowboys.wildwest.dev", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 				// empty APIExports so we do not add global kubernetes APIExport.
@@ -1442,7 +1457,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Log("Starting test...")
-			testCase.work(t, kubelikeVWConfig, wildwestVWConfig, kubelikeWorkspace, wildwestWorkspace, wildwestSyncTargetName)
+			testCase.work(t, kubelikeVWConfig, wildwestVWConfig, kubelikeWorkspace, wildwestWorkspace, wildwestSyncTargetName, wildwestSyncer)
 		})
 	}
 }
@@ -1781,7 +1796,7 @@ func TestUpsyncerVirtualWorkspace(t *testing.T) {
 			t.Logf("Deploying syncer into workspace %s", kubelikeWorkspace)
 			kubelikeSyncer := framework.NewSyncerFixture(t, server, kubelikeWorkspace,
 				framework.WithSyncTarget(kubelikeWorkspace, "kubelike"),
-				framework.WithExtraResources("persistentvolumes"),
+				framework.WithExtraResources("persistentvolumes", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 				framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 					if !isFakePCluster {
 						// Only need to install services,ingresses and persistentvolumes in a logical cluster
@@ -1793,6 +1808,7 @@ func TestUpsyncerVirtualWorkspace(t *testing.T) {
 					kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 						metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
 						metav1.GroupResource{Group: "core.k8s.io", Resource: "persistentvolumes"},
+						metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 					)
 					require.NoError(t, err)
 				}),

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -595,7 +595,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				t.Logf("Deploying second syncer into workspace %s", wildwestClusterName)
 				wildwestSecondSyncTargetName := wildwestSyncTargetName + "second"
 				wildwestSecondSyncer := framework.NewSyncerFixture(t, server, wildwestClusterName,
-					framework.WithExtraResources("cowboys.wildwest.dev", "services"),
+					framework.WithExtraResources("cowboys.wildwest.dev", "services", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 					framework.WithSyncTarget(wildwestClusterName, wildwestSecondSyncTargetName),
 					framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 						// Always install the crd regardless of whether the target is
@@ -608,6 +608,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 							// Only need to install services in a logical cluster
 							kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 								metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+								metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 							)
 						}
 					}),
@@ -818,7 +819,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				t.Logf("Deploying second syncer into workspace %s", wildwestClusterName)
 				wildwestSecondSyncTargetName := wildwestSyncTargetName + "second"
 				wildwestSecondSyncer := framework.NewSyncerFixture(t, server, wildwestClusterName,
-					framework.WithExtraResources("cowboys.wildwest.dev"),
+					framework.WithExtraResources("cowboys.wildwest.dev", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 					framework.WithSyncTarget(wildwestClusterName, wildwestSecondSyncTargetName),
 					framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 						// Always install the crd regardless of whether the target is
@@ -833,6 +834,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 							require.NoError(t, err)
 							kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 								metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+								metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 							)
 						}
 					}),
@@ -1306,6 +1308,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 			t.Logf("Deploying syncer into workspace %s", kubelikeWorkspace)
 			kubelikeSyncer := framework.NewSyncerFixture(t, server, kubelikeWorkspace,
+				framework.WithExtraResources("roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 				framework.WithSyncTarget(kubelikeWorkspace, "kubelike"),
 				framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 					if !isFakePCluster {
@@ -1317,6 +1320,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 					t.Logf("Installing test CRDs into sink cluster...")
 					kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
 						metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+						metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 						metav1.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
 					)
 					require.NoError(t, err)
@@ -1383,7 +1387,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 			t.Logf("Deploying syncer into workspace %s", wildwestWorkspace)
 			wildwestSyncer := framework.NewSyncerFixture(t, server, wildwestWorkspace,
-				framework.WithExtraResources("cowboys.wildwest.dev"),
+				framework.WithExtraResources("cowboys.wildwest.dev", "roles.rbac.authorization.k8s.io", "rolebindings.rbac.authorization.k8s.io"),
 				// empty APIExports so we do not add global kubernetes APIExport.
 				framework.WithAPIExports(""),
 				framework.WithSyncTarget(wildwestWorkspace, wildwestSyncTargetName),
@@ -1396,7 +1400,9 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 					fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					if isFakePCluster {
 						// Only need to install services in a non-logical cluster
-						kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: "core.k8s.io", Resource: "services"})
+						kubefixtures.Create(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(),
+							metav1.GroupResource{Group: "core.k8s.io", Resource: "services"},
+							metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"})
 					}
 				}),
 			).Start(t)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
 
Dynamically deploy DNS nameserver k8s resources, one set per workspace. Each set of resources is composed of:
- a serviceaccount
- a role with one rule to access only one configmap 
- a rolebinding
- a deployment (the DNS nameserver for the workspace)
- a service

The spec controller checks for DNS endpoint readiness before syncing to pclusters.

All DNS objects associated to all workspaces bound to the workload ws are deployed in the synctarget namespace. Initial network policies design document review with @davidfestal shows this approach allows workspaces segmentation.

This PR does not support:
- upgrade: once created, DNS objects are never updated
- workspace deletion (yet). The DNS objects are currently never deleted 
- SyncTarget deletion might be supported (not tested)

## Related issue(s)

Fixes #1987
