### PR TITLE
:seedling: test-server: split New/Start/Ready phases

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -193,7 +193,7 @@ func startFrontProxy(
 
 		// intentionally load again every iteration because it can change
 		configLoader := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: filepath.Join(workDirPath, ".kcp/admin.kubeconfig")},
-			&clientcmd.ConfigOverrides{CurrentContext: "system:admin"},
+			&clientcmd.ConfigOverrides{CurrentContext: "base"},
 		)
 		config, err := configLoader.ClientConfig()
 		if err != nil {

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -28,7 +28,7 @@ import (
 	shard "github.com/kcp-dev/kcp/cmd/test-server/kcp"
 )
 
-func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA, hostIP string, logDirPath, workDirPath, cacheServerConfigPath string) (<-chan error, error) {
+func newShard(ctx context.Context, n int, args []string, servingCA *crypto.CA, hostIP string, logDirPath, workDirPath, cacheServerConfigPath string) (*shard.Shard, error) {
 	// create serving cert
 	hostnames := sets.NewString("localhost", hostIP)
 	klog.Infof("Creating shard server %d serving cert with hostnames %v", n, hostnames)
@@ -86,9 +86,10 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 		args = append(args, fmt.Sprintf("--cache-server-kubeconfig-file=%s", cacheServerConfigPath))
 	}
 
-	return shard.Start(ctx,
+	return shard.NewShard(
 		fmt.Sprintf("kcp-%d", n),                              // name
 		filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d", n)), // runtime directory, etcd data etc.
 		logFilePath,
-		args)
+		args,
+	), nil
 }

--- a/cmd/test-server/main.go
+++ b/cmd/test-server/main.go
@@ -79,9 +79,17 @@ func start(shardFlags []string) error {
 	defer cancelFn()
 
 	logFilePath := flag.Lookup("log-file-path").Value.String()
-	errCh, err := shard.Start(ctx, "kcp", ".kcp", logFilePath,
+	shard := shard.NewShard(
+		"kcp",
+		".kcp",
+		logFilePath,
 		append(shardFlags, "--audit-log-path", filepath.Join(filepath.Dir(logFilePath), "audit.log")),
 	)
+	if err := shard.Start(ctx); err != nil {
+		return err
+	}
+
+	errCh, err := shard.WaitForReady(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Decouple the steps to start the test server so we can define a new test-server, start it then call WaitForReady to ensure shard readiness

This is another change decoupled from the [shard-standalone-vw branch](https://github.com/hardys/kcp/commit/bf7cbeec5276aec5b4e84e9d54631307cb6b0c7c) from @ncdc

## Related issue(s)
Follow-up to #2297 and another incremental step towards integrating the the [shard-standalone-vw branch](https://github.com/hardys/kcp/commit/bf7cbeec5276aec5b4e84e9d54631307cb6b0c7c) from @ncdc 
Fixes #
