### PR TITLE
🐛 cliplugins/bind: fix incorrect error message

### DIFF
--- a/pkg/cliplugins/bind/plugin/bind_compute.go
+++ b/pkg/cliplugins/bind/plugin/bind_compute.go
@@ -217,7 +217,7 @@ func bindReady(bindings []*apisv1alpha1.APIBinding, placement *schedulingv1alpha
 			} else if conditions.IsFalse(binding, apisv1alpha1.APIExportValid) {
 				conditionMessage = conditions.GetMessage(binding, apisv1alpha1.APIExportValid)
 			}
-			return false, fmt.Sprintf("not bound to apiexport '%s:%s': %s", binding.Spec.Reference.Workspace.Path, binding.Spec.Reference.Workspace.Path, conditionMessage)
+			return false, fmt.Sprintf("not bound to apiexport '%s:%s': %s", binding.Spec.Reference.Workspace.Path, binding.Spec.Reference.Workspace.ExportName, conditionMessage)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When binding a workspace to compute, if some of the apibindings is not ready, the `bind` cli will output an error like:

```
error: bind compute is not ready placement-23sk5wr9: not bound to apiexport 'root:compute:root:compute': Unable to bind APIs: naming conflict with a bound API kubernetes, spec.names.plural=pods is...
```

This error is confusing, as the workspace is duplicated, and doesn't specify the export name: 'root:compute:root:compute'

This PR changes it to include the name of the export, as in: 'root:compute:kubernetes'