### PR TITLE
🌱 sharded-test-server: add quiet support to front-proxy

### DIFF
--- a/cmd/sharded-test-server/frontproxy.go
+++ b/cmd/sharded-test-server/frontproxy.go
@@ -49,6 +49,7 @@ func startFrontProxy(
 	hostIP string,
 	logDirPath, workDirPath string,
 	vwPort string,
+	quiet bool,
 ) error {
 	blue := color.New(color.BgGreen, color.FgBlack).SprintFunc()
 	inverse := color.New(color.BgHiWhite, color.FgGreen).SprintFunc()
@@ -155,6 +156,10 @@ func startFrontProxy(
 	cmd.Stdout = writer
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = writer
+
+	if quiet {
+		writer.StopOut()
+	}
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -242,7 +242,7 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	}
 
 	// start front-proxy
-	if err := startFrontProxy(ctx, proxyFlags, servingCA, hostIP.String(), logDirPath, workDirPath, vwPort); err != nil {
+	if err := startFrontProxy(ctx, proxyFlags, servingCA, hostIP.String(), logDirPath, workDirPath, vwPort, quiet); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
Make the front proxy in sharded-test-server honor `--quiet`

## Related issue(s)

Fixes #
