### PR TITLE
🐛Syncer: Remaining fixes on downstream namespace cleaning

### DIFF
--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -169,11 +169,11 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetWorkspace logicalcluster.
 					if namespace != "" {
 						// Use namespace lister
 						nsObj, err := namespaceLister.Get(namespace)
-						if err != nil && !errors.IsNotFound(err) {
-							utilruntime.HandleError(err)
+						if errors.IsNotFound(err) {
 							return
 						}
-						if errors.IsNotFound(err) {
+						if err != nil {
+							utilruntime.HandleError(err)
 							return
 						}
 						c.downstreamNSCleaner.PlanCleaning(namespace)

--- a/pkg/syncer/spec/spec_controller.go
+++ b/pkg/syncer/spec/spec_controller.go
@@ -29,6 +29,7 @@ import (
 	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
 	"github.com/kcp-dev/logicalcluster/v2"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -168,10 +169,14 @@ func NewSpecSyncer(syncerLogger logr.Logger, syncTargetWorkspace logicalcluster.
 					if namespace != "" {
 						// Use namespace lister
 						nsObj, err := namespaceLister.Get(namespace)
-						if err != nil {
+						if err != nil && !errors.IsNotFound(err) {
 							utilruntime.HandleError(err)
 							return
 						}
+						if errors.IsNotFound(err) {
+							return
+						}
+						c.downstreamNSCleaner.PlanCleaning(namespace)
 						nsLocatorHolder, ok = nsObj.(*unstructured.Unstructured)
 						if !ok {
 							utilruntime.HandleError(fmt.Errorf("unexpected object type: %T", nsObj))


### PR DESCRIPTION
## Summary

This Remaining fixes on downstream namespace cleaning in the Syncer

## Related issues

No dedicated issue.
This fixes issues found in the code when working on issue https://github.com/kcp-dev/kcp/issues/2358
