### PR TITLE
:bug: Increase CRD cleanup requeue delay; remove e2e test

### DIFF
--- a/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
+++ b/pkg/reconciler/apis/crdcleanup/crdcleanup_controller.go
@@ -44,9 +44,10 @@ import (
 )
 
 const (
-	ControllerName = "kcp-crdcleanup"
-
+	ControllerName                 = "kcp-crdcleanup"
 	DefaultIdentitySecretNamespace = "kcp-system"
+
+	AgeThreshold time.Duration = time.Minute * 30
 )
 
 // NewController returns a new controller for CRD cleanup
@@ -248,9 +249,8 @@ func (c *controller) process(ctx context.Context, key string) error {
 
 	age := time.Since(obj.CreationTimestamp.Time)
 
-	ageThreshold := time.Second * 10
-	if age < ageThreshold {
-		duration := ageThreshold - age
+	if age < AgeThreshold {
+		duration := AgeThreshold - age
 		logger.V(4).Info("Requeueing until CRD is older to give some time for the bindings to complete initialization", "duration", duration)
 		c.queue.AddAfter(key, duration)
 		return nil


### PR DESCRIPTION
Requeue is increased from 10 seconds to 30 minutes.

## Summary

When KCP is under heavy load during e2e test runs, it can take a long time for a new `APIBinding` to complete reconciliation.  In some cases, it takes longer than the requeue delay configured in the CRD cleanup controller, which means the newly-created CRD will be deleted before initialization of its corresponding `APIBinding` is complete.

The obvious fix is to increase the requeue delay, but there is an e2e test that waits on this delay to ensure CRDs are cleaned up properly. Unfortunately waiting becomes infeasible if the delay is increased to the order of minutes or hours instead of seconds.

Therefore the e2e test is removed in favor of an expanded unit test. The queue is mocked out in the unit test, and the test function emulates time going forward by decreasing the CRD's `creationTimestamp` before calling `process` again.

## Related issue(s)

Fixes #2507
