### PR TITLE
🌱 pkg/authorization: add delegation reason in audit

### DIFF
--- a/pkg/authorization/bootstrap_policy_authorizer.go
+++ b/pkg/authorization/bootstrap_policy_authorizer.go
@@ -29,11 +29,11 @@ import (
 )
 
 type BootstrapPolicyAuthorizer struct {
-	delegate *rbac.RBACAuthorizer
+	bootstrapPolicy *rbac.RBACAuthorizer
 }
 
 func NewBootstrapPolicyAuthorizer(informers kcpkubernetesinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver) {
-	a := &BootstrapPolicyAuthorizer{delegate: rbac.New(
+	a := &BootstrapPolicyAuthorizer{bootstrapPolicy: rbac.New(
 		&rbac.RoleGetter{Lister: informers.Rbac().V1().Roles().Lister().Cluster(genericcontrolplane.LocalAdminCluster)},
 		&rbac.RoleBindingLister{Lister: informers.Rbac().V1().RoleBindings().Lister().Cluster(genericcontrolplane.LocalAdminCluster)},
 		&rbac.ClusterRoleGetter{Lister: informers.Rbac().V1().ClusterRoles().Lister().Cluster(genericcontrolplane.LocalAdminCluster)},
@@ -44,13 +44,13 @@ func NewBootstrapPolicyAuthorizer(informers kcpkubernetesinformers.SharedInforme
 }
 
 func (a *BootstrapPolicyAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
-	dec, reason, err := a.delegate.Authorize(ctx, attr)
+	dec, reason, err := a.bootstrapPolicy.Authorize(ctx, attr)
 	if err != nil {
 		err = fmt.Errorf("error authorizing bootstrap policy: %w", err)
 	}
-	return dec, fmt.Sprintf("bootstrap policy reason: %v", reason), err
+	return dec, fmt.Sprintf("bootstrap policy: %v", reason), err
 }
 
 func (a *BootstrapPolicyAuthorizer) RulesFor(ctx context.Context, user user.Info, namespace string) ([]authorizer.ResourceRuleInfo, []authorizer.NonResourceRuleInfo, bool, error) {
-	return a.delegate.RulesFor(ctx, user, namespace)
+	return a.bootstrapPolicy.RulesFor(ctx, user, namespace)
 }

--- a/pkg/authorization/decorator_test.go
+++ b/pkg/authorization/decorator_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorization
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	auditapis "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+func TestDecorator(t *testing.T) {
+	alwaysAllow := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionAllow, "unanonymized allow", nil
+	})
+	alwaysDeny := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionDeny, "unanonymized denial", nil
+	})
+	alwaysNoOpinion := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionNoOpinion, "unanonymized no-opinion", nil
+	})
+	alwaysError := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		return authorizer.DecisionNoOpinion, "unanonymized failure", errors.New("unanonymized error")
+	})
+
+	for name, tc := range map[string]struct {
+		authz        authorizer.Authorizer
+		wantDecision authorizer.Decision
+		wantAudit    map[string]string
+		wantReason   string
+	}{
+		"topAllows": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "top: access granted",
+
+			wantAudit: map[string]string{
+				"top/decision": "Allowed",
+				"top/reason":   "unanonymized allow",
+			},
+		},
+		"topAllowsWithoutReasonAnnotation": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "access granted",
+
+			wantAudit: map[string]string{
+				"top/decision": "Allowed",
+				"top/reason":   "unanonymized allow",
+			},
+		},
+		"topAllowsWithoutReasonAnnotationWithoutAnonymization": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "unanonymized allow",
+
+			wantAudit: map[string]string{
+				"top/decision": "Allowed",
+				"top/reason":   "unanonymized allow",
+			},
+		},
+		"topAllowsWithoutReasonAnnotationWithoutAnonymizationWithoutAuditLogging": {
+			authz: NewDecorator("top", alwaysAllow),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "unanonymized allow",
+
+			wantAudit: nil,
+		},
+		"topDelegatesToAllow": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-bottom",
+					NewDecorator("bottom", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "access granted",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Allowed",
+				"bottom/reason":   "unanonymized allow",
+
+				"top/decision": "Allowed",
+				"top/reason":   "delegating due to top-to-bottom: bottom: access granted",
+			},
+		},
+		"topDelegatesToDeny": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-bottom",
+					NewDecorator("bottom", alwaysDeny).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionDeny,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Denied",
+				"bottom/reason":   "unanonymized denial",
+
+				"top/decision": "Denied",
+				"top/reason":   "delegating due to top-to-bottom: bottom: access denied",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToDeny": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysDeny).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionDeny,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Denied",
+				"bottom/reason":   "unanonymized denial",
+
+				"middle/decision": "Denied",
+				"middle/reason":   "delegating due to middle-to-bottom: bottom: access denied",
+
+				"top/decision": "Denied",
+				"top/reason":   "delegating due to top-to-middle: middle: access denied",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToAllow": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "access granted",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "Allowed",
+				"bottom/reason":   "unanonymized allow",
+
+				"middle/decision": "Allowed",
+				"middle/reason":   "delegating due to middle-to-bottom: bottom: access granted",
+
+				"top/decision": "Allowed",
+				"top/reason":   "delegating due to top-to-middle: middle: access granted",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToNoOpinion": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysNoOpinion).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "NoOpinion",
+				"bottom/reason":   "unanonymized no-opinion",
+
+				"middle/decision": "NoOpinion",
+				"middle/reason":   "delegating due to middle-to-bottom: bottom: access denied",
+
+				"top/decision": "NoOpinion",
+				"top/reason":   "delegating due to top-to-middle: middle: access denied",
+			},
+		},
+		"topDelegatesToDelegateDelegatesToError": {
+			authz: NewDecorator("top",
+				DelegateAuthorization("top-to-middle", NewDecorator("middle",
+					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysError).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
+			).AddAuditLogging().AddAnonymization(),
+
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "access denied",
+
+			wantAudit: map[string]string{
+				"bottom/decision": "NoOpinion",
+				"bottom/reason":   "reason: unanonymized failure, error: unanonymized error",
+
+				"middle/decision": "NoOpinion",
+				"middle/reason":   "reason: delegating due to middle-to-bottom: bottom: access denied, error: unanonymized error",
+
+				"top/decision": "NoOpinion",
+				"top/reason":   "reason: delegating due to top-to-middle: middle: access denied, error: unanonymized error",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := audit.WithAuditContext(context.Background(), newAuditContext(auditapis.LevelMetadata))
+			attr := authorizer.AttributesRecord{}
+			dec, reason, _ := tc.authz.Authorize(ctx, attr)
+			if dec != tc.wantDecision {
+				t.Errorf("want decision %v got %v", tc.wantDecision, dec)
+			}
+			ev := audit.AuditEventFrom(ctx)
+			if diff := cmp.Diff(tc.wantAudit, ev.Annotations); diff != "" {
+				t.Errorf("audit log annotations differ: %v", diff)
+			}
+			if tc.wantReason != reason {
+				t.Errorf("want reason %q, got %q", tc.wantReason, reason)
+			}
+		})
+	}
+}
+
+func newAuditContext(l auditapis.Level) *audit.AuditContext {
+	return &audit.AuditContext{
+		Event: &auditapis.Event{
+			Level: l,
+		},
+	}
+}

--- a/pkg/authorization/local_authorizer.go
+++ b/pkg/authorization/local_authorizer.go
@@ -78,5 +78,5 @@ func (a *LocalAuthorizer) Authorize(ctx context.Context, attr authorizer.Attribu
 	if err != nil {
 		err = fmt.Errorf("error authorizing local policy for cluster %q: %w", cluster.Name, err)
 	}
-	return dec, fmt.Sprintf("local policy for cluster %q reason: %v", cluster.Name, reason), err
+	return dec, fmt.Sprintf("local cluster %q policy: %v", cluster.Name, reason), err
 }

--- a/pkg/authorization/maximal_permission_policy_authorizer.go
+++ b/pkg/authorization/maximal_permission_policy_authorizer.go
@@ -36,10 +36,6 @@ import (
 	rbacwrapper "github.com/kcp-dev/kcp/pkg/virtual/framework/wrappers/rbac"
 )
 
-const (
-	MaximalPermissionPolicyAccessNotPermittedReason = "access not permitted by maximal permission policy"
-)
-
 // NewMaximalPermissionPolicyAuthorizer returns an authorizer that first checks if the request is for a
 // bound resource or not. If the resource is bound it checks the maximal permission policy of the underlying API export.
 func NewMaximalPermissionPolicyAuthorizer(kubeInformers kcpkubernetesinformers.SharedInformerFactory, kcpInformers kcpinformers.SharedInformerFactory, delegate authorizer.Authorizer) authorizer.Authorizer {
@@ -87,27 +83,27 @@ type MaximalPermissionPolicyAuthorizer struct {
 func (a *MaximalPermissionPolicyAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
 	if IsDeepSubjectAccessReviewFrom(ctx, attr) {
 		// this is a deep SAR request, we have to skip the checks here and delegate to the subsequent authorizer.
-		return a.delegate.Authorize(ctx, attr)
+		return DelegateAuthorization("deep SAR request", a.delegate).Authorize(ctx, attr)
 	}
 
 	// get the cluster from the ctx.
 	lcluster, err := genericapirequest.ClusterNameFrom(ctx)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, MaximalPermissionPolicyAccessNotPermittedReason, fmt.Errorf("error getting cluster from request: %w", err)
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error getting cluster from request: %w", err)
 	}
 
 	bindingLogicalCluster, bound, err := a.getAPIBindingReferenceForAttributes(attr, lcluster)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, MaximalPermissionPolicyAccessNotPermittedReason, fmt.Errorf("error getting API binding reference: %w", err)
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error getting API binding reference: %w", err)
 	}
 
 	if !bound {
-		return a.delegate.Authorize(ctx, attr)
+		return DelegateAuthorization("unbound resource", a.delegate).Authorize(ctx, attr)
 	}
 
 	apiExport, found, err := a.getAPIExportByReference(bindingLogicalCluster)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, MaximalPermissionPolicyAccessNotPermittedReason, fmt.Errorf("error getting API export: %w", err)
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error getting API export: %w", err)
 	}
 
 	path := "unknown"
@@ -123,11 +119,11 @@ func (a *MaximalPermissionPolicyAuthorizer) Authorize(ctx context.Context, attr 
 	}
 
 	if apiExport.Spec.MaximalPermissionPolicy == nil {
-		return a.delegate.Authorize(ctx, attr)
+		return DelegateAuthorization(fmt.Sprintf("no maximum permission policy in API Export %q|%q", logicalcluster.From(apiExport), apiExport.Name), a.delegate).Authorize(ctx, attr)
 	}
 
 	if apiExport.Spec.MaximalPermissionPolicy.Local == nil {
-		return a.delegate.Authorize(ctx, attr)
+		return DelegateAuthorization(fmt.Sprintf("no local maximum permission policy in API Export %q|%q", logicalcluster.From(apiExport), apiExport.Name), a.delegate).Authorize(ctx, attr)
 	}
 
 	// If bound, create a rbac authorizer filtered to the cluster.
@@ -140,14 +136,14 @@ func (a *MaximalPermissionPolicyAuthorizer) Authorize(ctx context.Context, attr 
 		userInfo.Groups = append(userInfo.Groups, apisv1alpha1.MaximalPermissionPolicyRBACUserGroupPrefix+g)
 	}
 	dec, reason, err := clusterAuthorizer.Authorize(ctx, prefixedAttr)
+	reason = fmt.Sprintf("API export %q|%q policy: %v", logicalcluster.From(apiExport), apiExport.Name, reason)
 	if err != nil {
-		return authorizer.DecisionNoOpinion, reason, fmt.Errorf("error authorizing RBAC in API export cluster %q: %w", logicalcluster.From(apiExport), err)
+		return authorizer.DecisionNoOpinion, reason, fmt.Errorf("error authorizing API export cluster RBAC policy: %w", err)
 	}
-
 	if dec == authorizer.DecisionAllow {
-		return a.delegate.Authorize(ctx, attr)
+		return DelegateAuthorization(reason, a.delegate).Authorize(ctx, attr)
 	}
-	return authorizer.DecisionNoOpinion, fmt.Sprintf("API export cluster %q reason: %v", logicalcluster.From(apiExport), reason), nil
+	return authorizer.DecisionNoOpinion, reason, nil
 }
 
 func getAPIBindingReferenceForAttributes(apiBindingClusterLister apisv1alpha1listers.APIBindingClusterLister, attr authorizer.Attributes, clusterName logicalcluster.Name) (*apisv1alpha1.ExportReference, bool, error) {

--- a/pkg/authorization/system_crd_authorizer.go
+++ b/pkg/authorization/system_crd_authorizer.go
@@ -50,5 +50,5 @@ func (a *SystemCRDAuthorizer) Authorize(ctx context.Context, attr authorizer.Att
 		}
 	}
 
-	return a.delegate.Authorize(ctx, attr)
+	return DelegateAuthorization("no system CRD violation", a.delegate).Authorize(ctx, attr)
 }

--- a/pkg/authorization/workspace_content_authorizer.go
+++ b/pkg/authorization/workspace_content_authorizer.go
@@ -95,7 +95,7 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 				Groups: []string{"system:authenticated"},
 			}
 		}
-		return a.delegate.Authorize(ctx, attr)
+		return DelegateAuthorization("deep SAR request", a.delegate).Authorize(ctx, attr)
 	}
 
 	// Every authenticated user has access to the root workspace but not every service account.
@@ -104,15 +104,15 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 		if isAuthenticated && (isUser || isServiceAccountFromRootCluster) {
 			withGroups := deepCopyAttributes(attr)
 			withGroups.User.(*user.DefaultInfo).Groups = append(attr.GetUser().GetGroups(), bootstrap.SystemKcpClusterWorkspaceAccessGroup)
-			return a.delegate.Authorize(ctx, withGroups)
+			return DelegateAuthorization("root workspace access", a.delegate).Authorize(ctx, withGroups)
 		}
-		return authorizer.DecisionNoOpinion, "root workspace access by non-root service account not permitted", nil
+		return authorizer.DecisionNoOpinion, "root workspace access by non-root service account", nil
 	}
 
 	// non-root workspaces must have a parent
 	parentClusterName, hasParent := cluster.Name.Parent()
 	if !hasParent {
-		return authorizer.DecisionNoOpinion, "non-root workspace that does not have a parent", nil
+		return authorizer.DecisionNoOpinion, "parentless workspace", nil
 	}
 
 	parentAuthorizer := rbac.New(
@@ -137,22 +137,23 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 	ws, err := a.clusterWorkspaceLister.Cluster(parentClusterName).Get(cluster.Name.Base())
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return authorizer.DecisionDeny, "clusterworkspace not found", nil
+			return authorizer.DecisionDeny, fmt.Sprintf("workspace %v|%v not found", parentClusterName, cluster.Name.Base()), nil
 		}
-		return authorizer.DecisionNoOpinion, "error getting clusterworkspace", err
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error getting workspace %q|%q: %w", parentClusterName, cluster.Name.Base(), err)
 	}
 
 	if ws.Status.Phase != tenancyv1alpha1.ClusterWorkspacePhaseInitializing && ws.Status.Phase != tenancyv1alpha1.ClusterWorkspacePhaseReady {
-		return authorizer.DecisionNoOpinion, fmt.Sprintf("not permitted due to phase %q", ws.Status.Phase), nil
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("invalid %q workspace phase: %q", ws.Name, ws.Status.Phase), nil
 	}
 
+	var reason string
 	switch {
 	case isServiceAccountFromCluster:
 		// A service account declared in the requested workspace is authorized inside that workspace.
 		// Referencing such a service account in the parent workspace is not possible,
 		// hence authorization against "admin" or "access" verbs in the parent is not possible either.
 		extraGroups.Insert(bootstrap.SystemKcpClusterWorkspaceAccessGroup)
-
+		reason = "service account access"
 	case isUser:
 		verbToGroupMembership := map[string][]string{
 			"admin":  {bootstrap.SystemKcpClusterWorkspaceAccessGroup, bootstrap.SystemKcpClusterWorkspaceAdminGroup},
@@ -185,24 +186,25 @@ func (a *workspaceContentAuthorizer) Authorize(ctx context.Context, attr authori
 				extraGroups.Insert(groups...)
 			}
 		}
+		reason = fmt.Sprintf("%q content policy: %v", parentClusterName, strings.Join(reasonList, ","))
 		if len(errList) > 0 {
-			return authorizer.DecisionNoOpinion, strings.Join(reasonList, "\n"), utilerrors.NewAggregate(errList)
+			return authorizer.DecisionNoOpinion, reason, utilerrors.NewAggregate(errList)
 		}
 	}
 
 	// non-admin subjects don't have access to initializing workspaces.
 	if ws.Status.Phase == tenancyv1alpha1.ClusterWorkspacePhaseInitializing && !extraGroups.Has(bootstrap.SystemKcpClusterWorkspaceAdminGroup) {
-		return authorizer.DecisionNoOpinion, "not permitted, clusterworkspace is in initializing phase", nil
+		return authorizer.DecisionNoOpinion, fmt.Sprintf("invalid %q workspace phase: %q", ws.Name, ws.Status.Phase), nil
 	}
 
 	if len(extraGroups) == 0 {
-		return authorizer.DecisionNoOpinion, "not permitted, subject has not been granted any groups", nil
+		return authorizer.DecisionNoOpinion, "subject has not been granted any groups", nil
 	}
 
 	withGroups := deepCopyAttributes(attr)
 	withGroups.User.(*user.DefaultInfo).Groups = append(attr.GetUser().GetGroups(), extraGroups.List()...)
 
-	return a.delegate.Authorize(ctx, withGroups)
+	return DelegateAuthorization(reason, a.delegate).Authorize(ctx, withGroups)
 }
 
 func deepCopyAttributes(attr authorizer.Attributes) *authorizer.AttributesRecord {

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -102,22 +102,22 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, informer kcpkub
 
 	// kcp authorizers
 	bootstrapAuth, bootstrapRules := authz.NewBootstrapPolicyAuthorizer(informer)
-	bootstrapAuth = authz.NewDecorator(bootstrapAuth, "bootstrap.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	bootstrapAuth = authz.NewDecorator("bootstrap.authorization.kcp.dev", bootstrapAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	localAuth, localResolver := authz.NewLocalAuthorizer(informer)
-	localAuth = authz.NewDecorator(localAuth, "local.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	localAuth = authz.NewDecorator("local.authorization.kcp.dev", localAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	maxPermissionPolicyAuth := authz.NewMaximalPermissionPolicyAuthorizer(informer, kcpinformer, union.New(bootstrapAuth, localAuth))
-	maxPermissionPolicyAuth = authz.NewDecorator(maxPermissionPolicyAuth, "maxpermissionpolicy.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	maxPermissionPolicyAuth = authz.NewDecorator("maxpermissionpolicy.authorization.kcp.dev", maxPermissionPolicyAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	systemCRDAuth := authz.NewSystemCRDAuthorizer(maxPermissionPolicyAuth)
-	systemCRDAuth = authz.NewDecorator(systemCRDAuth, "systemcrd.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	systemCRDAuth = authz.NewDecorator("systemcrd.authorization.kcp.dev", systemCRDAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	contentAuth := authz.NewWorkspaceContentAuthorizer(informer, workspaceLister, systemCRDAuth)
-	contentAuth = authz.NewDecorator(contentAuth, "content.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	contentAuth = authz.NewDecorator("content.authorization.kcp.dev", contentAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	topLevelAuth := authz.NewTopLevelOrganizationAccessAuthorizer(informer, workspaceLister, contentAuth)
-	topLevelAuth = authz.NewDecorator(topLevelAuth, "toplevel.authorization.kcp.dev").AddAuditLogging().AddAnonymization()
+	topLevelAuth = authz.NewDecorator("toplevel.authorization.kcp.dev", topLevelAuth).AddAuditLogging().AddAnonymization()
 
 	authorizers = append(authorizers, topLevelAuth)
 

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -214,10 +214,10 @@ func digestUrl(urlPath, rootPathPrefix string) (
 
 func newAuthorizer(kubeClusterClient, deepSARClient kcpkubernetesclientset.ClusterInterface, kcpinformers kcpinformers.SharedInformerFactory) authorizer.Authorizer {
 	maximalPermissionAuth := virtualapiexportauth.NewMaximalPermissionAuthorizer(deepSARClient, kcpinformers.Apis().V1alpha1().APIExports())
-	maximalPermissionAuth = authorization.NewDecorator(maximalPermissionAuth, "virtual.apiexport.maxpermissionpolicy.authorization.kcp.dev").AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+	maximalPermissionAuth = authorization.NewDecorator("virtual.apiexport.maxpermissionpolicy.authorization.kcp.dev", maximalPermissionAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
 	apiExportsContentAuth := virtualapiexportauth.NewAPIExportsContentAuthorizer(maximalPermissionAuth, kubeClusterClient)
-	apiExportsContentAuth = authorization.NewDecorator(apiExportsContentAuth, "virtual.apiexport.content.authorization.kcp.dev").AddAuditLogging().AddAnonymization()
+	apiExportsContentAuth = authorization.NewDecorator("virtual.apiexport.content.authorization.kcp.dev", apiExportsContentAuth).AddAuditLogging().AddAnonymization()
 
 	return apiExportsContentAuth
 }


### PR DESCRIPTION
## Summary
This is scavenging `DelegateAuthorization` from https://github.com/kcp-dev/kcp/pull/2089 to have delegation resons included in the kcp audit log.

Example for delegated authorization:
```
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": "access granted",
    "bootstrap.authorization.kcp.dev/decision": "Allowed",
    "bootstrap.authorization.kcp.dev/reason": "bootstrap policy: RBAC: allowed by ClusterRoleBinding \"system:kcp:clusterworkspace:admin\" of ClusterRole \"cluster-admin\" to Group \"system:kcp:clusterworkspace:admin\"",
    "content.authorization.kcp.dev/decision": "Allowed",
    "content.authorization.kcp.dev/reason": "delegating due to \"root:e2e-org-b7zvn\" content policy: : systemcrd.authorization.kcp.dev: access granted",
    "maxpermissionpolicy.authorization.kcp.dev/decision": "Allowed",
    "maxpermissionpolicy.authorization.kcp.dev/reason": "delegating due to unbound resource: bootstrap.authorization.kcp.dev: access granted",
    "systemcrd.authorization.kcp.dev/decision": "Allowed",
    "systemcrd.authorization.kcp.dev/reason": "delegating due to no system CRD violation: maxpermissionpolicy.authorization.kcp.dev: access granted",
    "tenancy.kcp.dev/workspace": "root:e2e-org-b7zvn:provider-a",
    "toplevel.authorization.kcp.dev/decision": "Allowed",
    "toplevel.authorization.kcp.dev/reason": "delegating due to root workspace policy for \"e2e-org-b7zvn\": RBAC: allowed by ClusterRoleBinding \"system:admin:system:kcp:clusterworkspace:admin\" of ClusterRole \"cluster-admin\" to Group \"system:kcp:clusterworkspace:admin\": content.authorization.kcp.dev: access granted"
```