### PR TITLE
:seedling: :*: use 'logicalCluster' instead of 'this'

### DIFF
--- a/config/root-phase0/bootstrap.go
+++ b/config/root-phase0/bootstrap.go
@@ -52,14 +52,14 @@ func Bootstrap(ctx context.Context, kcpClient kcpclient.Interface, rootDiscovery
 	// set LogicalCluster to Initializing
 	return wait.PollImmediateUntilWithContext(ctx, time.Millisecond*100, func(ctx context.Context) (done bool, err error) {
 		logger := klog.FromContext(ctx).WithValues("bootstrapping", "root-phase0")
-		this, err := kcpClient.CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+		logicalCluster, err := kcpClient.CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
 		if err != nil {
 			logger.Error(err, "failed to get this workspace in root")
 			return false, nil
 		}
-		if this.Status.Phase == corev1alpha1.LogicalClusterPhaseScheduling {
-			this.Status.Phase = corev1alpha1.LogicalClusterPhaseInitializing
-			_, err = kcpClient.CoreV1alpha1().LogicalClusters().UpdateStatus(ctx, this, metav1.UpdateOptions{})
+		if logicalCluster.Status.Phase == corev1alpha1.LogicalClusterPhaseScheduling {
+			logicalCluster.Status.Phase = corev1alpha1.LogicalClusterPhaseInitializing
+			_, err = kcpClient.CoreV1alpha1().LogicalClusters().UpdateStatus(ctx, logicalCluster, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Error(err, "failed to update LogicalCluster root:cluster")
 				return false, nil

--- a/pkg/admission/logicalcluster/admission_test.go
+++ b/pkg/admission/logicalcluster/admission_test.go
@@ -432,9 +432,9 @@ func (l fakeLogicalClusterClusterLister) List(selector labels.Selector) (ret []*
 
 func (l fakeLogicalClusterClusterLister) Cluster(cluster logicalcluster.Name) corev1alpha1listers.LogicalClusterLister {
 	var perCluster []*corev1alpha1.LogicalCluster
-	for _, this := range l {
-		if logicalcluster.From(this) == cluster {
-			perCluster = append(perCluster, this)
+	for _, logicalCluster := range l {
+		if logicalcluster.From(logicalCluster) == cluster {
+			perCluster = append(perCluster, logicalCluster)
 		}
 	}
 	return fakeLogicalClusterLister(perCluster)

--- a/pkg/admission/namespacelifecycle/admission.go
+++ b/pkg/admission/namespacelifecycle/admission.go
@@ -112,14 +112,14 @@ func (l *workspaceNamespaceLifecycle) Admit(ctx context.Context, a admission.Att
 		return apierrors.NewInternalError(err)
 	}
 
-	this, err := l.getLogicalCluster(clusterName)
+	logicalCluster, err := l.getLogicalCluster(clusterName)
 	// The shard hosting the workspace could be down,
 	// just return error from legacy namespace lifecycle admission in this case
 	if err != nil && !apierrors.IsNotFound(err) {
 		return admissionErr
 	}
 
-	if this.DeletionTimestamp.IsZero() {
+	if logicalCluster.DeletionTimestamp.IsZero() {
 		return admissionErr
 	}
 

--- a/pkg/admission/pathannotation/pathannotation_admission.go
+++ b/pkg/admission/pathannotation/pathannotation_admission.go
@@ -101,13 +101,13 @@ func (p *pathAnnotationPlugin) Admit(ctx context.Context, a admission.Attributes
 		return nil
 	}
 
-	this, err := p.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+	logicalCluster, err := p.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 	if err != nil {
 		return admission.NewForbidden(a, fmt.Errorf("cannot get this workspace: %w", err))
 	}
-	thisPath := this.Annotations[core.LogicalClusterPathAnnotationKey]
+	thisPath := logicalCluster.Annotations[core.LogicalClusterPathAnnotationKey]
 	if thisPath == "" {
-		thisPath = logicalcluster.From(this).Path().String()
+		thisPath = logicalcluster.From(logicalCluster).Path().String()
 	}
 
 	if thisPath != "" && value != thisPath {
@@ -142,13 +142,13 @@ func (p *pathAnnotationPlugin) Validate(ctx context.Context, a admission.Attribu
 
 	value, found := u.GetAnnotations()[core.LogicalClusterPathAnnotationKey]
 	if pathAnnotationResources.Has(a.GetResource().GroupResource().String()) || found {
-		this, err := p.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+		logicalCluster, err := p.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 		if err != nil {
 			return admission.NewForbidden(a, fmt.Errorf("cannot get this workspace: %w", err))
 		}
-		thisPath := this.Annotations[core.LogicalClusterPathAnnotationKey]
+		thisPath := logicalCluster.Annotations[core.LogicalClusterPathAnnotationKey]
 		if thisPath == "" {
-			thisPath = logicalcluster.From(this).Path().String()
+			thisPath = logicalcluster.From(logicalCluster).Path().String()
 		}
 
 		if value != thisPath {

--- a/pkg/admission/workspace/admission.go
+++ b/pkg/admission/workspace/admission.go
@@ -109,11 +109,11 @@ func (o *workspace) Admit(ctx context.Context, a admission.Attributes, _ admissi
 
 		// copy required groups from LogicalCluster to new child-Worksapce
 		if _, found := cw.Annotations[authorization.RequiredGroupsAnnotationKey]; !found || !isSystemPrivileged {
-			this, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+			logicalCluster, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 			if err != nil {
 				return admission.NewForbidden(a, err)
 			}
-			if thisValue, found := this.Annotations[authorization.RequiredGroupsAnnotationKey]; found {
+			if thisValue, found := logicalCluster.Annotations[authorization.RequiredGroupsAnnotationKey]; found {
 				if cw.Annotations == nil {
 					cw.Annotations = map[string]string{}
 				}
@@ -200,11 +200,11 @@ func (o *workspace) Validate(ctx context.Context, a admission.Attributes, _ admi
 
 		// check that required groups match with LogicalCluster
 		if !isSystemPrivileged {
-			this, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+			logicalCluster, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 			if err != nil {
 				return admission.NewForbidden(a, err)
 			}
-			expected := this.Annotations[authorization.RequiredGroupsAnnotationKey]
+			expected := logicalCluster.Annotations[authorization.RequiredGroupsAnnotationKey]
 			if cw.Annotations[authorization.RequiredGroupsAnnotationKey] != expected {
 				return admission.NewForbidden(a, fmt.Errorf("missing required groups annotation %s=%s", authorization.RequiredGroupsAnnotationKey, expected))
 			}

--- a/pkg/admission/workspace/admission_test.go
+++ b/pkg/admission/workspace/admission_test.go
@@ -713,9 +713,9 @@ func (l fakeLogicalClusterClusterLister) List(selector labels.Selector) (ret []*
 
 func (l fakeLogicalClusterClusterLister) Cluster(cluster logicalcluster.Name) corev1alpha1listers.LogicalClusterLister {
 	var perCluster []*corev1alpha1.LogicalCluster
-	for _, this := range l {
-		if logicalcluster.From(this) == cluster {
-			perCluster = append(perCluster, this)
+	for _, logicalCluster := range l {
+		if logicalcluster.From(logicalCluster) == cluster {
+			perCluster = append(perCluster, logicalCluster)
 		}
 	}
 	return fakeLogicalClusterLister(perCluster)

--- a/pkg/admission/workspacetypeexists/admission.go
+++ b/pkg/admission/workspacetypeexists/admission.go
@@ -126,7 +126,7 @@ func (o *workspacetypeExists) Admit(ctx context.Context, a admission.Attributes,
 		return nil
 	}
 
-	this, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+	logicalCluster, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 	if err != nil {
 		return admission.NewForbidden(a, fmt.Errorf("workspace type cannot be resolved: %w", err))
 	}
@@ -134,7 +134,7 @@ func (o *workspacetypeExists) Admit(ctx context.Context, a admission.Attributes,
 	// if the user has not provided any type, use the default from the parent workspace
 	empty := tenancyv1beta1.WorkspaceTypeReference{}
 	if ws.Spec.Type == empty {
-		typeAnnotation, found := this.Annotations[tenancyv1beta1.LogicalClusterTypeAnnotationKey]
+		typeAnnotation, found := logicalCluster.Annotations[tenancyv1beta1.LogicalClusterTypeAnnotationKey]
 		if !found {
 			return admission.NewForbidden(a, fmt.Errorf("annotation %s on LogicalCluster must be set", tenancyv1beta1.LogicalClusterTypeAnnotationKey))
 		}
@@ -155,9 +155,9 @@ func (o *workspacetypeExists) Admit(ctx context.Context, a admission.Attributes,
 		}
 	}
 
-	thisPath := this.Annotations[core.LogicalClusterPathAnnotationKey]
+	thisPath := logicalCluster.Annotations[core.LogicalClusterPathAnnotationKey]
 	if thisPath == "" {
-		thisPath = logicalcluster.From(this).Path().String()
+		thisPath = logicalcluster.From(logicalCluster).Path().String()
 	}
 
 	cwt, err := o.resolveTypeRef(logicalcluster.NewPath(thisPath), tenancyv1alpha1.WorkspaceTypeReference{
@@ -292,11 +292,11 @@ func (o *workspacetypeExists) Validate(ctx context.Context, a admission.Attribut
 		}
 
 		// validate whether the workspace type is allowed in its parent, and the workspace type allows that parent
-		this, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
+		logicalCluster, err := o.logicalClusterLister.Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 		if err != nil {
 			return admission.NewForbidden(a, fmt.Errorf("workspace type cannot be resolved: %w", err))
 		}
-		typeAnnotation, found := this.Annotations[tenancyv1beta1.LogicalClusterTypeAnnotationKey]
+		typeAnnotation, found := logicalCluster.Annotations[tenancyv1beta1.LogicalClusterTypeAnnotationKey]
 		if !found {
 			return admission.NewForbidden(a, fmt.Errorf("annotation %s on LogicalCluster must be set", tenancyv1beta1.LogicalClusterTypeAnnotationKey))
 		}

--- a/pkg/admission/workspacetypeexists/admission_test.go
+++ b/pkg/admission/workspacetypeexists/admission_test.go
@@ -511,9 +511,9 @@ func (l fakeLogicalClusterClusterLister) List(selector labels.Selector) (ret []*
 
 func (l fakeLogicalClusterClusterLister) Cluster(cluster logicalcluster.Name) corev1alpha1listers.LogicalClusterLister {
 	var perCluster []*corev1alpha1.LogicalCluster
-	for _, this := range l {
-		if logicalcluster.From(this) == cluster {
-			perCluster = append(perCluster, this)
+	for _, logicalCluster := range l {
+		if logicalcluster.From(logicalCluster) == cluster {
+			perCluster = append(perCluster, logicalCluster)
 		}
 	}
 	return fakeLogicalClusterLister(perCluster)

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -134,8 +134,8 @@ func (c *State) DeleteWorkspace(shard string, ws *tenancyv1beta1.Workspace) {
 	}
 }
 
-func (c *State) UpsertLogicalCluster(shard string, this *corev1alpha1.LogicalCluster) {
-	clusterName := logicalcluster.From(this)
+func (c *State) UpsertLogicalCluster(shard string, logicalCluster *corev1alpha1.LogicalCluster) {
+	clusterName := logicalcluster.From(logicalCluster)
 
 	c.lock.RLock()
 	got := c.clusterShards[clusterName]
@@ -148,8 +148,8 @@ func (c *State) UpsertLogicalCluster(shard string, this *corev1alpha1.LogicalClu
 	}
 }
 
-func (c *State) DeleteLogicalCluster(shard string, this *corev1alpha1.LogicalCluster) {
-	clusterName := logicalcluster.From(this)
+func (c *State) DeleteLogicalCluster(shard string, logicalCluster *corev1alpha1.LogicalCluster) {
+	clusterName := logicalcluster.From(logicalCluster)
 
 	c.lock.RLock()
 	got := c.clusterShards[clusterName]

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -242,19 +242,19 @@ func (c *Controller) process(ctx context.Context, key string) error {
 		twInformer := corev1alpha1informers.NewLogicalClusterClusterInformer(client, resyncPeriod, nil)
 		twInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				this := obj.(*corev1alpha1.LogicalCluster)
-				c.state.UpsertLogicalCluster(shard.Name, this)
+				logicalCluster := obj.(*corev1alpha1.LogicalCluster)
+				c.state.UpsertLogicalCluster(shard.Name, logicalCluster)
 			},
 			UpdateFunc: func(old, obj interface{}) {
-				this := obj.(*corev1alpha1.LogicalCluster)
-				c.state.UpsertLogicalCluster(shard.Name, this)
+				logicalCluster := obj.(*corev1alpha1.LogicalCluster)
+				c.state.UpsertLogicalCluster(shard.Name, logicalCluster)
 			},
 			DeleteFunc: func(obj interface{}) {
 				if final, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 					obj = final.Obj
 				}
-				this := obj.(*corev1alpha1.LogicalCluster)
-				c.state.DeleteLogicalCluster(shard.Name, this)
+				logicalCluster := obj.(*corev1alpha1.LogicalCluster)
+				c.state.DeleteLogicalCluster(shard.Name, logicalCluster)
 			},
 		})
 

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile.go
@@ -32,10 +32,10 @@ const (
 )
 
 type reconciler interface {
-	reconcile(ctx context.Context, this *corev1alpha1.LogicalCluster) (reconcileStatus, error)
+	reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) (reconcileStatus, error)
 }
 
-func (c *Controller) reconcile(ctx context.Context, this *corev1alpha1.LogicalCluster) (bool, error) {
+func (c *Controller) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) (bool, error) {
 	reconcilers := []reconciler{
 		&metaDataReconciler{},
 		&phaseReconciler{},
@@ -48,7 +48,7 @@ func (c *Controller) reconcile(ctx context.Context, this *corev1alpha1.LogicalCl
 	for _, r := range reconcilers {
 		var err error
 		var status reconcileStatus
-		status, err = r.reconcile(ctx, this)
+		status, err = r.reconcile(ctx, logicalCluster)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_url.go
+++ b/pkg/reconciler/core/logicalcluster/logicalcluster_reconcile_url.go
@@ -29,7 +29,7 @@ type urlReconciler struct {
 	shardExternalURL func() string
 }
 
-func (r *urlReconciler) reconcile(ctx context.Context, this *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
-	this.Status.URL = strings.TrimSuffix(r.shardExternalURL(), "/") + logicalcluster.From(this).Path().RequestPath()
+func (r *urlReconciler) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) (reconcileStatus, error) {
+	logicalCluster.Status.URL = strings.TrimSuffix(r.shardExternalURL(), "/") + logicalcluster.From(logicalCluster).Path().RequestPath()
 	return reconcileStatusContinue, nil
 }

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -179,7 +179,7 @@ func (b *APIBinder) enqueueAPIBinding(obj interface{}, logger logr.Logger) {
 	logger = logging.WithObject(logger, apiBinding)
 
 	clusterName := logicalcluster.From(apiBinding)
-	this, err := b.getLogicalCluster(clusterName)
+	logicalCluster, err := b.getLogicalCluster(clusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// The workspace was deleted or is no longer initializing, so we can safely ignore this event.
@@ -189,7 +189,7 @@ func (b *APIBinder) enqueueAPIBinding(obj interface{}, logger logr.Logger) {
 		return // nothing we can do here
 	}
 
-	b.enqueueLogicalCluster(this, logger)
+	b.enqueueLogicalCluster(logicalCluster, logger)
 }
 
 // enqueueWorkspaceTypes enqueues all clusterworkspaces (which are only those that are initializing, because of

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_reconcile.go
@@ -42,8 +42,8 @@ import (
 	"github.com/kcp-dev/kcp/pkg/logging"
 )
 
-func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalCluster) error {
-	annotationValue, found := this.Annotations[v1beta1.LogicalClusterTypeAnnotationKey]
+func (b *APIBinder) reconcile(ctx context.Context, logicalCluster *corev1alpha1.LogicalCluster) error {
+	annotationValue, found := logicalCluster.Annotations[v1beta1.LogicalClusterTypeAnnotationKey]
 	if !found {
 		return nil
 	}
@@ -57,7 +57,7 @@ func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalClu
 	)
 
 	var errors []error
-	clusterName := logicalcluster.From(this)
+	clusterName := logicalcluster.From(logicalCluster)
 	logger.V(2).Info("initializing APIBindings for workspace")
 
 	// Start with the WorkspaceType specified by the ClusterWorkspace
@@ -66,7 +66,7 @@ func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalClu
 		logger.Error(err, "error getting WorkspaceType")
 
 		conditions.MarkFalse(
-			this,
+			logicalCluster,
 			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
 			tenancyv1alpha1.WorkspaceInitializedWorkspaceTypeInvalid,
 			conditionsv1alpha1.ConditionSeverityError,
@@ -84,7 +84,7 @@ func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalClu
 		logger.Error(err, "error resolving transitive types")
 
 		conditions.MarkFalse(
-			this,
+			logicalCluster,
 			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
 			tenancyv1alpha1.WorkspaceInitializedWorkspaceTypeInvalid,
 			conditionsv1alpha1.ConditionSeverityError,
@@ -196,7 +196,7 @@ func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalClu
 		logger.Error(utilerrors.NewAggregate(errors), "error initializing APIBindings")
 
 		conditions.MarkFalse(
-			this,
+			logicalCluster,
 			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
 			tenancyv1alpha1.WorkspaceInitializedAPIBindingErrors,
 			conditionsv1alpha1.ConditionSeverityError,
@@ -235,7 +235,7 @@ func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalClu
 		sort.Strings(incomplete)
 
 		conditions.MarkFalse(
-			this,
+			logicalCluster,
 			tenancyv1alpha1.WorkspaceAPIBindingsInitialized,
 			tenancyv1alpha1.WorkspaceInitializedWaitingOnAPIBindings,
 			conditionsv1alpha1.ConditionSeverityInfo,
@@ -245,7 +245,7 @@ func (b *APIBinder) reconcile(ctx context.Context, this *corev1alpha1.LogicalClu
 		return nil
 	}
 
-	this.Status.Initializers = initialization.EnsureInitializerAbsent(tenancyv1alpha1.WorkspaceAPIBindingsInitializer, this.Status.Initializers)
+	logicalCluster.Status.Initializers = initialization.EnsureInitializerAbsent(tenancyv1alpha1.WorkspaceAPIBindingsInitializer, logicalCluster.Status.Initializers)
 
 	return nil
 }

--- a/pkg/server/localproxy.go
+++ b/pkg/server/localproxy.go
@@ -72,19 +72,19 @@ func WithLocalProxy(
 
 	logicalClusterInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			this := obj.(*corev1alpha1.LogicalCluster)
-			indexState.UpsertLogicalCluster(shardName, this)
+			logicalCluster := obj.(*corev1alpha1.LogicalCluster)
+			indexState.UpsertLogicalCluster(shardName, logicalCluster)
 		},
 		UpdateFunc: func(old, obj interface{}) {
-			this := obj.(*corev1alpha1.LogicalCluster)
-			indexState.UpsertLogicalCluster(shardName, this)
+			logicalCluster := obj.(*corev1alpha1.LogicalCluster)
+			indexState.UpsertLogicalCluster(shardName, logicalCluster)
 		},
 		DeleteFunc: func(obj interface{}) {
 			if final, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 				obj = final.Obj
 			}
-			this := obj.(*corev1alpha1.LogicalCluster)
-			indexState.DeleteLogicalCluster(shardName, this)
+			logicalCluster := obj.(*corev1alpha1.LogicalCluster)
+			indexState.DeleteLogicalCluster(shardName, logicalCluster)
 		},
 	})
 

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -495,11 +495,11 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 		"gamma",
 	} {
 		clusterClient := user1VwKcpClusterClients[initializer].CoreV1alpha1().LogicalClusters()
-		this, err := clusterClient.Cluster(wsClusterName.Path()).Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+		logicalCluster, err := clusterClient.Cluster(wsClusterName.Path()).Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
 		require.NoError(t, err)
 
 		t.Logf("Attempt to do something more than just removing our initializer %q, get denied", initializer)
-		patchBytes := patchBytesFor(this, func(workspace *corev1alpha1.LogicalCluster) {
+		patchBytes := patchBytesFor(logicalCluster, func(workspace *corev1alpha1.LogicalCluster) {
 			workspace.Status.Initializers = []corev1alpha1.LogicalClusterInitializer{"wrong"}
 		})
 		_, err = clusterClient.Cluster(wsClusterName.Path()).Patch(ctx, corev1alpha1.LogicalClusterName, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
@@ -508,7 +508,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 		}
 
 		t.Logf("Remove just our initializer %q", initializer)
-		patchBytes = patchBytesFor(this, func(workspace *corev1alpha1.LogicalCluster) {
+		patchBytes = patchBytesFor(logicalCluster, func(workspace *corev1alpha1.LogicalCluster) {
 			workspace.Status.Initializers = initialization.EnsureInitializerAbsent(initialization.InitializerForType(workspacetypes[initializer]), workspace.Status.Initializers)
 		})
 		_, err = clusterClient.Cluster(wsClusterName.Path()).Patch(ctx, corev1alpha1.LogicalClusterName, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

<details>
<summary>Script used to generate this</summary>

```
commit 226d0d24566680c029c1ccb558021e815d7d0071
Author: Steve Kuznetsov <skuznets@redhat.com>
Date:   Wed Dec 21 07:22:28 2022 -0700

    automated refactor

diff --git a/go.mod b/go.mod
index dcad2074..98cf850f 100644
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/coredns/caddy v1.1.1
 	github.com/coredns/coredns v1.9.3
+	github.com/dave/dst v0.27.2
 	github.com/egymgmbh/go-prefix-writer v0.0.0-20180609083313-7326ea162eca
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/evanphx/json-patch v5.6.0+incompatible
@@ -34,6 +35,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.5.0
 	go.uber.org/multierr v1.7.0
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
+	golang.org/x/tools v0.1.12
 	gopkg.in/square/go-jose.v2 v2.2.2
 	k8s.io/api v0.24.3
 	k8s.io/apiextensions-apiserver v0.24.3
@@ -162,7 +164,6 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
-	golang.org/x/tools v0.1.12 // indirect
 	gonum.org/v1/gonum v0.6.2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd // indirect
diff --git a/go.sum b/go.sum
index 8b906ef0..4a8f683a 100644
--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,9 @@ github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/dave/dst v0.27.2 h1:4Y5VFTkhGLC1oddtNwuxxe36pnyLxMFXT51FOzH8Ekc=
+github.com/dave/dst v0.27.2/go.mod h1:jHh6EOibnHgcUW3WjKHisiooEkYwqpHLBSX1iOBhEyc=
+github.com/dave/jennifer v1.5.0 h1:HmgPN93bVDpkQyYbqhCHj5QlgvUkvEOzMyEvKLgCRrg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -690,8 +693,8 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
diff --git a/refactor.go b/refactor.go
new file mode 100644
index 00000000..7f7b6bef
--- /dev/null
+++ b/refactor.go
@@ -0,0 +1,174 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"os"
+	"path/filepath"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/decorator"
+	"github.com/dave/dst/decorator/resolver/gopackages"
+	"github.com/dave/dst/dstutil"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/tools/go/packages"
+)
+
+type options struct {
+	packageNames []string
+}
+
+func newOptions() *options {
+	o := &options{}
+	return o
+}
+
+func (o *options) addFlags(fs *flag.FlagSet) {
+}
+
+func (o *options) complete(args []string) error {
+	o.packageNames = args
+	return nil
+}
+
+func (o *options) validate() error {
+	if len(o.packageNames) == 0 {
+		return errors.New("packages to scan are required arguments")
+	}
+	return nil
+}
+
+func main() {
+	o := newOptions()
+	o.addFlags(flag.CommandLine)
+	flag.Parse()
+	if err := o.complete(flag.Args()); err != nil {
+		logrus.WithError(err).Fatal("could not complete options")
+	}
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("invalid options")
+	}
+	if err := rewrite(o.packageNames); err != nil {
+		logrus.WithError(err).Fatal("failed to re-write source")
+	}
+}
+
+func rewrite(packageNames []string) error {
+	pkgs, err := decorator.Load(&packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedImports | packages.NeedTypes | packages.NeedTypesSizes |
+			packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedModule,
+		Tests: true,
+	}, packageNames...)
+	if err != nil {
+		return fmt.Errorf("failed to load source: %w", err)
+	}
+	for _, pkg := range pkgs {
+		restorer := decorator.NewRestorerWithImports(pkg.PkgPath, gopackages.New(""))
+		fileRestorer := restorer.FileRestorer()
+		for i, file := range pkg.Syntax {
+			filePath := pkg.CompiledGoFiles[i]
+			dir := pkg.Dir
+			if pkg.Module != nil { // even though we ask for modules, if we run on a single file we don't get them
+				dir = pkg.Module.Dir
+			}
+			relPath, err := filepath.Rel(dir, filePath)
+			if err != nil {
+				return fmt.Errorf("should not happen: could not find relative path to %s from %s", filePath, pkg.Dir)
+			}
+
+			logrus.WithFields(logrus.Fields{"file": relPath}).Info("Considering file.")
+			var updates int
+			mutatedNode := dstutil.Apply(file, nil, func(cursor *dstutil.Cursor) bool {
+				for _, update := range []func(pkg *decorator.Package, cursor *dstutil.Cursor, fileRestorer *decorator.FileRestorer) int{
+					rewriteThisName,
+				} {
+					updates += update(pkg, cursor, fileRestorer)
+				}
+				return true
+			})
+			if updates > 0 {
+				logrus.WithFields(logrus.Fields{"file": relPath, "updates": updates}).Info("Updating file.")
+				previous, err := os.ReadFile(filePath)
+				if err != nil {
+					return fmt.Errorf("failed to read contents of %s: %w", filePath, err)
+				}
+				f, err := os.OpenFile(filePath, os.O_RDWR|os.O_TRUNC, 0666)
+				if err != nil {
+					return fmt.Errorf("failed to open %s for writing: %w", relPath, err)
+				}
+				if err := fileRestorer.Fprint(f, mutatedNode.(*dst.File)); err != nil {
+					if err := os.WriteFile(filePath, previous, 0666); err != nil {
+						logrus.WithFields(logrus.Fields{"file": relPath}).WithError(err).Error("Failed to restore contents of file.")
+					}
+					return fmt.Errorf("failed to write %s: %w", relPath, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func rewriteThisName(pkg *decorator.Package, cursor *dstutil.Cursor, fileRestorer *decorator.FileRestorer) int {
+	var updated int
+	switch node := cursor.Node().(type) {
+	case *dst.Ident:
+		if node.Name != "this" {
+			break
+		}
+		astNode, ok := pkg.Decorator.Ast.Nodes[node]
+		if !ok {
+			logrus.Info("no astNode")
+			break
+		}
+		astIdent, ok := astNode.(*ast.Ident)
+		if !ok {
+			logrus.Infof("astNode not an ident: %T", astNode)
+			break
+		}
+		var objType types.Object
+		def, ok := pkg.TypesInfo.Defs[astIdent]
+		if ok && def != nil {
+			objType = def
+		}
+
+		use, ok := pkg.TypesInfo.Uses[astIdent]
+		if ok && use != nil {
+			objType = use
+		}
+
+		if objType == nil {
+			break
+		}
+
+		if node.Name == "this" && objType.Type().String() == "*github.com/kcp-dev/kcp/pkg/apis/core/v1alpha1.LogicalCluster" {
+			cursor.Replace(&dst.Ident{
+				Name: "cluster",
+				Path: node.Path,
+				Obj:  node.Obj,
+				Decs: node.Decs,
+			})
+			updated += 1
+		}
+	}
+	return updated
+}
```

</details>