### PR TITLE
🐛 Fix parsing of requests to root path of a workload cluster

### DIFF
--- a/pkg/server/filters/filters.go
+++ b/pkg/server/filters/filters.go
@@ -88,11 +88,11 @@ func WithClusterScope(apiHandler http.Handler) http.HandlerFunc {
 
 			i := strings.Index(path, "/")
 			if i == -1 {
-				responsewriters.ErrorNegotiated(
-					apierrors.NewBadRequest(fmt.Sprintf("unable to parse cluster: no `/` found in path %s", path)),
-					errorCodecs, schema.GroupVersion{},
-					w, req)
-				return
+				// If we haven't found a /, append one and modify the index.
+				// The following avoids returning an http.BadRequest when a client
+				// doesn't specify a path with a trailing slash.
+				path = path + "/"
+				i = len(path) - 1
 			}
 			clusterName, path = logicalcluster.New(path[:i]), path[i:]
 			req.URL.Path = path


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Summary
kcp is rejecting (valid) calls to the root path of a cluster. With a default setup, the following error is returned:

```
# with KUBECONFIG pointing to some workload cluster within kcp
$ kubectl get --raw='/'
[{
  "metadata": {},
  "status": "Failure",
  "message": "unable to parse cluster: no `/` found in path root",
  "reason": "BadRequest",
  "code": 400
}]
```

This PR resolves this issue by fixing the parsing and removing the error. With this fix:

```
# with KUBECONFIG pointing to some workload cluster within kcp
$ kubectl get --raw='/'
{
  "paths": [
    "/api",
    "/api/v1",
    "/apis",
    "/apis/",
    "/apis/admissionregistration.k8s.io",
    "/apis/admissionregistration.k8s.io/v1",
    "/apis/apiextensions.k8s.io",
    ...
  ]
}
```

## Related issue(s)

Supersedes #2405 
