### PR TITLE
🐛 Fix double identities for wildcard requests from APIExport virtual workspace

### DIFF
--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -275,17 +275,31 @@ func decorateWildcardPathsWithResourceIdentities(urlPath string, ids *identities
 		return urlPath, nil
 	}
 
-	if strings.Contains(comps[5], ":") {
-		return urlPath, nil
+	// It's possible the incoming request already has an identity specified. Make sure we exclude that when
+	// determining the resource in question.
+	parts := strings.SplitN(comps[5], ":", 2)
+	if len(parts) == 0 {
+		return "", fmt.Errorf("invalid resource %q", comps[5])
 	}
 
-	gr := schema.GroupResource{Group: comps[3], Resource: comps[5]}
+	resource := parts[0]
+
+	gr := schema.GroupResource{Group: comps[3], Resource: resource}
 	if id, found := ids.grIdentity(gr); found {
 		if len(id) == 0 {
 			return "", fmt.Errorf("identity for %s is unknown", gr)
 		}
 
-		comps[5] += ":" + id
+		passedInIdentity := ""
+		if len(parts) > 1 {
+			passedInIdentity = parts[1]
+		}
+
+		if passedInIdentity != "" && passedInIdentity != id {
+			return "", fmt.Errorf("invalid identity %q for resource %q", passedInIdentity, resource)
+		}
+
+		comps[5] = resource + ":" + id
 
 		return "/" + path.Join(comps...), nil
 	}

--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -280,7 +280,11 @@ func decorateWildcardPathsWithResourceIdentities(urlPath string, ids *identities
 		if len(id) == 0 {
 			return "", fmt.Errorf("identity for %s is unknown", gr)
 		}
-		comps[5] += ":" + id
+
+		// Check if identity already exists in the URL path before appending it.
+		if !strings.Contains(comps[5], ":") {
+			comps[5] += ":" + id
+		}
 
 		return "/" + path.Join(comps...), nil
 	}

--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -275,16 +275,17 @@ func decorateWildcardPathsWithResourceIdentities(urlPath string, ids *identities
 		return urlPath, nil
 	}
 
+	if strings.Contains(comps[5], ":") {
+		return urlPath, nil
+	}
+
 	gr := schema.GroupResource{Group: comps[3], Resource: comps[5]}
 	if id, found := ids.grIdentity(gr); found {
 		if len(id) == 0 {
 			return "", fmt.Errorf("identity for %s is unknown", gr)
 		}
 
-		// Check if identity already exists in the URL path before appending it.
-		if !strings.Contains(comps[5], ":") {
-			comps[5] += ":" + id
-		}
+		comps[5] += ":" + id
 
 		return "/" + path.Join(comps...), nil
 	}

--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -275,7 +275,7 @@ func decorateWildcardPathsWithResourceIdentities(urlPath string, ids *identities
 		return urlPath, nil
 	}
 
-	// It's possible the incoming request already has an identity specified. Make sure we exclude that when
+	// It's possible the outgoing request already has an identity specified. Make sure we exclude that when
 	// determining the resource in question.
 	parts := strings.SplitN(comps[5], ":", 2)
 	if len(parts) == 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -498,7 +498,9 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.Options.Virtual.Enabled {
-		if err := s.installVirtualWorkspaces(ctx, controllerConfig, delegationChainHead, s.GenericConfig.Authentication, s.GenericConfig.ExternalAddress, s.GenericConfig.AuditPolicyRuleEvaluator, s.preHandlerChainMux); err != nil {
+		virtualWorkspacesConfig := rest.CopyConfig(s.GenericConfig.LoopbackClientConfig)
+		virtualWorkspacesConfig = rest.AddUserAgent(virtualWorkspacesConfig, "virtual-workspaces")
+		if err := s.installVirtualWorkspaces(ctx, virtualWorkspacesConfig, delegationChainHead, s.GenericConfig.Authentication, s.GenericConfig.ExternalAddress, s.GenericConfig.AuditPolicyRuleEvaluator, s.preHandlerChainMux); err != nil {
 			return err
 		}
 	}

--- a/pkg/virtual/apiexport/builder/forwarding.go
+++ b/pkg/virtual/apiexport/builder/forwarding.go
@@ -47,7 +47,7 @@ func provideAPIExportFilteredRestStorage(ctx context.Context, clusterClient kcpd
 		return nil, fmt.Errorf("unable to create a selector from the provided labels")
 	}
 
-	return registry.ProvideReadOnlyRestStorage(ctx, clusterClient, registry.WithStaticLabelSelector(requirements))
+	return registry.ProvideReadOnlyRestStorage(ctx, clusterClient, registry.WithStaticLabelSelector(requirements), nil)
 }
 
 // provideDelegatingRestStorage returns a forwarding storage build function, with an optional storage wrapper e.g. to add label based filtering.

--- a/pkg/virtual/framework/forwardingregistry/rest_test.go
+++ b/pkg/virtual/framework/forwardingregistry/rest_test.go
@@ -110,9 +110,8 @@ func newStorage(t *testing.T, clusterClient kcpdynamic.ClusterInterface, apiExpo
 		nil,
 		clusterClient,
 		patchConflictRetryBackoff,
-		func(_ schema.GroupResource, store *forwardingregistry.StoreFuncs) *forwardingregistry.StoreFuncs {
-			return store
-		})
+		forwardingregistry.StorageWrapperFunc(func(_ schema.GroupResource, store *forwardingregistry.StoreFuncs) {
+		}))
 }
 
 func createResource(namespace, name string) *unstructured.Unstructured {

--- a/pkg/virtual/framework/forwardingregistry/wrappers.go
+++ b/pkg/virtual/framework/forwardingregistry/wrappers.go
@@ -36,7 +36,7 @@ func WithStaticLabelSelector(labelSelector labels.Requirements) StorageWrapper {
 }
 
 func WithLabelSelector(labelSelectorFrom func(ctx context.Context) labels.Requirements) StorageWrapper {
-	return func(resource schema.GroupResource, storage *StoreFuncs) *StoreFuncs {
+	return StorageWrapperFunc(func(resource schema.GroupResource, storage *StoreFuncs) {
 		delegateLister := storage.ListerFunc
 		storage.ListerFunc = func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
 			selector := options.LabelSelector
@@ -74,7 +74,5 @@ func WithLabelSelector(labelSelectorFrom func(ctx context.Context) labels.Requir
 			options.LabelSelector = selector.Add(labelSelectorFrom(ctx)...)
 			return delegateWatcher.Watch(ctx, options)
 		}
-
-		return storage
-	}
+	})
 }

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -19,6 +19,7 @@ package builder
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -86,6 +87,17 @@ func BuildVirtualWorkspace(
 		v.Schema.Raw = bs // wipe schemas. We don't want validation here.
 	}
 
+	getTenancyIdentity := func() (string, error) {
+		export, err := wildcardKcpInformers.Apis().V1alpha1().APIExports().Lister().Cluster(tenancyv1alpha1.RootCluster).Get("tenancy.kcp.dev")
+		if err != nil {
+			return "", err
+		}
+		if export.Status.IdentityHash == "" {
+			return "", errors.New("identity hash is empty")
+		}
+		return export.Status.IdentityHash, nil
+	}
+
 	wildcardWorkspacesName := initializingworkspaces.VirtualWorkspaceName + "-wildcard-workspaces"
 	wildcardWorkspaces := &virtualworkspacesdynamic.DynamicVirtualWorkspace{
 		RootPathResolver: framework.RootPathResolverFunc(func(urlPath string, requestContext context.Context) (accepted bool, prefixToStrip string, completedContext context.Context) {
@@ -108,12 +120,12 @@ func BuildVirtualWorkspace(
 			return nil
 		}),
 		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
-			return &apiSetRetriever{
+			return &singleResourceAPIDefinitionSetProvider{
 				config:               mainConfig,
 				dynamicClusterClient: dynamicClusterClient,
 				exposeSubresources:   false,
 				resource:             &clusterWorkspaceResource,
-				storageProvider:      provideFilteredReadOnlyRestStorage,
+				storageProvider:      provideFilteredClusterWorkspacesReadOnlyRestStorage(getTenancyIdentity),
 			}, nil
 		},
 	}
@@ -145,12 +157,12 @@ func BuildVirtualWorkspace(
 			return nil
 		}),
 		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
-			return &apiSetRetriever{
+			return &singleResourceAPIDefinitionSetProvider{
 				config:               mainConfig,
 				dynamicClusterClient: dynamicClusterClient,
 				exposeSubresources:   true,
 				resource:             &clusterWorkspaceResource,
-				storageProvider:      provideDelegatingRestStorage,
+				storageProvider:      provideDelegatingClusterWorkspacesRestStorage(getTenancyIdentity),
 			}, nil
 		},
 	}
@@ -230,7 +242,7 @@ func BuildVirtualWorkspace(
 
 				initializer := tenancyv1alpha1.ClusterWorkspaceInitializer(dynamiccontext.APIDomainKeyFrom(request.Context()))
 				if clusterWorkspace.Status.Phase != tenancyv1alpha1.ClusterWorkspacePhaseInitializing || !initialization.InitializerPresent(initializer, clusterWorkspace.Status.Initializers) {
-					http.Error(writer, fmt.Sprintf("initializer %q cannot access this workspace %v %v", initializer, clusterWorkspace.Status.Phase, clusterWorkspace.Status.Initializers), http.StatusForbidden)
+					http.Error(writer, fmt.Sprintf("initializer %q cannot access this workspace", initializer), http.StatusForbidden)
 					return
 				}
 
@@ -355,7 +367,7 @@ func URLFor(initializerName tenancyv1alpha1.ClusterWorkspaceInitializer) string 
 	return path.Join("/services", initializingworkspaces.VirtualWorkspaceName, string(initializerName))
 }
 
-type apiSetRetriever struct {
+type singleResourceAPIDefinitionSetProvider struct {
 	config               genericapiserver.CompletedConfig
 	dynamicClusterClient kcpdynamic.ClusterInterface
 	resource             *apisv1alpha1.APIResourceSchema
@@ -363,7 +375,7 @@ type apiSetRetriever struct {
 	storageProvider      func(ctx context.Context, clusterClient kcpdynamic.ClusterInterface, initializer tenancyv1alpha1.ClusterWorkspaceInitializer) (apiserver.RestProviderFunc, error)
 }
 
-func (a *apiSetRetriever) GetAPIDefinitionSet(ctx context.Context, key dynamiccontext.APIDomainKey) (apis apidefinition.APIDefinitionSet, apisExist bool, err error) {
+func (a *singleResourceAPIDefinitionSetProvider) GetAPIDefinitionSet(ctx context.Context, key dynamiccontext.APIDomainKey) (apis apidefinition.APIDefinitionSet, apisExist bool, err error) {
 	restProvider, err := a.storageProvider(ctx, a.dynamicClusterClient, tenancyv1alpha1.ClusterWorkspaceInitializer(key))
 	if err != nil {
 		return nil, false, err
@@ -390,7 +402,7 @@ func (a *apiSetRetriever) GetAPIDefinitionSet(ctx context.Context, key dynamicco
 	return apis, len(apis) > 0, nil
 }
 
-var _ apidefinition.APIDefinitionSetGetter = &apiSetRetriever{}
+var _ apidefinition.APIDefinitionSetGetter = &singleResourceAPIDefinitionSetProvider{}
 
 func newAuthorizer(client kcpkubernetesclientset.ClusterInterface) authorizer.AuthorizerFunc {
 	return func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -539,6 +539,19 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 			t.Fatalf("got %#v error from initial list, expected unauthorized", err)
 		}
 	}
+
+	t.Log("Ensure get workspace requests are 404 now that it is not initializing")
+	for _, initializer := range []string{
+		"alpha",
+		"beta",
+		"gamma",
+	} {
+		wsClient := user1VwKcpClusterClients[initializer].TenancyV1alpha1().ClusterWorkspaces()
+		_, err := wsClient.Cluster(logicalcluster.From(ws)).Get(ctx, ws.Name, metav1.GetOptions{})
+		if !errors.IsNotFound(err) {
+			t.Fatalf("got %v error from get, expected not found", err)
+		}
+	}
 }
 
 func workspaceForType(workspaceType *tenancyv1alpha1.ClusterWorkspaceType, testLabelSelector map[string]string) *tenancyv1alpha1.ClusterWorkspace {


### PR DESCRIPTION
## Summary

Fix a bug where wildcard requests coming from the APIExport virtual workspace for "built-in" kcp types (e.g. ClusterWorkspaceTypes) had the identity set by the virtual workspace, then set a second time by `decorateWildcardPathsWithResourceIdentities`.

## Related issue(s)

Fixes #2184
Fixes #2308
Incorporates & supersedes #2245