### PR TITLE
🐛 sharded-test-server: fix the way we calculate the embedded etcd client ports

### DIFF
--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -62,8 +62,8 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 	if n > 0 {
 		args = append(args, fmt.Sprintf("--shard-name=shard-%d", n))
 		args = append(args, fmt.Sprintf("--root-shard-kubeconfig-file=%s", filepath.Join(workDirPath, ".kcp-0/admin.kubeconfig")))
-		args = append(args, fmt.Sprintf("--embedded-etcd-client-port=%d", 2379+n+1))
-		args = append(args, fmt.Sprintf("--embedded-etcd-peer-port=%d", (2379+n+1)+1)) // prev value +1
+		args = append(args, fmt.Sprintf("--embedded-etcd-client-port=%d", embeddedEtcdClientPort(n)))
+		args = append(args, fmt.Sprintf("--embedded-etcd-peer-port=%d", embeddedEtcdPeerPort(n)))
 	}
 	args = append(args,
 		/*fmt.Sprintf("--cluster-workspace-shard-name=kcp-%d", n),*/
@@ -91,4 +91,12 @@ func startShard(ctx context.Context, n int, args []string, servingCA *crypto.CA,
 		filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d", n)), // runtime directory, etcd data etc.
 		logFilePath,
 		args)
+}
+
+func embeddedEtcdClientPort(n int) int {
+	return 2380 + (n * 2) - 1
+}
+
+func embeddedEtcdPeerPort(n int) int {
+	return 2380 + (n * 2)
 }

--- a/cmd/sharded-test-server/shard_test.go
+++ b/cmd/sharded-test-server/shard_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestEmbeddedEtcdClientPort(t *testing.T) {
+	scenarios := []struct {
+		n            int
+		expectedPort int
+	}{
+		{
+			1,
+			2381,
+		},
+		{
+			2,
+			2383,
+		},
+		{
+			3,
+			2385,
+		},
+		{
+			4,
+			2387,
+		},
+		{
+			5,
+			2389,
+		},
+		{
+			6,
+			2391,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actualPort := embeddedEtcdClientPort(scenario.n)
+		if actualPort != scenario.expectedPort {
+			t.Fatalf("unexpected etcd client port %d, expected %d, for n = %d", actualPort, scenario.expectedPort, scenario.n)
+		}
+	}
+}
+
+func TestEmbeddedEtcdPeerPort(t *testing.T) {
+	scenarios := []struct {
+		n            int
+		expectedPort int
+	}{
+		{
+			1,
+			2382,
+		},
+		{
+			2,
+			2384,
+		},
+		{
+			3,
+			2386,
+		},
+		{
+			4,
+			2388,
+		},
+		{
+			5,
+			2390,
+		},
+		{
+			6,
+			2392,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actualPort := embeddedEtcdPeerPort(scenario.n)
+		if actualPort != scenario.expectedPort {
+			t.Fatalf("unexpected etcd peer port %d, expected %d, for n = %d", actualPort, scenario.expectedPort, scenario.n)
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
previously the ports were overlapping with a previous instance

## Related issue(s)

needed by https://github.com/kcp-dev/kcp/issues/342 
