### PR TITLE
:seedling: Correct the typo in an error message

### DIFF
--- a/pkg/server/options/authentication.go
+++ b/pkg/server/options/authentication.go
@@ -175,7 +175,7 @@ func (s *AdminAuthentication) WriteKubeConfig(config genericapiserver.CompletedC
 
 	// give up: either there is no new generated shard admin token or the kubeconfig file is malicious.
 	if shardAdminToken == "" {
-		return fmt.Errorf("cannot create the 'admin.kubeconfig` file with an empty token for the %s user", shardAdminUserName)
+		return fmt.Errorf("cannot create the 'admin.kubeconfig' file with an empty token for the %s user", shardAdminUserName)
 	}
 
 	externalKubeConfig := createKubeConfig(kcpAdminToken, shardAdminToken, userToken, externalKubeConfigHost, "", externalCACert)


### PR DESCRIPTION
## Summary
The quote used to highlight `admin.kubeconfig` in the error message [1] was closed using a backtick leading to a quote mismatch. So, just changed the quotes over there.  (just a simple change)
