### PR TITLE
:bug: workspace controller: use loopback client for local shard

### DIFF
--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -52,6 +52,7 @@ const (
 )
 
 func NewController(
+	shardName string,
 	shardExternalURL func() string,
 	kcpClusterClient kcpclientset.ClusterInterface,
 	kubeClusterClient kubernetes.ClusterInterface,
@@ -66,6 +67,7 @@ func NewController(
 	c := &Controller{
 		queue: queue,
 
+		shardName:        shardName,
 		shardExternalURL: shardExternalURL,
 
 		logicalClusterAdminConfig: logicalClusterAdminConfig,
@@ -119,6 +121,7 @@ type workspaceResource = committer.Resource[*tenancyv1beta1.WorkspaceSpec, *tena
 type Controller struct {
 	queue workqueue.RateLimitingInterface
 
+	shardName                 string
 	shardExternalURL          func() string
 	logicalClusterAdminConfig *rest.Config
 

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile.go
@@ -65,6 +65,9 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1beta1.Workspace
 	// the returned client establishes a direct connection with the shard with credentials stored in r.logicalClusterAdminConfig.
 	// TODO:(p0lyn0mial): make it more efficient, maybe we need a per shard client pool or we could use an HTTPRoundTripper
 	kcpDirectClientFor := func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error) {
+		if shard.Name == c.shardName {
+			return c.kcpClusterClient, nil
+		}
 		shardConfig := restclient.CopyConfig(c.logicalClusterAdminConfig)
 		shardConfig.Host = shard.Spec.BaseURL
 		shardClient, err := kcpclientset.NewForConfig(shardConfig)
@@ -78,6 +81,9 @@ func (c *Controller) reconcile(ctx context.Context, ws *tenancyv1beta1.Workspace
 	// the returned client establishes a direct connection with the shard with credentials stored in r.logicalClusterAdminConfig.
 	// TODO:(p0lyn0mial): make it more efficient, maybe we need a per shard client pool or we could use an HTTPRoundTripper
 	kubeDirectClientFor := func(shard *corev1alpha1.Shard) (kubernetes.ClusterInterface, error) {
+		if shard.Name == c.shardName {
+			return c.kubeClusterClient, nil
+		}
 		shardConfig := restclient.CopyConfig(c.logicalClusterAdminConfig)
 		shardConfig.Host = shard.Spec.BaseURL
 		shardClient, err := kubernetes.NewForConfig(shardConfig)

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -416,6 +416,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 	logicalClusterAdminConfig = rest.AddUserAgent(logicalClusterAdminConfig, workspace.ControllerName)
 
 	workspaceController, err := workspace.NewController(
+		s.Options.Extra.ShardName,
 		s.CompletedConfig.ShardExternalURL,
 		kcpClusterClient,
 		kubeClusterClient,


### PR DESCRIPTION
## Summary
This means we can bootstrap without relying on the shard BaseURL, which may not be available during bootstrapping e.g if the endpoint is behind a k8s service controlled by a readiness probe

