### PR TITLE
🐛 Fix Syncer-related e2e flake due to the use of environment variable

### DIFF
--- a/cmd/syncer/cmd/syncer.go
+++ b/cmd/syncer/cmd/syncer.go
@@ -18,6 +18,8 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"os"
 
 	"github.com/kcp-dev/logicalcluster/v2"
 	"github.com/spf13/cobra"
@@ -105,6 +107,11 @@ func Run(ctx context.Context, options *synceroptions.Options) error {
 	downstreamConfig.QPS = options.QPS
 	downstreamConfig.Burst = options.Burst
 
+	namespace := os.Getenv("NAMESPACE")
+	if namespace == "" {
+		return errors.New("missing environment variable: NAMESPACE")
+	}
+
 	if err := syncer.StartSyncer(
 		ctx,
 		&syncer.SyncerConfig{
@@ -119,6 +126,7 @@ func Run(ctx context.Context, options *synceroptions.Options) error {
 		},
 		numThreads,
 		options.APIImportPollInterval,
+		namespace,
 	); err != nil {
 		return err
 	}

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -367,8 +367,7 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 	} else {
 		// Start an in-process syncer
 		syncerConfig.DNSImage = "TODO"
-		os.Setenv("NAMESPACE", syncerID)
-		err := syncer.StartSyncer(ctx, syncerConfig, 2, 5*time.Second)
+		err := syncer.StartSyncer(ctx, syncerConfig, 2, 5*time.Second, syncerID)
 		require.NoError(t, err, "syncer failed to start")
 
 		_, err = downstreamKubeClient.RbacV1().ClusterRoles().Create(ctx, &rbacv1.ClusterRole{


### PR DESCRIPTION
## Summary

This fixes potential Syncer-related e2e flakes due to the use of an environment variable to pass to the Syncer the Namespace in which it should watch for DNS-related resources. 

## Related issue(s)

Possibly related flakes are https://github.com/kcp-dev/kcp/issues/2389 and https://github.com/kcp-dev/kcp/issues/2371