### PR TITLE
:sparkles: Adding DNS network policies

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -305,6 +305,12 @@ rules:
   - "watch"
   - "delete"
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+- apiGroups:
   - "apiextensions.k8s.io"
   resources:
   - customresourcedefinitions

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -69,6 +69,14 @@ rules:
   - "watch"
   - "list"
 - apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
+- apiGroups:
   - ""
   resources:
   - resource1
@@ -298,6 +306,14 @@ rules:
   - "get"
   - "watch"
   - "list"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
 - apiGroups:
   - ""
   resources:

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -61,6 +61,12 @@ rules:
   - "watch"
   - "delete"
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+- apiGroups:
   - "apiextensions.k8s.io"
   resources:
   - customresourcedefinitions

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -35,6 +35,12 @@ rules:
   - "watch"
   - "delete"
 - apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - "get"
+- apiGroups:
   - "apiextensions.k8s.io"
   resources:
   - customresourcedefinitions

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -42,6 +42,14 @@ rules:
   - "get"
   - "watch"
   - "list"
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - networkpolicies
+  verbs:
+  - "create"
+  - "list"
+  - "watch"
 {{- range $groupMapping := .GroupMappings}}
 - apiGroups:
   - "{{$groupMapping.APIGroup}}"

--- a/pkg/syncer/shared/namespace.go
+++ b/pkg/syncer/shared/namespace.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	NamespaceLocatorAnnotation = "kcp.io/namespace-locator"
+	TenantIDLabel              = "kcp.io/tenant-id"
 )
 
 // NamespaceLocator stores a logical cluster and namespace and is used

--- a/pkg/syncer/spec/dns/networkpolicy_dns.yaml
+++ b/pkg/syncer/spec/dns/networkpolicy_dns.yaml
@@ -14,7 +14,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              internal.workload.kcp.dev/cluster: Cluster
+              internal.workload.kcp.io/cluster: Cluster
       ports:
         - protocol: TCP
           port: 5353
@@ -26,8 +26,20 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
+        - podSelector:
+            matchLabels:
+              k8s-app: kube-dns
       ports:
         - protocol: TCP
           port: 53
         - protocol: UDP
           port: 53
+     # Give access to the API server to watch its associated configmap
+    - to:
+      # one ipBlock per IP (dynamically filled)
+      - ipBlock:
+          cidr: APIServerIP
+      ports:
+        - protocol: TCP
+          port: 6443
+

--- a/pkg/syncer/spec/dns/networkpolicy_dns.yaml
+++ b/pkg/syncer/spec/dns/networkpolicy_dns.yaml
@@ -14,7 +14,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              internal.workload.kcp.io/cluster: Cluster
+              kcp.io/tenant-id: TenantID
       ports:
         - protocol: TCP
           port: 5353

--- a/pkg/syncer/spec/dns/networkpolicy_dns.yaml
+++ b/pkg/syncer/spec/dns/networkpolicy_dns.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: Name
+  namespace: Namespace
+spec:
+  podSelector:
+    matchLabels:
+      app: Name
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              internal.workload.kcp.dev/cluster: Cluster
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+  egress:
+    # Only give access to coredns in kube-system
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53

--- a/pkg/syncer/spec/dns/resources.go
+++ b/pkg/syncer/spec/dns/resources.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 )
 
 //go:embed *.yaml
@@ -110,13 +110,13 @@ func MakeService(name, namespace string) *corev1.Service {
 	return service
 }
 
-func MakeNetworkPolicy(name, namespace, cluster string, kubeEndpoints *corev1.EndpointSubset) *networkingv1.NetworkPolicy {
+func MakeNetworkPolicy(name, namespace, tenantID string, kubeEndpoints *corev1.EndpointSubset) *networkingv1.NetworkPolicy {
 	np := networkPolicyTemplate.DeepCopy()
 
 	np.Name = name
 	np.Namespace = namespace
 	np.Spec.PodSelector.MatchLabels["app"] = name
-	np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels[workloadv1alpha1.InternalDownstreamClusterLabel] = cluster
+	np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels[shared.TenantIDLabel] = tenantID
 
 	to := make([]networkingv1.NetworkPolicyPeer, len(kubeEndpoints.Addresses))
 	for i, endpoint := range kubeEndpoints.Addresses {

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -269,7 +269,8 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluste
 		syncerNamespaceInformerFactory.Apps().V1().Deployments().Lister(),
 		dnsServiceLister,
 		syncerNamespaceInformerFactory.Core().V1().Endpoints().Lister(),
-		syncTargetName, syncTargetUID, dnsNamespace, dnsImage)
+		syncerNamespaceInformerFactory.Networking().V1().NetworkPolicies().Lister(),
+		syncTargetUID, syncTargetName, syncTargetKey, dnsNamespace, dnsImage)
 
 	return &c, nil
 }

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -270,7 +270,7 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluste
 		dnsServiceLister,
 		syncerNamespaceInformerFactory.Core().V1().Endpoints().Lister(),
 		syncerNamespaceInformerFactory.Networking().V1().NetworkPolicies().Lister(),
-		syncTargetUID, syncTargetName, syncTargetKey, dnsNamespace, dnsImage)
+		syncTargetUID, syncTargetName, dnsNamespace, dnsImage)
 
 	return &c, nil
 }

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -262,13 +262,11 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 		return err
 	}
 
-	if upstreamObj.GetLabels() != nil {
-		newNamespace.SetLabels(map[string]string{
-			// TODO: this should be set once at syncer startup and propagated around everywhere.
-			workloadv1alpha1.InternalDownstreamClusterLabel: c.syncTargetKey,
-			shared.TenantIDLabel:                            desiredTenantID,
-		})
-	}
+	newNamespace.SetLabels(map[string]string{
+		// TODO: this should be set once at syncer startup and propagated around everywhere.
+		workloadv1alpha1.InternalDownstreamClusterLabel: c.syncTargetKey,
+		shared.TenantIDLabel:                            desiredTenantID,
+	})
 
 	namespaceLister, err := c.getDownstreamLister(namespaceGVR)
 	if err != nil {
@@ -306,7 +304,9 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 
 	// Handle kcp upgrades by checking the tenant ID is set and correct
 	if tenantID, ok := unstrNamespace.GetLabels()[shared.TenantIDLabel]; !ok || tenantID != desiredTenantID {
-		unstrNamespace.GetLabels()[shared.TenantIDLabel] = desiredTenantID
+		labels := unstrNamespace.GetLabels()
+		labels[shared.TenantIDLabel] = desiredTenantID
+		unstrNamespace.SetLabels(labels)
 		_, err := namespaces.Update(ctx, unstrNamespace, metav1.UpdateOptions{})
 		return err
 	}

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -304,6 +304,13 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 		return fmt.Errorf("(namespace collision) namespace %s already exists, but has a different namespace locator annotation: %+v vs %+v", newNamespace.GetName(), nsLocator, desiredNSLocator)
 	}
 
+	// Handle kcp upgrades by checking the tenant ID is set and correct
+	if tenantID, ok := unstrNamespace.GetLabels()[shared.TenantIDLabel]; !ok || tenantID != desiredTenantID {
+		unstrNamespace.GetLabels()[shared.TenantIDLabel] = desiredTenantID
+		_, err := namespaces.Update(ctx, unstrNamespace, metav1.UpdateOptions{})
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -726,6 +726,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
 					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -775,6 +776,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
 					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -833,6 +835,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
 					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -600,6 +600,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 						toUnstructured(t, namespace("kcp-33jbiactwhg0", "",
 							map[string]string{
 								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+								"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 							},
 							map[string]string{
 								"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -647,6 +648,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 						toUnstructured(t, namespace("kcp-33jbiactwhg0", "",
 							map[string]string{
 								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+								"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 							},
 							map[string]string{
 								"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -940,6 +942,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 						toUnstructured(t, namespace("kcp-33jbiactwhg0", "",
 							map[string]string{
 								"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+								"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 							},
 							map[string]string{
 								"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -1049,6 +1052,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			toResources: []runtime.Object{
 				namespace("kcp-01c0zzvlqsi7n", "", map[string]string{
 					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					"kcp.io/tenant-id":                 "9Fn3Q4y5UDPmCOrYCujwdgCbD9SwOcKdcefYE7",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -200,7 +200,6 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	syncerNamespaceInformerFactory := kubernetesinformers.NewSharedInformerFactoryWithOptions(downstreamKubeClient, resyncPeriod, kubernetesinformers.WithNamespace(syncerNamespace))
 
 	downstreamSyncerDiscoveryClient := discovery.NewDiscoveryClient(downstreamKubeClient.RESTClient())
-
 	syncTargetGVRSource, err := resourcesync.NewSyncTargetGVRSource(
 		logger,
 		downstreamSyncerDiscoveryClient,

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -199,9 +199,6 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	// syncerNamespaceInformerFactory to watch some DNS-related resources in the dns namespace
 	syncerNamespaceInformerFactory := kubernetesinformers.NewSharedInformerFactoryWithOptions(downstreamKubeClient, resyncPeriod, kubernetesinformers.WithNamespace(syncerNamespace))
 
-	// downstreamInformerFactory to watch some DNS-related resources in the dns namespace
-	downstreamInformerFactory := kubernetesinformers.NewSharedInformerFactoryWithOptions(downstreamKubeClient, resyncPeriod, kubernetesinformers.WithNamespace(syncerNamespace))
-
 	downstreamSyncerDiscoveryClient := discovery.NewDiscoveryClient(downstreamKubeClient.RESTClient())
 
 	syncTargetGVRSource, err := resourcesync.NewSyncTargetGVRSource(
@@ -283,7 +280,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 
 	specSyncer, err := spec.NewSpecSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamURL, advancedSchedulingEnabled,
 		upstreamSyncerClusterClient, downstreamDynamicClient, downstreamKubeClient, ddsifForUpstreamSyncer, ddsifForDownstream, downstreamNamespaceController, syncTarget.GetUID(),
-		syncerNamespace, downstreamInformerFactory, cfg.DNSImage)
+		syncerNamespace, syncerNamespaceInformerFactory, cfg.DNSImage)
 
 	if err != nil {
 		return err

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -199,7 +199,11 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	// syncerNamespaceInformerFactory to watch some DNS-related resources in the dns namespace
 	syncerNamespaceInformerFactory := kubernetesinformers.NewSharedInformerFactoryWithOptions(downstreamKubeClient, resyncPeriod, kubernetesinformers.WithNamespace(syncerNamespace))
 
+	// downstreamInformerFactory to watch some DNS-related resources in the dns namespace
+	downstreamInformerFactory := kubernetesinformers.NewSharedInformerFactoryWithOptions(downstreamKubeClient, resyncPeriod, kubernetesinformers.WithNamespace(syncerNamespace))
+
 	downstreamSyncerDiscoveryClient := discovery.NewDiscoveryClient(downstreamKubeClient.RESTClient())
+
 	syncTargetGVRSource, err := resourcesync.NewSyncTargetGVRSource(
 		logger,
 		downstreamSyncerDiscoveryClient,
@@ -279,7 +283,8 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 
 	specSyncer, err := spec.NewSpecSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamURL, advancedSchedulingEnabled,
 		upstreamSyncerClusterClient, downstreamDynamicClient, downstreamKubeClient, ddsifForUpstreamSyncer, ddsifForDownstream, downstreamNamespaceController, syncTarget.GetUID(),
-		syncerNamespace, syncerNamespaceInformerFactory, cfg.DNSImage)
+		syncerNamespace, downstreamInformerFactory, cfg.DNSImage)
+
 	if err != nil {
 		return err
 	}

--- a/test/e2e/fixtures/kube/networking.k8s.io_networkpolicies.yaml
+++ b/test/e2e/fixtures/kube/networking.k8s.io_networkpolicies.yaml
@@ -1,0 +1,545 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kcp-dev/kubernetes/pull/4
+  creationTimestamp: null
+  name: networkpolicies.networking.k8s.io
+spec:
+  conversion:
+    strategy: None
+  group: networking.k8s.io
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    shortNames:
+    - netpol
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NetworkPolicy describes what network traffic is allowed for a
+          set of Pods
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior for this NetworkPolicy.
+            properties:
+              egress:
+                description: List of egress rules to be applied to the selected pods.
+                  Outgoing traffic is allowed if there are no NetworkPolicies selecting
+                  the pod (and cluster policy otherwise allows the traffic), OR if
+                  the traffic matches at least one egress rule across all of the NetworkPolicy
+                  objects whose podSelector matches the pod. If this field is empty
+                  then this NetworkPolicy limits all outgoing traffic (and serves
+                  solely to ensure that the pods it selects are isolated by default).
+                  This field is beta-level in 1.8
+                items:
+                  description: NetworkPolicyEgressRule describes a particular set
+                    of traffic that is allowed out of pods matched by a NetworkPolicySpec's
+                    podSelector. The traffic must match both ports and to. This type
+                    is beta-level in 1.8
+                  properties:
+                    ports:
+                      description: List of destination ports for outgoing traffic.
+                        Each item in this list is combined using a logical OR. If
+                        this field is empty or missing, this rule matches all ports
+                        (traffic not restricted by port). If this field is present
+                        and contains at least one item, then this rule allows traffic
+                        only if the traffic matches at least one port in the list.
+                      items:
+                        description: NetworkPolicyPort describes a port to allow traffic
+                          on
+                        properties:
+                          endPort:
+                            description: If set, indicates that the range of ports
+                              from port to endPort, inclusive, should be allowed by
+                              the policy. This field cannot be defined if the port
+                              field is not defined or if the port field is defined
+                              as a named (string) port. The endPort must be equal
+                              or greater than port.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can
+                              either be a numerical or named port on a pod. If this
+                              field is not provided, this matches all port names and
+                              numbers. If present, only traffic on the specified protocol
+                              AND port will be matched.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            description: The protocol (TCP, UDP, or SCTP) which traffic
+                              must match. If not specified, this field defaults to
+                              TCP.
+                            type: string
+                        type: object
+                      type: array
+                    to:
+                      description: List of destinations for outgoing traffic of pods
+                        selected for this rule. Items in this list are combined using
+                        a logical OR operation. If this field is empty or missing,
+                        this rule matches all destinations (traffic not restricted
+                        by destination). If this field is present and contains at
+                        least one item, this rule allows traffic only if the traffic
+                        matches at least one item in the to list.
+                      items:
+                        description: NetworkPolicyPeer describes a peer to allow traffic
+                          to/from. Only certain combinations of fields are allowed
+                        properties:
+                          ipBlock:
+                            description: IPBlock defines policy on a particular IPBlock.
+                              If this field is set then neither of the other fields
+                              can be.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP
+                                  Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should
+                                  not be included within an IP Block Valid examples
+                                  are "192.168.1.1/24" or "2001:db9::/64" Except values
+                                  will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: |-
+                              Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+                              If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          podSelector:
+                            description: |-
+                              This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+                              If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              ingress:
+                description: List of ingress rules to be applied to the selected pods.
+                  Traffic is allowed to a pod if there are no NetworkPolicies selecting
+                  the pod (and cluster policy otherwise allows the traffic), OR if
+                  the traffic source is the pod's local node, OR if the traffic matches
+                  at least one ingress rule across all of the NetworkPolicy objects
+                  whose podSelector matches the pod. If this field is empty then this
+                  NetworkPolicy does not allow any traffic (and serves solely to ensure
+                  that the pods it selects are isolated by default)
+                items:
+                  description: NetworkPolicyIngressRule describes a particular set
+                    of traffic that is allowed to the pods matched by a NetworkPolicySpec's
+                    podSelector. The traffic must match both ports and from.
+                  properties:
+                    from:
+                      description: List of sources which should be able to access
+                        the pods selected for this rule. Items in this list are combined
+                        using a logical OR operation. If this field is empty or missing,
+                        this rule matches all sources (traffic not restricted by source).
+                        If this field is present and contains at least one item, this
+                        rule allows traffic only if the traffic matches at least one
+                        item in the from list.
+                      items:
+                        description: NetworkPolicyPeer describes a peer to allow traffic
+                          to/from. Only certain combinations of fields are allowed
+                        properties:
+                          ipBlock:
+                            description: IPBlock defines policy on a particular IPBlock.
+                              If this field is set then neither of the other fields
+                              can be.
+                            properties:
+                              cidr:
+                                description: CIDR is a string representing the IP
+                                  Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                type: string
+                              except:
+                                description: Except is a slice of CIDRs that should
+                                  not be included within an IP Block Valid examples
+                                  are "192.168.1.1/24" or "2001:db9::/64" Except values
+                                  will be rejected if they are outside the CIDR range
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - cidr
+                            type: object
+                          namespaceSelector:
+                            description: |-
+                              Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+                              If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          podSelector:
+                            description: |-
+                              This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+                              If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    ports:
+                      description: List of ports which should be made accessible on
+                        the pods selected for this rule. Each item in this list is
+                        combined using a logical OR. If this field is empty or missing,
+                        this rule matches all ports (traffic not restricted by port).
+                        If this field is present and contains at least one item, then
+                        this rule allows traffic only if the traffic matches at least
+                        one port in the list.
+                      items:
+                        description: NetworkPolicyPort describes a port to allow traffic
+                          on
+                        properties:
+                          endPort:
+                            description: If set, indicates that the range of ports
+                              from port to endPort, inclusive, should be allowed by
+                              the policy. This field cannot be defined if the port
+                              field is not defined or if the port field is defined
+                              as a named (string) port. The endPort must be equal
+                              or greater than port.
+                            format: int32
+                            type: integer
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: The port on the given protocol. This can
+                              either be a numerical or named port on a pod. If this
+                              field is not provided, this matches all port names and
+                              numbers. If present, only traffic on the specified protocol
+                              AND port will be matched.
+                            x-kubernetes-int-or-string: true
+                          protocol:
+                            description: The protocol (TCP, UDP, or SCTP) which traffic
+                              must match. If not specified, this field defaults to
+                              TCP.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              podSelector:
+                description: Selects the pods to which this NetworkPolicy object applies.
+                  The array of ingress rules is applied to any pods selected by this
+                  field. Multiple network policies can select the same set of pods.
+                  In this case, the ingress rules for each are combined additively.
+                  This field is NOT optional and follows standard label selector semantics.
+                  An empty podSelector matches all pods in this namespace.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              policyTypes:
+                description: List of rule types that the NetworkPolicy relates to.
+                  Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"].
+                  If this field is not specified, it will default based on the existence
+                  of Ingress or Egress rules; policies that contain an Egress section
+                  are assumed to affect Egress, and all policies (whether or not they
+                  contain an Ingress section) are assumed to affect Ingress. If you
+                  want to write an egress-only policy, you must explicitly specify
+                  policyTypes [ "Egress" ]. Likewise, if you want to write a policy
+                  that specifies that no egress is allowed, you must specify a policyTypes
+                  value that include "Egress" (since such a policy would not include
+                  an Egress section and would otherwise default to just [ "Ingress"
+                  ]). This field is beta-level in 1.8
+                items:
+                  type: string
+                type: array
+            required:
+            - podSelector
+            type: object
+          status:
+            description: 'Status is the current state of the NetworkPolicy. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              conditions:
+                description: Conditions holds an array of metav1.Condition that describe
+                  the state of the NetworkPolicy. Current service state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions:
+  - v1

--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -884,6 +884,7 @@ func NewFakeWorkloadServer(t *testing.T, server RunningServer, org logicalcluste
 		metav1.GroupResource{Group: "core.k8s.io", Resource: "endpoints"},
 		metav1.GroupResource{Group: "core.k8s.io", Resource: "pods"},
 		metav1.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
+		metav1.GroupResource{Group: "networking.k8s.io", Resource: "networkpolicies"},
 	)
 
 	// Wait for the required crds to become ready

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -53,11 +53,7 @@ const sourceClusterName, sinkClusterName = "source", "sink"
 
 func TestClusterController(t *testing.T) {
 	t.Parallel()
-	framework.Suite(t, "transparent-multi-cluster:requires-kind")
-
-	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
-		t.Skip("Test requires a pcluster")
-	}
+	framework.Suite(t, "transparent-multi-cluster")
 
 	type runningServer struct {
 		client     wildwestv1alpha1client.WildwestV1alpha1Interface

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -53,7 +53,11 @@ const sourceClusterName, sinkClusterName = "source", "sink"
 
 func TestClusterController(t *testing.T) {
 	t.Parallel()
-	framework.Suite(t, "transparent-multi-cluster")
+	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+
+	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
+		t.Skip("Test requires a pcluster")
+	}
 
 	type runningServer struct {
 		client     wildwestv1alpha1client.WildwestV1alpha1Interface

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 	"github.com/kcp-dev/kcp/test/e2e/syncer/dns/workspace1"
@@ -91,6 +92,18 @@ func TestDNSResolution(t *testing.T) {
 	downstreamWS2NS1 := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace2.Spec.Cluster), "dns-ws2-ns1")
 	t.Logf("Downstream namespace 1 in workspace 2 is %s", downstreamWS2NS1)
 
+	t.Log("Checking network policies have been created")
+	framework.Eventually(t, func() (success bool, reason string) {
+		np, err := downstreamKubeClient.NetworkingV1().NetworkPolicies(syncer.SyncerID).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting network policies: %v\n", err)
+		}
+		if len(np.Items) != 2 {
+			return false, fmt.Sprintf("expecting 2 network policies, got: %d\n", len(np.Items))
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Network policies haven't been created")
+
 	t.Log("Checking fully qualified DNS name resolves")
 	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS1, "ping-fully-qualified", "PING svc.dns-ws1-ns1.svc.cluster.local ("),
 		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was not resolved")
@@ -106,6 +119,41 @@ func TestDNSResolution(t *testing.T) {
 	t.Log("Checking DNS name does not resolve across workspaces")
 	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS2NS1, "ping-fully-qualified-fail", "ping: bad"),
 		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was resolved")
+
+	t.Log("Change ping-fully-qualified deployment DNS config to use workspace 2 nameserver")
+	dnsServices, err := downstreamKubeClient.CoreV1().Services(syncer.SyncerID).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	require.True(t, len(dnsServices.Items) >= 2)
+
+	deployment, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS1).Get(ctx, "ping-fully-qualified", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	existingDNSIP := deployment.Spec.Template.Spec.DNSConfig.Nameservers[0]
+	newDNSIP := ""
+	for _, svc := range dnsServices.Items {
+		if strings.HasPrefix(svc.Name, "kcp-dns-") {
+			if svc.Spec.ClusterIP != existingDNSIP {
+				newDNSIP = svc.Spec.ClusterIP
+				break
+			}
+		}
+	}
+	require.NotEmpty(t, newDNSIP, "could not find another DNS service")
+	deployment.Spec.Template.Spec.DNSConfig.Nameservers[0] = newDNSIP
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deployment, err := downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS1).Get(ctx, "ping-fully-qualified", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		deployment.Spec.Template.Spec.DNSConfig.Nameservers[0] = newDNSIP
+		_, err = downstreamKubeClient.AppsV1().Deployments(downstreamWS1NS1).Update(ctx, deployment, metav1.UpdateOptions{})
+		return err
+	})
+	require.NoError(t, err)
+
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS1, "ping-fully-qualified", "ping: bad"),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was still not resolved")
 }
 
 func checkLogs(ctx context.Context, t *testing.T, downstreamKubeClient *kubernetes.Clientset, downstreamNamespace, containerName, expectedPrefix string) func() (success bool, reason string) {

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -120,7 +120,7 @@ func TestDNSResolution(t *testing.T) {
 	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS2NS1, "ping-fully-qualified-fail", "ping: bad"),
 		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was resolved")
 
-	t.Log("Change ping-fully-qualified deployment DNS config to use workspace 2 nameserver")
+	t.Log("Change ping-fully-qualified deployment DNS config to use workspace 2 nameserver and check the DNS name does not resolve")
 	dnsServices, err := downstreamKubeClient.CoreV1().Services(syncer.SyncerID).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err)
 	require.True(t, len(dnsServices.Items) >= 2)
@@ -153,7 +153,7 @@ func TestDNSResolution(t *testing.T) {
 	require.NoError(t, err)
 
 	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamWS1NS1, "ping-fully-qualified", "ping: bad"),
-		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was still not resolved")
+		wait.ForeverTestTimeout, time.Millisecond*500, "Service name was resolved")
 }
 
 func checkLogs(ctx context.Context, t *testing.T, downstreamKubeClient *kubernetes.Clientset, downstreamNamespace, containerName, expectedPrefix string) func() (success bool, reason string) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Restrict access to DNS pods to workspace associated to them. Also, make sure DNS pods have only access to CoreDNS pods.

This is enforced by create this networking policy, one per workspace:

```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: Name
  namespace: Namespace
spec:
  podSelector:
    matchLabels:
      app: Name
  policyTypes:
    - Ingress
    - Egress
  ingress:
    - from:
        - namespaceSelector:
            matchLabels:
              internal.workload.kcp.io/cluster: Cluster # workspace key
      ports:
        - protocol: TCP
          port: 5353
        - protocol: UDP
          port: 5353
  egress:
    # Only give access to coredns in kube-system
    - to:
        - namespaceSelector:
            matchLabels:
              kubernetes.io/metadata.name: kube-system
        - podSelector:
            matchLabels:
              k8s-app: kube-dns
      ports:
        - protocol: TCP
          port: 53
        - protocol: UDP
          port: 53
     # Give access to the API server to watch its associated configmap
    - to:
# one ipBlock per IP (dynamically filled)
      - ipBlock:
          cidr: APIServerIP/32
# one ports per endpoint port (dynamically filled)
      ports:
        - protocol: TCP
           port: 6443
```


## Related issue(s)

Fix https://github.com/kcp-dev/kcp/issues/1988

Related issue for cleaning up DNS-related resources: https://github.com/kcp-dev/kcp/issues/2358
