### PR TITLE
🐛 syncer: Fix wrong logic in dns-related process

### DIFF
--- a/pkg/syncer/namespace/namespace_downstream_controller.go
+++ b/pkg/syncer/namespace/namespace_downstream_controller.go
@@ -115,10 +115,7 @@ func NewDownstreamController(
 			return downstreamInformers.ForResource(namespaceGVR).Lister().List(labels.Everything())
 		},
 		isDowntreamNamespaceEmpty: func(ctx context.Context, namespace string) (bool, error) {
-			gvrs, err := syncerInformers.SyncableGVRs()
-			if err != nil {
-				return false, err
-			}
+			gvrs := syncerInformers.SyncableGVRs()
 			for _, k := range gvrs {
 				// Skip namespaces.
 				if k.Group == "" && k.Version == "v1" && k.Resource == "namespaces" {

--- a/pkg/syncer/namespace/namespace_upstream_controller.go
+++ b/pkg/syncer/namespace/namespace_upstream_controller.go
@@ -110,10 +110,7 @@ func NewUpstreamController(
 			return namespaces[0].(*unstructured.Unstructured), nil
 		},
 		isDowntreamNamespaceEmpty: func(ctx context.Context, namespace string) (bool, error) {
-			gvrs, err := syncerInformers.SyncableGVRs()
-			if err != nil {
-				return false, err
-			}
+			gvrs := syncerInformers.SyncableGVRs()
 			for _, k := range gvrs {
 				// Skip namespaces.
 				if k.Group == "" && k.Version == "v1" && k.Resource == "namespaces" {

--- a/pkg/syncer/resourcesync/controller.go
+++ b/pkg/syncer/resourcesync/controller.go
@@ -74,7 +74,7 @@ type SyncerInformerFactory interface {
 	AddUpstreamEventHandler(handler ResourceEventHandlerPerGVR)
 	AddDownstreamEventHandler(handler ResourceEventHandlerPerGVR)
 	InformerForResource(gvr schema.GroupVersionResource) (*SyncerInformer, bool)
-	SyncableGVRs() ([]schema.GroupVersionResource, error)
+	SyncableGVRs() []schema.GroupVersionResource
 	Start(ctx context.Context, numThreads int)
 }
 
@@ -200,14 +200,14 @@ func (c *Controller) InformerForResource(gvr schema.GroupVersionResource) (*Sync
 	return nil, false
 }
 
-func (c *Controller) SyncableGVRs() ([]schema.GroupVersionResource, error) {
+func (c *Controller) SyncableGVRs() []schema.GroupVersionResource {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	gvrs := []schema.GroupVersionResource{}
 	for gvr := range c.syncerInformerMap {
 		gvrs = append(gvrs, gvr)
 	}
-	return gvrs, nil
+	return gvrs
 }
 
 func (c *Controller) startWorker(ctx context.Context) {

--- a/pkg/syncer/spec/dns/dns_process.go
+++ b/pkg/syncer/spec/dns/dns_process.go
@@ -18,7 +18,6 @@ package dns
 
 import (
 	"context"
-	"errors"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 
@@ -79,60 +78,66 @@ func NewDNSProcessor(
 	}
 }
 
-// Process reconciles all DNS objects: it checks they exist and are up-to-date.
-func (d *DNSProcessor) Process(ctx context.Context, workspace logicalcluster.Name) error {
+// EnsureDNSUpAndReady creates all DNS-related resources if necessary.
+// It also checks that the DNS Deployment for this workspace
+// are effectively reachable through the Service.
+// It returns true if the DNS is setup and reachable, and returns an error if there was an error
+// during the check or creation of the DNS-related resources.
+func (d *DNSProcessor) EnsureDNSUpAndReady(ctx context.Context, workspace logicalcluster.Name) (bool, error) {
 	logger := klog.FromContext(ctx)
 	logger.WithName("dns")
 
 	dnsID := shared.GetDNSID(workspace, d.syncTargetUID, d.syncTargetName)
 	logger.WithValues("name", dnsID, "namespace", d.dnsNamespace)
 
-	logger.Info("checking if all dns objects exist and are up-to-date")
+	logger.V(4).Info("checking if all dns objects exist and are up-to-date")
 	ctx = klog.NewContext(ctx, logger)
 
+	// Get the expected Endpoints resource
+	endpoints, err := d.endpointLister.Endpoints(d.dnsNamespace).Get(dnsID)
+	if err == nil {
+		// DNS is ready if the Endpoints resource has at least one ready address
+		return hasAtLeastOneReadyAddress(endpoints), nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return false, err
+	}
+
+	// No Endpoints resource was found: try to create all the DNS-related resources
 	if err := d.processServiceAccount(ctx, dnsID); err != nil {
-		return err
+		return false, err
 	}
 	if err := d.processRole(ctx, dnsID); err != nil {
-		return err
+		return false, err
 	}
 	if err := d.processRoleBinding(ctx, dnsID); err != nil {
-		return err
+		return false, err
 	}
 	if err := d.processDeployment(ctx, dnsID); err != nil {
-		return err
+		return false, err
 	}
 	if err := d.processService(ctx, dnsID); err != nil {
-		return err
+		return false, err
 	}
-
-	// Check at least one endpoint is ready.
-	endpoints, err := d.endpointLister.Endpoints(d.dnsNamespace).Get(dnsID)
-	if err != nil {
-		return err
-	}
-
-	if !hasAtLeastOneReadyAddress(endpoints) {
-		return errors.New("no DNS endpoints available yet (retrying)")
-	}
-
-	return nil
+	// Since the Endpoints resource was not found, the DNS is not yet ready,
+	// even though all the required resources have been created
+	// (deployment still needs to start).
+	return false, nil
 }
 
 func (d *DNSProcessor) processServiceAccount(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
 
-	expected := MakeServiceAccount(name, d.dnsNamespace)
 	_, err := d.serviceAccountLister.ServiceAccounts(d.dnsNamespace).Get(name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err := d.downstreamKubeClient.CoreV1().ServiceAccounts(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
-			if err != nil {
-				logger.Error(err, "failed to create ServiceAccount (retrying)")
-				return err // retry
-			}
+	if apierrors.IsNotFound(err) {
+		expected := MakeServiceAccount(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.CoreV1().ServiceAccounts(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
 			logger.Info("ServiceAccount created")
 		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Error(err, "failed to get ServiceAccount (retrying)")
 		return err
 	}
@@ -145,17 +150,15 @@ func (d *DNSProcessor) processServiceAccount(ctx context.Context, name string) e
 func (d *DNSProcessor) processRole(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
 
-	expected := MakeRole(name, d.dnsNamespace)
 	_, err := d.roleLister.Roles(d.dnsNamespace).Get(name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err := d.downstreamKubeClient.RbacV1().Roles(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
-			if err != nil {
-				logger.Error(err, "failed to create Role (retrying)")
-				return err // retry
-			}
+	if apierrors.IsNotFound(err) {
+		expected := MakeRole(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.RbacV1().Roles(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
 			logger.Info("Role created")
 		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Error(err, "failed to get Role (retrying)")
 		return err
 	}
@@ -168,17 +171,15 @@ func (d *DNSProcessor) processRole(ctx context.Context, name string) error {
 func (d *DNSProcessor) processRoleBinding(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
 
-	expected := MakeRoleBinding(name, d.dnsNamespace)
 	_, err := d.roleBindingLister.RoleBindings(d.dnsNamespace).Get(name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err := d.downstreamKubeClient.RbacV1().RoleBindings(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
-			if err != nil {
-				logger.Error(err, "failed to create RoleBinding (retrying)")
-				return err // retry
-			}
+	if apierrors.IsNotFound(err) {
+		expected := MakeRoleBinding(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.RbacV1().RoleBindings(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
 			logger.Info("RoleBinding created")
 		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Error(err, "failed to get RoleBinding (retrying)")
 		return err
 	}
@@ -191,17 +192,15 @@ func (d *DNSProcessor) processRoleBinding(ctx context.Context, name string) erro
 func (d *DNSProcessor) processDeployment(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
 
-	expected := MakeDeployment(name, d.dnsNamespace, d.dnsImage)
 	_, err := d.deploymentLister.Deployments(d.dnsNamespace).Get(name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err := d.downstreamKubeClient.AppsV1().Deployments(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
-			if err != nil {
-				logger.Error(err, "failed to create Deployment (retrying)")
-				return err // retry
-			}
+	if apierrors.IsNotFound(err) {
+		expected := MakeDeployment(name, d.dnsNamespace, d.dnsImage)
+		_, err = d.downstreamKubeClient.AppsV1().Deployments(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
 			logger.Info("Deployment created")
 		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Error(err, "failed to get Deployment (retrying)")
 		return err
 	}
@@ -214,17 +213,15 @@ func (d *DNSProcessor) processDeployment(ctx context.Context, name string) error
 func (d *DNSProcessor) processService(ctx context.Context, name string) error {
 	logger := klog.FromContext(ctx)
 
-	expected := MakeService(name, d.dnsNamespace)
 	_, err := d.serviceLister.Services(d.dnsNamespace).Get(name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			_, err := d.downstreamKubeClient.CoreV1().Services(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
-			if err != nil {
-				logger.Error(err, "failed to create Service (retrying)")
-				return err // retry
-			}
+	if apierrors.IsNotFound(err) {
+		expected := MakeService(name, d.dnsNamespace)
+		_, err = d.downstreamKubeClient.CoreV1().Services(d.dnsNamespace).Create(ctx, expected, metav1.CreateOptions{})
+		if err == nil {
 			logger.Info("Service created")
 		}
+	}
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Error(err, "failed to get Service (retrying)")
 		return err
 	}

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-logr/logr"
@@ -105,21 +106,21 @@ func deepEqualApartFromStatus(logger logr.Logger, oldUnstrob, newUnstrob *unstru
 	return true
 }
 
-func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResource, key string) error {
+func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResource, key string) (retryAfter *time.Duration, err error) {
 	logger := klog.FromContext(ctx)
 
 	// from upstream
 	clusterName, upstreamNamespace, name, err := kcpcache.SplitMetaClusterNamespaceKey(key)
 	if err != nil {
 		logger.Error(err, "Invalid key")
-		return nil
+		return nil, nil
 	}
 	logger = logger.WithValues(logging.WorkspaceKey, clusterName, logging.NamespaceKey, upstreamNamespace, logging.NameKey, name)
 
 	desiredNSLocator := shared.NewNamespaceLocator(clusterName, c.syncTargetWorkspace, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
 	jsonNSLocator, err := json.Marshal(desiredNSLocator)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var downstreamNamespace string
@@ -127,7 +128,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	if upstreamNamespace != "" {
 		downstreamNamespaces, err := c.downstreamNSInformer.Informer().GetIndexer().ByIndex(byNamespaceLocatorIndexName, string(jsonNSLocator))
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if len(downstreamNamespaces) == 1 {
@@ -140,13 +141,13 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 			for _, namespace := range downstreamNamespaces {
 				namespacesCollisions = append(namespacesCollisions, namespace.(*unstructured.Unstructured).GetName())
 			}
-			return fmt.Errorf("(namespace collision) found multiple downstream namespaces: %s for upstream namespace %s|%s", strings.Join(namespacesCollisions, ","), clusterName, upstreamNamespace)
+			return nil, fmt.Errorf("(namespace collision) found multiple downstream namespaces: %s for upstream namespace %s|%s", strings.Join(namespacesCollisions, ","), clusterName, upstreamNamespace)
 		} else {
 			logger.V(4).Info("No downstream namespaces found")
 			downstreamNamespace, err = shared.PhysicalClusterNamespaceName(desiredNSLocator)
 			if err != nil {
 				logger.Error(err, "Error hashing namespace")
-				return nil
+				return nil, nil
 			}
 		}
 	}
@@ -155,12 +156,12 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	// get the upstream object
 	syncerInformer, ok := c.syncerInformers.InformerForResource(gvr)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	obj, exists, err := syncerInformer.UpstreamInformer.Informer().GetIndexer().GetByKey(kcpcache.ToClusterAwareKey(clusterName.String(), upstreamNamespace, name))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !exists {
 		// deleted upstream => delete downstream
@@ -171,43 +172,53 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 			err = c.downstreamClient.Resource(gvr).Delete(ctx, name, metav1.DeleteOptions{})
 		}
 		if err != nil && !apierrors.IsNotFound(err) {
-			return err
+			return nil, err
 		}
-		return nil
+		return nil, nil
 	}
 
 	// upsert downstream
 	upstreamObj, ok := obj.(*unstructured.Unstructured)
 	if !ok {
-		return fmt.Errorf("object to synchronize is expected to be Unstructured, but is %T", obj)
+		return nil, fmt.Errorf("object to synchronize is expected to be Unstructured, but is %T", obj)
 	}
 
 	if downstreamNamespace != "" {
 		if err := c.ensureDownstreamNamespaceExists(ctx, downstreamNamespace, upstreamObj); err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		// In cluser-wide resources we also need to check for possible collisions, as the resource could exist in the pcluster but now owned by this workspace.
 		// TODO(jmprusi): We should indicate the collision somehow (condition/annotation?) to avoid retrying the resource over and over.
 		if err := c.clusterWideCollisionCheck(ctx, gvr, upstreamObj); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	// Make sure the DNS nameserver for the spec workspace is up and running
-	if err := c.dnsProcessor.Process(ctx, clusterName); err != nil {
+	deploymentGVR := schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}
+
+	// Make sure the DNS nameserver for the current workspace is up and running
+	if dnsUpAndReady, err := c.dnsProcessor.EnsureDNSUpAndReady(ctx, clusterName); err != nil {
 		logger.Error(err, "failed to check DNS nameserver is up and running (retrying)")
-		return err
+		return nil, err
+	} else if !dnsUpAndReady && gvr == deploymentGVR {
+		logger.Info("DNS Server is not ready for the deployment resource to sync: requeue the deployment in 500ms")
+		retryDelay := 500 * time.Millisecond
+		return &retryDelay, nil
 	}
 
 	if added, err := c.ensureSyncerFinalizer(ctx, gvr, upstreamObj); added {
 		// The successful update of the upstream resource finalizer will trigger a new reconcile
-		return nil
+		return nil, nil
 	} else if err != nil {
-		return err
+		return nil, err
 	}
 
-	return c.applyToDownstream(ctx, gvr, downstreamNamespace, upstreamObj)
+	return nil, c.applyToDownstream(ctx, gvr, downstreamNamespace, upstreamObj)
 }
 
 // TODO: This function is there as a quick and dirty implementation of namespace creation.

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -1085,7 +1085,7 @@ func TestSyncerProcess(t *testing.T) {
 			toClient.ClearActions()
 
 			key := kcpcache.ToClusterAwareKey(tc.resourceToProcessLogicalClusterName, tc.fromNamespace.Name, tc.resourceToProcessName)
-			err = controller.process(context.Background(),
+			_, err = controller.process(context.Background(),
 				tc.gvr,
 				key,
 			)
@@ -1382,7 +1382,7 @@ func (f *fakeSyncerInformers) InformerForResource(gvr schema.GroupVersionResourc
 		DownstreamInformer: f.downStreamInformer,
 	}, true
 }
-func (f *fakeSyncerInformers) SyncableGVRs() ([]schema.GroupVersionResource, error) {
-	return []schema.GroupVersionResource{{Group: "apps", Version: "v1", Resource: "deployments"}}, nil
+func (f *fakeSyncerInformers) SyncableGVRs() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{{Group: "apps", Version: "v1", Resource: "deployments"}}
 }
 func (f *fakeSyncerInformers) Start(ctx context.Context, numThreads int) {}

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -747,7 +747,7 @@ func (f *fakeSyncerInformers) InformerForResource(gvr schema.GroupVersionResourc
 		DownstreamInformer: f.downStreamInformer,
 	}, true
 }
-func (f *fakeSyncerInformers) SyncableGVRs() ([]schema.GroupVersionResource, error) {
-	return []schema.GroupVersionResource{{Group: "apps", Version: "v1", Resource: "deployments"}}, nil
+func (f *fakeSyncerInformers) SyncableGVRs() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{{Group: "apps", Version: "v1", Resource: "deployments"}}
 }
 func (f *fakeSyncerInformers) Start(ctx context.Context, numThreads int) {}


### PR DESCRIPTION
## Summary

We should:
- trigger the creation of the CoreDNS deployment (if not already created) by the Syncer on any resource syncing, at the condition that deployments are part of the synced GVRs for this synced target.
- wait for the CoreDNS deployment to be reachable through a service before syncing a resource, but only when syncing a deployment. In this case, the deployment resource should be requeued after a small delay.

## Related issue(s)

Fixes flaky e2e tests 
