### PR TITLE
:seedling: sharded-test-server: consistently use workDirPath

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -77,17 +77,17 @@ func startFrontProxy(
 			Path: "/services/",
 			// TODO: support multiple virtual workspace backend servers
 			Backend:         fmt.Sprintf("https://localhost:%s", vwPort),
-			BackendServerCA: ".kcp/serving-ca.crt",
-			ProxyClientCert: ".kcp-front-proxy/requestheader.crt",
-			ProxyClientKey:  ".kcp-front-proxy/requestheader.key",
+			BackendServerCA: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.crt"),
+			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.key"),
 		},
 		{
 			Path: "/clusters/",
 			// TODO: support multiple shard backend servers
 			Backend:         "https://localhost:6444",
-			BackendServerCA: ".kcp/serving-ca.crt",
-			ProxyClientCert: ".kcp-front-proxy/requestheader.crt",
-			ProxyClientKey:  ".kcp-front-proxy/requestheader.key",
+			BackendServerCA: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+			ProxyClientCert: filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.crt"),
+			ProxyClientKey:  filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.key"),
 		},
 	}
 
@@ -110,7 +110,7 @@ func startFrontProxy(
 	if err := clientcmdapi.MinifyConfig(&raw); err != nil {
 		return err
 	}
-	if err := clientcmd.WriteToFile(raw, ".kcp/root.kubeconfig"); err != nil {
+	if err := clientcmd.WriteToFile(raw, filepath.Join(workDirPath, ".kcp/root.kubeconfig")); err != nil {
 		return err
 	}
 

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 
 	machineryutilnet "k8s.io/apimachinery/pkg/util/net"
@@ -63,41 +64,75 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	defer cancelFn()
 
 	// create request header CA and client cert for front-proxy to connect to shards
-	requestHeaderCA, err := crypto.MakeSelfSignedCA(".kcp/requestheader-ca.crt", ".kcp/requestheader-ca.key", ".kcp/requestheader-ca-serial.txt", "kcp-front-proxy-requestheader-ca", 365)
+	requestHeaderCA, err := crypto.MakeSelfSignedCA(
+		filepath.Join(workDirPath, ".kcp/requestheader-ca.crt"),
+		filepath.Join(workDirPath, ".kcp/requestheader-ca.key"),
+		filepath.Join(workDirPath, ".kcp/requestheader-ca-serial.txt"),
+		"kcp-front-proxy-requestheader-ca",
+		365,
+	)
 	if err != nil {
 		fmt.Printf("failed to create requestheader-ca: %v\n", err)
 		os.Exit(1)
 	}
-	_, err = requestHeaderCA.MakeClientCertificate(".kcp-front-proxy/requestheader.crt", ".kcp-front-proxy/requestheader.key", &user.DefaultInfo{Name: "kcp-front-proxy"}, 365)
+	_, err = requestHeaderCA.MakeClientCertificate(
+		filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.crt"),
+		filepath.Join(workDirPath, ".kcp-front-proxy/requestheader.key"),
+		&user.DefaultInfo{Name: "kcp-front-proxy"},
+		365,
+	)
 	if err != nil {
 		fmt.Printf("failed to create requestheader client cert: %v\n", err)
 		os.Exit(1)
 	}
 
 	// create client CA and kcp-admin client cert to connect through front-proxy
-	clientCA, err := crypto.MakeSelfSignedCA(".kcp/client-ca.crt", ".kcp/client-ca.key", ".kcp/client-ca-serial.txt", "kcp-client-ca", 365)
+	clientCA, err := crypto.MakeSelfSignedCA(
+		filepath.Join(workDirPath, ".kcp/client-ca.crt"),
+		filepath.Join(workDirPath, ".kcp/client-ca.key"),
+		filepath.Join(workDirPath, ".kcp/client-ca-serial.txt"),
+		"kcp-client-ca",
+		365,
+	)
 	if err != nil {
 		fmt.Printf("failed to create client-ca: %v\n", err)
 		os.Exit(1)
 	}
-	_, err = clientCA.MakeClientCertificate(".kcp/kcp-admin.crt", ".kcp/kcp-admin.key", &user.DefaultInfo{
-		Name:   "kcp-admin",
-		Groups: []string{bootstrap.SystemKcpClusterWorkspaceAdminGroup, bootstrap.SystemKcpAdminGroup},
-	}, 365)
+	_, err = clientCA.MakeClientCertificate(
+		filepath.Join(workDirPath, ".kcp/kcp-admin.crt"),
+		filepath.Join(workDirPath, ".kcp/kcp-admin.key"),
+		&user.DefaultInfo{
+			Name:   "kcp-admin",
+			Groups: []string{bootstrap.SystemKcpClusterWorkspaceAdminGroup, bootstrap.SystemKcpAdminGroup},
+		},
+		365,
+	)
 	if err != nil {
 		fmt.Printf("failed to create kcp-admin client cert: %v\n", err)
 		os.Exit(1)
 	}
 
 	// create server CA to be used to sign shard serving certs
-	servingCA, err := crypto.MakeSelfSignedCA(".kcp/serving-ca.crt", ".kcp/serving-ca.key", ".kcp/serving-ca-serial.txt", "kcp-serving-ca", 365)
+	servingCA, err := crypto.MakeSelfSignedCA(
+		filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+		filepath.Join(workDirPath, ".kcp/serving-ca.key"),
+		filepath.Join(workDirPath, ".kcp/serving-ca-serial.txt"),
+		"kcp-serving-ca",
+		365,
+	)
 	if err != nil {
-		fmt.Printf("failed to create requestheader-ca: %v\n", err)
+		fmt.Printf("failed to create serving-ca: %v\n", err)
 		os.Exit(1)
 	}
 
 	// create service account signing and verification key
-	if _, err := crypto.MakeSelfSignedCA(".kcp/service-account.crt", ".kcp/service-account.key", ".kcp/service-account-serial.txt", "kcp-service-account-signing-ca", 365); err != nil {
+	if _, err := crypto.MakeSelfSignedCA(
+		filepath.Join(workDirPath, ".kcp/service-account.crt"),
+		filepath.Join(workDirPath, ".kcp/service-account.key"),
+		filepath.Join(workDirPath, ".kcp/service-account-serial.txt"),
+		"kcp-service-account-signing-ca",
+		365,
+	); err != nil {
 		fmt.Printf("failed to create service-account-signing-ca: %v\n", err)
 		os.Exit(1)
 	}
@@ -139,7 +174,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		vwPort = "7444"
 
 		for i := 0; i < numberOfShards; i++ {
-			virtualWorkspaceErrCh, err := startVirtual(ctx, i, logDirPath)
+			virtualWorkspaceErrCh, err := startVirtual(ctx, i, logDirPath, workDirPath)
 			if err != nil {
 				return fmt.Errorf("error starting virtual workspaces server %d: %w", i, err)
 			}

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -36,7 +36,7 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server cert: %w", err)
 	}
-	if err := cert.WriteCertConfigFile(fmt.Sprintf(".kcp-%d/apiserver.crt", n), filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d/apiserver.key", n))); err != nil {
+	if err := cert.WriteCertConfigFile(filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d/apiserver.crt", n)), filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d/apiserver.key", n))); err != nil {
 		return nil, fmt.Errorf("failed to write server cert: %w", err)
 	}
 
@@ -61,7 +61,7 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 
 	if n > 0 {
 		args = append(args, fmt.Sprintf("--shard-name=shard-%d", n))
-		args = append(args, "--root-shard-kubeconfig-file=.kcp-0/admin.kubeconfig")
+		args = append(args, fmt.Sprintf("--root-shard-kubeconfig-file=%s", filepath.Join(workDirPath, ".kcp-0/admin.kubeconfig")))
 		args = append(args, fmt.Sprintf("--embedded-etcd-client-port=%d", 2379+n+1))
 		args = append(args, fmt.Sprintf("--embedded-etcd-peer-port=%d", (2379+n+1)+1)) // prev value +1
 	}


### PR DESCRIPTION
## Summary
This allows the -work-dir-path option to accept a path other than $PWD

Co-authored-by @ncdc - this is derived from his [shard-standalone-vw branch](https://github.com/hardys/kcp/commit/bf7cbeec5276aec5b4e84e9d54631307cb6b0c7c) which I'm breaking into a series of smaller commits/PRs

## Related issue(s)
The  [shard-standalone-vw branch](https://github.com/hardys/kcp/commit/bf7cbeec5276aec5b4e84e9d54631307cb6b0c7c) adopts a client-cert auth model which we can reuse to resolve #2274 by switching to client-cert for the informer auth (the client-cert changes will be proposed via a subsequent PR)