### PR TITLE
:bug: Fix group in scheduling.kcp.dev maximum permission policy cluster role

### DIFF
--- a/config/root/clusterrole-scheduling-maximal-permission-policy.yaml
+++ b/config/root/clusterrole-scheduling-maximal-permission-policy.yaml
@@ -8,7 +8,7 @@ rules:
   resources:
   - locations
   - placements
-- apiGroups: ["apiresource.kcp.dev"]
+- apiGroups: ["scheduling.kcp.dev"]
   verbs: ["get","list","watch"]
   resources:
   - locations/status


### PR DESCRIPTION
This PR fixes wrong `apiGroups` for sub-resources in the `scheduling.kcp.dev` group maximum permission policy cluster role. 