### PR TITLE
:seedling: follow-ups of workspace refactor

### DIFF
--- a/pkg/authorization/workspace_content_authorizer_test.go
+++ b/pkg/authorization/workspace_content_authorizer_test.go
@@ -162,7 +162,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			wantReason:         "not permitted due to phase \"Scheduling\"",
 		},
 		{
-			testName: "service account of same workspace is denied on initializing workspace",
+			testName: "service account of same workspace is allowed on initializing workspace",
 
 			requestedWorkspace: "root:initializing",
 			requestingUser:     newServiceAccountWithCluster("somebody", "root:initializing", "system:authenticated"),

--- a/pkg/cliplugins/bind/plugin/bind.go
+++ b/pkg/cliplugins/bind/plugin/bind.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/kcp-dev/logicalcluster/v3"
@@ -83,8 +82,8 @@ func (b *BindOptions) Validate() error {
 		return errors.New("`root:ws:apiexport_object` reference to bind is required as an argument")
 	}
 
-	if !strings.HasPrefix(b.APIExportRef, "root") || !logicalcluster.NewPath(b.APIExportRef).IsValid() {
-		return fmt.Errorf("fully qualified reference to workspace where APIExport exists is required. The format is `root:<ws>:<apiexport>`")
+	if !logicalcluster.NewPath(b.APIExportRef).IsValid() {
+		return fmt.Errorf("fully qualified reference to workspace where APIExport exists is required. The format is `<logical-cluster-name>:<apiexport>` or `<full>:<path>:<to>:<apiexport>`")
 	}
 
 	return b.Options.Validate()

--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -254,7 +254,6 @@ func (o *SyncOptions) Run(ctx context.Context) error {
 		KCPNamespace: o.KCPNamespace,
 		Namespace:    o.DownstreamNamespace,
 
-		// run the syncer against a logical cluster, not the path, to make it resilient to workspace moves
 		SyncTargetPath: logicalcluster.From(syncTarget).Path().String(),
 		SyncTarget:     o.SyncTargetName,
 		SyncTargetUID:  string(syncTarget.UID),


### PR DESCRIPTION
Follow-ups of https://github.com/kcp-dev/kcp/pull/2510.

It probably isn't descriptive enough.
It probably isn't descriptive enough.
It probably isn't descriptive enough.
It probably isn't descriptive enough.
It probably isn't descriptive enough.
It probably isn't descriptive enough.
It probably isn't descriptive enough.
It probably isn't descriptive enough.