### PR TITLE
:seedling: Update .goreleaser.yaml to build binaries with CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ builds:
   ignore:
   - goos: darwin
     goarch: ppc64le
+  env:
+  - CGO_ENABLED=0
 - id: "kubectl-kcp"
   main: ./cmd/kubectl-kcp
   binary: bin/kubectl-kcp
@@ -32,6 +34,8 @@ builds:
     goarch: ppc64le
   - goos: windows
     goarch: ppc64le
+  env:
+  - CGO_ENABLED=0
 - id: "kubectl-workspace"
   main: ./cmd/kubectl-workspace
   binary: bin/kubectl-workspace
@@ -54,6 +58,8 @@ builds:
     post:
       - ln -sfr bin/kubectl-workspace bin/kubectl-workspaces
       - ln -sfr bin/kubectl-workspace bin/kubectl-ws
+  env:
+  - CGO_ENABLED=0
 archives:
 - id: kcp
   builds:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add `CGO_ENABLED=to` to `.goreleaser.yaml`.

I downloaded kcp 0.10.0 from [the release page](https://github.com/kcp-dev/kcp/releases/tag/v0.10.0)  and executed it on `Ubuntu 18.04.06 LTS`, but got the following error.

```
ubuntu@ip-XXX-XXX-XXX-XXX:~$ ./bin/kcp 
./bin/kcp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./bin/kcp)
./bin/kcp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./bin/kcp)
ubuntu@ip-XXX-XXX-XXX-XXX:~$ ls -la  /lib/x86_64-linux-gnu/libc.so.6
lrwxrwxrwx 1 root root 12 May  3  2022 /lib/x86_64-linux-gnu/libc.so.6 -> libc-2.27.so
```

It seems that kcp doesn't need CGO and [Dockerfile](https://github.com/kcp-dev/kcp/blob/2b5c1f10d964b2ddb682564a5bfc37c3e958243c/Dockerfile#L27) is already built with `CGO_ENABLED=0`.
