### PR TITLE
:bug: Add request, latency, and workqueue metrics to front proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/miekg/dns v1.1.50
 	github.com/muesli/reflow v0.1.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+	github.com/prometheus/client_golang v1.13.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
@@ -127,7 +128,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	compbasemetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+// WithLatencyTracking tracks the number of seconds it took the wrapped handler
+// to complete.
+func WithLatencyTracking(delegate http.Handler) http.Handler {
+	return promhttp.InstrumentHandlerDuration(requestLatencies.HistogramVec, delegate)
+}
+
+// TODO(csams): enhance metrics to include shard url
+var (
+	requestLatencies = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Name: "proxy_request_duration_seconds",
+			Help: "Response latency distribution in seconds for each verb and HTTP response code.",
+			Buckets: []float64{0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"method", "code"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(requestLatencies)
+	})
+}
+
+func init() {
+	Register()
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -21,10 +21,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	userinfo "k8s.io/apiserver/pkg/authentication/user"
@@ -32,7 +32,7 @@ import (
 )
 
 func newTransport(clientCert, clientKeyFile, caFile string) (*http.Transport, error) {
-	caCert, err := ioutil.ReadFile(caFile)
+	caCert, err := os.ReadFile(caFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CA file %q: %w", caFile, err)
 	}
@@ -56,7 +56,7 @@ func newTransport(clientCert, clientKeyFile, caFile string) (*http.Transport, er
 
 // WithProxyAuthHeaders does client cert termination by extracting the user and groups and
 // passing them through access headers to the shard.
-func WithProxyAuthHeaders(delegate http.HandlerFunc, userHeader, groupHeader string, extraHeaderPrefix string) http.HandlerFunc {
+func WithProxyAuthHeaders(delegate http.Handler, userHeader, groupHeader string, extraHeaderPrefix string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if u, ok := request.UserFrom(r.Context()); ok {
 			appendClientCertAuthHeaders(r.Header, u, userHeader, groupHeader, extraHeaderPrefix)


### PR DESCRIPTION
Signed-off-by: Christopher Sams <csams@redhat.com>

## Summary
Add front proxy specific metrics to enable accurate SLO tracking across shards even in the case of a shard being down.

Fixes #2301 
