### PR TITLE
🌱 add new flag (root-directory) for the cache server binary

### DIFF
--- a/cmd/cache-server/main.go
+++ b/cmd/cache-server/main.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -32,7 +34,20 @@ import (
 )
 
 func main() {
-	serverOptions := options.NewOptions(".kcp-cache")
+	rootDir := flag.String("root-directory", ".kcp-cache", "Path to the root directory where all files required by this server will be stored")
+
+	var cacheServerFlags, remainingFlags []string
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "--root-directory") {
+			cacheServerFlags = append(cacheServerFlags, arg)
+			continue
+		}
+		remainingFlags = append(remainingFlags, arg)
+	}
+	flag.CommandLine.Parse(cacheServerFlags) //nolint:errcheck
+	os.Args = append([]string{os.Args[0]}, remainingFlags...)
+
+	serverOptions := options.NewOptions(*rootDir)
 	cmd := &cobra.Command{
 		Use:   "cache-server",
 		Short: "Runs the cache server for KCP",

--- a/pkg/cache/server/options/options.go
+++ b/pkg/cache/server/options/options.go
@@ -111,5 +111,6 @@ func (o *Options) Complete() (*CompletedOptions, error) {
 }
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	// TODO: figure out what flags needs to be exposed
+	o.EmbeddedEtcd.AddFlags(fs)
+	o.SecureServing.AddFlags(fs)
 }

--- a/pkg/server/options/cache.go
+++ b/pkg/server/options/cache.go
@@ -58,7 +58,10 @@ func (c *Cache) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.KubeconfigFile, "cache-server-kubeconfig-file", c.KubeconfigFile, "Kubeconfig for the cache server this instance connects to (defaults to loop back configuration).")
 	fs.BoolVar(&c.Enabled, "run-cache-server", c.Enabled, "If set to true it turns the cache server support on this instance (default false).")
 
-	c.Server.AddFlags(fs)
+	// note do not add cache server's flag c.Server.AddFlags(fs)
+	// it will cause an undefined behavior as some flags will be overwritten (also defined by the kcp server)
+	// as of today all required flags (embedded etcd, secure port)) are provided by the kcp server, so we are fine for now
+	// it will be finally addressed in https://github.com/kcp-dev/kcp/issues/2021
 }
 
 func (c *Cache) Complete() (cacheCompleted, error) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
adds a new flag (`root-directory`) to the cache server binary. The flag will be used by the `sharded-test-server` to the controller where the assets for the cache server are created.

In addition to that, it also exposes `o.EmbeddedEtcd.AddFlags(fs)` and `o.SecureServing.AddFlags(fs)` for the cache server binary. Those flags will be consumed by the `sharded-test-server` binary.

Lastly, it slightly changes the way options are used when the cache server runs in-process with kcp. That is, in that case the cache servers options are simply omitted because they overlap with the ones defined by kcp. This causes some undefined behavior. The issue will be eventually addressed by https://github.com/kcp-dev/kcp/issues/2021

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342