### PR TITLE
🌱 Use buildx to build KCP images

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -17,7 +17,13 @@ jobs:
     name: Build KCP Image
     runs-on: ubuntu-latest
     outputs:
-      sha_short: ${{ steps.vars.outputs.sha_short }}
+      sha_short: ${{ env.sha_short }}
+    strategy:
+      matrix:
+        platforms:
+        - linux/amd64
+        - linux/arm64
+        - linux/ppc64le
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -26,28 +32,42 @@ jobs:
 
       - name: Get the short sha
         id: vars
-        run: echo "::set-output name=sha_short::$(echo ${{ github.sha }} | cut -b -7)"
+        run: |
+          echo "sha_short=$(echo ${{ github.sha }} | cut -b -7)" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      # Build and push a KCP image, tagged with latest and the commit SHA.
-      - name: Build KCP Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: kcp
-          tags: latest ${{ steps.vars.outputs.sha_short }} ${{ github.ref_name }}
-          archs: amd64, ppc64le, arm64
-          containerfiles: |
-            ./Dockerfile
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Push to ghcr.io
-        id: push-to-ghcr
-        uses: redhat-actions/push-to-registry@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }} ${{ github.ref_name }}
-          registry: ghcr.io/${{ github.repository_owner }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/kcp
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=${{ env.sha_short }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push ${{ matrix.platform }}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=$GITHUB_REF_NAME-{{ matrix.platform }}
+          cache-to: type=gha,scope=$GITHUB_REF_NAME-{{ matrix.platform }},mode=max
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder workspace/bin/kcp-front-proxy workspace/bin/kcp workspace/bin/virtual-workspaces /
 COPY --from=builder workspace/bin/kubectl-* /usr/local/bin/
 COPY --from=builder workspace/bin/kubectl /usr/local/bin/
-RUN ln -s /usr/local/bin/kubectl-workspace /usr/local/bin/kubectl-workspaces && ln -s /usr/local/bin/kubectl-workspace /usr/local/bin/kubectl-ws
 ENV KUBECONFIG=/etc/kcp/config/admin.kubeconfig
 # Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
 RUN mkdir -p /data && \


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This changeset includes a few changes to optimize our github action builds to run under 10 minutes. In more details it:
- Switches from buildah to buildx, buildah has a really old version that doesn't support caching in Github actions (ubuntu repositories).
- Introduces a build matrix, which lets different platforms to run in parallel
- Introduces caching for docker build layers
- Switches from output variables (deprecated) to environment vars

Signed-off-by: Vince Prignano <vince@prigna.com>

## Related issue(s)

Kind of related to #902 
