### PR TITLE
🌱 Use deletion handling keyfunc where needed

### DIFF
--- a/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_controller.go
@@ -87,7 +87,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
+++ b/pkg/reconciler/tenancy/logicalcluster/logicalcluster_controller.go
@@ -103,7 +103,7 @@ type Controller struct {
 }
 
 func (c *Controller) enqueue(obj interface{}) {
-	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -114,7 +114,7 @@ func (c *Controller) enqueue(obj interface{}) {
 }
 
 func (c *Controller) enqueueCRB(obj interface{}) {
-	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -189,7 +189,7 @@ type Controller struct {
 }
 
 func filterNamespace(obj interface{}) bool {
-	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return false

--- a/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_controller.go
+++ b/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_controller.go
@@ -42,7 +42,7 @@ import (
 	workloadv1alpha1informers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions/workload/v1alpha1"
 	apisv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/apis/v1alpha1"
 	workloadv1alpha1listers "github.com/kcp-dev/kcp/pkg/client/listers/workload/v1alpha1"
-	indexers "github.com/kcp-dev/kcp/pkg/indexers"
+	"github.com/kcp-dev/kcp/pkg/indexers"
 	"github.com/kcp-dev/kcp/pkg/logging"
 	"github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/apidefinition"
 	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
@@ -148,7 +148,7 @@ type APIReconciler struct {
 }
 
 func (c *APIReconciler) enqueueSyncTarget(obj interface{}, logger logr.Logger, logSuffix string) {
-	key, err := kcpcache.MetaClusterNamespaceKeyFunc(obj)
+	key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 	if err != nil {
 		runtime.HandleError(err)
 		return


### PR DESCRIPTION
## Summary
Switch places that potentially might get a cache.DeletedFinalStateUnknown to use the deletion handling key function variant.

## Related issue(s)

Fixes #
