### PR TITLE
🐛 give the front proxy a distinct config for direct(internal) shard communication.

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -129,6 +129,7 @@ func startFrontProxy(
 		fmt.Sprintf("--mapping-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/mapping.yaml")),
 		fmt.Sprintf("--root-directory=%s", filepath.Join(workDirPath, ".kcp-front-proxy")),
 		fmt.Sprintf("--root-kubeconfig=%s", filepath.Join(workDirPath, ".kcp/root.kubeconfig")),
+		fmt.Sprintf("--shards-kubeconfig=%s", filepath.Join(workDirPath, ".kcp-front-proxy/shards.kubeconfig")),
 		fmt.Sprintf("--client-ca-file=%s", filepath.Join(workDirPath, ".kcp/client-ca.crt")),
 		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/apiserver.crt")),
 		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(workDirPath, ".kcp-front-proxy/apiserver.key")),
@@ -259,4 +260,29 @@ func writeAdminKubeConfig(hostIP string, workDirPath string) error {
 	}
 
 	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp/admin.kubeconfig"))
+}
+
+func writeShardKubeConfig(workDirPath string) error {
+	var kubeConfig clientcmdapi.Config
+	kubeConfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
+		"shard-admin": {
+			ClientKey:         filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.key"),
+			ClientCertificate: filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.crt"),
+		},
+	}
+	kubeConfig.Clusters = map[string]*clientcmdapi.Cluster{
+		"base": {
+			CertificateAuthority: filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
+		},
+	}
+	kubeConfig.Contexts = map[string]*clientcmdapi.Context{
+		"base": {Cluster: "base", AuthInfo: "shard-admin"},
+	}
+	kubeConfig.CurrentContext = "base"
+
+	if err := clientcmdapi.FlattenConfig(&kubeConfig); err != nil {
+		return err
+	}
+
+	return clientcmd.WriteToFile(kubeConfig, filepath.Join(workDirPath, ".kcp-front-proxy/shards.kubeconfig"))
 }

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -113,6 +113,24 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		os.Exit(1)
 	}
 
+	// TODO:(p0lyn0mial): in the future we need a separate group valid only for the proxy
+	// so that it can make wildcard requests against shards
+	// for now we will use the privileged system:masters group to bypass the authz stack
+	// create system:masters client cert to connect to shards
+	_, err = clientCA.MakeClientCertificate(
+		filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.crt"),
+		filepath.Join(workDirPath, ".kcp-front-proxy/shard-admin.key"),
+		&user.DefaultInfo{
+			Name:   "shard-admin",
+			Groups: []string{"system:masters"},
+		},
+		365,
+	)
+	if err != nil {
+		fmt.Printf("failed to create front proxy shard admin client cert: %v\n", err)
+		os.Exit(1)
+	}
+
 	// create server CA to be used to sign shard serving certs
 	servingCA, err := crypto.MakeSelfSignedCA(
 		filepath.Join(workDirPath, ".kcp/serving-ca.crt"),
@@ -176,11 +194,6 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		shards = append(shards, shard)
 	}
 
-	// write kcp-admin kubeconfig talking to the front-proxy with a client-cert
-	if err := writeAdminKubeConfig(hostIP.String(), workDirPath); err != nil {
-		return err
-	}
-
 	vwPort := "6444"
 	virtualWorkspacesErrCh := make(chan indexErrTuple)
 	if standaloneVW {
@@ -199,6 +212,14 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		}
 	}
 
+	// write kcp-admin kubeconfig talking to the front-proxy with a client-cert
+	if err := writeAdminKubeConfig(hostIP.String(), workDirPath); err != nil {
+		return err
+	}
+	// this is system-master kubeconfig used by the front-proxy to talk to shards
+	if err := writeShardKubeConfig(workDirPath); err != nil {
+		return err
+	}
 	// start front-proxy
 	if err := startFrontProxy(ctx, proxyFlags, servingCA, hostIP.String(), logDirPath, workDirPath, vwPort); err != nil {
 		return err

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -46,6 +46,7 @@ type ExtraConfig struct {
 	// the clients can wildcard-list/watch most kcp resources.
 	ResolveIdentities func(ctx context.Context) error
 	RootShardConfig   *rest.Config
+	ShardsConfig      *rest.Config
 
 	AuthenticationInfo    genericapiserver.AuthenticationInfo
 	ServingInfo           *genericapiserver.SecureServingInfo
@@ -85,6 +86,11 @@ func NewConfig(opts *proxyoptions.Options) (*Config, error) {
 	}
 	if err := c.Options.Authentication.ApplyTo(&c.AuthenticationInfo, c.ServingInfo, c.RootShardConfig); err != nil {
 		return nil, err
+	}
+
+	c.ShardsConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Options.ShardsKubeconfig}, nil).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load shard kubeconfig: %w", err)
 	}
 
 	c.AdditionalAuthEnabled = c.Options.Authentication.AdditionalAuthEnabled()

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -19,10 +19,12 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	proxyoptions "github.com/kcp-dev/kcp/pkg/proxy/options"
 	bootstrap "github.com/kcp-dev/kcp/pkg/server/bootstrap"
@@ -78,7 +80,10 @@ func NewConfig(opts *proxyoptions.Options) (*Config, error) {
 		return nil, fmt.Errorf("failed to load root kubeconfig: %w", err)
 	}
 
-	c.RootShardConfig, c.ResolveIdentities = bootstrap.NewConfigWithWildcardIdentities(nonIdentityRootConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nil)
+	var kcpShardIdentityRoundTripper func(rt http.RoundTripper) http.RoundTripper
+	kcpShardIdentityRoundTripper, c.ResolveIdentities = bootstrap.NewWildcardIdentitiesWrappingRoundTripper(bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nonIdentityRootConfig, nil)
+	c.RootShardConfig = rest.CopyConfig(nonIdentityRootConfig)
+	c.RootShardConfig.Wrap(kcpShardIdentityRoundTripper)
 
 	var loopbackClientConfig *rest.Config
 	if err := c.Options.SecureServing.ApplyTo(&c.ServingInfo, &loopbackClientConfig); err != nil {
@@ -88,10 +93,15 @@ func NewConfig(opts *proxyoptions.Options) (*Config, error) {
 		return nil, err
 	}
 
-	c.ShardsConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Options.ShardsKubeconfig}, nil).ClientConfig()
+	c.ShardsConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: c.Options.ShardsKubeconfig},
+		// We override the Server here so that the user doesn't have to specify unused server value
+		// The Server must have HTTPS scheme otherwise CA won't be loaded (see IsConfigTransportTLS method)
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: "https://fakeserver.io"}}).ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load shard kubeconfig: %w", err)
 	}
+	c.ShardsConfig.Wrap(kcpShardIdentityRoundTripper)
 
 	c.AdditionalAuthEnabled = c.Options.Authentication.AdditionalAuthEnabled()
 

--- a/pkg/proxy/options/options.go
+++ b/pkg/proxy/options/options.go
@@ -27,12 +27,13 @@ import (
 )
 
 type Options struct {
-	SecureServing   apiserveroptions.SecureServingOptionsWithLoopback
-	Authentication  Authentication
-	MappingFile     string
-	RootDirectory   string
-	RootKubeconfig  string
-	ProfilerAddress string
+	SecureServing    apiserveroptions.SecureServingOptionsWithLoopback
+	Authentication   Authentication
+	MappingFile      string
+	RootDirectory    string
+	RootKubeconfig   string
+	ShardsKubeconfig string
+	ProfilerAddress  string
 }
 
 func NewOptions() *Options {
@@ -56,6 +57,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.MappingFile, "mapping-file", o.MappingFile, "Config file mapping paths to backends")
 	fs.StringVar(&o.RootDirectory, "root-directory", o.RootDirectory, "Root directory.")
 	fs.StringVar(&o.RootKubeconfig, "root-kubeconfig", o.RootKubeconfig, "The path to the kubeconfig of the root shard.")
+	fs.StringVar(&o.ShardsKubeconfig, "shards-kubeconfig", o.ShardsKubeconfig, "The path to the kubeconfig used for communication with all shards. The server name if provided is replaced with a shard's hostname.")
 	fs.StringVar(&o.ProfilerAddress, "profiler-address", "", "[Address]:port to bind the profiler to")
 }
 
@@ -87,6 +89,9 @@ func (o *Options) Validate() []error {
 
 	if o.MappingFile == "" {
 		errs = append(errs, fmt.Errorf("--mapping-file is required"))
+	}
+	if len(o.ShardsKubeconfig) == 0 {
+		errs = append(errs, fmt.Errorf("--shards-kubeconfig is required"))
 	}
 
 	errs = append(errs, o.SecureServing.Validate()...)

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -60,7 +60,7 @@ func NewServer(ctx context.Context, c CompletedConfig) (*Server, error) {
 		s.CompletedConfig.RootShardConfig.Host,
 		s.KcpSharedInformerFactory.Tenancy().V1alpha1().ClusterWorkspaceShards(),
 		func(shard *tenancyv1alpha1.ClusterWorkspaceShard) (kcpclientset.ClusterInterface, error) {
-			shardConfig := restclient.CopyConfig(s.CompletedConfig.RootShardConfig)
+			shardConfig := restclient.CopyConfig(s.CompletedConfig.ShardsConfig)
 			shardConfig.Host = shard.Spec.BaseURL
 			shardClient, err := kcpclientset.NewForConfig(shardConfig)
 			if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The front proxy needs a direct and privileged way of authNZ with any shard. At the same time it needs to be able to validate an incoming certificate from a shard.

This PR allows the above by introducing a kubeconfig that holds a client certificate and a CA certificate for validating incoming certs.
The new kubeconfig can be passed via `shards-kubeconfig` flag.

Previously an incorrect configuration was used for communication with shards. As a result the proxy didn't work in a multi shard environment.

## Related issue(s)

required by https://github.com/kcp-dev/kcp/issues/342

fixes https://github.com/kcp-dev/kcp/issues/2274