### PR TITLE
:seedling: Cross-compile container image binaries from host platform

### DIFF
--- a/.github/workflows/kcp-image.yaml
+++ b/.github/workflows/kcp-image.yaml
@@ -10,6 +10,10 @@ on:
       - 'release-*'
     tags:
     - 'v*'
+  pull_request:
+    branches:
+      - main
+      - 'release-*'
 
 jobs:
   build:
@@ -57,4 +61,3 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le
           cache-from: type=gha,scope=${{ github.ref_name }}-buildx
           cache-to: type=gha,scope=${{ github.ref_name }}-buildx,mode=max
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the binary
-FROM golang:1.19 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.19 AS builder
 WORKDIR /workspace
 
 # Install dependencies.
@@ -43,9 +43,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Copy the sources
 COPY ./ ./
 
+ARG TARGETOS
+ARG TARGETARCH
+
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
-    make
+    make OS=${TARGETOS} ARCH=${TARGETARCH}
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/hack/verify-go-versions.sh
+++ b/hack/verify-go-versions.sh
@@ -20,7 +20,7 @@ set -o pipefail
 VERSION=$(grep "go 1." go.mod | sed 's/go //')
 
 grep "tag: \"" .ci-operator.yaml | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in .ci-operator.yaml, expected ${VERSION}"; exit 1; }
-grep "FROM golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
+grep "FROM .* golang:" Dockerfile | { ! grep -v "${VERSION}"; } || { echo "Wrong go version in Dockerfile, expected ${VERSION}"; exit 1; }
 grep -w "go-version:" .github/workflows/*.yaml | { ! grep -v "go-version: v${VERSION}"; } || { echo "Wrong go version in .github/workflows/*.yaml, expected ${VERSION}"; exit 1; }
 # Note CONTRIBUTING.md isn't copied in the Dockerfile
 if [ -e CONTRIBUTING.md ]; then


### PR DESCRIPTION
## Summary

The compilation of the binaries in the builder stage of the container image is very slow when QEMU is used: 

```
#44 [linux/amd64 builder 11/11] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make
#44 881.5 ln -sf kubectl-workspace bin/kubectl-workspaces
#44 881.5 ln -sf kubectl-workspace bin/kubectl-ws
#44 DONE 882.2s

#49 [linux/arm64 builder 11/11] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make
#49 5526.2 ln -sf kubectl-workspace bin/kubectl-workspaces
#49 5526.3 ln -sf kubectl-workspace bin/kubectl-ws
#49 DONE 5527.0s

#50 [linux/ppc64le builder 11/11] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make
#50 5266.1 ln -sf kubectl-workspace bin/kubectl-workspaces
#50 5266.4 ln -sf kubectl-workspace bin/kubectl-ws
#50 DONE 5266.9s
```

This PR switches to using Golang cross-compilation instead of QEMU, by forcing the builder stage to run the same platform as that of the host one, that gives:

```
#27 [linux/amd64 builder 11/11] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make OS=linux ARCH=amd64
#27 963.1 ln -sf kubectl-workspace bin/kubectl-workspaces
#27 963.2 ln -sf kubectl-workspace bin/kubectl-ws
#27 DONE 963.8s

#28 [linux/amd64->arm64 builder 11/11] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make OS=linux ARCH=arm64
#28 987.2 ln -sf kubectl-workspace bin/kubectl-workspaces
#28 987.3 ln -sf kubectl-workspace bin/kubectl-ws
#28 DONE 989.2s

#26 [linux/amd64->ppc64le builder 11/11] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg/mod     make OS=linux ARCH=ppc64le
#26 991.1 ln -sf kubectl-workspace bin/kubectl-workspaces
#26 991.1 ln -sf kubectl-workspace bin/kubectl-ws
#26 DONE 991.1s
```

It also triggers the image build workflow on pull requests, so non-regression of the container image build is covered, though the result image is not pushed to any registry.