### PR TITLE
🐛 pkg/softimpersonation: deep copy rest config

### DIFF
--- a/pkg/softimpersonation/softimpersonation.go
+++ b/pkg/softimpersonation/softimpersonation.go
@@ -36,7 +36,7 @@ const (
 // WithSoftImpersonatedConfig returns a clone of the input rest.Config
 // with an additional header containing the given user info marshalled in Json.
 func WithSoftImpersonatedConfig(config *rest.Config, userInfo kuser.Info) (*rest.Config, error) {
-	impersonatedonfig := *config
+	impersonatedonfig := rest.CopyConfig(config)
 
 	userInfoJson, err := marshalUserInfo(userInfo)
 	if err != nil {
@@ -50,7 +50,7 @@ func WithSoftImpersonatedConfig(config *rest.Config, userInfo kuser.Info) (*rest
 			userInfoJson: userInfoJson,
 		}
 	})
-	return &impersonatedonfig, nil
+	return impersonatedonfig, nil
 }
 
 // softImpersonationTransport adds the 'X-Kcp-Internal-Soft-Impersonation'


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
`.Wrap` mutates the `WrapTransport` field of the given rest config. This should be covered as part of the shallow copy, however this is a dangerous coupling. This changes to `rest.CopyConfig` in order to have a guaranteed deep copy of the given rest config.

## Related issue(s)

Fixes #2136
