### PR TITLE
:bug: Clean up shadow CRDs after API bindings are deleted

### DIFF
--- a/pkg/indexers/apibinding.go
+++ b/pkg/indexers/apibinding.go
@@ -53,6 +53,22 @@ func IndexAPIBindingByClusterAndAcceptedClaimedGroupResources(obj interface{}) (
 	return ret, nil
 }
 
+const APIBindingByBoundResourceUID = "byBoundResourceUID"
+
+func IndexAPIBindingByBoundResourceUID(obj interface{}) ([]string, error) {
+	apiBinding, ok := obj.(*apisv1alpha1.APIBinding)
+	if !ok {
+		return []string{}, fmt.Errorf("obj %T is not an APIBinding", obj)
+	}
+
+	var ret []string
+	for _, r := range apiBinding.Status.BoundResources {
+		ret = append(ret, r.Schema.UID)
+	}
+
+	return ret, nil
+}
+
 const APIBindingByBoundResources = "byBoundResources"
 
 func IndexAPIBindingByBoundResources(obj interface{}) ([]string, error) {

--- a/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
+++ b/pkg/reconciler/apis/apibindingdeletion/apibinding_deletion_controller.go
@@ -260,7 +260,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		if apibindingCopy.Finalizers[i] == APIBindingFinalizer {
 			continue
 		}
-		filtered = append(filtered, APIBindingFinalizer)
+		filtered = append(filtered, apibindingCopy.Finalizers[i])
 	}
 	if len(apibindingCopy.Finalizers) == len(filtered) {
 		return nil

--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdcleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	kcpapiextensionsclientset "github.com/kcp-dev/apiextensions-apiserver/pkg/client/clientset/versioned"
+	kcpapiextensionsv1informers "github.com/kcp-dev/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	apisinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibinding"
+)
+
+const (
+	ControllerName = "kcp-crdcleanup"
+
+	DefaultIdentitySecretNamespace = "kcp-system"
+)
+
+// NewController returns a new controller for CRD cleanup
+func NewController(
+	crdInformer kcpapiextensionsv1informers.CustomResourceDefinitionClusterInformer,
+	crdClusterClient kcpapiextensionsclientset.ClusterInterface,
+	apiBindingInformer apisinformers.APIBindingInformer,
+) (*controller, error) {
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
+
+	c := &controller{
+		queue: queue,
+		getCRD: func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+			return crdInformer.Lister().Cluster(clusterName).Get(name)
+		},
+		getAPIBindingsByBoundResourceUID: func(name string) ([]*apisv1alpha1.APIBinding, error) {
+			return indexers.ByIndex[*apisv1alpha1.APIBinding](apiBindingInformer.Informer().GetIndexer(), indexers.APIBindingByBoundResourceUID, name)
+		},
+		deleteCRD: func(ctx context.Context, name string) error {
+			return crdClusterClient.ApiextensionsV1().CustomResourceDefinitions().Cluster(apibinding.ShadowWorkspaceName).Delete(ctx, name, metav1.DeleteOptions{})
+		},
+	}
+
+	indexers.AddIfNotPresentOrDie(
+		apiBindingInformer.Informer().GetIndexer(),
+		cache.Indexers{
+			indexers.APIBindingByBoundResourceUID: indexers.IndexAPIBindingByBoundResourceUID,
+		},
+	)
+
+	crdInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				return false
+			}
+
+			return logicalcluster.From(crd) == apibinding.ShadowWorkspaceName
+		},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				c.enqueueCRD(obj)
+			},
+			UpdateFunc: func(_, newObj interface{}) {
+				c.enqueueCRD(newObj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				c.enqueueCRD(obj)
+			},
+		},
+	})
+
+	apiBindingInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				c.enqueueFromAPIBinding(oldObj, newObj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				c.enqueueFromAPIBinding(nil, obj)
+			},
+		},
+	)
+
+	return c, nil
+}
+
+// controller deletes bound CRDs when they are no longer in use by any APIBindings
+type controller struct {
+	queue workqueue.RateLimitingInterface
+
+	getCRD                           func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error)
+	getAPIBindingsByBoundResourceUID func(name string) ([]*apisv1alpha1.APIBinding, error)
+	deleteCRD                        func(ctx context.Context, name string) error
+}
+
+// enqueueCRD enqueues a CRD.
+func (c *controller) enqueueCRD(obj interface{}) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	logger := logging.WithQueueKey(logging.WithReconciler(klog.Background(), ControllerName), key)
+	logger.V(4).Info("queueing CRD")
+	c.queue.Add(key)
+}
+
+func (c *controller) enqueueFromAPIBinding(oldObj, newObj interface{}) {
+	newBinding, ok := newObj.(*apisv1alpha1.APIBinding)
+	if !ok {
+		return
+	}
+
+	logger := logging.WithObject(logging.WithReconciler(klog.Background(), ControllerName), newBinding)
+
+	// Looking at old and new versions in case a schema gets removed from an APIExport.
+	// In that case, the last APIBinding to have the schema removed will trigger the CRD delete,
+	// but only the old version will have the reference to the schema.
+
+	uidSet := sets.String{}
+
+	if oldObj != nil {
+		oldBinding, ok := oldObj.(*apisv1alpha1.APIBinding)
+		if !ok {
+			return
+		}
+
+		for _, boundResource := range oldBinding.Status.BoundResources {
+			uidSet.Insert(boundResource.Schema.UID)
+		}
+	}
+
+	for _, boundResource := range newBinding.Status.BoundResources {
+		uidSet.Insert(boundResource.Schema.UID)
+	}
+
+	for uid := range uidSet {
+		key := kcpcache.ToClusterAwareKey(apibinding.ShadowWorkspaceName.String(), "", uid)
+		logging.WithQueueKey(logger, key).V(2).Info("queueing CRD via APIBinding")
+		c.queue.Add(key)
+	}
+}
+
+// Start starts the controller, which stops when ctx.Done() is closed.
+func (c *controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+func (c *controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), key)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(4).Info("processing key")
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *controller) process(ctx context.Context, key string) error {
+	clusterName, _, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	obj, err := c.getCRD(clusterName, name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil // object deleted before we handled it
+		}
+		return err
+	}
+
+	logger := logging.WithObject(klog.FromContext(ctx), obj)
+	ctx = klog.NewContext(ctx, logger)
+
+	result, err := c.getAPIBindingsByBoundResourceUID(obj.Name)
+	if err != nil {
+		return err
+	}
+
+	if len(result) > 0 {
+		// An APIBinding that uses this bound CRD was found. Thus don't delete.
+		return nil
+	}
+
+	age := time.Since(obj.CreationTimestamp.Time)
+
+	ageThreshold := time.Second * 10
+	if age < ageThreshold {
+		duration := ageThreshold - age
+		logger.V(4).Info("Requeueing until CRD is older to give some time for the bindings to complete initialization", "duration", duration)
+		c.queue.AddAfter(key, duration)
+		return nil
+	}
+
+	logger.V(1).Info("Deleting CRD")
+	if err := c.deleteCRD(ctx, obj.Name); err != nil {
+		if errors.IsNotFound(err) {
+			return nil // object deleted before we handled it
+		}
+		return err
+	}
+
+	return nil
+}

--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller_test.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crdcleanup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	conditionsv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/apis/conditions/v1alpha1"
+)
+
+func TestBoundCRDDeletion(t *testing.T) {
+	schemaUID := "f1249438-5c68-11ed-823e-f875a46c726b"
+
+	apiBinding := &apisv1alpha1.APIBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Status: apisv1alpha1.APIBindingStatus{
+			Phase: apisv1alpha1.APIBindingPhaseBound,
+			Conditions: conditionsv1alpha1.Conditions{{
+				Type:   apisv1alpha1.BindingUpToDate,
+				Status: corev1.ConditionTrue,
+			}},
+			BoundResources: []apisv1alpha1.BoundAPIResource{{
+				Schema: apisv1alpha1.BoundAPIResourceSchema{
+					UID: schemaUID,
+				},
+			}},
+		},
+	}
+
+	establishedCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              schemaUID,
+			CreationTimestamp: metav1.NewTime(time.Now().Add(time.Second * -11)),
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{{
+				Type:   apiextensionsv1.Established,
+				Status: apiextensionsv1.ConditionTrue,
+			}},
+		},
+	}
+
+	newCRD := establishedCRD.DeepCopy()
+	newCRD.Status.Conditions[0].Status = apiextensionsv1.ConditionFalse
+	newCRD.CreationTimestamp = metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name               string
+		crd                *apiextensionsv1.CustomResourceDefinition
+		apiBindingsInIndex []*apisv1alpha1.APIBinding
+		expectDeletion     bool
+	}{
+		{
+			name:               "find matching binding in index",
+			crd:                establishedCRD,
+			apiBindingsInIndex: []*apisv1alpha1.APIBinding{apiBinding},
+			expectDeletion:     false,
+		},
+		{
+			name:               "no bindings",
+			crd:                establishedCRD,
+			apiBindingsInIndex: []*apisv1alpha1.APIBinding{},
+			expectDeletion:     true,
+		},
+		{
+			name:               "CRD is not old enough to delete",
+			crd:                newCRD,
+			apiBindingsInIndex: []*apisv1alpha1.APIBinding{},
+			expectDeletion:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deleteHappened := false
+
+			controller := &controller{
+				queue: workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+				getCRD: func(clusterName logicalcluster.Name, name string) (*apiextensionsv1.CustomResourceDefinition, error) {
+					return tt.crd, nil
+				},
+				getAPIBindingsByBoundResourceUID: func(name string) ([]*apisv1alpha1.APIBinding, error) {
+					return tt.apiBindingsInIndex, nil
+				},
+				deleteCRD: func(ctx context.Context, name string) error {
+					deleteHappened = true
+					return nil
+				},
+			}
+
+			err := controller.process(context.Background(), schemaUID)
+			if err != nil {
+				t.Errorf("Unexpected error: %q", err)
+			}
+
+			if deleteHappened != tt.expectDeletion {
+				t.Errorf("Expected deletion: %t, but instead actual deletion: %t", tt.expectDeletion, deleteHappened)
+			}
+		})
+	}
+}

--- a/pkg/server/apiextensions.go
+++ b/pkg/server/apiextensions.go
@@ -185,6 +185,13 @@ func (c *apiBindingAwareCRDLister) Refresh(crd *apiextensionsv1.CustomResourceDe
 	// If crd has the identity annotation, make sure it's added to refreshed
 	if identity := crd.Annotations[apisv1alpha1.AnnotationAPIIdentityKey]; identity != "" {
 		refreshed.Annotations[apisv1alpha1.AnnotationAPIIdentityKey] = identity
+	} else if _, ok := crd.Annotations[apisv1alpha1.AnnotationBoundCRDKey]; ok {
+		// HACK: Need to set a placeholder value for the identity annotation when a bound CRD is being deleted.
+		// When the CRD finalizer tries to delete all the instances of this CRD, it will use this identity as part of the etcd lookup prefix.
+		// If the identity annotation is not found, it will actually panic, crashing the kcp process.
+		// Note that all instances of this CRD should already cleaned up when the APIBindings were deleted.
+		// See https://github.com/kcp-dev/kcp/issues/2304
+		refreshed.Annotations[apisv1alpha1.AnnotationAPIIdentityKey] = "placeholder"
 	}
 
 	// If crd was only partial metadata, make sure refreshed is too

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -59,6 +59,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apibindingdeletion"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apiexport"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/apiresource"
+	"github.com/kcp-dev/kcp/pkg/reconciler/apis/crdcleanup"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/identitycache"
 	"github.com/kcp-dev/kcp/pkg/reconciler/apis/permissionclaimlabel"
 	"github.com/kcp-dev/kcp/pkg/reconciler/cache/replication"
@@ -785,6 +786,37 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 		initializingWorkspacesKcpInformers.WaitForCacheSync(hookContext.StopCh)
 
 		go c.Start(goContext(hookContext), 2)
+		return nil
+	})
+}
+
+func (s *Server) installCRDCleanupController(ctx context.Context, config *rest.Config, server *genericapiserver.GenericAPIServer) error {
+	config = rest.CopyConfig(config)
+	config = rest.AddUserAgent(kcpclienthelper.SetMultiClusterRoundTripper(config), crdcleanup.ControllerName)
+
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c, err := crdcleanup.NewController(
+		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
+		crdClusterClient,
+		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
+	)
+	if err != nil {
+		return err
+	}
+
+	return server.AddPostStartHook(postStartHookName(crdcleanup.ControllerName), func(hookContext genericapiserver.PostStartHookContext) error {
+		logger := klog.FromContext(ctx).WithValues("postStartHook", postStartHookName(crdcleanup.ControllerName))
+		if err := s.waitForSync(hookContext.StopCh); err != nil {
+			logger.Error(err, "failed to finish post-start-hook")
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
+
+		go c.Start(goContext(hookContext), 2)
+
 		return nil
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -467,6 +467,9 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.installAPIBindingController(ctx, controllerConfig, delegationChainHead, s.DynamicDiscoverySharedInformerFactory); err != nil {
 			return err
 		}
+		if err := s.installCRDCleanupController(ctx, controllerConfig, delegationChainHead); err != nil {
+			return err
+		}
 	}
 
 	if s.Options.Controllers.EnableAll || enabled.Has("apiexport") {

--- a/test/e2e/apibinding/apibinding_deletion_test.go
+++ b/test/e2e/apibinding/apibinding_deletion_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	kcpapiextensionsclientset "github.com/kcp-dev/apiextensions-apiserver/pkg/client/clientset/versioned"
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	"github.com/kcp-dev/logicalcluster/v2"
@@ -62,6 +63,9 @@ func TestAPIBindingDeletion(t *testing.T) {
 
 	kcpClusterClient, err := clientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct kcp cluster client for server")
+
+	crdClusterClient, err := kcpapiextensionsclientset.NewForConfig(server.RootShardSystemMasterBaseConfig(t))
+	require.NoError(t, err, "failed to construct crd cluster client for server")
 
 	dynamicClusterClient, err := kcpdynamic.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
@@ -159,6 +163,9 @@ func TestAPIBindingDeletion(t *testing.T) {
 	_, err = cowboyClusterClient.Create(logicalcluster.WithCluster(ctx, consumerWorkspace), cowboy, metav1.CreateOptions{})
 	require.NoError(t, err, "error creating cowboy in consumer workspace %q", consumerWorkspace)
 
+	apiBindingCopy, err := kcpClusterClient.ApisV1alpha1().APIBindings().Get(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding.Name, metav1.GetOptions{})
+	require.NoError(t, err, "error getting apibinding in consumer workspace %q", consumerWorkspace)
+
 	err = kcpClusterClient.ApisV1alpha1().APIBindings().Delete(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding.Name, metav1.DeleteOptions{})
 	require.NoError(t, err)
 
@@ -233,6 +240,13 @@ func TestAPIBindingDeletion(t *testing.T) {
 	t.Logf("apibinding should be deleted")
 	require.Eventually(t, func() bool {
 		_, err := kcpClusterClient.ApisV1alpha1().APIBindings().Get(logicalcluster.WithCluster(ctx, consumerWorkspace), apiBinding.Name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond)
+
+	crdName := apiBindingCopy.Status.BoundResources[0].Schema.UID
+	t.Logf("shadow CRD %s should be deleted", crdName)
+	require.Eventually(t, func() bool {
+		_, err := crdClusterClient.Cluster(logicalcluster.New("system:bound-crds")).ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
 		return apierrors.IsNotFound(err)
 	}, wait.ForeverTestTimeout, 100*time.Millisecond)
 }


### PR DESCRIPTION
## Summary

When all API bindings that use a particular APIResourceSchema are deleted, the CRDs that back those bindings need to be deleted.

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->

Fixes #2300
