### PR TITLE
 ✨ sharded-test-server: support for running the caching layer

### DIFF
--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/abiosoft/lineprefix"
+	"github.com/fatih/color"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/cmd/test-server/helpers"
+	kcpclient "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func startCacheServer(ctx context.Context, logDirPath, workingDir string) (<-chan error, string, error) {
+	red := color.New(color.BgHiRed, color.FgHiWhite).SprintFunc()
+	inverse := color.New(color.BgHiWhite, color.FgHiRed).SprintFunc()
+	out := lineprefix.New(
+		lineprefix.Prefix(red(strings.ToUpper("cache"))),
+		lineprefix.Color(color.New(color.FgHiRed)),
+	)
+	loggerOut := lineprefix.New(
+		lineprefix.Prefix(inverse(strings.ToUpper("cache"))),
+		lineprefix.Color(color.New(color.FgHiWhite)),
+	)
+	cacheWorkingDir := filepath.Join(workingDir, ".kcp-cache")
+	cachePort := 8012
+	commandLine := framework.DirectOrGoRunCommand("cache-server")
+	commandLine = append(
+		commandLine,
+		fmt.Sprintf("--root-directory=%s", cacheWorkingDir),
+		"--embedded-etcd-client-port=8010",
+		"--embedded-etcd-peer-port=8011",
+		fmt.Sprintf("--secure-port=%d", cachePort),
+	)
+	fmt.Fprintf(out, "running: %v\n", strings.Join(commandLine, " "))
+	cmd := exec.CommandContext(ctx, commandLine[0], commandLine[1:]...)
+
+	logFilePath := filepath.Join(logDirPath, ".kcp-cache", "out.log")
+	if err := os.MkdirAll(filepath.Dir(logFilePath), 0755); err != nil {
+		return nil, "", err
+	}
+	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, "", err
+	}
+
+	writer := helpers.NewHeadWriter(logFile, out)
+	cmd.Stdout = writer
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = writer
+
+	if err := cmd.Start(); err != nil {
+		return nil, "", err
+	}
+
+	terminatedCh := make(chan error, 1)
+	go func() {
+		terminatedCh <- cmd.Wait()
+	}()
+
+	// wait for readiness
+	logger := klog.FromContext(ctx)
+	logger.Info("waiting for the cache server to be up")
+	cacheKubeconfigPath := filepath.Join(cacheWorkingDir, "cache.kubeconfig")
+	for {
+		time.Sleep(time.Second)
+
+		select {
+		case <-ctx.Done():
+			return nil, "", fmt.Errorf("context canceled")
+		case err := <-terminatedCh:
+			var exitErr *exec.ExitError
+			if err == nil {
+				return nil, "", fmt.Errorf("the cahce server terminated unexpectedly with exit code 0")
+			} else if errors.As(err, &exitErr) {
+				return nil, "", fmt.Errorf("the cache server terminated with exit code %d", exitErr.ExitCode())
+			}
+			return nil, "", fmt.Errorf("the cache server terminated with unknown error: %w", err)
+		default:
+		}
+
+		if _, err := os.Stat(filepath.Join(cacheWorkingDir, "apiserver.crt")); os.IsNotExist(err) {
+			logger.V(3).Info("failed to read the cache server certificate file", "err", err, "path", filepath.Join(cacheWorkingDir, "apiserver.crt"))
+			continue
+		}
+
+		if _, err := os.Stat(cacheKubeconfigPath); os.IsNotExist(err) {
+			cacheServerCert, err := ioutil.ReadFile(filepath.Join(cacheWorkingDir, "apiserver.crt"))
+			if err != nil {
+				return nil, "", err
+			}
+			cacheServerKubeConfig := clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"cache": {
+						Server:                   fmt.Sprintf("https://localhost:%d", cachePort),
+						CertificateAuthorityData: cacheServerCert,
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"cache": {
+						Cluster: "cache",
+					},
+				},
+				CurrentContext: "cache",
+			}
+			if err = clientcmd.WriteToFile(cacheServerKubeConfig, cacheKubeconfigPath); err != nil {
+				return nil, "", err
+			}
+		}
+
+		cacheServerKubeConfig, err := clientcmd.LoadFromFile(cacheKubeconfigPath)
+		if err != nil {
+			return nil, "", err
+		}
+		cacheClientConfig := clientcmd.NewNonInteractiveClientConfig(*cacheServerKubeConfig, "cache", nil, nil)
+		cacheClientRestConfig, err := cacheClientConfig.ClientConfig()
+		if err != nil {
+			return nil, "", err
+		}
+		cacheClient, err := kcpclient.NewClusterForConfig(cacheClientRestConfig)
+		if err != nil {
+			return nil, "", err
+		}
+
+		res := cacheClient.RESTClient().Get().AbsPath("/readyz").Do(ctx)
+		if err := res.Error(); err != nil {
+			logger.V(3).Info("the cache server is not ready", "err", err)
+		} else {
+			var rc int
+			res.StatusCode(&rc)
+			if rc == http.StatusOK {
+				logger.V(3).Info("the cache server is ready")
+				break
+			}
+			if bs, err := res.Raw(); err != nil {
+				logger.V(3).Info("the cache server is not ready", "err", err)
+			} else {
+				logger.V(3).WithValues("rc", rc, "raw", string(bs)).Info("the cache server is not ready")
+			}
+		}
+	}
+	fmt.Fprintf(loggerOut, "the cache server is ready\n")
+	return terminatedCh, cacheKubeconfigPath, nil
+}

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -28,7 +28,7 @@ import (
 	shard "github.com/kcp-dev/kcp/cmd/test-server/kcp"
 )
 
-func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA, hostIP string, logDirPath, workDirPath string) (<-chan error, error) {
+func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA, hostIP string, logDirPath, workDirPath, cacheServerConfigPath string) (<-chan error, error) {
 	// create serving cert
 	hostnames := sets.NewString("localhost", hostIP)
 	klog.Infof("Creating shard server %d serving cert with hostnames %v", n, hostnames)
@@ -82,6 +82,9 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 		fmt.Sprintf("--secure-port=%d", 6444+n),
 		"--virtual-workspaces-workspaces.authorization-cache.resync-period=1s",
 	)
+	if len(cacheServerConfigPath) > 0 {
+		args = append(args, fmt.Sprintf("--cache-server-kubeconfig-file=%s", cacheServerConfigPath))
+	}
 
 	return shard.Start(ctx,
 		fmt.Sprintf("kcp-%d", n),                              // name


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
adds support for running the `cache-server` to the `sharded-test-server` binary.
support for caching can be turned on by passing `--run-cache-server=true` flag, then the test binary will:
1. configure the cache to listen on port `8012` (HTTPS)
2. configure the cache to use embedded-etcd (ports `8010`, `8011`)
3. configure the cache to use `filepath.Join(workingDir, ".kcp-cache")` directory
4. run the cache server
5. wait for the cache server's serving certificate
6. use the certificate to create a kubeconfig at the path configured in `3`
7. wait until the cache becomes ready

next, the test binary will configure each shard with the following flags:
1. `--run-cache-server=true` - inherited from the test binary itself
2. `--cache-server-kubeconfig-file` - that points to the kubeconfig created in step `6`. A shard will use the config to establish connection with the cache server


in the future we could run the caching layer by default, for now (until it proves to work), it has to be gated with a flag.

## Related issue(s)

part of https://github.com/kcp-dev/kcp/issues/342
