### PR TITLE
🐛 Fix: watch a certain synctarget only

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -479,9 +479,10 @@ func (o *SyncOptions) enableSyncerForWorkspace(ctx context.Context, config *rest
 			Resources:     []string{"synctargets"},
 		},
 		{
-			Verbs:     []string{"get", "list", "watch"},
-			APIGroups: []string{workloadv1alpha1.SchemeGroupVersion.Group},
-			Resources: []string{"synctargets"},
+			Verbs:         []string{"get", "list", "watch"},
+			APIGroups:     []string{workloadv1alpha1.SchemeGroupVersion.Group},
+			Resources:     []string{"synctargets"},
+			ResourceNames: []string{syncTargetName},
 		},
 		{
 			Verbs:         []string{"update", "patch"},


### PR DESCRIPTION
Signed-off-by: Jian Qiu <jqiu@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

syncer should only watch a certain synctarget, but not all synctarget in the workspace.

## Related issue(s)

Fixes #
