### PR TITLE
✨ Version check between the compiled syncer and the deployment yaml

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -123,6 +123,7 @@ func Run(ctx context.Context, options *synceroptions.Options) error {
 			SyncTargetUID:                 options.SyncTargetUID,
 			DNSImage:                      options.DNSImage,
 			DownstreamNamespaceCleanDelay: options.DownstreamNamespaceCleanDelay,
+			ExpectedKCPVersion:            options.ExpectedKCPVersion,
 		},
 		numThreads,
 		options.APIImportPollInterval,

--- a/cmd/syncer/options/options.go
+++ b/cmd/syncer/options/options.go
@@ -45,6 +45,7 @@ type Options struct {
 	SyncedResourceTypes           []string
 	DNSImage                      string
 	DownstreamNamespaceCleanDelay time.Duration
+	ExpectedKCPVersion            string
 
 	APIImportPollInterval time.Duration
 }
@@ -82,6 +83,7 @@ func (options *Options) AddFlags(fs *pflag.FlagSet) {
 		"Options are:\n"+strings.Join(kcpfeatures.KnownFeatures(), "\n")) // hide kube-only gates
 	fs.StringVar(&options.DNSImage, "dns-image", options.DNSImage, "kcp DNS server image.")
 	fs.DurationVar(&options.DownstreamNamespaceCleanDelay, "downstream-namespace-clean-delay", options.DownstreamNamespaceCleanDelay, "Time to wait before deleting a downstream namespace, defaults to 30s.")
+	fs.StringVar(&options.ExpectedKCPVersion, "expectedKCPVersion", options.ExpectedKCPVersion, "The expected compiled KCP version of the syncer")
 
 	options.Logs.AddFlags(fs)
 }

--- a/pkg/apis/workload/v1alpha1/synctarget_types.go
+++ b/pkg/apis/workload/v1alpha1/synctarget_types.go
@@ -183,6 +183,10 @@ const (
 
 	// ErrorHeartbeatMissedReason indicates that a heartbeat update was not received within the configured threshold.
 	ErrorHeartbeatMissedReason = "ErrorHeartbeat"
+
+	// VersionMismatchReason indicates that the compiled version of the Syncer is not the same as the expected version
+	// (set by the `kcp workload sync` CLI command).
+	VersionMismatchReason = "ErrorVersionMismatch"
 )
 
 func (in *SyncTarget) SetConditions(conditions conditionsv1alpha1.Conditions) {

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -211,6 +211,235 @@ spec:
         - --qps=123.4
         - --burst=456
         - --dns-image=image
+        - --expectedKCPVersion=the-kcp-version
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: image
+        imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: kcp-config
+          mountPath: /kcp/
+          readOnly: true
+      serviceAccountName: kcp-syncer-sync-target-name-34b23c4k
+      volumes:
+        - name: kcp-config
+          secret:
+            secretName: kcp-syncer-sync-target-name-34b23c4k
+            optional: false
+`
+
+	actualYAML, err := renderSyncerResources(templateInput{
+		ServerURL:                   "server-url",
+		Token:                       "token",
+		CAData:                      "ca-data",
+		KCPNamespace:                "kcp-namespace",
+		Namespace:                   "kcp-syncer-sync-target-name-34b23c4k",
+		LogicalCluster:              "root:default:foo",
+		SyncTarget:                  "sync-target-name",
+		SyncTargetUID:               "sync-target-uid",
+		Image:                       "image",
+		Replicas:                    1,
+		ResourcesToSync:             []string{"resource1", "resource2"},
+		APIImportPollIntervalString: "1m",
+		QPS:                         123.4,
+		Burst:                       456,
+		ExpectedKCPVersion:          "the-kcp-version",
+	}, "kcp-syncer-sync-target-name-34b23c4k", []string{"resource1", "resource2"})
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))
+}
+
+func TestNewSyncerYAMLWithSyncerVersionChecksDisabled(t *testing.T) {
+	expectedYAML := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k-token
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+  annotations:
+    kubernetes.io/service-account.name: kcp-syncer-sync-target-name-34b23c4k
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
+  - "delete"
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - resource1
+  - resource2
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kcp-syncer-sync-target-name-34b23c4k
+subjects:
+- kind: ServiceAccount
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kcp-dns-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "apps"
+  resources:
+  - deployments
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - "create"
+  - "get"
+  - "list"
+  - "update"
+  - "delete"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kcp-dns-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kcp-dns-sync-target-name-34b23c4k
+subjects:
+  - kind: ServiceAccount
+    name: kcp-syncer-sync-target-name-34b23c4k
+    namespace: kcp-syncer-sync-target-name-34b23c4k
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: default-cluster
+      cluster:
+        certificate-authority-data: ca-data
+        server: server-url
+    contexts:
+    - name: default-context
+      context:
+        cluster: default-cluster
+        namespace: kcp-namespace
+        user: default-user
+    current-context: default-context
+    users:
+    - name: default-user
+      user:
+        token: token
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kcp-syncer-sync-target-name-34b23c4k
+  namespace: kcp-syncer-sync-target-name-34b23c4k
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: kcp-syncer-sync-target-name-34b23c4k
+  template:
+    metadata:
+      labels:
+        app: kcp-syncer-sync-target-name-34b23c4k
+    spec:
+      containers:
+      - name: kcp-syncer
+        command:
+        - /ko-app/syncer
+        args:
+        - --from-kubeconfig=/kcp/kubeconfig
+        - --sync-target-name=sync-target-name
+        - --sync-target-uid=sync-target-uid
+        - --from-cluster=root:default:foo
+        - --api-import-poll-interval=1m
+        - --resources=resource1
+        - --resources=resource2
+        - --qps=123.4
+        - --burst=456
+        - --dns-image=image
         env:
         - name: NAMESPACE
           valueFrom:
@@ -441,6 +670,7 @@ spec:
         - --burst=456
         - --feature-gates=myfeature=true
         - --dns-image=image
+        - --expectedKCPVersion=the-kcp-version
         env:
         - name: NAMESPACE
           valueFrom:
@@ -477,6 +707,7 @@ spec:
 		APIImportPollIntervalString:         "1m",
 		DownstreamNamespaceCleanDelayString: "2s",
 		FeatureGatesString:                  "myfeature=true",
+		ExpectedKCPVersion:                  "the-kcp-version",
 	}, "kcp-syncer-sync-target-name-34b23c4k", []string{"resource1", "resource2"})
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expectedYAML, string(actualYAML)))

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -192,6 +192,9 @@ spec:
         - --feature-gates={{ .FeatureGatesString }}
 {{- end}}
         - --dns-image={{.Image}}
+{{- if .ExpectedKCPVersion }}
+        - --expectedKCPVersion={{.ExpectedKCPVersion}}
+{{- end}}
         env:
         - name: NAMESPACE
           valueFrom:

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/yaml"
 
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apiresource/v1alpha1"
@@ -595,6 +596,7 @@ func syncerConfigFromCluster(t *testing.T, downstreamConfig *rest.Config, namesp
 		SyncTargetUID:                 syncTargetUID,
 		DNSImage:                      dnsImage,
 		DownstreamNamespaceCleanDelay: 2 * time.Second,
+		ExpectedKCPVersion:            version.Get().GitVersion,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: David Festal <dfestal@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The `kcp workload sync` command now adds an `--expectedKCPVersion` flag to the `syncer` areguments in the deployment, and the `syncer` binary verifies it matches its compiled version.

## Related issue(s)

Fixes kcp-dev/contrib-tmc#82
