### PR TITLE
:sparkles: plugin/sync: don't update the synctarget if `--update` is not set

### DIFF
--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -573,6 +573,7 @@ func TestSyncWorkload(t *testing.T) {
 		syncTargetName,
 		"--syncer-image",
 		"ghcr.io/kcp-dev/kcp/syncer-c2e3073d5026a8f7f2c47a50c16bdbec:41ca72b",
+		"--update",
 		"--output-file", "-",
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Avoid updating an existing synctarget when using the `kcp workload sync` plugin.

* Adds a new flag to signal the intention to update the already existing synctarget: `--update`

## Related issue(s)

Fixes #
