### PR TITLE
🐛 docs: mkdir before moving

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -102,6 +102,7 @@ jobs:
           w
           q
           EOF
+          mkdir -p content/en/${{ github.ref }}
           mv content/en/main content/en/${{ github.ref }}
           hugo --minify
           rsync -av public/${{ github.ref }} ../../docs


### PR DESCRIPTION
## Summary
The docs workflow was failing on tags because it was trying to move content to a directory that did not yet exist.

## Related issue(s)

Fixes #2502
