### PR TITLE
:sparkles:  Install Calico in kind for CI testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
     - uses: container-tools/kind-action@v2
       name: Kubernetes KinD Cluster w/local registry
       with:
-        version: v0.14.0
+        version: v0.17.0
         config: test/e2e/kind/config-calico.yaml
 
     # Install Calico

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,20 @@ jobs:
         name: Kubernetes KinD Cluster w/local registry
         with:
           version: v0.17.0
+          config: test/e2e/kind/config-calico.yaml
 
+      # Install Calico
+      - run: |-
+          kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/release-v3.24/manifests/calico.yaml
+          kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
+
+      # Install ko
       - run: |-
           go install github.com/google/ko@latest
+
+      # wait for Calico to be ready
+      - run: |-
+          kubectl wait pods -n kube-system -l k8s-app=calico-node --for=condition=Ready --timeout=90s
 
       - run: |-
           LOG_DIR=/tmp/e2e/shared-server/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 SUITES=transparent-multi-cluster:requires-kind \
@@ -77,9 +88,20 @@ jobs:
       name: Kubernetes KinD Cluster w/local registry
       with:
         version: v0.14.0
+        config: test/e2e/kind/config-calico.yaml
 
+    # Install Calico
+    - run: |-
+        kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/release-v3.24/manifests/calico.yaml
+        kubectl -n kube-system set env daemonset/calico-node FELIX_IGNORELOOSERPF=true
+
+    # Install ko
     - run: |-
         go install github.com/google/ko@latest
+
+    # wait for Calico to be ready
+    - run: |-
+        kubectl wait pods -n kube-system -l k8s-app=calico-node --for=condition=Ready --timeout=90s
 
     - run: |-
         LOG_DIR=/tmp/e2e/sharded/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 SUITES=transparent-multi-cluster:requires-kind \

--- a/test/e2e/kind/config-calico.yaml
+++ b/test/e2e/kind/config-calico.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: kind
+nodes:
+networking:
+  disableDefaultCNI: true
+  podSubnet: 192.169.0.0/16


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Default kind configuration does not support network policies. This PR modifies the kind configuration disabling kindnet and install Calico.



## Related issue(s)

/cc @davidfestal 
