### PR TITLE
:bug: clusterworkspaceshard: fix admission and shard creation for multi-shard setups

### DIFF
--- a/config/crds/tenancy.kcp.dev_clusterworkspaceshards.yaml
+++ b/config/crds/tenancy.kcp.dev_clusterworkspaceshards.yaml
@@ -52,10 +52,8 @@ spec:
               ClusterWorkspaceShard.
             properties:
               baseURL:
-                description: "baseURL is the address of the KCP shard for direct connections,
-                  e.g. by some front-proxy doing the fan-out to the shards. \n This
-                  will be defaulted to the shard's external address if not specified.
-                  Note that this is only sensible in single-shards setups."
+                description: baseURL is the address of the KCP shard for direct connections,
+                  e.g. by some front-proxy doing the fan-out to the shards.
                 format: uri
                 minLength: 1
                 type: string
@@ -78,12 +76,12 @@ spec:
                   server associated with this shard. It can be a direct address, an
                   address of a front-proxy or even an address of an LB. As of today
                   this address is assigned to APIExports. \n This will be defaulted
-                  to the shard's base address if not specified."
+                  to the value of the baseURL."
                 format: uri
                 minLength: 1
                 type: string
             required:
-            - externalURL
+            - baseURL
             type: object
           status:
             description: ClusterWorkspaceShardStatus communicates the observed state

--- a/config/root-phase0/apiexport-shards.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiexport-shards.tenancy.kcp.dev.yaml
@@ -5,7 +5,7 @@ metadata:
   name: shards.tenancy.kcp.dev
 spec:
   latestResourceSchemas:
-  - v220803-e095b93c.clusterworkspaceshards.tenancy.kcp.dev
+  - v221113-fe47bd04.clusterworkspaceshards.tenancy.kcp.dev
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-clusterworkspaceshards.tenancy.kcp.dev.yaml
+++ b/config/root-phase0/apiresourceschema-clusterworkspaceshards.tenancy.kcp.dev.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.dev/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v220803-e095b93c.clusterworkspaceshards.tenancy.kcp.dev
+  name: v221113-fe47bd04.clusterworkspaceshards.tenancy.kcp.dev
 spec:
   group: tenancy.kcp.dev
   names:
@@ -47,10 +47,8 @@ spec:
           description: ClusterWorkspaceShardSpec holds the desired state of the ClusterWorkspaceShard.
           properties:
             baseURL:
-              description: "baseURL is the address of the KCP shard for direct connections,
-                e.g. by some front-proxy doing the fan-out to the shards. \n This
-                will be defaulted to the shard's external address if not specified.
-                Note that this is only sensible in single-shards setups."
+              description: baseURL is the address of the KCP shard for direct connections,
+                e.g. by some front-proxy doing the fan-out to the shards.
               format: uri
               minLength: 1
               type: string
@@ -73,12 +71,12 @@ spec:
                 server associated with this shard. It can be a direct address, an
                 address of a front-proxy or even an address of an LB. As of today
                 this address is assigned to APIExports. \n This will be defaulted
-                to the shard's base address if not specified."
+                to the value of the baseURL."
               format: uri
               minLength: 1
               type: string
           required:
-          - externalURL
+          - baseURL
           type: object
         status:
           description: ClusterWorkspaceShardStatus communicates the observed state

--- a/config/root/bootstrap.go
+++ b/config/root/bootstrap.go
@@ -21,13 +21,10 @@ package root
 import (
 	"context"
 	"embed"
-	"encoding/base64"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	confighelpers "github.com/kcp-dev/kcp/config/helpers"
 )
@@ -38,12 +35,7 @@ var fs embed.FS
 // Bootstrap creates resources in this package by continuously retrying the list.
 // This is blocking, i.e. it only returns (with error) when the context is closed or with nil when
 // the bootstrapping is successfully completed.
-func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, shardName string, shardVirtualWorkspaceURL string, kubeconfig clientcmdapi.Config, homePrefix string, homeWorkspaceCreatorGroups []string, batteriesIncluded sets.String) error {
-	kubeconfigRaw, err := clientcmd.Write(kubeconfig)
-	if err != nil {
-		return err
-	}
-
+func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInterface, rootDynamicClient dynamic.Interface, homePrefix string, homeWorkspaceCreatorGroups []string, batteriesIncluded sets.String) error {
 	homeWorkspaceCreatorGroupReplacement := ""
 	for _, group := range homeWorkspaceCreatorGroups {
 		homeWorkspaceCreatorGroupReplacement += `
@@ -56,9 +48,6 @@ func Bootstrap(ctx context.Context, rootDiscoveryClient discovery.DiscoveryInter
 	}
 
 	return confighelpers.Bootstrap(ctx, rootDiscoveryClient, rootDynamicClient, batteriesIncluded, fs, confighelpers.ReplaceOption(
-		"SHARD_NAME", shardName,
-		"SHARD_VIRTUAL_WORKSPACE_URL", shardVirtualWorkspaceURL,
-		"SHARD_KUBECONFIG", base64.StdEncoding.EncodeToString(kubeconfigRaw),
 		"HOME_CREATOR_GROUPS", homeWorkspaceCreatorGroupReplacement,
 		"HOMEPREFIX", homePrefix,
 	))

--- a/config/root/clusterworkspaceshard.yaml
+++ b/config/root/clusterworkspaceshard.yaml
@@ -1,9 +1,0 @@
-apiVersion: tenancy.kcp.dev/v1alpha1
-kind: ClusterWorkspaceShard
-metadata:
-  name: SHARD_NAME
-spec:
-  virtualWorkspaceURL: SHARD_VIRTUAL_WORKSPACE_URL
-  credentials:
-    namespace: default
-    name: shard-root-kubeconfig

--- a/config/root/secret-shard.yaml
+++ b/config/root/secret-shard.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: shard-SHARD_NAME-kubeconfig
-  namespace: default
-  annotations:
-    bootstrap.kcp.dev/create-only: ""
-data:
-  kubeconfig: SHARD_KUBECONFIG

--- a/pkg/admission/clusterworkspaceshard/admission.go
+++ b/pkg/admission/clusterworkspaceshard/admission.go
@@ -23,10 +23,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 
-	"github.com/kcp-dev/kcp/pkg/admission/initializers"
 	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
 
@@ -50,50 +48,10 @@ func Register(plugins *admission.Plugins) {
 
 type clusterWorkspaceShard struct {
 	*admission.Handler
-
-	shardBaseURL            string
-	shardExternalURL        string
-	externalAddressProvider func() string
 }
 
 // Ensure that the required admission interfaces are implemented.
-var _ = admission.ValidationInterface(&clusterWorkspaceShard{})
 var _ = admission.MutationInterface(&clusterWorkspaceShard{})
-var _ = initializers.WantsExternalAddressProvider(&clusterWorkspaceShard{})
-var _ = initializers.WantsShardExternalURL(&clusterWorkspaceShard{})
-
-// Validate ensures that
-// - baseURL is set
-// - externalURL is set
-func (o *clusterWorkspaceShard) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
-	if a.GetResource().GroupResource() != tenancyv1alpha1.Resource("clusterworkspaceshards") {
-		return nil
-	}
-
-	u, ok := a.GetObject().(*unstructured.Unstructured)
-	if !ok {
-		return fmt.Errorf("unexpected type %T", a.GetObject())
-	}
-	cws := &tenancyv1alpha1.ClusterWorkspaceShard{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cws); err != nil {
-		return fmt.Errorf("failed to convert unstructured to ClusterWorkspace: %w", err)
-	}
-
-	var errs field.ErrorList
-
-	if cws.Spec.BaseURL == "" {
-		errs = append(errs, field.Required(field.NewPath("spec", "baseURL"), ""))
-	}
-	if cws.Spec.ExternalURL == "" {
-		errs = append(errs, field.Required(field.NewPath("spec", "externalURL"), ""))
-	}
-
-	if len(errs) > 0 {
-		return admission.NewForbidden(a, errs.ToAggregate())
-	}
-
-	return nil
-}
 
 // Admit sets.
 func (o *clusterWorkspaceShard) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) (err error) {
@@ -110,27 +68,8 @@ func (o *clusterWorkspaceShard) Admit(_ context.Context, a admission.Attributes,
 		return fmt.Errorf("failed to convert unstructured to ClusterWorkspaceShard: %w", err)
 	}
 
-	externalAddress := ""
-	if o.externalAddressProvider != nil {
-		externalAddress = o.externalAddressProvider()
-	}
-
-	if cws.Spec.BaseURL == "" {
-		switch {
-		case o.shardBaseURL != "":
-			cws.Spec.BaseURL = o.shardBaseURL
-		case externalAddress != "":
-			cws.Spec.BaseURL = "https://" + externalAddress
-		}
-	}
-
 	if cws.Spec.ExternalURL == "" {
-		switch {
-		case o.shardExternalURL != "":
-			cws.Spec.ExternalURL = o.shardExternalURL
-		case externalAddress != "":
-			cws.Spec.ExternalURL = "https://" + externalAddress
-		}
+		cws.Spec.ExternalURL = cws.Spec.BaseURL
 	}
 
 	if cws.Spec.VirtualWorkspaceURL == "" {
@@ -144,16 +83,4 @@ func (o *clusterWorkspaceShard) Admit(_ context.Context, a admission.Attributes,
 	u.Object = raw
 
 	return nil
-}
-
-func (o *clusterWorkspaceShard) SetShardBaseURL(shardBaseURL string) {
-	o.shardBaseURL = shardBaseURL
-}
-
-func (o *clusterWorkspaceShard) SetShardExternalURL(shardExternalURL string) {
-	o.shardExternalURL = shardExternalURL
-}
-
-func (o *clusterWorkspaceShard) SetExternalAddressProvider(externalAddressProvider func() string) {
-	o.externalAddressProvider = externalAddressProvider
 }

--- a/pkg/admission/clusterworkspacetypeexists/admission_test.go
+++ b/pkg/admission/clusterworkspacetypeexists/admission_test.go
@@ -193,7 +193,7 @@ func TestAdmit(t *testing.T) {
 						"creationTimestamp": nil,
 					},
 					"spec": map[string]interface{}{
-						"externalURL": "",
+						"baseURL": "",
 					},
 					"status": map[string]interface{}{},
 				}},

--- a/pkg/admission/initializers/initializer.go
+++ b/pkg/admission/initializers/initializer.go
@@ -107,62 +107,6 @@ func (i *clientConfigInitializer) Initialize(plugin admission.Interface) {
 	}
 }
 
-// NewExternalAddressInitializer returns an admission plugin initializer that injects
-// an external address provider into the admission plugin.
-func NewExternalAddressInitializer(
-	externalAddressProvider func() string,
-) *externalAddressInitializer {
-	return &externalAddressInitializer{
-		externalAddressProvider: externalAddressProvider,
-	}
-}
-
-type externalAddressInitializer struct {
-	externalAddressProvider func() string
-}
-
-func (i *externalAddressInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantsExternalAddressProvider); ok {
-		wants.SetExternalAddressProvider(i.externalAddressProvider)
-	}
-}
-
-// NewShardBaseURLInitializer returns an admission plugin initializer that injects
-// the default shard base URL provider into the admission plugin.
-func NewShardBaseURLInitializer(shardBaseURL string) *shardBaseURLInitializer {
-	return &shardBaseURLInitializer{
-		shardBaseURL: shardBaseURL,
-	}
-}
-
-type shardBaseURLInitializer struct {
-	shardBaseURL string
-}
-
-func (i *shardBaseURLInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantsShardBaseURL); ok {
-		wants.SetShardBaseURL(i.shardBaseURL)
-	}
-}
-
-// NewShardExternalURLInitializer returns an admission plugin initializer that injects
-// the default shard external URL provider into the admission plugin.
-func NewShardExternalURLInitializer(shardExternalURL string) *shardExternalURLInitializer {
-	return &shardExternalURLInitializer{
-		shardExternalURL: shardExternalURL,
-	}
-}
-
-type shardExternalURLInitializer struct {
-	shardExternalURL string
-}
-
-func (i *shardExternalURLInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantsShardExternalURL); ok {
-		wants.SetShardExternalURL(i.shardExternalURL)
-	}
-}
-
 // NewKubeQuotaConfigurationInitializer returns an admission plugin initializer that injects quota.Configuration
 // into admission plugins.
 func NewKubeQuotaConfigurationInitializer(quotaConfiguration quota.Configuration) *kubeQuotaConfigurationInitializer {

--- a/pkg/admission/initializers/interfaces.go
+++ b/pkg/admission/initializers/interfaces.go
@@ -48,24 +48,6 @@ type WantsDeepSARClient interface {
 	SetDeepSARClient(kcpkubernetesclientset.ClusterInterface)
 }
 
-// WantsExternalAddressProvider interface should be implemented by admission plugins
-// that want to have an external address provider injected.
-type WantsExternalAddressProvider interface {
-	SetExternalAddressProvider(externalAddressProvider func() string)
-}
-
-// WantsShardBaseURL interface should be implemented by admission plugins
-// that want to have the default shard base url injected.
-type WantsShardBaseURL interface {
-	SetShardBaseURL(string)
-}
-
-// WantsShardExternalURL interface should be implemented by admission plugins
-// that want to have the shard external url injected.
-type WantsShardExternalURL interface {
-	SetShardExternalURL(string)
-}
-
 // WantsServerShutdownChannel interface should be implemented by admission plugins that want to perform cleanup
 // activities when the main server context/channel is done.
 type WantsServerShutdownChannel interface {

--- a/pkg/apis/tenancy/v1alpha1/types.go
+++ b/pkg/apis/tenancy/v1alpha1/types.go
@@ -531,13 +531,11 @@ type ClusterWorkspaceShardSpec struct {
 	// baseURL is the address of the KCP shard for direct connections, e.g. by some
 	// front-proxy doing the fan-out to the shards.
 	//
-	// This will be defaulted to the shard's external address if not specified. Note that this
-	// is only sensible in single-shards setups.
-	//
+	// +required
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Format=uri
 	// +kubebuilder:validation:MinLength=1
-	// +optional
-	BaseURL string `json:"baseURL,omitempty"`
+	BaseURL string `json:"baseURL"`
 
 	// externalURL is the externally visible address presented to users in Workspace URLs.
 	// Changing this will break all existing workspaces on that shard, i.e. existing
@@ -553,21 +551,20 @@ type ClusterWorkspaceShardSpec struct {
 	//
 	// This will be defaulted to the value of the baseURL.
 	//
+	// +optional
 	// +kubebuilder:validation:Format=uri
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:Required
-	// +required
-	ExternalURL string `json:"externalURL"`
+	ExternalURL string `json:"externalURL,omitempty"`
 
 	// virtualWorkspaceURL is the address of the virtual workspace server associated with this shard.
 	// It can be a direct address, an address of a front-proxy or even an address of an LB.
 	// As of today this address is assigned to APIExports.
 	//
-	// This will be defaulted to the shard's base address if not specified.
+	// This will be defaulted to the value of the baseURL.
 	//
+	// +optional
 	// +kubebuilder:validation:Format=uri
 	// +kubebuilder:validation:MinLength=1
-	// +optional
 	VirtualWorkspaceURL string `json:"virtualWorkspaceURL,omitempty"`
 }
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -2857,7 +2857,8 @@ func schema_pkg_apis_tenancy_v1alpha1_ClusterWorkspaceShardSpec(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"baseURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "baseURL is the address of the KCP shard for direct connections, e.g. by some front-proxy doing the fan-out to the shards.\n\nThis will be defaulted to the shard's external address if not specified. Note that this is only sensible in single-shards setups.",
+							Description: "baseURL is the address of the KCP shard for direct connections, e.g. by some front-proxy doing the fan-out to the shards.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2865,20 +2866,19 @@ func schema_pkg_apis_tenancy_v1alpha1_ClusterWorkspaceShardSpec(ref common.Refer
 					"externalURL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "externalURL is the externally visible address presented to users in Workspace URLs. Changing this will break all existing workspaces on that shard, i.e. existing kubeconfigs of clients will be invalid. Hence, when changing this value, the old URL used by clients must keep working.\n\nThe external address will not be unique if a front-proxy does a fan-out to shards, but all workspace client will talk to the front-proxy. In that case, put the address of the front-proxy here.\n\nNote that movement of shards is only possible (in the future) between shards that share a common external URL.\n\nThis will be defaulted to the value of the baseURL.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"virtualWorkspaceURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "virtualWorkspaceURL is the address of the virtual workspace server associated with this shard. It can be a direct address, an address of a front-proxy or even an address of an LB. As of today this address is assigned to APIExports.\n\nThis will be defaulted to the shard's base address if not specified.",
+							Description: "virtualWorkspaceURL is the address of the virtual workspace server associated with this shard. It can be a direct address, an address of a front-proxy or even an address of an LB. As of today this address is assigned to APIExports.\n\nThis will be defaulted to the value of the baseURL.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"externalURL"},
+				Required: []string{"baseURL"},
 			},
 		},
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -108,6 +108,11 @@ type ExtraConfig struct {
 	preHandlerChainMux   *handlerChainMuxes
 	quotaAdmissionStopCh chan struct{}
 
+	// URL getters depending on genericspiserver.ExternalAddress which is initialized on server run
+	ShardBaseURL             func() string
+	ShardExternalURL         func() string
+	ShardVirtualWorkspaceURL func() string
+
 	// informers
 	KcpSharedInformerFactory              kcpinformers.SharedInformerFactory
 	KubeSharedInformerFactory             kcpkubernetesinformers.SharedInformerFactory
@@ -244,6 +249,10 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 
 		c.identityConfig = rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)
 		c.identityConfig.Wrap(kcpShardIdentityRoundTripper)
+		c.KcpClusterClient, err = kcpclient.NewClusterForConfig(c.identityConfig) // this is now generic to be used for all kcp API groups
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// create an empty non-functional factory so that code that uses it but doesn't need it, doesn't have to check against the nil value
 		c.TemporaryRootShardKcpSharedInformerFactory = kcpinformers.NewSharedInformerFactory(nil, resyncPeriod)
@@ -251,11 +260,11 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		// The informers here are not used before the informers are actually started (i.e. no race).
 
 		c.identityConfig, c.resolveIdentities = bootstrap.NewConfigWithWildcardIdentities(c.GenericConfig.LoopbackClientConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nil)
-	}
-
-	c.KcpClusterClient, err = kcpclient.NewClusterForConfig(c.identityConfig) // this is now generic to be used for all kcp API groups
-	if err != nil {
-		return nil, err
+		c.KcpClusterClient, err = kcpclient.NewClusterForConfig(c.identityConfig) // this is now generic to be used for all kcp API groups
+		if err != nil {
+			return nil, err
+		}
+		c.RootShardKcpClusterClient = c.KcpClusterClient
 	}
 	c.KcpSharedInformerFactory = kcpinformers.NewSharedInformerFactoryWithOptions(
 		c.KcpClusterClient.Cluster(logicalcluster.Wildcard),
@@ -393,13 +402,29 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		kcpadmissioninitializers.NewKubeClusterClientInitializer(c.KubeClusterClient),
 		kcpadmissioninitializers.NewKcpClusterClientInitializer(c.KcpClusterClient),
 		kcpadmissioninitializers.NewDeepSARClientInitializer(c.DeepSARClient),
-		kcpadmissioninitializers.NewShardBaseURLInitializer(opts.Extra.ShardBaseURL),
-		kcpadmissioninitializers.NewShardExternalURLInitializer(opts.Extra.ShardExternalURL),
 		// The external address is provided as a function, as its value may be updated
 		// with the default secure port, when the config is later completed.
-		kcpadmissioninitializers.NewExternalAddressInitializer(func() string { return c.GenericConfig.ExternalAddress }),
 		kcpadmissioninitializers.NewKubeQuotaConfigurationInitializer(quotaConfiguration),
 		kcpadmissioninitializers.NewServerShutdownInitializer(c.quotaAdmissionStopCh),
+	}
+
+	c.ShardBaseURL = func() string {
+		if opts.Extra.ShardBaseURL != "" {
+			return opts.Extra.ShardBaseURL
+		}
+		return "https://" + c.GenericConfig.ExternalAddress
+	}
+	c.ShardExternalURL = func() string {
+		if opts.Extra.ShardExternalURL != "" {
+			return opts.Extra.ShardExternalURL
+		}
+		return "https://" + c.GenericConfig.ExternalAddress
+	}
+	c.ShardVirtualWorkspaceURL = func() string {
+		if opts.Extra.ShardVirtualWorkspaceURL != "" {
+			return opts.Extra.ShardVirtualWorkspaceURL
+		}
+		return "https://" + c.GenericConfig.ExternalAddress
 	}
 
 	c.Apis, err = genericcontrolplane.CreateKubeAPIServerConfig(c.GenericConfig, opts.GenericControlPlane, c.KubeSharedInformerFactory, admissionPluginInitializers, storageFactory)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,7 +18,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 	"time"
@@ -32,7 +31,6 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/genericcontrolplane"
 
@@ -46,7 +44,6 @@ import (
 	kcpfeatures "github.com/kcp-dev/kcp/pkg/features"
 	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/informer"
-	"github.com/kcp-dev/kcp/pkg/logging"
 )
 
 const resyncPeriod = 10 * time.Hour
@@ -186,6 +183,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 		if s.Options.Extra.ShardName == tenancyv1alpha1.RootShard {
 			logger.Info("bootstrapping root workspace phase 0")
+
 			// bootstrap root workspace phase 0 only if we are on the root shard, no APIBinding resources yet
 			if err := configrootphase0.Bootstrap(goContext(hookContext),
 				s.KcpClusterClient.Cluster(tenancyv1alpha1.RootCluster),
@@ -249,53 +247,50 @@ func (s *Server) Run(ctx context.Context) error {
 			default:
 			}
 			logger.Info("finished starting kcp informers for the root shard")
-
-			shard := &tenancyv1alpha1.ClusterWorkspaceShard{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        s.Options.Extra.ShardName,
-					Annotations: map[string]string{logicalcluster.AnnotationKey: tenancyv1alpha1.RootCluster.String()},
-				},
-				Spec: tenancyv1alpha1.ClusterWorkspaceShardSpec{
-					BaseURL:             fmt.Sprintf("https://%v", s.GenericConfig.ExternalAddress),
-					ExternalURL:         fmt.Sprintf("https://%v", s.Options.Extra.ShardExternalURL),
-					VirtualWorkspaceURL: s.Options.Extra.ShardVirtualWorkspaceURL,
-				},
-			}
-			logger := logging.WithObject(logger, shard)
-
-			if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
-				logger.Info("getting ClusterWorkspaceShard from the root shard")
-				existingShard, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Get(ctx, shard.Name, metav1.GetOptions{})
-				if err != nil && !errors.IsNotFound(err) {
-					logger.Error(err, "failed getting ClusterWorkspaceShard from the root workspace")
-					return false, nil
-				}
-				if errors.IsNotFound(err) {
-					logger.Info("creating ClusterWorkspaceShard resource in the root workspace because it doesn't exist")
-					if _, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Create(ctx, shard, metav1.CreateOptions{}); err != nil {
-						logger.Error(err, "failed creating ClusterWorkspaceShard in the root workspace")
-						return false, nil
-					}
-					logger.Info("finished creating ClusterWorkspaceShard resource in the root workspace")
-					return true, nil
-				}
-				existingShard.Spec.BaseURL = shard.Spec.BaseURL
-				existingShard.Spec.ExternalURL = shard.Spec.ExternalURL
-				existingShard.Spec.VirtualWorkspaceURL = shard.Spec.VirtualWorkspaceURL
-				if _, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Update(ctx, existingShard, metav1.UpdateOptions{}); err != nil {
-					logger.Error(err, "failed updating ClusterWorkspaceShard in the root workspace")
-					return false, nil
-				}
-				logger.Info("updated ClusterWorkspaceShard resource in the root workspace")
-				return true, nil
-			}); err != nil {
-				logger.Error(err, "failed reconciling ClusterWorkspaceShard resource in the root workspace")
-				return nil // don't klog.Fatal. This only happens when context is cancelled.
-			}
 		}
 
 		s.KcpSharedInformerFactory.Start(hookContext.StopCh)
 		s.KcpSharedInformerFactory.WaitForCacheSync(hookContext.StopCh)
+
+		// create or update shard
+		shard := &tenancyv1alpha1.ClusterWorkspaceShard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        s.Options.Extra.ShardName,
+				Annotations: map[string]string{logicalcluster.AnnotationKey: tenancyv1alpha1.RootCluster.String()},
+			},
+			Spec: tenancyv1alpha1.ClusterWorkspaceShardSpec{
+				BaseURL:             s.CompletedConfig.ShardBaseURL(),
+				ExternalURL:         s.CompletedConfig.ShardExternalURL(),
+				VirtualWorkspaceURL: s.CompletedConfig.ShardVirtualWorkspaceURL(),
+			},
+		}
+		logger.Info("Creating or updating ClusterWorkspaceShard", "shard", s.Options.Extra.ShardName)
+		if err := wait.PollInfiniteWithContext(goContext(hookContext), time.Second, func(ctx context.Context) (bool, error) {
+			existingShard, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Get(ctx, shard.Name, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				logger.Error(err, "failed getting ClusterWorkspaceShard from the root workspace")
+				return false, nil
+			} else if errors.IsNotFound(err) {
+				if _, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Create(ctx, shard, metav1.CreateOptions{}); err != nil {
+					logger.Error(err, "failed creating ClusterWorkspaceShard in the root workspace")
+					return false, nil
+				}
+				logger.Info("Created ClusterWorkspaceShard", "shard", s.Options.Extra.ShardName)
+				return true, nil
+			}
+			existingShard.Spec.BaseURL = shard.Spec.BaseURL
+			existingShard.Spec.ExternalURL = shard.Spec.ExternalURL
+			existingShard.Spec.VirtualWorkspaceURL = shard.Spec.VirtualWorkspaceURL
+			if _, err := s.RootShardKcpClusterClient.Cluster(tenancyv1alpha1.RootCluster).TenancyV1alpha1().ClusterWorkspaceShards().Update(ctx, existingShard, metav1.UpdateOptions{}); err != nil {
+				logger.Error(err, "failed updating ClusterWorkspaceShard in the root workspace")
+				return false, nil
+			}
+			logger.Info("Updated ClusterWorkspaceShard", "shard", s.Options.Extra.ShardName)
+			return true, nil
+		}); err != nil {
+			logger.Error(err, "failed reconciling ClusterWorkspaceShard resource in the root workspace")
+			return nil // don't klog.Fatal. This only happens when context is cancelled.
+		}
 
 		select {
 		case <-hookContext.StopCh:
@@ -314,25 +309,9 @@ func (s *Server) Run(ctx context.Context) error {
 		if s.Options.Extra.ShardName == tenancyv1alpha1.RootShard {
 			// the root ws is only present on the root shard
 			logger.Info("starting bootstrapping root workspace phase 1")
-			servingCert, _ := delegationChainHead.SecureServingInfo.Cert.CurrentCertKeyContent()
 			if err := configroot.Bootstrap(goContext(hookContext),
 				s.BootstrapApiExtensionsClusterClient.Cluster(tenancyv1alpha1.RootCluster).Discovery(),
 				s.BootstrapDynamicClusterClient.Cluster(tenancyv1alpha1.RootCluster),
-				s.Options.Extra.ShardName,
-				s.Options.Extra.ShardVirtualWorkspaceURL,
-				clientcmdapi.Config{
-					Clusters: map[string]*clientcmdapi.Cluster{
-						// cross-cluster is the virtual cluster running by default
-						"shard": {
-							Server:                   "https://" + delegationChainHead.ExternalAddress,
-							CertificateAuthorityData: servingCert, // TODO(sttts): wire controller updating this when it changes, or use CA
-						},
-					},
-					Contexts: map[string]*clientcmdapi.Context{
-						"shard": {Cluster: "shard"},
-					},
-					CurrentContext: "shard",
-				},
 				logicalcluster.New(s.Options.HomeWorkspaces.HomeRootPrefix).Base(),
 				s.Options.HomeWorkspaces.HomeCreatorGroups,
 				sets.NewString(s.Options.Extra.BatteriesIncluded...),


### PR DESCRIPTION
Admission is not the right place to default the shard.status URLs values as it is run on the server side and the server side is always the root shard. This PR moves it into the server initialization "client-side".