### PR TITLE
:bug: pkg/authorization: prevent double audit logs

### DIFF
--- a/pkg/authorization/decorator_test.go
+++ b/pkg/authorization/decorator_test.go
@@ -49,7 +49,7 @@ func TestDecorator(t *testing.T) {
 		wantReason   string
 	}{
 		"topAllows": {
-			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation(),
+			authz: EnableAuditLogging(NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
 
 			wantDecision: authorizer.DecisionAllow,
 			wantReason:   "top: access granted",
@@ -59,8 +59,16 @@ func TestDecorator(t *testing.T) {
 				"top/reason":   "unanonymized allow",
 			},
 		},
+		"topAllowsWithoutAudit": {
+			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation(),
+
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "top: access granted",
+
+			wantAudit: nil,
+		},
 		"topAllowsWithoutReasonAnnotation": {
-			authz: NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization(),
+			authz: EnableAuditLogging(NewDecorator("top", alwaysAllow).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionAllow,
 			wantReason:   "access granted",
@@ -71,7 +79,7 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topAllowsWithoutReasonAnnotationWithoutAnonymization": {
-			authz: NewDecorator("top", alwaysAllow).AddAuditLogging(),
+			authz: EnableAuditLogging(NewDecorator("top", alwaysAllow).AddAuditLogging()),
 
 			wantDecision: authorizer.DecisionAllow,
 			wantReason:   "unanonymized allow",
@@ -82,7 +90,7 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topAllowsWithoutReasonAnnotationWithoutAnonymizationWithoutAuditLogging": {
-			authz: NewDecorator("top", alwaysAllow),
+			authz: EnableAuditLogging(NewDecorator("top", alwaysAllow)),
 
 			wantDecision: authorizer.DecisionAllow,
 			wantReason:   "unanonymized allow",
@@ -90,10 +98,10 @@ func TestDecorator(t *testing.T) {
 			wantAudit: nil,
 		},
 		"topDelegatesToAllow": {
-			authz: NewDecorator("top",
+			authz: EnableAuditLogging(NewDecorator("top",
 				DelegateAuthorization("top-to-bottom",
 					NewDecorator("bottom", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
-			).AddAuditLogging().AddAnonymization(),
+			).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionAllow,
 			wantReason:   "access granted",
@@ -107,10 +115,10 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topDelegatesToDeny": {
-			authz: NewDecorator("top",
+			authz: EnableAuditLogging(NewDecorator("top",
 				DelegateAuthorization("top-to-bottom",
 					NewDecorator("bottom", alwaysDeny).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
-			).AddAuditLogging().AddAnonymization(),
+			).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionDeny,
 			wantReason:   "access denied",
@@ -124,11 +132,11 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topDelegatesToDelegateDelegatesToDeny": {
-			authz: NewDecorator("top",
+			authz: EnableAuditLogging(NewDecorator("top",
 				DelegateAuthorization("top-to-middle", NewDecorator("middle",
 					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysDeny).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
 				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
-			).AddAuditLogging().AddAnonymization(),
+			).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionDeny,
 			wantReason:   "access denied",
@@ -145,11 +153,11 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topDelegatesToDelegateDelegatesToAllow": {
-			authz: NewDecorator("top",
+			authz: EnableAuditLogging(NewDecorator("top",
 				DelegateAuthorization("top-to-middle", NewDecorator("middle",
 					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysAllow).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
 				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
-			).AddAuditLogging().AddAnonymization(),
+			).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionAllow,
 			wantReason:   "access granted",
@@ -166,11 +174,11 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topDelegatesToDelegateDelegatesToNoOpinion": {
-			authz: NewDecorator("top",
+			authz: EnableAuditLogging(NewDecorator("top",
 				DelegateAuthorization("top-to-middle", NewDecorator("middle",
 					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysNoOpinion).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
 				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
-			).AddAuditLogging().AddAnonymization(),
+			).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionNoOpinion,
 			wantReason:   "access denied",
@@ -187,11 +195,11 @@ func TestDecorator(t *testing.T) {
 			},
 		},
 		"topDelegatesToDelegateDelegatesToError": {
-			authz: NewDecorator("top",
+			authz: EnableAuditLogging(NewDecorator("top",
 				DelegateAuthorization("top-to-middle", NewDecorator("middle",
 					DelegateAuthorization("middle-to-bottom", NewDecorator("bottom", alwaysError).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
 				).AddAuditLogging().AddAnonymization().AddReasonAnnotation()),
-			).AddAuditLogging().AddAnonymization(),
+			).AddAuditLogging().AddAnonymization()),
 
 			wantDecision: authorizer.DecisionNoOpinion,
 			wantReason:   "access denied",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -360,7 +360,10 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 			}
 		}
 
+		authorizerWithoutAudit := genericConfig.Authorization.Authorizer
+		genericConfig.Authorization.Authorizer = authorization.EnableAuditLogging(genericConfig.Authorization.Authorizer)
 		apiHandler = genericapiserver.DefaultBuildHandlerChainBeforeAuthz(apiHandler, genericConfig)
+		genericConfig.Authorization.Authorizer = authorizerWithoutAudit
 
 		// this will be replaced in DefaultBuildHandlerChain. So at worst we get twice as many warning.
 		// But this is not harmful as the kcp warnings are not many.


### PR DESCRIPTION
## Summary
Currently, double audit log entries are generated because the authorization chain is used multiple times. Examples:

1. Subject access reviews: kubernetes/pkg/registry/authorization/subjectaccessreview/rest.go
2. Escalation authorization: kubernetes/pkg/registry/rbac/escalation_check.go
3. bind authorization: kubernetes/pkg/registry/rbac/escalation_check.go

This prevents it by setting a context in the main handler authorization chain only.

## Related issue(s)

Fixes #2500
