### PR TITLE
:book: Correcting the link to the developers doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ documentation:
 ## Contributing
 
 We ❤️ our contributors! If you're interested in helping us out, please head over to our [Contributing](CONTRIBUTING.md)
-and [Developer](docs/developers) guides.
+and [Developer](docs/content/en/main/concepts/developers) guides.
 
 ## Getting in touch
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The link to the developers doc is currently broken


## Related issue(s)

Fixes #
