### PR TITLE
🌱 Protect imports target with Go version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ $(OPENSHIFT_GOIMPORTS):
 	GOBIN=$(TOOLS_GOBIN_DIR) $(GO_INSTALL) github.com/openshift-eng/openshift-goimports $(OPENSHIFT_GOIMPORTS_BIN) $(OPENSHIFT_GOIMPORTS_VER)
 
 .PHONY: imports
-imports: $(OPENSHIFT_GOIMPORTS)
+imports: $(OPENSHIFT_GOIMPORTS) verify-go-versions
 	$(OPENSHIFT_GOIMPORTS) -m github.com/kcp-dev/kcp
 
 $(TOOLS_DIR)/verify_boilerplate.py:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Go 1.19 will update files on a clean checkout if `make imports` is run;
require the user to acknowledge this with the IGNORE_GO_VERSION var.

/cc @csams

## Related issue(s)

Fixes #
