### PR TITLE
🌱 goreleaser: distinguish tags and PRs

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -27,12 +27,22 @@ jobs:
       run: 'git tag -d $(git tag -l | grep -v "^v")'
     - name: Set LDFLAGS
       run: echo LDFLAGS="$(make ldflags)" >> $GITHUB_ENV
-    - name: Run GoReleaser
+    - name: Run GoReleaser on tag
+      if: github.event_name != 'pull_request'
       uses: goreleaser/goreleaser-action@v3
       with:
         distribution: goreleaser
         version: latest
         args: release --timeout 60m
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run GoReleaser on pull request
+      if: github.event_name == 'pull_request'
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --timeout 60m --snapshot
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: cytopia/upload-artifact-retry-action@v0.1.7


### PR DESCRIPTION
## Summary
#2492 added testing goreleaser in CI, but the upcoming goreleaser action v4 for some reason no longer detects non-tagged commits and automatically enables snapshot mode. This is an attempt to do that. Please let me know if there is a cleaner way to do this in GH actions

## Related issue(s)

Fixes #
