### PR TITLE
:bug: Ignore APIBinding 403 errors when changing WS

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -173,11 +173,11 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
 		bindings, err := o.getAPIBindings(ctx, o.kcpClusterClient, newServerHost)
 		if err != nil {
 			// display the error, but don't stop the current workspace from being reported.
-			fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v", err)
+			fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 		}
 		if err = findUnresolvedPermissionClaims(o.Out, bindings); err != nil {
 			// display the error, but don't stop the current workspace from being reported.
-			fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v", err)
+			fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 		}
 
 		return currentWorkspace(o.Out, newServerHost, shortWorkspaceOutput(o.ShortWorkspaceOutput), nil)
@@ -319,17 +319,17 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
 	bindings, err := o.getAPIBindings(ctx, o.kcpClusterClient, newServerHost)
 	if err != nil {
 		// display the error, but don't stop the current workspace from being reported.
-		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v", err)
+		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 	}
 	if err := findUnresolvedPermissionClaims(o.Out, bindings); err != nil {
 		// display the error, but don't stop the current workspace from being reported.
-		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v", err)
+		fmt.Fprintf(o.ErrOut, "error checking APIBindings: %v\n", err)
 	}
 
 	return currentWorkspace(o.Out, newServerHost, shortWorkspaceOutput(o.ShortWorkspaceOutput), workspaceType)
 }
 
-// getAPIBindings retrieves APIBindings within the workspace
+// getAPIBindings retrieves APIBindings within the workspace.
 func getAPIBindings(ctx context.Context, kcpClusterClient kcpclientset.ClusterInterface, host string) ([]apisv1alpha1.APIBinding, error) {
 	_, clusterName, err := pluginhelpers.ParseClusterURL(host)
 	if err != nil {
@@ -337,6 +337,10 @@ func getAPIBindings(ctx context.Context, kcpClusterClient kcpclientset.ClusterIn
 	}
 
 	apiBindings, err := kcpClusterClient.Cluster(clusterName).ApisV1alpha1().APIBindings().List(ctx, metav1.ListOptions{})
+	// If the user is not allowed to view APIBindings in the workspace, there's nothing to show.
+	if apierrors.IsForbidden(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

Signed-off-by: Nolan Brubaker <nolan@nbrubaker.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When changing to a workspace where the user could not `GET` APIBindings, the 403 error would be bubbled up to the command's output.
This change ignores the error, since it's not actionable and is expected.

## Related issue(s)

Fixes: #2390
