### PR TITLE
✨ Refactor Syncer based on the enhanced ddsif, with controller manager and endpoints controller

### DIFF
--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -27,8 +27,8 @@
 /pkg/admission/webhook/generic_webhook.go:143:3: function "Infof" should not be used, convert to contextual logging
 /pkg/admission/webhook/generic_webhook.go:143:3: function "V" should not be used, convert to contextual logging
 /pkg/authorization/delegated/authorizer.go:45:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/cliplugins/workload/plugin/sync.go:616:4: function "Infof" should not be used, convert to contextual logging
-/pkg/cliplugins/workload/plugin/sync.go:616:4: function "V" should not be used, convert to contextual logging
+/pkg/cliplugins/workload/plugin/sync.go:615:4: function "Infof" should not be used, convert to contextual logging
+/pkg/cliplugins/workload/plugin/sync.go:615:4: function "V" should not be used, convert to contextual logging
 /pkg/dns/plugin/nsmap/namespace.go:68:2: function "Info" should not be used, convert to contextual logging
 /pkg/dns/plugin/nsmap/namespace.go:68:2: function "V" should not be used, convert to contextual logging
 /pkg/embeddedetcd/server.go:44:2: function "Info" should not be used, convert to contextual logging
@@ -61,10 +61,10 @@
 /pkg/informer/informer.go:595:4: function "V" should not be used, convert to contextual logging
 /pkg/informer/informer.go:597:4: function "InfoS" should not be used, convert to contextual logging
 /pkg/informer/informer.go:597:4: function "V" should not be used, convert to contextual logging
+/pkg/informer/informer.go:927:4: function "InfoS" should not be used, convert to contextual logging
+/pkg/informer/informer.go:927:4: function "V" should not be used, convert to contextual logging
 /pkg/informer/informer.go:929:4: function "InfoS" should not be used, convert to contextual logging
 /pkg/informer/informer.go:929:4: function "V" should not be used, convert to contextual logging
-/pkg/informer/informer.go:931:4: function "InfoS" should not be used, convert to contextual logging
-/pkg/informer/informer.go:931:4: function "V" should not be used, convert to contextual logging
 /pkg/logging/constants.go:100:9: Additional arguments to WithValues should always be Key Value pairs. Please check if there is any key or value missing.
 /pkg/logging/constants.go:52:9: Key positional arguments are expected to be inlined constant strings. Please replace ReconcilerKey provided with string value.
 /pkg/logging/constants.go:57:9: Key positional arguments are expected to be inlined constant strings. Please replace QueueKeyKey provided with string value.
@@ -75,52 +75,52 @@
 /pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_resource_reconcile.go:67:4: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_metadata.go:80:5: Key positional arguments are expected to be inlined constant strings. Please replace &{tenancyv1alpha1 ExperimentalWorkspaceOwnerAnnotationKey} provided with string value.
 /pkg/reconciler/tenancy/workspace/workspace_reconcile_metadata.go:55:5: Key positional arguments are expected to be inlined constant strings. Please replace &{tenancyv1alpha1 ExperimentalWorkspaceOwnerAnnotationKey} provided with string value.
-/pkg/reconciler/workload/resource/resource_controller.go:399:32: function "Enabled" should not be used, convert to contextual logging
-/pkg/reconciler/workload/resource/resource_controller.go:399:32: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/workload/resource/resource_controller.go:399:8: function "Enabled" should not be used, convert to contextual logging
-/pkg/reconciler/workload/resource/resource_controller.go:399:8: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:158:2: function "Infof" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:158:2: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:172:2: function "Infof" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:172:2: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:239:2: function "InfoS" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:240:8: function "InfoS" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:286:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:290:2: function "Infof" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:345:3: function "Errorf" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:350:2: function "Infof" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:350:2: function "V" should not be used, convert to contextual logging
-/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:352:3: function "Errorf" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:398:32: function "Enabled" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:398:32: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:398:8: function "Enabled" should not be used, convert to contextual logging
+/pkg/reconciler/workload/resource/resource_controller.go:398:8: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:157:2: function "Infof" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:157:2: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:171:2: function "Infof" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:171:2: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:238:2: function "InfoS" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:239:8: function "InfoS" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:285:3: function "Errorf" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:289:2: function "Infof" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:344:3: function "Errorf" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:349:2: function "Infof" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:349:2: function "V" should not be used, convert to contextual logging
+/pkg/reconciler/workload/synctargetexports/synctargetexports_controller.go:351:3: function "Errorf" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_reconcile.go:49:4: function "Infof" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_reconcile.go:49:4: function "V" should not be used, convert to contextual logging
 /pkg/reconciler/workload/synctargetexports/synctargetexports_reconcile.go:60:5: function "Warningf" should not be used, convert to contextual logging
 /pkg/server/localproxy.go:137:4: function "Infof" should not be used, convert to contextual logging
 /pkg/server/localproxy.go:150:4: function "Infof" should not be used, convert to contextual logging
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
-/pkg/syncer/endpoints/endpoint_downstream_controller.go:128:2: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
-/pkg/syncer/endpoints/endpoint_downstream_controller.go:152:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/endpoints/endpoint_downstream_controller.go:152:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/endpoints/endpoint_downstream_controller.go:129:2: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
+/pkg/syncer/endpoints/endpoint_downstream_controller.go:153:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/endpoints/endpoint_downstream_controller.go:153:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/namespace/namespace_downstream_process.go:45:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
 /pkg/syncer/namespace/namespace_downstream_process.go:89:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/namespace/namespace_downstream_process.go:89:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/spec/spec_controller.go:182:15: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/spec/spec_controller.go:182:15: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/spec/spec_controller.go:184:15: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/spec/spec_controller.go:184:15: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
 /pkg/syncer/spec/spec_process.go:118:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:118:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:118:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:136:4: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
 /pkg/syncer/spec/spec_process.go:154:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
 /pkg/syncer/spec/spec_process.go:391:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/status/status_process.go:157:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/status/status_process.go:157:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:157:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:154:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/status/status_process.go:154:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:154:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
 /pkg/syncer/status/status_process.go:70:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
 /pkg/syncer/status/status_process.go:70:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/syncer.go:101:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetName provided with string value.
-/pkg/syncer/syncer.go:101:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetWorkspace provided with string value.
-/pkg/syncer/syncer.go:212:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetKey provided with string value.
-/pkg/tunneler/dialer.go:148:8: function "Infof" should not be used, convert to contextual logging
-/pkg/tunneler/dialer.go:148:8: function "V" should not be used, convert to contextual logging
+/pkg/syncer/syncer.go:196:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetKey provided with string value.
+/pkg/syncer/syncer.go:85:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetName provided with string value.
+/pkg/syncer/syncer.go:85:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetWorkspace provided with string value.
+/pkg/tunneler/dialer.go:151:8: function "Infof" should not be used, convert to contextual logging
+/pkg/tunneler/dialer.go:151:8: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:157:3: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:157:3: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:161:2: function "Infof" should not be used, convert to contextual logging
@@ -131,20 +131,20 @@
 /pkg/tunneler/listener.go:168:3: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:180:3: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:180:3: function "V" should not be used, convert to contextual logging
-/pkg/tunneler/listener.go:211:2: function "Infof" should not be used, convert to contextual logging
-/pkg/tunneler/listener.go:211:2: function "V" should not be used, convert to contextual logging
+/pkg/tunneler/listener.go:210:2: function "Infof" should not be used, convert to contextual logging
+/pkg/tunneler/listener.go:210:2: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:82:4: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:82:4: function "V" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:146:3: function "InfoS" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:146:3: function "V" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:178:5: function "Infof" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:178:5: function "V" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:182:4: function "Infof" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:182:4: function "V" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:195:4: function "Infof" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:195:4: function "V" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:230:4: function "Infof" should not be used, convert to contextual logging
-/pkg/tunneler/tunnel.go:230:4: function "V" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:145:3: function "InfoS" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:145:3: function "V" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:177:5: function "Infof" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:177:5: function "V" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:181:4: function "Infof" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:181:4: function "V" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:194:4: function "Infof" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:194:4: function "V" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:229:4: function "Infof" should not be used, convert to contextual logging
+/pkg/tunneler/tunnel.go:229:4: function "V" should not be used, convert to contextual logging
 /pkg/virtual/apiexport/builder/build.go:140:7: function "Errorf" should not be used, convert to contextual logging
 /pkg/virtual/framework/dynamic/apiserver/serving_info.go:185:3: function "Infof" should not be used, convert to contextual logging
 /pkg/virtual/framework/dynamic/apiserver/serving_info.go:185:3: function "V" should not be used, convert to contextual logging

--- a/hack/logcheck.out
+++ b/hack/logcheck.out
@@ -97,25 +97,28 @@
 /pkg/server/localproxy.go:137:4: function "Infof" should not be used, convert to contextual logging
 /pkg/server/localproxy.go:150:4: function "Infof" should not be used, convert to contextual logging
 /pkg/server/options/controllers.go:54:3: function "Fatal" should not be used, convert to contextual logging
+/pkg/syncer/endpoints/endpoint_downstream_controller.go:128:2: Additional arguments to Info should always be Key Value pairs. Please check if there is any key or value missing.
+/pkg/syncer/endpoints/endpoint_downstream_controller.go:152:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/endpoints/endpoint_downstream_controller.go:152:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/namespace/namespace_downstream_process.go:45:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
 /pkg/syncer/namespace/namespace_downstream_process.go:89:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/namespace/namespace_downstream_process.go:89:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/spec/spec_controller.go:163:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/spec/spec_controller.go:163:16: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/spec/spec_controller.go:182:15: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/spec/spec_controller.go:182:15: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
 /pkg/syncer/spec/spec_process.go:118:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:118:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:118:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
 /pkg/syncer/spec/spec_process.go:136:4: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
 /pkg/syncer/spec/spec_process.go:154:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/spec/spec_process.go:386:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
-/pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:137:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
-/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
-/pkg/syncer/status/status_process.go:67:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
-/pkg/syncer/syncer.go:180:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetKey provided with string value.
-/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetName provided with string value.
-/pkg/syncer/syncer.go:78:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetWorkspace provided with string value.
+/pkg/syncer/spec/spec_process.go:391:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/status/status_process.go:157:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NameKey} provided with string value.
+/pkg/syncer/status/status_process.go:157:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging NamespaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:157:11: Key positional arguments are expected to be inlined constant strings. Please replace &{logging WorkspaceKey} provided with string value.
+/pkg/syncer/status/status_process.go:70:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamName provided with string value.
+/pkg/syncer/status/status_process.go:70:11: Key positional arguments are expected to be inlined constant strings. Please replace DownstreamNamespace provided with string value.
+/pkg/syncer/syncer.go:101:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetName provided with string value.
+/pkg/syncer/syncer.go:101:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetWorkspace provided with string value.
+/pkg/syncer/syncer.go:212:11: Key positional arguments are expected to be inlined constant strings. Please replace SyncTargetKey provided with string value.
 /pkg/tunneler/dialer.go:148:8: function "Infof" should not be used, convert to contextual logging
 /pkg/tunneler/dialer.go:148:8: function "V" should not be used, convert to contextual logging
 /pkg/tunneler/listener.go:157:3: function "Infof" should not be used, convert to contextual logging

--- a/pkg/informer/informer.go
+++ b/pkg/informer/informer.go
@@ -353,13 +353,13 @@ func (d *GenericDiscoveringDynamicSharedInformerFactory[Informer, Lister, Generi
 	return inf
 }
 
-// Listers returns a map of per-resource-type listers for all types that are
+// Informers returns a map of per-resource-type generic informers for all types that are
 // known by this informer factory, and that are synced.
 //
 // If any informers aren't synced, their GVRs are returned so that they can be
 // checked and processed later.
-func (d *GenericDiscoveringDynamicSharedInformerFactory[Informer, Lister, GenericInformer]) Listers() (listers map[schema.GroupVersionResource]Lister, notSynced []schema.GroupVersionResource) {
-	listers = map[schema.GroupVersionResource]Lister{}
+func (d *GenericDiscoveringDynamicSharedInformerFactory[Informer, Lister, GenericInformer]) Informers() (informers map[schema.GroupVersionResource]GenericInformer, notSynced []schema.GroupVersionResource) {
+	informers = map[schema.GroupVersionResource]GenericInformer{}
 
 	d.informersLock.RLock()
 	defer d.informersLock.RUnlock()
@@ -372,38 +372,10 @@ func (d *GenericDiscoveringDynamicSharedInformerFactory[Informer, Lister, Generi
 			continue
 		}
 
-		listers[gvr] = informer.Lister()
+		informers[gvr] = informer
 	}
 
-	return listers, notSynced
-}
-
-// Lister returns a lister for the given resource-type, whether it is
-// known by this informer factory, and whether it is synced.
-func (d *GenericDiscoveringDynamicSharedInformerFactory[Informer, Lister, GenericInformer]) Lister(gvr schema.GroupVersionResource) (lister Lister, known, synced bool) {
-	d.informersLock.RLock()
-	defer d.informersLock.RUnlock()
-
-	informer, ok := d.informers[gvr]
-	if !ok {
-		return lister, false, false
-	}
-
-	return informer.Lister(), true, informer.Informer().HasSynced()
-}
-
-// Informer returns an informer for the given resource-type if it exists, whether it is
-// known by this informer factory, and whether it is synced.
-func (d *GenericDiscoveringDynamicSharedInformerFactory[Informer, Lister, GenericInformer]) Informer(gvr schema.GroupVersionResource) (informer Informer, known, synced bool) {
-	d.informersLock.RLock()
-	defer d.informersLock.RUnlock()
-
-	genericInformer, ok := d.informers[gvr]
-	if !ok {
-		return informer, false, false
-	}
-
-	return genericInformer.Informer(), true, genericInformer.Informer().HasSynced()
+	return informers, notSynced
 }
 
 // GVREventHandler is an event handler that includes the GroupVersionResource

--- a/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
+++ b/pkg/reconciler/apis/permissionclaimlabel/permissionclaimlabel_reconcile.go
@@ -245,9 +245,9 @@ func claimFromSetKey(key string) apisv1alpha1.PermissionClaim {
 }
 
 func (c *controller) getInformerForGroupResource(group, resource string) (kcpkubernetesinformers.GenericClusterInformer, schema.GroupVersionResource, error) {
-	listers, _ := c.ddsif.Listers()
+	informers, _ := c.ddsif.Informers()
 
-	for gvr := range listers {
+	for gvr := range informers {
 		if gvr.Group == group && gvr.Resource == resource {
 			informer, err := c.ddsif.ForResource(gvr)
 			// once we find one, return.

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -373,11 +373,11 @@ func (c *Controller) enqueueResourcesForNamespace(ns *corev1.Namespace) error {
 	logger = logger.WithValues("nsLocations", nsLocations.List())
 
 	logger.V(4).Info("getting listers")
-	listers, notSynced := c.ddsif.Listers()
+	informers, notSynced := c.ddsif.Informers()
 	var errs []error
-	for gvr, lister := range listers {
+	for gvr, informer := range informers {
 		logger = logger.WithValues("gvr", gvr.String())
-		objs, err := lister.ByCluster(clusterName).ByNamespace(ns.Name).List(labels.Everything())
+		objs, err := informer.Lister().ByCluster(clusterName).ByNamespace(ns.Name).List(labels.Everything())
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error listing %q in %s|%s: %w", gvr, clusterName, ns.Name, err))
 			continue
@@ -438,9 +438,9 @@ func (c *Controller) enqueueSyncTarget(obj interface{}) {
 func (c *Controller) enqueueSyncTargetKey(syncTargetKey string) {
 	logger := logging.WithReconciler(klog.Background(), ControllerName).WithValues("syncTargetKey", syncTargetKey)
 
-	listers, _ := c.ddsif.Listers()
+	informers, _ := c.ddsif.Informers()
 	queued := map[string]int{}
-	for gvr := range listers {
+	for gvr := range informers {
 		inf, err := c.ddsif.ForResource(gvr)
 		if err != nil {
 			runtime.HandleError(err)

--- a/pkg/syncer/controllermanager/controllermanager.go
+++ b/pkg/syncer/controllermanager/controllermanager.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllermanager
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"github.com/kcp-dev/kcp/pkg/logging"
+)
+
+const (
+	ControllerNamePrefix = "syncer-controller-manager-"
+)
+
+type InformerSource struct {
+	Subscribe func(id string) <-chan struct{}
+	Informer  func(gvr schema.GroupVersionResource) (informer cache.SharedIndexInformer, known, synced bool)
+}
+
+type Controller interface {
+	Start(ctx context.Context, numThreads int)
+}
+
+type ControllerDefintion struct {
+	RequiredGVRs []schema.GroupVersionResource
+	NumThreads   int
+	Create       func(syncedInformers map[schema.GroupVersionResource]cache.SharedIndexInformer) (Controller, error)
+}
+
+func NewControllerManager(ctx context.Context, suffix string, informerSource InformerSource, controllers map[string]ControllerDefintion) *ControllerManager {
+	controllerManager := ControllerManager{
+		name:                  ControllerNamePrefix + suffix,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerNamePrefix+suffix),
+		informerSource:        informerSource,
+		controllerDefinitions: controllers,
+		startedControllers:    map[string]context.CancelFunc{},
+	}
+
+	apisChanged := informerSource.Subscribe(controllerManager.name)
+
+	logger := klog.FromContext(ctx)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-apisChanged:
+				logger.V(4).Info("got API change notification")
+				controllerManager.queue.Add("resync") // this queue only ever has one key in it, as long as it's constant we are OK
+			}
+		}
+	}()
+
+	return &controllerManager
+}
+
+type ControllerManager struct {
+	name                  string
+	queue                 workqueue.RateLimitingInterface
+	informerSource        InformerSource
+	controllerDefinitions map[string]ControllerDefintion
+	startedControllers    map[string]context.CancelFunc
+}
+
+// Start starts the controller, which stops when ctx.Done() is closed.
+func (c *ControllerManager) Start(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), c.name)
+	logger.Info("Starting controller manager")
+	defer logger.Info("Shutting down controller manager")
+
+	go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	<-ctx.Done()
+}
+
+func (c *ControllerManager) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *ControllerManager) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	c.UpdateControllers(ctx)
+	c.queue.Forget(key)
+	return true
+}
+
+func (c *ControllerManager) UpdateControllers(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	controllersToStart := map[string]map[schema.GroupVersionResource]cache.SharedIndexInformer{}
+controllerLoop:
+	for controllerName, controllerDefinition := range c.controllerDefinitions {
+		requiredGVRs := controllerDefinition.RequiredGVRs
+		informers := make(map[schema.GroupVersionResource]cache.SharedIndexInformer, len(requiredGVRs))
+		for _, gvr := range requiredGVRs {
+			if informer, known, synced := c.informerSource.Informer(gvr); !known {
+				continue controllerLoop
+			} else if !synced {
+				logger.V(2).Info("waiting for the informer to be synced before starting controller", "gvr", gvr, "controller", controllerName)
+				c.queue.AddAfter("resync", time.Second)
+				continue controllerLoop
+			} else {
+				informers[gvr] = informer
+			}
+		}
+		controllersToStart[controllerName] = informers
+	}
+
+	// Create and start missing controllers that have their required GVRs synced
+	newlyStartedControllers := map[string]context.CancelFunc{}
+	for controllerName, informers := range controllersToStart {
+		if _, ok := c.startedControllers[controllerName]; ok {
+			// The controller is already started
+			continue
+		}
+		controllerDefinition, ok := c.controllerDefinitions[controllerName]
+		if !ok {
+			logger.V(2).Info("cannot find controller definition", "controller", controllerName)
+			continue
+		}
+
+		// Create the controller
+		controller, err := controllerDefinition.Create(informers)
+		if err != nil {
+			logger.Error(err, "error creating controller", "controller", controllerName)
+			continue
+		}
+
+		for _, informer := range informers {
+			if err := informer.GetStore().Resync(); err != nil {
+				logger.Error(err, "error resyncing informer controller", "controller", controllerName)
+				continue
+			}
+		}
+
+		// Start the controller
+		controllerContext, cancelFunc := context.WithCancel(ctx)
+		go controller.Start(controllerContext, controllerDefinition.NumThreads)
+		newlyStartedControllers[c.name] = cancelFunc
+	}
+
+	// Remove obsolete controllers that don't have their required GVRs anymore
+	for controllerName, cancelFunc := range c.startedControllers {
+		if _, ok := controllersToStart[controllerName]; ok {
+			// The controller is still expected => don't remove it
+			continue
+		}
+		// The controller should not be running
+		// Stop it and remove it from the list of started controllers
+		cancelFunc()
+		delete(c.startedControllers, controllerName)
+	}
+
+	// Add missing controllers that were created and started above
+	for controllerName, cancelFunc := range newlyStartedControllers {
+		c.startedControllers[controllerName] = cancelFunc
+	}
+}

--- a/pkg/syncer/endpoints/endpoint_downstream_controller.go
+++ b/pkg/syncer/endpoints/endpoint_downstream_controller.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+)
+
+const (
+	ControllerName = "syncer-endpoint-controller"
+)
+
+func NewEndpointController(
+	syncerLogger logr.Logger,
+	downstreamClient dynamic.Interface,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	syncedInformers map[schema.GroupVersionResource]cache.SharedIndexInformer,
+) (*EndpointController, error) {
+	endpointsGVR := corev1.SchemeGroupVersion.WithResource("endpoints")
+
+	c := &EndpointController{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName),
+	}
+
+	logger := logging.WithReconciler(syncerLogger, ControllerName)
+
+	endpointsInformer, ok := syncedInformers[endpointsGVR]
+	if !ok {
+		return nil, errors.New("endpoints informer should be available")
+	}
+
+	endpointsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.AddToQueue(obj, logger)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.AddToQueue(newObj, logger)
+		},
+		DeleteFunc: func(obj interface{}) {
+			c.AddToQueue(obj, logger)
+		},
+	})
+
+	return c, nil
+}
+
+type EndpointController struct {
+	queue workqueue.RateLimitingInterface
+}
+
+func (c *EndpointController) AddToQueue(obj interface{}, logger logr.Logger) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	logging.WithQueueKey(logger, key).V(2).Info("queueing", "key", key)
+	c.queue.Add(key)
+}
+
+// Start starts N worker processes processing work items.
+func (c *EndpointController) Start(ctx context.Context, numThreads int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), ControllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting syncer workers")
+	defer logger.Info("Stopping syncer workers")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+
+	<-ctx.Done()
+}
+
+// startWorker processes work items until stopCh is closed.
+func (c *EndpointController) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *EndpointController) processNextWorkItem(ctx context.Context) bool {
+	// Wait until there is a new item in the working queue
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+
+	qk := key.(string)
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), qk)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("processing", qk)
+
+	// No matter what, tell the queue we're done with this key, to unblock
+	// other workers.
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, qk); err != nil {
+		utilruntime.HandleError(fmt.Errorf("%s failed to sync %q, err: %w", ControllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}
+
+func (c *EndpointController) process(ctx context.Context, key string) error {
+	logger := klog.FromContext(ctx)
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+	logger = logger.WithValues(logging.NamespaceKey, namespace, logging.NameKey, name)
+
+	logger.Info("Processing endpoint")
+
+	// TODO(davidfestal): check if a service synced from KCP exists with the same name.
+	// If it's the case, then label the Endpoints resource so that it can be Upsynced.
+	// We should also cleanup the endpoint (remove the label) when the corresonding service is removed.
+	return nil
+}

--- a/pkg/syncer/indexers/indexes.go
+++ b/pkg/syncer/indexers/indexes.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package indexers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+const (
+	ByNamespaceLocatorIndexName = "syncer-spec-ByNamespaceLocator"
+)
+
+// indexByNamespaceLocator is a cache.IndexFunc that indexes namespaces by the namespaceLocator annotation.
+func IndexByNamespaceLocator(obj interface{}) ([]string, error) {
+	metaObj, ok := obj.(metav1.Object)
+	if !ok {
+		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
+	}
+	if loc, found, err := shared.LocatorFromAnnotations(metaObj.GetAnnotations()); err != nil {
+		return []string{}, fmt.Errorf("failed to get locator from annotations: %w", err)
+	} else if !found {
+		return []string{}, nil
+	} else {
+		bs, err := json.Marshal(loc)
+		if err != nil {
+			return []string{}, fmt.Errorf("failed to marshal locator %#v: %w", loc, err)
+		}
+		return []string{string(bs)}, nil
+	}
+}

--- a/pkg/syncer/namespace/namespace_downstream_controller.go
+++ b/pkg/syncer/namespace/namespace_downstream_controller.go
@@ -120,7 +120,7 @@ func NewDownstreamController(
 			return informer.Lister().Get(downstreamNamespaceName)
 		},
 		listDownstreamNamespaces: func() ([]runtime.Object, error) {
-			informer, err := ddsifForUpstreamSyncer.ForResource(namespaceGVR)
+			informer, err := ddsifForDownstream.ForResource(namespaceGVR)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/syncer/resourcesync/controller.go
+++ b/pkg/syncer/resourcesync/controller.go
@@ -26,13 +26,12 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/go-logr/logr"
-	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
-	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
-	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,9 +40,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -55,6 +54,7 @@ import (
 	clientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned"
 	workloadv1alpha1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/workload/v1alpha1"
 	workloadv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
 )
 
@@ -63,47 +63,35 @@ const (
 	controllerName = "kcp-syncer-resourcesync-controller"
 )
 
-type SyncerInformer struct {
-	UpstreamInformer   kcpkubernetesinformers.GenericClusterInformer
-	DownstreamInformer informers.GenericInformer
-	cancel             context.CancelFunc
-}
-
-type SyncerInformerFactory interface {
-	AddUpstreamEventHandler(handler ResourceEventHandlerPerGVR)
-	AddDownstreamEventHandler(handler ResourceEventHandlerPerGVR)
-	InformerForResource(gvr schema.GroupVersionResource) (*SyncerInformer, bool)
-	SyncableGVRs() (map[schema.GroupVersionResource]*SyncerInformer, error)
-	Start(ctx context.Context, numThreads int)
-}
-
-type ResourceEventHandlerPerGVR func(schema.GroupVersionResource) cache.ResourceEventHandler
+var _ informer.GVRSource = (*Controller)(nil)
 
 // controller is a control loop that watches synctarget. It starts/stops spec syncer and status syncer
 // per gvr based on synctarget.Status.SyncedResources.
 // All the spec/status syncer share the same downstreamNSInformer and upstreamSecretInformer. Informers
 // for gvr is started separated for each syncer.
 type Controller struct {
-	queue                        workqueue.RateLimitingInterface
-	upstreamDynamicClusterClient kcpdynamic.ClusterInterface
-	downstreamDynamicClient      dynamic.Interface
-	downstreamKubeClient         kubernetes.Interface
+	queue                workqueue.RateLimitingInterface
+	downstreamKubeClient kubernetes.Interface
 
-	upstreamEventHandlers   []ResourceEventHandlerPerGVR
-	downstreamEventHandlers []ResourceEventHandlerPerGVR
+	cachedDiscovery discovery.CachedDiscoveryInterface
 
-	syncTargetName        string
-	syncTargetClusterName logicalcluster.Name
-	syncTargetUID         types.UID
-	syncTargetLister      workloadv1alpha1listers.SyncTargetLister
-	kcpClient             clientset.Interface
+	syncTargetUID               types.UID
+	syncTargetLister            workloadv1alpha1listers.SyncTargetLister
+	synctargetInformerCacheSync cache.InformerSynced
+	kcpClient                   clientset.Interface
 
-	syncerInformerMap map[schema.GroupVersionResource]*SyncerInformer
-	mutex             sync.RWMutex
+	gvrs map[schema.GroupVersionResource]informer.GVRPartialMetadata
+
+	mutex sync.RWMutex
+
+	// Support subscribers that want to know when Synced GVRs have changed.
+	subscribersLock sync.Mutex
+	subscribers     []chan<- struct{}
 }
 
 func NewController(
 	syncerLogger logr.Logger,
+	discoveryClient discovery.DiscoveryInterface,
 	upstreamDynamicClusterClient kcpdynamic.ClusterInterface,
 	downstreamDynamicClient dynamic.Interface,
 	downstreamKubeClient kubernetes.Interface,
@@ -112,20 +100,16 @@ func NewController(
 	syncTargetName string,
 	syncTargetClusterName logicalcluster.Name,
 	syncTargetUID types.UID,
-) (SyncerInformerFactory, error) {
+) (*Controller, error) {
 	c := &Controller{
-		queue:                        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
-		upstreamDynamicClusterClient: upstreamDynamicClusterClient,
-		downstreamDynamicClient:      downstreamDynamicClient,
-		downstreamKubeClient:         downstreamKubeClient,
-		kcpClient:                    kcpClient,
-		upstreamEventHandlers:        []ResourceEventHandlerPerGVR{},
-		downstreamEventHandlers:      []ResourceEventHandlerPerGVR{},
-		syncerInformerMap:            map[schema.GroupVersionResource]*SyncerInformer{},
-		syncTargetName:               syncTargetName,
-		syncTargetClusterName:        syncTargetClusterName,
-		syncTargetUID:                syncTargetUID,
-		syncTargetLister:             syncTargetInformer.Lister(),
+		queue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		cachedDiscovery:             memory.NewMemCacheClient(discoveryClient),
+		downstreamKubeClient:        downstreamKubeClient,
+		kcpClient:                   kcpClient,
+		syncTargetUID:               syncTargetUID,
+		syncTargetLister:            syncTargetInformer.Lister(),
+		synctargetInformerCacheSync: syncTargetInformer.Informer().HasSynced,
+		gvrs:                        map[schema.GroupVersionResource]informer.GVRPartialMetadata{},
 	}
 
 	logger := logging.WithReconciler(syncerLogger, controllerName)
@@ -181,30 +165,6 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	<-ctx.Done()
 }
 
-func (c *Controller) AddUpstreamEventHandler(handler ResourceEventHandlerPerGVR) {
-	c.upstreamEventHandlers = append(c.upstreamEventHandlers, handler)
-}
-
-func (c *Controller) AddDownstreamEventHandler(handler ResourceEventHandlerPerGVR) {
-	c.downstreamEventHandlers = append(c.downstreamEventHandlers, handler)
-}
-
-func (c *Controller) InformerForResource(gvr schema.GroupVersionResource) (*SyncerInformer, bool) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-	if informer, ok := c.syncerInformerMap[gvr]; ok {
-		return informer, true
-	}
-
-	return nil, false
-}
-
-func (c *Controller) SyncableGVRs() (map[schema.GroupVersionResource]*SyncerInformer, error) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-	return c.syncerInformerMap, nil
-}
-
 func (c *Controller) startWorker(ctx context.Context) {
 	for c.processNextWorkItem(ctx) {
 	}
@@ -247,8 +207,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 
 	syncTarget, err := c.syncTargetLister.Get(name)
 	if apierrors.IsNotFound(err) {
-		c.stopUnusedSyncerInformers(ctx, map[schema.GroupVersionResource]bool{})
-		return nil
+		return c.removeUnusedGVRs(ctx, map[schema.GroupVersionResource]bool{})
 	}
 
 	if err != nil {
@@ -260,6 +219,8 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	}
 
 	requiredGVRs := getAllGVRs(syncTarget)
+
+	c.cachedDiscovery.Invalidate()
 
 	var errs []error
 	var unauthorizedGVRs []string
@@ -282,10 +243,14 @@ func (c *Controller) process(ctx context.Context, key string) error {
 			continue
 		}
 
-		c.startSyncerInformer(ctx, gvr, syncTarget)
+		if err := c.addGVR(ctx, gvr, syncTarget); err != nil {
+			return err
+		}
 	}
 
-	c.stopUnusedSyncerInformers(ctx, requiredGVRs)
+	if err := c.removeUnusedGVRs(ctx, requiredGVRs); err != nil {
+		return err
+	}
 
 	newSyncTarget := syncTarget.DeepCopy()
 
@@ -365,79 +330,163 @@ func (c *Controller) checkSSAR(ctx context.Context, gvr schema.GroupVersionResou
 	return sar.Status.Allowed, nil
 }
 
-// stopUnusedSyncerInformers stop syncers for gvrs not in requiredGVRs.
-func (c *Controller) stopUnusedSyncerInformers(ctx context.Context, requiredGVRs map[schema.GroupVersionResource]bool) {
+// removeUnusedGVRs stop syncers for gvrs not in requiredGVRs.
+func (c *Controller) removeUnusedGVRs(ctx context.Context, requiredGVRs map[schema.GroupVersionResource]bool) error {
 	logger := klog.FromContext(ctx)
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	for gvr, informer := range c.syncerInformerMap {
+	updated := false
+	for gvr := range c.gvrs {
 		if _, ok := requiredGVRs[gvr]; !ok {
 			logger.WithValues("gvr", gvr.String()).V(2).Info("Stop syncer for gvr")
-			informer.cancel()
-			delete(c.syncerInformerMap, gvr)
+			delete(c.gvrs, gvr)
+			updated = true
+		}
+	}
+
+	if updated {
+		c.notifySubscribers(ctx)
+	}
+	return nil
+}
+
+func (c *Controller) GVRs() map[schema.GroupVersionResource]informer.GVRPartialMetadata {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	gvrs := make(map[schema.GroupVersionResource]informer.GVRPartialMetadata, len(c.gvrs)+len(builtinGVRs)+1)
+	gvrs[corev1.SchemeGroupVersion.WithResource("namespaces")] = informer.GVRPartialMetadata{
+		Scope: apiextensionsv1.ClusterScoped,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Singular: "namespace",
+			Kind:     "Namespace",
+		},
+	}
+	for key, value := range builtinGVRs {
+		gvrs[key] = value
+	}
+	for key, value := range c.gvrs {
+		gvrs[key] = value
+	}
+	return gvrs
+}
+
+func (c *Controller) getGVRPartialMetadata(gvr schema.GroupVersionResource) (*informer.GVRPartialMetadata, error) {
+	apiResourceList, err := c.cachedDiscovery.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
+	if err != nil {
+		return nil, err
+	}
+	for _, apiResource := range apiResourceList.APIResources {
+		if apiResource.Name == gvr.Resource {
+			var resourceScope apiextensionsv1.ResourceScope
+			if apiResource.Namespaced {
+				resourceScope = apiextensionsv1.NamespaceScoped
+			} else {
+				resourceScope = apiextensionsv1.ClusterScoped
+			}
+
+			return &informer.GVRPartialMetadata{
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind:     apiResource.Kind,
+						Singular: apiResource.SingularName,
+					},
+					Scope: resourceScope,
+				},
+				nil
+		}
+	}
+	return nil, fmt.Errorf("unable to retrieve discovery for GVR: %s", gvr)
+}
+
+func (c *Controller) Ready() bool {
+	return c.synctargetInformerCacheSync()
+}
+
+func (c *Controller) Subscribe() <-chan struct{} {
+	c.subscribersLock.Lock()
+	defer c.subscribersLock.Unlock()
+
+	// Use a buffered channel so we can always send at least 1, regardless of consumer status.
+	changes := make(chan struct{}, 1)
+	c.subscribers = append(c.subscribers, changes)
+
+	return changes
+}
+
+func (c *Controller) notifySubscribers(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+
+	c.subscribersLock.Lock()
+	defer c.subscribersLock.Unlock()
+
+	for index, ch := range c.subscribers {
+		logger.V(4).Info("Attempting to notify subscribers", "index", index)
+		select {
+		case ch <- struct{}{}:
+			logger.V(4).Info("Successfully notified subscriber", "index", index)
+		default:
+			logger.V(4).Info("Unable to notify subscriber - channel full", "index", index)
 		}
 	}
 }
 
-func (c *Controller) startSyncerInformer(ctx context.Context, gvr schema.GroupVersionResource, syncTarget *workloadv1alpha1.SyncTarget) {
+func (c *Controller) addGVR(ctx context.Context, gvr schema.GroupVersionResource, syncTarget *workloadv1alpha1.SyncTarget) error {
 	logger := klog.FromContext(ctx)
 
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if _, ok := c.syncerInformerMap[gvr]; ok {
+	if _, ok := c.gvrs[gvr]; ok {
 		logger.V(2).Info("Informer is started already")
-		return
+		return nil
 	}
 
-	syncTargetKey := workloadv1alpha1.ToSyncTargetKey(c.syncTargetClusterName, c.syncTargetName)
-
-	upstreamInformer := kcpdynamicinformer.NewFilteredDynamicInformer(c.upstreamDynamicClusterClient, gvr, resyncPeriod, cache.Indexers{
-		kcpcache.ClusterIndexName:             kcpcache.ClusterIndexFunc,
-		kcpcache.ClusterAndNamespaceIndexName: kcpcache.ClusterAndNamespaceIndexFunc}, func(o *metav1.ListOptions) {},
-	)
-	downstreamInformer := dynamicinformer.NewFilteredDynamicInformer(c.downstreamDynamicClient, gvr, metav1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, func(o *metav1.ListOptions) {
-		o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
-	})
-
-	for _, handler := range c.upstreamEventHandlers {
-		upstreamInformer.Informer().AddEventHandler(handler(gvr))
+	partialMetadata, err := c.getGVRPartialMetadata(gvr)
+	if err != nil {
+		return err
 	}
 
-	for _, handler := range c.downstreamEventHandlers {
-		downstreamInformer.Informer().AddEventHandler(handler(gvr))
-	}
+	c.gvrs[gvr] = *partialMetadata
 
-	logger.V(2).Info("Start informer for gvr")
-	syncerCtx, cancel := context.WithCancel(ctx)
+	c.notifySubscribers(ctx)
+	return nil
+}
 
-	go downstreamInformer.Informer().Run(syncerCtx.Done())
-	go upstreamInformer.Informer().Run(syncerCtx.Done())
-
-	c.syncerInformerMap[gvr] = &SyncerInformer{
-		cancel:             cancel,
-		UpstreamInformer:   upstreamInformer,
-		DownstreamInformer: downstreamInformer,
-	}
+var builtinGVRs = map[schema.GroupVersionResource]informer.GVRPartialMetadata{
+	{
+		Version:  "v1",
+		Resource: "configmaps",
+	}: {
+		Scope: apiextensionsv1.NamespaceScoped,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Singular: "configMap",
+			Kind:     "configmap",
+		},
+	},
+	{
+		Version:  "v1",
+		Resource: "secrets",
+	}: {
+		Scope: apiextensionsv1.NamespaceScoped,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Singular: "secret",
+			Kind:     "Secret",
+		},
+	},
 }
 
 func getAllGVRs(synctarget *workloadv1alpha1.SyncTarget) map[schema.GroupVersionResource]bool {
 	// TODO(jmprusi): Added Configmaps and Secrets to the default syncing, but we should figure out
 	//                a way to avoid doing that: https://github.com/kcp-dev/kcp/issues/727
-	gvrs := map[schema.GroupVersionResource]bool{
-		{
-			Version:  "v1",
-			Resource: "configmaps",
-		}: true,
-		{
-			Version:  "v1",
-			Resource: "secrets",
-		}: true,
+	gvrs := map[schema.GroupVersionResource]bool{}
+
+	for gvr := range builtinGVRs {
+		gvrs[gvr] = true
 	}
 
-	// TODO(qiujian16) We currently checks the API compaibility on the server side. When we change to check the
+	// TODO(qiujian16) We currently checks the API compatibility on the server side. When we change to check the
 	// compatibility on the syncer side, this part needs to be changed.
 	for _, r := range synctarget.Status.SyncedResources {
 		if r.State != workloadv1alpha1.ResourceSchemaAcceptedState {

--- a/pkg/syncer/shared/finalizer.go
+++ b/pkg/syncer/shared/finalizer.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
-	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,9 +39,9 @@ const (
 	SyncerFinalizerNamePrefix = "workload.kcp.io/syncer-"
 )
 
-func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersionResource, upstreamInformer kcpkubernetesinformers.GenericClusterInformer, upstreamClient kcpdynamic.ClusterInterface, upstreamNamespace, syncTargetKey string, logicalClusterName logicalcluster.Name, resourceName string) error {
+func EnsureUpstreamFinalizerRemoved(ctx context.Context, gvr schema.GroupVersionResource, upstreamLister kcpcache.GenericClusterLister, upstreamClient kcpdynamic.ClusterInterface, upstreamNamespace, syncTargetKey string, logicalClusterName logicalcluster.Name, resourceName string) error {
 	logger := klog.FromContext(ctx)
-	upstreamObjFromLister, err := upstreamInformer.Lister().ByCluster(logicalClusterName).ByNamespace(upstreamNamespace).Get(resourceName)
+	upstreamObjFromLister, err := upstreamLister.ByCluster(logicalClusterName).ByNamespace(upstreamNamespace).Get(resourceName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/syncer/shared/helpers.go
+++ b/pkg/syncer/shared/helpers.go
@@ -71,3 +71,12 @@ func GetDNSID(clusterName logicalcluster.Name, syncTargetUID types.UID, syncTarg
 
 	return fmt.Sprintf("kcp-dns-%s-%s-%s", syncTargetName, uid36hash[:8], workspace36hash[:8])
 }
+
+func ContainsGVR(gvrs []schema.GroupVersionResource, gvr schema.GroupVersionResource) bool {
+	for _, item := range gvrs {
+		if gvr == item {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/syncer/shared/namespace.go
+++ b/pkg/syncer/shared/namespace.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/martinlindhe/base36"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -104,4 +105,8 @@ func PhysicalClusterNamespaceName(l NamespaceLocator) (string, error) {
 	// use 12 chars of the base36hash, should be enough to avoid collisions and
 	// keep the namespaces short enough.
 	return fmt.Sprintf("kcp-%s", base36hash[:12]), nil
+}
+
+func IsNamespace(gvr schema.GroupVersionResource) bool {
+	return gvr.Resource == "namespaces" && gvr.Group == "" && gvr.Version == "v1"
 }

--- a/pkg/syncer/shared/namespace.go
+++ b/pkg/syncer/shared/namespace.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/martinlindhe/base36"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -105,8 +104,4 @@ func PhysicalClusterNamespaceName(l NamespaceLocator) (string, error) {
 	// use 12 chars of the base36hash, should be enough to avoid collisions and
 	// keep the namespaces short enough.
 	return fmt.Sprintf("kcp-%s", base36hash[:12]), nil
-}
-
-func IsNamespace(gvr schema.GroupVersionResource) bool {
-	return gvr.Resource == "namespaces" && gvr.Group == "" && gvr.Version == "v1"
 }

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -19,6 +19,7 @@ package spec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -26,10 +27,10 @@ import (
 	"github.com/go-logr/logr"
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
-	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,18 +40,15 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	listersappsv1 "k8s.io/client-go/listers/apps/v1"
-	listerscorev1 "k8s.io/client-go/listers/core/v1"
-	listersrbacv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
 	"github.com/kcp-dev/kcp/pkg/logging"
-	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
 	"github.com/kcp-dev/kcp/pkg/syncer/shared"
 	"github.com/kcp-dev/kcp/pkg/syncer/spec/dns"
 	specmutators "github.com/kcp-dev/kcp/pkg/syncer/spec/mutators"
@@ -58,9 +56,10 @@ import (
 )
 
 const (
-	controllerName              = "kcp-workload-syncer-spec"
-	byNamespaceLocatorIndexName = "syncer-spec-ByNamespaceLocator"
+	controllerName = "kcp-workload-syncer-spec"
 )
+
+var namespaceGVR schema.GroupVersionResource = corev1.SchemeGroupVersion.WithResource("namespaces")
 
 type Controller struct {
 	queue workqueue.RateLimitingInterface
@@ -68,10 +67,13 @@ type Controller struct {
 	mutators     mutatorGvrMap
 	dnsProcessor *dns.DNSProcessor
 
-	upstreamClient            kcpdynamic.ClusterInterface
-	downstreamClient          dynamic.Interface
-	syncerInformers           resourcesync.SyncerInformerFactory
-	downstreamNSInformer      informers.GenericInformer
+	upstreamClient   kcpdynamic.ClusterInterface
+	downstreamClient dynamic.Interface
+
+	getUpstreamLister                 func(gvr schema.GroupVersionResource) (kcpcache.GenericClusterLister, error)
+	getDownstreamLister               func(gvr schema.GroupVersionResource) (cache.GenericLister, error)
+	listDownstreamNamespacesByLocator func(jsonLocator string) ([]interface{}, error)
+
 	downstreamNSCleaner       shared.Cleaner
 	syncTargetName            string
 	syncTargetClusterName     logicalcluster.Name
@@ -83,16 +85,12 @@ type Controller struct {
 func NewSpecSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluster.Name, syncTargetName, syncTargetKey string,
 	upstreamURL *url.URL, advancedSchedulingEnabled bool,
 	upstreamClient kcpdynamic.ClusterInterface, downstreamClient dynamic.Interface, downstreamKubeClient kubernetes.Interface,
-	upstreamInformers kcpdynamicinformer.DynamicSharedInformerFactory, downstreamInformers dynamicinformer.DynamicSharedInformerFactory, downstreamNSCleaner shared.Cleaner,
-	syncerInformers resourcesync.SyncerInformerFactory,
+	ddsifForUpstreamSyncer *ddsif.DiscoveringDynamicSharedInformerFactory,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	downstreamNSCleaner shared.Cleaner,
 	syncTargetUID types.UID,
-	serviceAccountLister listerscorev1.ServiceAccountLister,
-	roleLister listersrbacv1.RoleLister,
-	roleBindingLister listersrbacv1.RoleBindingLister,
-	deploymentLister listersappsv1.DeploymentLister,
-	serviceLister listerscorev1.ServiceLister,
-	endpointLister listerscorev1.EndpointsLister,
 	dnsNamespace string,
+	syncerNamespaceInformerFactory informers.SharedInformerFactory,
 	dnsImage string) (*Controller, error) {
 	c := Controller{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
@@ -101,7 +99,34 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluste
 		downstreamClient:    downstreamClient,
 		downstreamNSCleaner: downstreamNSCleaner,
 
-		syncerInformers:           syncerInformers,
+		getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			lister, known, synced := ddsifForDownstream.Lister(gvr)
+			if !known {
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			if !synced {
+				return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+			}
+			return lister, nil
+		},
+		getUpstreamLister: func(gvr schema.GroupVersionResource) (kcpcache.GenericClusterLister, error) {
+			lister, known, synced := ddsifForUpstreamSyncer.Lister(gvr)
+			if !known {
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			if !synced {
+				return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+			}
+			return lister, nil
+		},
+
+		listDownstreamNamespacesByLocator: func(jsonLocator string) ([]interface{}, error) {
+			nsInformer, err := ddsifForDownstream.ForResource(namespaceGVR)
+			if err != nil {
+				return nil, err
+			}
+			return nsInformer.Informer().GetIndexer().ByIndex(indexers.ByNamespaceLocatorIndexName, jsonLocator)
+		},
 		syncTargetName:            syncTargetName,
 		syncTargetClusterName:     syncTargetClusterName,
 		syncTargetUID:             syncTargetUID,
@@ -109,127 +134,137 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalcluste
 		advancedSchedulingEnabled: advancedSchedulingEnabled,
 	}
 
-	namespaceGVR := schema.GroupVersionResource{
-		Group:    "",
-		Version:  "v1",
-		Resource: "namespaces",
-	}
-	namespaceLister := downstreamInformers.ForResource(namespaceGVR).Lister()
-
-	err := downstreamInformers.ForResource(namespaceGVR).Informer().AddIndexers(cache.Indexers{byNamespaceLocatorIndexName: indexByNamespaceLocator})
-	if err != nil {
-		return nil, err
-	}
-	c.downstreamNSInformer = downstreamInformers.ForResource(namespaceGVR)
-
 	logger := logging.WithReconciler(syncerLogger, controllerName)
 
-	syncerInformers.AddUpstreamEventHandler(
-		func(gvr schema.GroupVersionResource) cache.ResourceEventHandler {
-			logger.V(2).Info("Set up upstream informer", "gvr", gvr.String())
-			return cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
-					c.AddToQueue(gvr, obj, logger)
-				},
-				UpdateFunc: func(oldObj, newObj interface{}) {
-					oldUnstrob := oldObj.(*unstructured.Unstructured)
-					newUnstrob := newObj.(*unstructured.Unstructured)
+	ddsifForUpstreamSyncer.AddEventHandler(
+		ddsif.GVREventHandlerFuncs{
+			AddFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if shared.IsNamespace(gvr) {
+					return
+				}
+				c.AddToQueue(gvr, obj, logger)
+			},
+			UpdateFunc: func(gvr schema.GroupVersionResource, oldObj, newObj interface{}) {
+				if shared.IsNamespace(gvr) {
+					return
+				}
+				oldUnstrob := oldObj.(*unstructured.Unstructured)
+				newUnstrob := newObj.(*unstructured.Unstructured)
 
-					if !deepEqualApartFromStatus(logger, oldUnstrob, newUnstrob) {
-						c.AddToQueue(gvr, newUnstrob, logger)
-					}
-				},
-				DeleteFunc: func(obj interface{}) {
-					c.AddToQueue(gvr, obj, logger)
-				},
-			}
-		})
+				if !deepEqualApartFromStatus(logger, oldUnstrob, newUnstrob) {
+					c.AddToQueue(gvr, newUnstrob, logger)
+				}
+			},
+			DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if shared.IsNamespace(gvr) {
+					return
+				}
+				c.AddToQueue(gvr, obj, logger)
+			},
+		},
+	)
 
-	syncerInformers.AddDownstreamEventHandler(
-		func(gvr schema.GroupVersionResource) cache.ResourceEventHandler {
-			logger.V(2).Info("Set up downstream informer", "gvr", gvr.String())
-			return cache.ResourceEventHandlerFuncs{
-				DeleteFunc: func(obj interface{}) {
-					key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-					if err != nil {
-						utilruntime.HandleError(fmt.Errorf("error getting key for type %T: %w", obj, err))
+	ddsifForDownstream.AddEventHandler(
+		ddsif.GVREventHandlerFuncs{
+			DeleteFunc: func(gvr schema.GroupVersionResource, obj interface{}) {
+				if shared.IsNamespace(gvr) {
+					return
+				}
+				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("error getting key for type %T: %w", obj, err))
+					return
+				}
+				namespace, name, err := cache.SplitMetaNamespaceKey(key)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("error splitting key %q: %w", key, err))
+				}
+				logger := logging.WithQueueKey(logger, key).WithValues("gvr", gvr, DownstreamNamespace, namespace, DownstreamName, name)
+				logger.V(3).Info("processing delete event")
+
+				var nsLocatorHolder *unstructured.Unstructured
+				var ok bool
+				// Handle namespaced resources
+				if namespace != "" {
+					// Use namespace lister
+					namespaceLister, known, synced := ddsifForDownstream.Lister(namespaceGVR)
+					if !known || !synced {
+						utilruntime.HandleError(errors.New("informer should be up and synced for namespaces in the upstream syncer informer factory"))
 						return
 					}
-					namespace, name, err := cache.SplitMetaNamespaceKey(key)
-					if err != nil {
-						utilruntime.HandleError(fmt.Errorf("error splitting key %q: %w", key, err))
-					}
-					logger := logging.WithQueueKey(logger, key).WithValues("gvr", gvr, DownstreamNamespace, namespace, DownstreamName, name)
-					logger.V(3).Info("processing delete event")
 
-					var nsLocatorHolder *unstructured.Unstructured
-					var ok bool
-					// Handle namespaced resources
-					if namespace != "" {
-						// Use namespace lister
-						nsObj, err := namespaceLister.Get(namespace)
-						if errors.IsNotFound(err) {
-							return
-						}
-						if err != nil {
-							utilruntime.HandleError(err)
-							return
-						}
-						c.downstreamNSCleaner.PlanCleaning(namespace)
-						nsLocatorHolder, ok = nsObj.(*unstructured.Unstructured)
-						if !ok {
-							utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", nsObj))
-							return
-						}
-					} else {
-						// The nsLocatorHolder is in the resource itself for cluster-scoped resources.
-						nsLocatorHolder, ok = obj.(*unstructured.Unstructured)
-						if !ok {
-							utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
-							return
-						}
-					}
-					logger = logging.WithObject(logger, nsLocatorHolder)
-
-					locator, ok := nsLocatorHolder.GetAnnotations()[shared.NamespaceLocatorAnnotation]
-					if !ok {
-						utilruntime.HandleError(fmt.Errorf("unable to find the locator annotation in resource %s", nsLocatorHolder.GetName()))
+					nsObj, err := namespaceLister.Get(namespace)
+					if apierrors.IsNotFound(err) {
 						return
 					}
-					nsLocator := &shared.NamespaceLocator{}
-					err = json.Unmarshal([]byte(locator), nsLocator)
 					if err != nil {
 						utilruntime.HandleError(err)
 						return
 					}
-					logger.V(4).Info("found", "NamespaceLocator", nsLocator)
-					m := &metav1.ObjectMeta{
-						Annotations: map[string]string{
-							logicalcluster.AnnotationKey: nsLocator.ClusterName.String(),
-						},
-						Namespace: nsLocator.Namespace,
-						Name:      shared.GetUpstreamResourceName(gvr, name),
+					c.downstreamNSCleaner.PlanCleaning(namespace)
+					nsLocatorHolder, ok = nsObj.(*unstructured.Unstructured)
+					if !ok {
+						utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", nsObj))
+						return
 					}
-					c.AddToQueue(gvr, m, logger)
-				},
-			}
+				} else {
+					// The nsLocatorHolder is in the resource itself for cluster-scoped resources.
+					nsLocatorHolder, ok = obj.(*unstructured.Unstructured)
+					if !ok {
+						utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", obj))
+						return
+					}
+				}
+				logger = logging.WithObject(logger, nsLocatorHolder)
+
+				locator, ok := nsLocatorHolder.GetAnnotations()[shared.NamespaceLocatorAnnotation]
+				if !ok {
+					utilruntime.HandleError(fmt.Errorf("unable to find the locator annotation in resource %s", nsLocatorHolder.GetName()))
+					return
+				}
+				nsLocator := &shared.NamespaceLocator{}
+				err = json.Unmarshal([]byte(locator), nsLocator)
+				if err != nil {
+					utilruntime.HandleError(err)
+					return
+				}
+				logger.V(4).Info("found", "NamespaceLocator", nsLocator)
+				m := &metav1.ObjectMeta{
+					Annotations: map[string]string{
+						logicalcluster.AnnotationKey: nsLocator.ClusterName.String(),
+					},
+					Namespace: nsLocator.Namespace,
+					Name:      shared.GetUpstreamResourceName(gvr, name),
+				}
+				c.AddToQueue(gvr, m, logger)
+			},
 		})
 
 	secretMutator := specmutators.NewSecretMutator()
 
-	// make sure the secrets informer gets started
-	_ = upstreamInformers.ForResource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}).Informer()
+	dnsServiceLister := syncerNamespaceInformerFactory.Core().V1().Services().Lister()
+
 	deploymentMutator := specmutators.NewDeploymentMutator(upstreamURL, func(clusterName logicalcluster.Name, namespace string) ([]runtime.Object, error) {
-		return upstreamInformers.ForResource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}).Lister().ByCluster(clusterName).ByNamespace(namespace).List(labels.Everything())
-	}, serviceLister, syncTargetClusterName, syncTargetUID, syncTargetName, dnsNamespace)
+		secretLister, known, synced := ddsifForUpstreamSyncer.Lister(corev1.SchemeGroupVersion.WithResource("secrets"))
+		if !known || !synced {
+			return nil, errors.New("informer should be up and synced for namespaces in the upstream syncer informer factory")
+		}
+		return secretLister.ByCluster(clusterName).ByNamespace(namespace).List(labels.Everything())
+	}, dnsServiceLister, syncTargetClusterName, syncTargetUID, syncTargetName, dnsNamespace)
 
 	c.mutators = mutatorGvrMap{
 		deploymentMutator.GVR(): deploymentMutator.Mutate,
 		secretMutator.GVR():     secretMutator.Mutate,
 	}
 
-	c.dnsProcessor = dns.NewDNSProcessor(downstreamKubeClient, serviceAccountLister, roleLister, roleBindingLister, deploymentLister,
-		serviceLister, endpointLister, syncTargetName, syncTargetUID, dnsNamespace, dnsImage)
+	c.dnsProcessor = dns.NewDNSProcessor(downstreamKubeClient,
+		syncerNamespaceInformerFactory.Core().V1().ServiceAccounts().Lister(),
+		syncerNamespaceInformerFactory.Rbac().V1().Roles().Lister(),
+		syncerNamespaceInformerFactory.Rbac().V1().RoleBindings().Lister(),
+		syncerNamespaceInformerFactory.Apps().V1().Deployments().Lister(),
+		dnsServiceLister,
+		syncerNamespaceInformerFactory.Core().V1().Endpoints().Lister(),
+		syncTargetName, syncTargetUID, dnsNamespace, dnsImage)
 
 	return &c, nil
 }
@@ -306,23 +341,4 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	c.queue.Forget(key)
 
 	return true
-}
-
-// indexByNamespaceLocator is a cache.IndexFunc that indexes namespaces by the namespaceLocator annotation.
-func indexByNamespaceLocator(obj interface{}) ([]string, error) {
-	metaObj, ok := obj.(metav1.Object)
-	if !ok {
-		return []string{}, fmt.Errorf("obj is supposed to be a metav1.Object, but is %T", obj)
-	}
-	if loc, found, err := shared.LocatorFromAnnotations(metaObj.GetAnnotations()); err != nil {
-		return []string{}, fmt.Errorf("failed to get locator from annotations: %w", err)
-	} else if !found {
-		return []string{}, nil
-	} else {
-		bs, err := json.Marshal(loc)
-		if err != nil {
-			return []string{}, fmt.Errorf("failed to marshal locator %#v: %w", loc, err)
-		}
-		return []string{string(bs)}, nil
-	}
 }

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -126,7 +126,7 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	var downstreamNamespace string
 	// Only look for the downstream namespace if the resource is namespaced, avoid in case of cluster-scoped.
 	if upstreamNamespace != "" {
-		downstreamNamespaces, err := c.downstreamNSInformer.Informer().GetIndexer().ByIndex(byNamespaceLocatorIndexName, string(jsonNSLocator))
+		downstreamNamespaces, err := c.listDownstreamNamespacesByLocator(string(jsonNSLocator))
 		if err != nil {
 			return nil, err
 		}
@@ -154,16 +154,16 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	logger = logger.WithValues(DownstreamNamespace, downstreamNamespace)
 
 	// get the upstream object
-	syncerInformer, ok := c.syncerInformers.InformerForResource(gvr)
-	if !ok {
-		return nil, nil
-	}
-
-	obj, exists, err := syncerInformer.UpstreamInformer.Informer().GetIndexer().GetByKey(kcpcache.ToClusterAwareKey(clusterName.String(), upstreamNamespace, name))
+	upstreamSyncerLister, err := c.getUpstreamLister(gvr)
 	if err != nil {
 		return nil, err
 	}
-	if !exists {
+
+	obj, err := upstreamSyncerLister.ByCluster(clusterName).ByNamespace(upstreamNamespace).Get(name)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if apierrors.IsNotFound(err) {
 		// deleted upstream => delete downstream
 		logger.Info("Deleting downstream object for upstream object")
 		if downstreamNamespace != "" {
@@ -265,7 +265,12 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 	}
 
 	// Check if the namespace already exists, if not create it.
-	namespace, err := c.downstreamNSInformer.Lister().Get(newNamespace.GetName())
+	namespaceLister, err := c.getDownstreamLister(namespaceGVR)
+	if err != nil {
+		return err
+	}
+
+	namespace, err := namespaceLister.Get(newNamespace.GetName())
 	if apierrors.IsNotFound(err) {
 		_, err = namespaces.Create(ctx, newNamespace, metav1.CreateOptions{})
 		if err == nil {
@@ -299,12 +304,12 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 // TODO(jmprusi): merge with ensureDownstreamNamespaceExists and make it more generic.
 func (c *Controller) clusterWideCollisionCheck(ctx context.Context, gvr schema.GroupVersionResource, upstreamObj *unstructured.Unstructured) error {
 	// Check if the resource already exists, if so check if it has the correct namespace locator.
-	syncerInformer, ok := c.syncerInformers.InformerForResource(gvr)
-	if !ok {
-		return nil
+	downstreamLister, err := c.getDownstreamLister(gvr)
+	if err != nil {
+		return err
 	}
-	resource, err := syncerInformer.DownstreamInformer.Lister().Get(upstreamObj.GetName())
-	if err != nil && apierrors.IsNotFound(err) {
+	resource, err := downstreamLister.Get(upstreamObj.GetName())
+	if apierrors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return err
@@ -378,9 +383,9 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 	// TODO(jmprusi): When using syncer virtual workspace this condition would not be necessary anymore, since directly tested on the virtual workspace side.
 	stillOwnedByExternalActorForLocation := upstreamObj.GetAnnotations()[workloadv1alpha1.ClusterFinalizerAnnotationPrefix+c.syncTargetKey] != ""
 
-	syncerInformer, ok := c.syncerInformers.InformerForResource(gvr)
-	if !ok {
-		return nil
+	upstreamSyncerLister, err := c.getUpstreamLister(gvr)
+	if err != nil {
+		return err
 	}
 
 	logger = logger.WithValues(DownstreamName, transformedName)
@@ -398,7 +403,7 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 			if apierrors.IsNotFound(err) {
 				// That's not an error.
 				// Just think about removing the finalizer from the KCP location-specific resource:
-				return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, syncerInformer.UpstreamInformer, c.upstreamClient, upstreamObj.GetNamespace(), c.syncTargetKey, upstreamObjLogicalCluster, upstreamObj.GetName())
+				return shared.EnsureUpstreamFinalizerRemoved(ctx, gvr, upstreamSyncerLister, c.upstreamClient, upstreamObj.GetNamespace(), c.syncTargetKey, upstreamObjLogicalCluster, upstreamObj.GetName())
 			}
 			logger.Error(err, "Error deleting upstream resource from downstream")
 			return err

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -132,14 +132,14 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 		}
 
 		if len(downstreamNamespaces) == 1 {
-			namespace := downstreamNamespaces[0].(*unstructured.Unstructured)
+			namespace := downstreamNamespaces[0]
 			logger.WithValues(DownstreamName, namespace.GetName()).V(4).Info("Found downstream namespace for upstream namespace")
 			downstreamNamespace = namespace.GetName()
 		} else if len(downstreamNamespaces) > 1 {
 			// This should never happen unless there's some namespace collision.
 			var namespacesCollisions []string
 			for _, namespace := range downstreamNamespaces {
-				namespacesCollisions = append(namespacesCollisions, namespace.(*unstructured.Unstructured).GetName())
+				namespacesCollisions = append(namespacesCollisions, namespace.GetName())
 			}
 			return nil, fmt.Errorf("(namespace collision) found multiple downstream namespaces: %s for upstream namespace %s|%s", strings.Join(namespacesCollisions, ","), clusterName, upstreamNamespace)
 		} else {
@@ -264,12 +264,12 @@ func (c *Controller) ensureDownstreamNamespaceExists(ctx context.Context, downst
 		})
 	}
 
-	// Check if the namespace already exists, if not create it.
 	namespaceLister, err := c.getDownstreamLister(namespaceGVR)
 	if err != nil {
 		return err
 	}
 
+	// Check if the namespace already exists, if not create it.
 	namespace, err := namespaceLister.Get(newNamespace.GetName())
 	if apierrors.IsNotFound(err) {
 		_, err = namespaces.Create(ctx, newNamespace, metav1.CreateOptions{})

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -1179,13 +1179,13 @@ func TestSpecSyncerProcess(t *testing.T) {
 				<-downstreamDDSIFUpdated
 				t.Logf("%s: downstream ddsif synced", t.Name())
 
-				_, unsynced := ddsifForUpstreamSyncer.Listers()
+				_, unsynced := ddsifForUpstreamSyncer.Informers()
 				for _, gvr := range unsynced {
 					informer, _ := ddsifForUpstreamSyncer.ForResource(gvr)
 					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
 					t.Logf("%s: upstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
 				}
-				_, unsynced = ddsifForDownstream.Listers()
+				_, unsynced = ddsifForDownstream.Informers()
 				for _, gvr := range unsynced {
 					informer, _ := ddsifForDownstream.ForResource(gvr)
 					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)

--- a/pkg/syncer/spec/spec_process_test.go
+++ b/pkg/syncer/spec/spec_process_test.go
@@ -21,13 +21,12 @@ import (
 	"encoding/json"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
-	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
-	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +35,7 @@ import (
 	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,15 +43,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
 	"github.com/kcp-dev/kcp/pkg/syncer/spec/dns"
 )
 
@@ -64,16 +65,21 @@ func init() {
 }
 
 type mockedCleaner struct {
+	lock    sync.Mutex
 	toClean sets.String
 }
 
 func (c *mockedCleaner) PlanCleaning(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.toClean.Insert(key)
 }
 
 // CancelCleaning removes the key from the list of keys to be cleaned up.
 // If it wasn't planned for deletion, it does nothing.
 func (c *mockedCleaner) CancelCleaning(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.toClean.Delete(key)
 }
 
@@ -472,6 +478,60 @@ func TestDeepEqualApartFromStatus(t *testing.T) {
 	}
 }
 
+var _ ddsif.GVRSource = (*mockedGVRSource)(nil)
+
+type mockedGVRSource struct {
+}
+
+func (s *mockedGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	return map[schema.GroupVersionResource]ddsif.GVRPartialMetadata{
+		appsv1.SchemeGroupVersion.WithResource("deployments"): {
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "deployment",
+				Kind:     "Deployment",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "namespaces",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "configmaps",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "configmap",
+				Kind:     "ConfigMap",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "secrets",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "secret",
+				Kind:     "Secret",
+			},
+		},
+	}
+}
+
+func (s *mockedGVRSource) Ready() bool {
+	return true
+}
+
+func (s *mockedGVRSource) Subscribe() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
 func TestSpecSyncerProcess(t *testing.T) {
 	tests := map[string]struct {
 		fromNamespace *corev1.Namespace
@@ -489,9 +549,10 @@ func TestSpecSyncerProcess(t *testing.T) {
 		syncTargetUID             types.UID
 		advancedSchedulingEnabled bool
 
-		expectError         bool
-		expectActionsOnFrom []kcptesting.Action
-		expectActionsOnTo   []clienttesting.Action
+		expectError             bool
+		expectActionsOnFrom     []kcptesting.Action
+		expectActionsOnTo       []clienttesting.Action
+		expectNSCleaningPlanned []string
 	}{
 		"SpecSyncer sync deployment to downstream, upstream gets patched with the finalizer and the object is not created downstream (will be in the next reconciliation)": {
 			upstreamLogicalCluster: "root:org:ws",
@@ -608,7 +669,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 				),
 			},
 		},
-		"SpecSyncer upstream resource has the state workload annotation removed, expect deletion downstream": {
+		"SpecSyncer upstream resource has been removed, expect deletion downstream": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "root:org:ws", map[string]string{
 				"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
@@ -622,7 +683,23 @@ func TestSpecSyncerProcess(t *testing.T) {
 						"token":     []byte("token"),
 						"namespace": []byte("namespace"),
 					}),
-				deployment("theDeployment", "test", "root:org:ws", nil, nil, nil),
+			},
+			toResources: []runtime.Object{
+				namespace("kcp-33jbiactwhg0", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				},
+					map[string]string{
+						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
+					}),
+				deployment("theDeployment", "kcp-33jbiactwhg0", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				}, nil, []string{"workload.kcp.io/syncer-6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g"}),
+				dns.MakeServiceAccount("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRole("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeRoleBinding("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				dns.MakeDeployment("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n", "dnsimage"),
+				service("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
+				endpoints("kcp-dns-us-west1-1nuzj7pw-2fcy2vpi", "kcp-01c0zzvlqsi7n"),
 			},
 			resourceToProcessLogicalClusterName: "root:org:ws",
 			resourceToProcessName:               "theDeployment",
@@ -635,6 +712,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 					"kcp-33jbiactwhg0",
 				),
 			},
+			expectNSCleaningPlanned: []string{"kcp-33jbiactwhg0"},
 		},
 		"SpecSyncer deletion: object exist downstream": {
 			upstreamLogicalCluster: "root:org:ws",
@@ -644,7 +722,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
-					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -683,6 +761,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 					"kcp-33jbiactwhg0",
 				),
 			},
+			expectNSCleaningPlanned: []string{"kcp-33jbiactwhg0"},
 		},
 		"SpecSyncer deletion: object does not exists downstream, upstream finalizer should be removed": {
 			upstreamLogicalCluster: "root:org:ws",
@@ -692,7 +771,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
-					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -750,8 +829,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
-					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
-					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -918,8 +996,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			},
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
-					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
-					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				}, map[string]string{
 					"kcp.io/namespace-locator": `{"syncTarget":{"cluster":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"ANOTHERNAMESPACE"}`,
 				}),
@@ -951,8 +1028,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			},
 			toResources: []runtime.Object{
 				namespace("kcp-33jbiactwhg0", "", map[string]string{
-					"internal.workload.kcp.io/cluster":                             "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
-					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				}, map[string]string{},
 				),
 			},
@@ -971,7 +1047,7 @@ func TestSpecSyncerProcess(t *testing.T) {
 			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
 			toResources: []runtime.Object{
 				namespace("kcp-01c0zzvlqsi7n", "", map[string]string{
-					"state.workload.kcp.io/6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Sync",
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				},
 					map[string]string{
 						"kcp.io/namespace-locator": `{"syncTarget":{"path":"root:org:ws","name":"us-west1","uid":"syncTargetUID"},"cluster":"root:org:ws","namespace":"test"}`,
@@ -1045,27 +1121,40 @@ func TestSpecSyncerProcess(t *testing.T) {
 			toClient := dynamicfake.NewSimpleDynamicClient(scheme, tc.toResources...)
 			toKubeClient := kubefake.NewSimpleClientset(tc.toResources...)
 
-			fromInformers := kcpdynamicinformer.NewFilteredDynamicSharedInformerFactory(fromClusterClient, time.Hour, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + syncTargetKey + "=" + string(workloadv1alpha1.ResourceStateSync)
-			})
-			toInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(toClient, time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + syncTargetKey + "=" + string(workloadv1alpha1.ResourceStateSync)
-			})
+			ddsifForUpstreamSyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(fromClusterClient, nil, nil, &mockedGVRSource{}, cache.Indexers{})
+			require.NoError(t, err)
+
+			ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(toClient, nil,
+				func(o *metav1.ListOptions) {
+					o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+				},
+				&mockedGVRSource{},
+				cache.Indexers{
+					indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+				},
+			)
+			require.NoError(t, err)
+
+			var cacheSyncsForAlwaysRequiredGVRs []cache.InformerSynced
+			for _, alwaysRequired := range []string{"secrets", "namespaces"} {
+				if informer, err := ddsifForUpstreamSyncer.ForResource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: alwaysRequired}); err != nil {
+					require.NoError(t, err)
+				} else {
+					cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+				}
+				if informer, err := ddsifForDownstream.ForResource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: alwaysRequired}); err != nil {
+					require.NoError(t, err)
+				} else {
+					cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+				}
+			}
 
 			setupServersideApplyPatchReactor(toClient)
 			resourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClusterClient)
 
-			fakeInformers := newFakeSyncerInformers(tc.gvr, fromInformers, toInformers)
-
 			// toInformerFactory to watch some DNS-related resources in the dns namespace
 			toInformerFactory := informers.NewSharedInformerFactoryWithOptions(toKubeClient, time.Hour,
 				informers.WithNamespace("kcp-01c0zzvlqsi7n"))
-			serviceAccountLister := toInformerFactory.Core().V1().ServiceAccounts().Lister()
-			roleLister := toInformerFactory.Rbac().V1().Roles().Lister()
-			roleBindingLister := toInformerFactory.Rbac().V1().RoleBindings().Lister()
-			deploymentLister := toInformerFactory.Apps().V1().Deployments().Lister()
-			serviceLister := toInformerFactory.Core().V1().Services().Lister()
-			endpointLister := toInformerFactory.Core().V1().Endpoints().Lister()
 
 			upstreamURL, err := url.Parse("https://kcp.io:6443")
 			require.NoError(t, err)
@@ -1074,19 +1163,50 @@ func TestSpecSyncerProcess(t *testing.T) {
 				toClean: sets.String{},
 			}
 			controller, err := NewSpecSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, upstreamURL, tc.advancedSchedulingEnabled,
-				fromClusterClient, toClient, toKubeClient, fromInformers, toInformers, mockedCleaner, fakeInformers, syncTargetUID,
-				serviceAccountLister, roleLister, roleBindingLister, deploymentLister, serviceLister, endpointLister, "kcp-01c0zzvlqsi7n", "dnsimage")
+				fromClusterClient, toClient, toKubeClient, ddsifForUpstreamSyncer, ddsifForDownstream, mockedCleaner, syncTargetUID,
+				"kcp-01c0zzvlqsi7n", toInformerFactory, "dnsimage")
 			require.NoError(t, err)
 
-			fromInformers.Start(ctx.Done())
-			toInformers.Start(ctx.Done())
 			toInformerFactory.Start(ctx.Done())
-
-			fromInformers.WaitForCacheSync(ctx.Done())
-			toInformers.WaitForCacheSync(ctx.Done())
 			toInformerFactory.WaitForCacheSync(ctx.Done())
 
+			gvrsUpdated := make(chan struct{})
+			upstreamSyncerDDSIFUpdated := ddsifForDownstream.Subscribe("upstreamSyncer")
+			downstreamDDSIFUpdated := ddsifForDownstream.Subscribe("downstream")
+			go func() {
+				<-upstreamSyncerDDSIFUpdated
+				t.Logf("%s: upstream ddsif synced", t.Name())
+				<-downstreamDDSIFUpdated
+				t.Logf("%s: downstream ddsif synced", t.Name())
+
+				_, unsynced := ddsifForUpstreamSyncer.Listers()
+				for _, gvr := range unsynced {
+					informer, _ := ddsifForUpstreamSyncer.ForResource(gvr)
+					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
+					t.Logf("%s: upstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
+				}
+				_, unsynced = ddsifForDownstream.Listers()
+				for _, gvr := range unsynced {
+					informer, _ := ddsifForDownstream.ForResource(gvr)
+					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
+					t.Logf("%s: downstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
+				}
+				t.Logf("%s: gvrs updated", t.Name())
+				gvrsUpdated <- struct{}{}
+			}()
+
+			ddsifForUpstreamSyncer.Start(ctx.Done())
+			ddsifForDownstream.Start(ctx.Done())
+
+			go ddsifForUpstreamSyncer.StartWorker(ctx)
+			go ddsifForDownstream.StartWorker(ctx)
+
 			<-resourceWatcherStarted
+
+			cache.WaitForCacheSync(ctx.Done(), cacheSyncsForAlwaysRequiredGVRs...)
+			t.Logf("%s: secrets and namespaces informers synced", t.Name())
+
+			<-gvrsUpdated
 
 			fromClusterClient.ClearActions()
 			toClient.ClearActions()
@@ -1103,6 +1223,13 @@ func TestSpecSyncerProcess(t *testing.T) {
 			}
 			assert.Empty(t, cmp.Diff(tc.expectActionsOnFrom, fromClusterClient.Actions(), cmp.AllowUnexported(logicalcluster.Path{})))
 			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClient.Actions()))
+			mockedCleaner.lock.Lock()
+			defer mockedCleaner.lock.Unlock()
+			if tc.expectNSCleaningPlanned != nil {
+				assert.Equal(t, tc.expectNSCleaningPlanned, mockedCleaner.toClean.List())
+			} else {
+				assert.Equal(t, []string{}, mockedCleaner.toClean.List())
+			}
 		})
 	}
 }
@@ -1372,30 +1499,3 @@ func patchSecretSingleClusterAction(name, namespace string, patchType types.Patc
 		Patch:      patch,
 	}
 }
-
-type fakeSyncerInformers struct {
-	upstreamInformer   kcpkubernetesinformers.GenericClusterInformer
-	downStreamInformer informers.GenericInformer
-}
-
-func newFakeSyncerInformers(gvr schema.GroupVersionResource, upstreamInformers kcpdynamicinformer.DynamicSharedInformerFactory, downStreamInformers dynamicinformer.DynamicSharedInformerFactory) *fakeSyncerInformers {
-	return &fakeSyncerInformers{
-		upstreamInformer:   upstreamInformers.ForResource(gvr),
-		downStreamInformer: downStreamInformers.ForResource(gvr),
-	}
-}
-
-func (f *fakeSyncerInformers) AddUpstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
-}
-func (f *fakeSyncerInformers) AddDownstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
-}
-func (f *fakeSyncerInformers) InformerForResource(gvr schema.GroupVersionResource) (*resourcesync.SyncerInformer, bool) {
-	return &resourcesync.SyncerInformer{
-		UpstreamInformer:   f.upstreamInformer,
-		DownstreamInformer: f.downStreamInformer,
-	}, true
-}
-func (f *fakeSyncerInformers) SyncableGVRs() (map[schema.GroupVersionResource]*resourcesync.SyncerInformer, error) {
-	return map[schema.GroupVersionResource]*resourcesync.SyncerInformer{{Group: "apps", Version: "v1", Resource: "deployments"}: nil}, nil
-}
-func (f *fakeSyncerInformers) Start(ctx context.Context, numThreads int) {}

--- a/pkg/syncer/status/status_controller.go
+++ b/pkg/syncer/status/status_controller.go
@@ -81,7 +81,7 @@ func NewStatusSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalclus
 				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
 			}
 			if !synced {
-				return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+				return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory - should retry", gvr)
 			}
 			return lister, nil
 		},
@@ -91,7 +91,7 @@ func NewStatusSyncer(syncerLogger logr.Logger, syncTargetClusterName logicalclus
 				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
 			}
 			if !synced {
-				return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+				return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory -  should retry", gvr)
 			}
 			return lister, nil
 		},

--- a/pkg/syncer/status/status_process.go
+++ b/pkg/syncer/status/status_process.go
@@ -158,6 +158,10 @@ func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResourc
 	ctx = klog.NewContext(ctx, logger)
 
 	upstreamLister, err := c.getUpstreamLister(gvr)
+	if err != nil {
+		return err
+	}
+
 	if !resourceExists {
 		logger.Info("Downstream object does not exist. Removing finalizer on upstream object")
 		if err != nil {

--- a/pkg/syncer/status/status_process_test.go
+++ b/pkg/syncer/status/status_process_test.go
@@ -636,13 +636,13 @@ func TestStatusSyncerProcess(t *testing.T) {
 				<-downstreamDDSIFUpdated
 				t.Logf("%s: downstream ddsif synced", t.Name())
 
-				_, unsynced := ddsifForUpstreamSyncer.Listers()
+				_, unsynced := ddsifForUpstreamSyncer.Informers()
 				for _, gvr := range unsynced {
 					informer, _ := ddsifForUpstreamSyncer.ForResource(gvr)
 					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
 					t.Logf("%s: upstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
 				}
-				_, unsynced = ddsifForDownstream.Listers()
+				_, unsynced = ddsifForDownstream.Informers()
 				for _, gvr := range unsynced {
 					informer, _ := ddsifForDownstream.ForResource(gvr)
 					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)

--- a/test/e2e/conformance/cross_logical_cluster_list_test.go
+++ b/test/e2e/conformance/cross_logical_cluster_list_test.go
@@ -253,15 +253,15 @@ func TestCRDCrossLogicalClusterListPartialObjectMetadata(t *testing.T) {
 	t.Logf("Wait for the sheriff to show up in the informer")
 	// key := "default/" + client.ToClusterAwareKey(wsNormalCRD1a, "john-hicks-adams")
 	require.Eventually(t, func() bool {
-		listers, _ := informerFactory.Listers()
+		informers, _ := informerFactory.Informers()
 
-		lister := listers[sheriffsGVR]
-		if lister == nil {
+		informer := informers[sheriffsGVR]
+		if informer == nil {
 			t.Logf("Waiting for sheriffs to show up in dynamic informer")
 			return false
 		}
 
-		l, err := lister.List(labels.Everything())
+		l, err := informer.Lister().List(labels.Everything())
 		if err != nil {
 			t.Logf("Error listing sheriffs: %v", err)
 			return false


### PR DESCRIPTION
## Summary

PROOF PR of a refactoring of the Syncer to use common ddsif informer factories for all the Syncer + other controllers.
It also includes a controller manager, which allows starting / stopping GVR-specific controllers when new GVRs are supported in the list of Synced resources.

It is based on the work done on the ddsif in PR https://github.com/kcp-dev/kcp/pull/2440

## Related issue(s)

No related issue. But it is a pre-requisite to the merge of PRs like https://github.com/kcp-dev/kcp/pull/2338
