### PR TITLE
🐛 Syncer: add 'get' permission on downstream namespaces

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -56,6 +56,7 @@ rules:
   - namespaces
   verbs:
   - "create"
+  - "get"
   - "list"
   - "watch"
   - "delete"
@@ -285,6 +286,7 @@ rules:
   - namespaces
   verbs:
   - "create"
+  - "get"
   - "list"
   - "watch"
   - "delete"

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -30,6 +30,7 @@ rules:
   - namespaces
   verbs:
   - "create"
+  - "get"
   - "list"
   - "watch"
   - "delete"


### PR DESCRIPTION
## Summary

In some cases, especially when some concurrency occurs while creating the downstream namespace, the [syncer might need to `get` a just-created namespace](https://github.com/kcp-dev/kcp/blob/2d0e18c790b0d882ebb817c713c6301350f60bfa/pkg/syncer/spec/spec_process.go#L277).
But currently the `syncer` service account isn't granted the `get` permission on downstream namespaces, though it is granted both `list` and `watch`. This PR adds the `get` verb to the syncer cluster role.

## Related issue(s)

No related issue. Bug identified during the tests of another PR.