### PR TITLE
🐛 kcp: fix waitForOptionalSync method to wait for a proper signal

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -1387,7 +1387,7 @@ func (s *Server) waitForOptionalSync(stop <-chan struct{}) error {
 	select {
 	case <-stop:
 		return errors.New("timed out waiting for optional informers to sync")
-	case <-s.syncedCh:
+	case <-s.syncedOptionalCh:
 		return nil
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
before this method was waiting for `syncedCh` which is handled by `waitForSync` method.
`syncedOptionalCh` is fulfilled by `kcp-start-optional-informers`hook.

## Related issue(s)

Fixes #
