### PR TITLE
:sparkles: Front proxy user gating

### DIFF
--- a/pkg/proxy/options/options.go
+++ b/pkg/proxy/options/options.go
@@ -29,6 +29,7 @@ import (
 type Options struct {
 	SecureServing   apiserveroptions.SecureServingOptionsWithLoopback
 	Authentication  Authentication
+	UserGating      UserGating
 	MappingFile     string
 	RootDirectory   string
 	RootKubeconfig  string
@@ -39,6 +40,7 @@ func NewOptions() *Options {
 	o := &Options{
 		SecureServing:  *apiserveroptions.NewSecureServingOptions().WithLoopback(),
 		Authentication: *NewAuthentication(),
+		UserGating:     *NewUserGating(),
 		RootKubeconfig: "",
 		RootDirectory:  ".kcp",
 	}
@@ -53,6 +55,7 @@ func NewOptions() *Options {
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.SecureServing.AddFlags(fs)
 	o.Authentication.AddFlags(fs)
+	o.UserGating.AddFlags(fs)
 	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Config file mapping paths to backends")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")
@@ -91,6 +94,7 @@ func (o *Options) Validate() []error {
 
 	errs = append(errs, o.SecureServing.Validate()...)
 	errs = append(errs, o.Authentication.Validate()...)
+	errs = append(errs, o.UserGating.Validate()...)
 
 	return errs
 }

--- a/pkg/proxy/options/usergating.go
+++ b/pkg/proxy/options/usergating.go
@@ -17,8 +17,6 @@ limitations under the License.
 package options
 
 import (
-	"errors"
-
 	"github.com/spf13/pflag"
 )
 
@@ -40,8 +38,5 @@ func (o *UserGating) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (c *UserGating) Validate() []error {
-	if c.Enabled && c.DefaultRulesFile == "" {
-		return []error{errors.New("user gating requires a default rules file")}
-	}
 	return nil
 }

--- a/pkg/proxy/options/usergating.go
+++ b/pkg/proxy/options/usergating.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+)
+
+type UserGating struct {
+	Enabled          bool
+	DefaultRulesFile string
+}
+
+func NewUserGating() *UserGating {
+	return &UserGating{
+		Enabled:          false,
+		DefaultRulesFile: "",
+	}
+}
+
+func (o *UserGating) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.Enabled, "enable-user-gating", false, "Enabled user gating.")
+	fs.StringVar(&o.DefaultRulesFile, "user-gating-rules", "", "Provide a YAML file containing user gating rules.")
+}
+
+func (c *UserGating) Validate() []error {
+	if c.Enabled && c.DefaultRulesFile == "" {
+		return []error{errors.New("user gating requires a default rules file")}
+	}
+	return nil
+}

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
+	coreinformers "github.com/kcp-dev/client-go/informers"
+	coreclient "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/kcp-dev/logicalcluster/v2"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,8 +34,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	coreinformers "github.com/kcp-dev/client-go/informers"
-	coreclient "github.com/kcp-dev/client-go/kubernetes"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	kcpclienthelper "github.com/kcp-dev/apimachinery/pkg/client"
@@ -31,26 +32,33 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
+	coreinformers "github.com/kcp-dev/client-go/informers"
+	coreclient "github.com/kcp-dev/client-go/kubernetes"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	frontproxyfilters "github.com/kcp-dev/kcp/pkg/proxy/filters"
 	"github.com/kcp-dev/kcp/pkg/proxy/index"
+	"github.com/kcp-dev/kcp/pkg/proxy/usergating"
+	"github.com/kcp-dev/kcp/pkg/proxy/usergating/ruleset"
 	"github.com/kcp-dev/kcp/pkg/server"
 	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
 )
 
 type Server struct {
 	CompletedConfig
-	Handler                  http.Handler
-	IndexController          *index.Controller
-	KcpSharedInformerFactory kcpinformers.SharedInformerFactory
+	Handler                   http.Handler
+	IndexController           *index.Controller
+	UserGateController        *usergating.Controller
+	KcpSharedInformerFactory  kcpinformers.SharedInformerFactory
+	CoreSharedInformerFactory coreinformers.SharedInformerFactory
 }
 
 func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 	s := &Server{
 		CompletedConfig: c,
 	}
+
 	rootShardConfigInformerConfig := kcpclienthelper.SetCluster(restclient.CopyConfig(s.CompletedConfig.RootShardConfig), tenancyv1alpha1.RootCluster)
 	rootShardConfigInformerClient, err := kcpclient.NewForConfig(rootShardConfigInformerConfig)
 	if err != nil {
@@ -72,12 +80,30 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 		},
 	)
 
-	s.Handler, err = NewHandler(ctx, s.CompletedConfig.Options, s.IndexController)
-	if err != nil {
-		return s, err
+	if c.Options.UserGating.Enabled {
+		// setup the shared informer factory
+		rootShardCoreInformerClient, err := coreclient.NewForConfig(s.CompletedConfig.RootShardConfig)
+		if err != nil {
+			return s, fmt.Errorf("failed to create client for informers: %w", err)
+		}
+		s.CoreSharedInformerFactory = coreinformers.NewSharedInformerFactoryWithOptions(rootShardCoreInformerClient, 30*time.Minute)
+
+		// load the default rule set from file passed in options
+		data, err := os.ReadFile(c.Options.UserGating.DefaultRulesFile)
+		if err != nil {
+			return nil, err
+		}
+		rules, err := ruleset.FromYAML(data)
+		if err != nil {
+			return nil, err
+		}
+
+		// create the controller to watch for updates to the usergating secret in root:kcp-system
+		s.UserGateController = usergating.NewController(ctx, s.CoreSharedInformerFactory, rules)
 	}
 
-	return s, nil
+	s.Handler, err = NewHandler(ctx, s.CompletedConfig.Options, s.IndexController)
+	return s, err
 }
 
 // preparedServer is a private wrapper that enforces a call of PrepareRun() before Run can be invoked.
@@ -102,17 +128,27 @@ func (s preparedServer) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get or create identities: %w", err)
 	}
 
-	// start index
+	// start the index controller
 	go s.IndexController.Start(ctx, 2)
-
 	s.KcpSharedInformerFactory.Start(ctx.Done())
 	s.KcpSharedInformerFactory.WaitForCacheSync(ctx.Done())
 
-	// start the server
-	failedHandler := frontproxyfilters.NewUnauthorizedHandler()
+	// setup the handler chain
+	unauthorizedHandler := frontproxyfilters.NewUnauthorizedHandler()
+
+	// Start the user gate controller if it's enabled. This is near the end of
+	// the handler chain since it's really an authz check without the k8s
+	// machinery, and we need authn to populate user info.
+	if s.CompletedConfig.Options.UserGating.Enabled {
+		go s.UserGateController.Start(ctx, 2)
+		s.CoreSharedInformerFactory.Start(ctx.Done())
+		s.CoreSharedInformerFactory.WaitForCacheSync(ctx.Done())
+		s.Handler = usergating.WithUserGating(s.Handler, unauthorizedHandler, s.UserGateController.GetRuleSet)
+	}
+
 	s.Handler = frontproxyfilters.WithOptionalAuthentication(
 		s.Handler,
-		failedHandler,
+		unauthorizedHandler,
 		s.CompletedConfig.AuthenticationInfo.Authenticator,
 		s.CompletedConfig.AdditionalAuthEnabled)
 
@@ -121,6 +157,8 @@ func (s preparedServer) Run(ctx context.Context) error {
 	s.Handler = genericapifilters.WithRequestInfo(s.Handler, requestInfoFactory)
 	s.Handler = genericfilters.WithHTTPLogging(s.Handler)
 	s.Handler = genericfilters.WithPanicRecovery(s.Handler, requestInfoFactory)
+
+	// start the server
 	doneCh, _, err := s.CompletedConfig.ServingInfo.Serve(s.Handler, time.Second*60, ctx.Done())
 	if err != nil {
 		return err

--- a/pkg/proxy/usergating/controller.go
+++ b/pkg/proxy/usergating/controller.go
@@ -22,6 +22,9 @@ import (
 	"sync"
 	"time"
 
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/client-go/informers"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -30,8 +33,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
-	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
-	"github.com/kcp-dev/client-go/informers"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/proxy/usergating/ruleset"
 )

--- a/pkg/proxy/usergating/controller.go
+++ b/pkg/proxy/usergating/controller.go
@@ -103,16 +103,17 @@ func NewController(ctx context.Context, versionedInformers informers.SharedInfor
 
 // GetRuleSet returns the parsed rules that determine whether a user
 // is allowed through the gate.
-func (c *Controller) GetRuleSet() (ruleset.RuleSet, bool) {
+func (c *Controller) GetRuleSet() (*ruleset.RuleSet, bool) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	if c.Rules != nil {
-		return *c.Rules, true
+		clone := c.Rules.Clone()
+		return &clone, true
 	}
 	if c.DefaultRules != nil {
-		return *c.DefaultRules, true
+		return c.DefaultRules, true
 	}
-	return ruleset.RuleSet{}, false
+	return &ruleset.RuleSet{}, false
 }
 
 func (c *Controller) enqueueSecret(ctx context.Context, obj interface{}) {

--- a/pkg/proxy/usergating/controller.go
+++ b/pkg/proxy/usergating/controller.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usergating
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	kcpcache "github.com/kcp-dev/apimachinery/pkg/cache"
+	"github.com/kcp-dev/client-go/informers"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/proxy/usergating/ruleset"
+)
+
+const (
+	controllerName = "kcp-user-gating"
+	resyncPeriod   = 10 * time.Minute
+
+	UserGateNamespace = "kcp-system"
+	UserGateResource  = "usergate.kcp.dev"
+	RuleKey           = "ruleset.yaml"
+)
+
+type SecretGetter func(string) (*v1.Secret, error)
+
+// Controller maintains a set of rules configured from a secret in
+// root:kcp-system that determine which users can use the service.
+type Controller struct {
+	queue workqueue.RateLimitingInterface
+
+	GetSecret SecretGetter
+
+	lock  sync.RWMutex
+	Rules *ruleset.RuleSet
+
+	DefaultRules *ruleset.RuleSet
+}
+
+// NewController creates a controller that watches a secret named
+// usergate.kcp.dev in root:kcp-system. The secret contains yaml under the key
+// "usergate.yaml" that describes which users are allowed or denied access to
+// the system.
+func NewController(ctx context.Context, versionedInformers informers.SharedInformerFactory, defaultRules *ruleset.RuleSet) *Controller {
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName)
+	secretInformer := versionedInformers.Core().V1().Secrets().Cluster(tenancyv1alpha1.RootCluster)
+
+	c := &Controller{
+		queue:        queue,
+		GetSecret:    secretInformer.Lister().Secrets(UserGateNamespace).Get,
+		DefaultRules: defaultRules,
+	}
+
+	secretInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.FilteringResourceEventHandler{
+			FilterFunc: func(obj interface{}) bool {
+				if secret, ok := obj.(v1.Secret); ok {
+					return secret.Name == UserGateResource
+				}
+				return false
+			},
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					c.enqueueSecret(ctx, obj)
+				},
+				UpdateFunc: func(old, obj interface{}) {
+					c.enqueueSecret(ctx, obj)
+				},
+				DeleteFunc: func(obj interface{}) {
+					c.lock.Lock()
+					defer c.lock.Unlock()
+					c.Rules = nil
+				},
+			},
+		},
+		resyncPeriod)
+	return c
+}
+
+// GetRuleSet returns the parsed rules that determine whether a user
+// is allowed through the gate.
+func (c *Controller) GetRuleSet() (ruleset.RuleSet, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if c.Rules != nil {
+		return *c.Rules, true
+	}
+	if c.DefaultRules != nil {
+		return *c.DefaultRules, true
+	}
+	return ruleset.RuleSet{}, false
+}
+
+func (c *Controller) enqueueSecret(ctx context.Context, obj interface{}) {
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+// Start the controller.
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+
+	logger := klog.FromContext(ctx).WithValues("controller", controllerName)
+	logger.Info("Starting controller")
+	defer logger.Info("Shutting down controller")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	k, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	key := k.(string)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, key); err != nil {
+		runtime.HandleError(fmt.Errorf("%q controller failed to sync %q, err: %w", controllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *Controller) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+	logger.WithValues("key", key).Info("updating usergate secret")
+
+	secret, err := c.GetSecret(key)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			c.lock.Lock()
+			defer c.lock.Unlock()
+			c.Rules = nil
+
+			return nil
+		}
+		return err
+	}
+
+	rules, err := ruleset.FromYAML(secret.Data[RuleKey])
+	if err != nil {
+		return err
+	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.Rules = rules
+
+	return nil
+}

--- a/pkg/proxy/usergating/handler.go
+++ b/pkg/proxy/usergating/handler.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package usergating
+
+import (
+	"context"
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/proxy/usergating/ruleset"
+)
+
+type UserGate struct {
+	GetRuleSet ruleset.RuleSetGetter
+}
+
+func WithUserGating(delegate http.Handler, failed http.Handler, getRuleSet ruleset.RuleSetGetter) http.Handler {
+	gate := &UserGate{
+		GetRuleSet: getRuleSet,
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		u, ok := request.UserFrom(ctx)
+		if !ok {
+			delegate.ServeHTTP(w, r)
+			return
+		}
+
+		decision := gate.Decide(ctx, u)
+		if decision != authorizer.DecisionDeny {
+			delegate.ServeHTTP(w, r)
+			return
+		}
+
+		failed.ServeHTTP(w, r)
+	})
+}
+
+// Decide whether the user is allowed to make the request
+func (a *UserGate) Decide(ctx context.Context, info user.Info) authorizer.Decision {
+	logger := klog.FromContext(ctx).WithValues("component", "usergate")
+	logger.V(1).Info("checking auth", "user", info.GetName())
+
+	if rules, found := a.GetRuleSet(); found {
+		if rules.UserNameIsAllowed(info.GetName()) {
+			return authorizer.DecisionAllow
+		}
+		return authorizer.DecisionDeny
+	}
+	return authorizer.DecisionNoOpinion
+}

--- a/pkg/proxy/usergating/handler.go
+++ b/pkg/proxy/usergating/handler.go
@@ -44,7 +44,7 @@ func WithUserGating(delegate http.Handler, failed http.Handler, getRuleSet rules
 			return
 		}
 
-		decision := gate.Decide(ctx, u)
+		decision := gate.Authorize(ctx, u)
 		if decision != authorizer.DecisionDeny {
 			delegate.ServeHTTP(w, r)
 			return
@@ -54,9 +54,9 @@ func WithUserGating(delegate http.Handler, failed http.Handler, getRuleSet rules
 	})
 }
 
-// Decide whether the user is allowed to make the request
-func (a *UserGate) Decide(ctx context.Context, info user.Info) authorizer.Decision {
-	logger := klog.FromContext(ctx).WithValues("component", "usergate")
+// Authorize whether the user is allowed to make the request
+func (a *UserGate) Authorize(ctx context.Context, info user.Info) authorizer.Decision {
+	logger := klog.FromContext(ctx).WithValues("component", "user-gating")
 	logger.V(1).Info("checking auth", "user", info.GetName())
 
 	if rules, found := a.GetRuleSet(); found {

--- a/pkg/proxy/usergating/ruleset/ruleset.go
+++ b/pkg/proxy/usergating/ruleset/ruleset.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type RuleSetGetter func() (RuleSet, bool)
+type RuleSetGetter func() (*RuleSet, bool)
 
 type matchFunc func(string) bool
 
@@ -90,4 +90,17 @@ func FromYAML(data []byte) (*RuleSet, error) {
 	}
 
 	return &rules, nil
+}
+
+func (rs *RuleSet) Clone() RuleSet {
+	d := make([]matchFunc, len(rs.denyMatchers))
+	copy(d, rs.denyMatchers)
+
+	a := make([]matchFunc, len(rs.allowMatchers))
+	copy(a, rs.allowMatchers)
+
+	return RuleSet{
+		allowMatchers: a,
+		denyMatchers:  d,
+	}
 }

--- a/pkg/proxy/usergating/ruleset/ruleset.go
+++ b/pkg/proxy/usergating/ruleset/ruleset.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ruleset
+
+import (
+	"fmt"
+	"regexp"
+
+	"sigs.k8s.io/yaml"
+)
+
+type RuleSetGetter func() (RuleSet, bool)
+
+type matchFunc func(string) bool
+
+type rawRuleSet struct {
+	DeniedUserNames  []string `json:"denied_user_names,omitempty"`
+	AllowedUserNames []string `json:"allowed_user_names,omitempty"`
+}
+
+// RuleSet holds rules for determining whether a user is authorized to perform
+// some action. Rules come in two types: deny and allow. Each rule's
+// raw form is a regular expression string. A RuleSet holds the corresponding
+// rexexp string matching functions.
+type RuleSet struct {
+	denyMatchers  []matchFunc
+	allowMatchers []matchFunc
+}
+
+// UserNameIsAllowed applies a RuleSet to the given name to determine whether
+// the user is authorized perform some action. Deny rules are applied first, and
+// a matching user name is immediately denied. Allow rules are applied next, and
+// only a matching user name is allowed.
+func (rs *RuleSet) UserNameIsAllowed(name string) bool {
+	// deny rules get priority
+	for _, denied := range rs.denyMatchers {
+		if denied(name) {
+			return false
+		}
+	}
+
+	// only allow requests with user names that match to continue
+	for _, allowed := range rs.allowMatchers {
+		if allowed(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// FromYAML populates a RuleSet from yaml data
+func FromYAML(data []byte) (*RuleSet, error) {
+	var rawRules rawRuleSet
+	if err := yaml.Unmarshal(data, &rawRules); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal gating rules: %w", err)
+	}
+
+	rules := RuleSet{}
+
+	// populate disallow patterns
+	for _, s := range rawRules.DeniedUserNames {
+		r, err := regexp.Compile(s)
+		if err != nil {
+			return nil, err
+		}
+		rules.denyMatchers = append(rules.denyMatchers, r.MatchString)
+	}
+
+	// populate allow patterns
+	for _, s := range rawRules.AllowedUserNames {
+		r, err := regexp.Compile(s)
+		if err != nil {
+			return nil, err
+		}
+		rules.allowMatchers = append(rules.allowMatchers, r.MatchString)
+	}
+
+	return &rules, nil
+}

--- a/pkg/proxy/usergating/ruleset/ruleset_test.go
+++ b/pkg/proxy/usergating/ruleset/ruleset_test.go
@@ -1,0 +1,56 @@
+package ruleset
+
+import (
+	"testing"
+)
+
+const (
+	doc = `
+denied_user_names:
+  - "@hack.er$"
+  - "hacker@doesnoevil.com"
+
+allowed_user_names:
+  - "@doesnoevil.com$"
+  - "^user@example.com$"
+  - "^user@hack.er"
+`
+)
+
+func TestRuleSet(t *testing.T) {
+	rules, err := FromYAML([]byte(doc))
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// should allow: not denied and username is exact match
+	if !rules.UserNameIsAllowed("user@example.com") {
+		t.Fail()
+	}
+
+	// should deny: user name is not explicitly allowed
+	if rules.UserNameIsAllowed("user@example.com.foo") {
+		t.Fail()
+	}
+
+	// should deny: user name is not explicitly allowed
+	if rules.UserNameIsAllowed("some+user@example.com") {
+		t.Fail()
+	}
+
+	// should deny: explicit denials take precedence even if user is explicitly allowed
+	if rules.UserNameIsAllowed("user@hack.er") {
+		t.Fail()
+	}
+
+	// should allow: user matches allow rule and does not match any deny rule
+	if !rules.UserNameIsAllowed("you@doesnoevil.com") {
+		t.Fail()
+	}
+
+	// should deny: user matches a deny rule
+	if rules.UserNameIsAllowed("hacker@doesnoevil.com") {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
## Summary
I'm exploring an authorization check in the front proxy that can prevent requests from reaching shards even for authenticated users.

It works through a rule set of allow and deny lists. Each rule is a regular expression. The set is defined in `root:kcp-system` as yaml embedded in a secret. A controller in the proxy monitors the secret for changes. A proxy admin can configure a default rule set file on the command line as a fallback.

Denies are checked first. Any matching denial rule results in an immediate unauthorized even if the user matches an allow rule.

Allows are checked next. Any success results in an authorized request.

All requests that match neither deny nor allow rules are unauthorized.