### PR TITLE
🐛 cache: do not use protobufs for self-communication

### DIFF
--- a/pkg/cache/server/config.go
+++ b/pkg/cache/server/config.go
@@ -159,15 +159,6 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 	opts.Etcd.StorageConfig.EncodeVersioner = runtime.NewMultiGroupVersioner(apiextensionsv1beta1.SchemeGroupVersion, schema.GroupKind{Group: apiextensionsv1beta1.GroupName})
 	serverConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: *opts.Etcd}
 
-	// use protobufs for self-communication.
-	// Since not every generic apiserver has to support protobufs, we
-	// cannot default to it in generic apiserver and need to explicitly
-	// set it in kube-apiserver.
-	serverConfig.LoopbackClientConfig.ContentConfig.ContentType = "application/vnd.kubernetes.protobuf"
-	// disable compression for self-communication, since we are going to be
-	// on a fast local network
-	serverConfig.LoopbackClientConfig.DisableCompression = true
-
 	// an ordered list of HTTP round trippers that add
 	// shard and cluster awareness to all clients that use
 	// the loopback config.
@@ -202,7 +193,6 @@ func NewConfig(opts *cacheserveroptions.CompletedOptions, optionalLocalShardRest
 		},
 		"customresourcedefinitions")
 	rt = rest.AddUserAgent(rt, "kcp-cache-server")
-	rt.ContentConfig.ContentType = "application/json"
 
 	var err error
 	c.ApiExtensionsClusterClient, err = kcpapiextensionsclientset.NewForConfig(rt)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Since the `c.ApiExtensionsClusterClient` used by the apiextention server is wrapped into `rt` we cannot use protobuf. We maintain a custom `RoundTripper` that assumes json. This also means protobuf was never used before and it is safe to remove.

## Related issue(s)

Fixes #
