### PR TITLE
⚠️ Move Workspace.Status.{Cluster, URL} to Spec

### DIFF
--- a/config/crds/tenancy.kcp.io_workspaces.yaml
+++ b/config/crds/tenancy.kcp.io_workspaces.yaml
@@ -28,7 +28,7 @@ spec:
       name: Phase
       type: string
     - description: URL to access the workspace
-      jsonPath: .status.URL
+      jsonPath: .spec.URL
       name: URL
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -66,6 +66,19 @@ spec:
             default: {}
             description: WorkspaceSpec holds the desired state of the ClusterWorkspace.
             properties:
+              URL:
+                description: "URL is the address under which the Kubernetes-cluster-like
+                  endpoint can be found. This URL can be used to access the workspace
+                  with standard Kubernetes client libraries and command line tools.
+                  \n Set by the system."
+                type: string
+              cluster:
+                description: "cluster is the name of the logical cluster this workspace
+                  is stored under. \n Set by the system."
+                type: string
+                x-kubernetes-validations:
+                - message: cluster is immutable
+                  rule: self == oldSelf
               shard:
                 description: "location constraints where this workspace can be scheduled
                   to. \n If the no location is specified, an arbitrary location is
@@ -149,22 +162,15 @@ spec:
                 - message: path is immutable
                   rule: '!has(oldSelf.path) || !has(self.path) || self.path == oldSelf.path'
             type: object
+            x-kubernetes-validations:
+            - message: URL cannot be unset
+              rule: '!has(oldSelf.URL) || has(self.URL)'
+            - message: cluster cannot be unset
+              rule: '!has(oldSelf.cluster) || has(self.cluster)'
           status:
             default: {}
             description: WorkspaceStatus communicates the observed state of the Workspace.
             properties:
-              URL:
-                description: url is the address under which the Kubernetes-cluster-like
-                  endpoint can be found. This URL can be used to access the workspace
-                  with standard Kubernetes client libraries and command line tools.
-                type: string
-              cluster:
-                description: cluster is the name of the logical cluster this workspace
-                  is stored under.
-                type: string
-                x-kubernetes-validations:
-                - message: cluster is immutable
-                  rule: self == oldSelf
               conditions:
                 description: Current processing state of the ClusterWorkspace.
                 items:
@@ -228,11 +234,6 @@ spec:
                 - Ready
                 type: string
             type: object
-            x-kubernetes-validations:
-            - message: cluster is immutable
-              rule: '!has(oldSelf.cluster) || has(self.cluster)'
-            - message: URL cannot be unset
-              rule: '!has(oldSelf.URL) || has(self.URL)'
         required:
         - spec
         type: object

--- a/config/root-phase0/apiexport-tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiexport-tenancy.kcp.io.yaml
@@ -5,9 +5,9 @@ metadata:
   name: tenancy.kcp.io
 spec:
   latestResourceSchemas:
-  - v221219-9eb351177.workspaces.tenancy.kcp.io
   - v221219-c92ed8152.clusterworkspaces.tenancy.kcp.io
   - v221219-c92ed8152.workspacetypes.tenancy.kcp.io
+  - v230106-48fd7f1e.workspaces.tenancy.kcp.io
   maximalPermissionPolicy:
     local: {}
 status: {}

--- a/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-workspaces.tenancy.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v221219-9eb351177.workspaces.tenancy.kcp.io
+  name: v230106-48fd7f1e.workspaces.tenancy.kcp.io
 spec:
   group: tenancy.kcp.io
   names:
@@ -26,7 +26,7 @@ spec:
       name: Phase
       type: string
     - description: URL to access the workspace
-      jsonPath: .status.URL
+      jsonPath: .spec.URL
       name: URL
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -63,6 +63,19 @@ spec:
           default: {}
           description: WorkspaceSpec holds the desired state of the ClusterWorkspace.
           properties:
+            URL:
+              description: "URL is the address under which the Kubernetes-cluster-like
+                endpoint can be found. This URL can be used to access the workspace
+                with standard Kubernetes client libraries and command line tools.
+                \n Set by the system."
+              type: string
+            cluster:
+              description: "cluster is the name of the logical cluster this workspace
+                is stored under. \n Set by the system."
+              type: string
+              x-kubernetes-validations:
+              - message: cluster is immutable
+                rule: self == oldSelf
             shard:
               description: "location constraints where this workspace can be scheduled
                 to. \n If the no location is specified, an arbitrary location is chosen."
@@ -144,22 +157,15 @@ spec:
               - message: path is immutable
                 rule: '!has(oldSelf.path) || !has(self.path) || self.path == oldSelf.path'
           type: object
+          x-kubernetes-validations:
+          - message: URL cannot be unset
+            rule: '!has(oldSelf.URL) || has(self.URL)'
+          - message: cluster cannot be unset
+            rule: '!has(oldSelf.cluster) || has(self.cluster)'
         status:
           default: {}
           description: WorkspaceStatus communicates the observed state of the Workspace.
           properties:
-            URL:
-              description: url is the address under which the Kubernetes-cluster-like
-                endpoint can be found. This URL can be used to access the workspace
-                with standard Kubernetes client libraries and command line tools.
-              type: string
-            cluster:
-              description: cluster is the name of the logical cluster this workspace
-                is stored under.
-              type: string
-              x-kubernetes-validations:
-              - message: cluster is immutable
-                rule: self == oldSelf
             conditions:
               description: Current processing state of the ClusterWorkspace.
               items:
@@ -222,11 +228,6 @@ spec:
               - Ready
               type: string
           type: object
-          x-kubernetes-validations:
-          - message: cluster is immutable
-            rule: '!has(oldSelf.cluster) || has(self.cluster)'
-          - message: URL cannot be unset
-            rule: '!has(oldSelf.URL) || has(self.URL)'
       required:
       - spec
       type: object

--- a/pkg/apis/tenancy/projection/workspaces.go
+++ b/pkg/apis/tenancy/projection/workspaces.go
@@ -32,9 +32,9 @@ func ProjectWorkspaceToClusterWorkspace(from *tenancyv1beta1.Workspace, to *tena
 			Selector: from.Spec.Location.Selector,
 		}
 	}
-	to.Status.BaseURL = from.Status.URL
+	to.Status.Cluster = from.Spec.Cluster
+	to.Status.BaseURL = from.Spec.URL
 	to.Status.Phase = from.Status.Phase
 	to.Status.Initializers = from.Status.Initializers
-	to.Status.Cluster = from.Status.Cluster
 	to.Status.Conditions = from.Status.Conditions
 }

--- a/pkg/apis/tenancy/v1beta1/types_workspace_test.go
+++ b/pkg/apis/tenancy/v1beta1/types_workspace_test.go
@@ -38,26 +38,26 @@ func TestWorkspaceCELValidation(t *testing.T) {
 		},
 		{
 			name:    "unset URL",
-			old:     `{"status":{"URL": "abc"}}`,
-			current: `{"status":{}}`,
+			old:     `{"spec":{"URL": "abc"}}`,
+			current: `{"spec":{}}`,
 			wantErrs: []string{
-				"status: Invalid value: \"object\": URL cannot be unset",
+				"spec: Invalid value: \"object\": URL cannot be unset",
 			},
 		},
 		{
 			name:    "unset cluster",
-			old:     `{"status":{"cluster": "abc"}}`,
-			current: `{"status":{}}`,
+			old:     `{"spec":{"cluster": "abc"}}`,
+			current: `{"spec":{}}`,
 			wantErrs: []string{
-				"status: Invalid value: \"object\": cluster is immutable",
+				"spec: Invalid value: \"object\": cluster cannot be unset",
 			},
 		},
 		{
 			name:    "change cluster",
-			old:     `{"status":{"cluster": "abc"}}`,
-			current: `{"status":{"cluster": "def"}}`,
+			old:     `{"spec":{"cluster": "abc"}}`,
+			current: `{"spec":{"cluster": "def"}}`,
 			wantErrs: []string{
-				"status.cluster: Invalid value: \"string\": cluster is immutable",
+				"spec.cluster: Invalid value: \"string\": cluster is immutable",
 			},
 		},
 		{

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -214,7 +214,7 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		newServerHost = homeWorkspace.Status.URL
+		newServerHost = homeWorkspace.Spec.URL
 
 	case ".":
 		cfg, err := o.ClientConfig.ClientConfig()
@@ -828,9 +828,9 @@ func (o *TreeOptions) populateBranch(ctx context.Context, tree treeprint.Tree, n
 	}
 
 	for _, workspace := range results.Items {
-		_, currentClusterName, err := pluginhelpers.ParseClusterURL(workspace.Status.URL)
+		_, currentClusterName, err := pluginhelpers.ParseClusterURL(workspace.Spec.URL)
 		if err != nil {
-			return fmt.Errorf("current config context URL %q does not point to workspace", workspace.Status.URL)
+			return fmt.Errorf("current config context URL %q does not point to workspace", workspace.Spec.URL)
 		}
 		err = o.populateBranch(ctx, b, currentClusterName)
 		if err != nil {

--- a/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
@@ -200,6 +200,7 @@ func TestCreate(t *testing.T) {
 						Name: name,
 					},
 					Spec: tenancyv1beta1.WorkspaceSpec{
+						URL: fmt.Sprintf("https://test%s", currentClusterName.Join(name).RequestPath()),
 						Type: tenancyv1beta1.WorkspaceTypeReference{
 							Name: "universal",
 							Path: "root",
@@ -207,7 +208,6 @@ func TestCreate(t *testing.T) {
 					},
 					Status: tenancyv1beta1.WorkspaceStatus{
 						Phase: corev1alpha1.LogicalClusterPhaseReady,
-						URL:   fmt.Sprintf("https://test%s", currentClusterName.Join(name).RequestPath()),
 					},
 				})
 			}
@@ -228,7 +228,7 @@ func TestCreate(t *testing.T) {
 					obj.Status.Phase = corev1alpha1.LogicalClusterPhaseReady
 					u := parseURLOrDie(u.String())
 					u.Path = currentClusterName.Join(obj.Name).RequestPath()
-					obj.Status.URL = u.String()
+					obj.Spec.URL = u.String()
 					obj.Spec.Type = workspaceType
 					if err := client.Tracker().Cluster(currentClusterName).Create(tenancyv1beta1.SchemeGroupVersion.WithResource("workspaces"), obj, ""); err != nil {
 						return false, nil, err
@@ -1204,7 +1204,7 @@ func TestUse(t *testing.T) {
 					}
 					if !tt.unready[lcluster.Path()][name] {
 						obj.Status.Phase = corev1alpha1.LogicalClusterPhaseReady
-						obj.Status.URL = fmt.Sprintf("https://test%s", lcluster.Path().Join(name).RequestPath())
+						obj.Spec.URL = fmt.Sprintf("https://test%s", lcluster.Path().Join(name).RequestPath())
 					}
 					objs = append(objs, obj)
 				}
@@ -1221,13 +1221,11 @@ func TestUse(t *testing.T) {
 							Name: "user-name",
 						},
 						Spec: tenancyv1beta1.WorkspaceSpec{
+							URL: fmt.Sprintf("https://test%s", homeWorkspaceLogicalCluster.RequestPath()),
 							Type: tenancyv1beta1.WorkspaceTypeReference{
 								Name: "home",
 								Path: "root",
 							},
-						},
-						Status: tenancyv1beta1.WorkspaceStatus{
-							URL: fmt.Sprintf("https://test%s", homeWorkspaceLogicalCluster.RequestPath()),
 						},
 					}, nil
 				}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -72,14 +72,14 @@ func (c *State) UpsertWorkspace(shard string, ws *tenancyv1beta1.Workspace) {
 	got := c.shardWorkspaceNameCluster[shard][clusterName][ws.Name]
 	c.lock.RUnlock()
 
-	if got.String() == ws.Status.Cluster {
+	if got.String() == ws.Spec.Cluster {
 		return
 	}
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if got := c.shardWorkspaceNameCluster[shard][clusterName][ws.Name]; got.String() != ws.Status.Cluster {
+	if got := c.shardWorkspaceNameCluster[shard][clusterName][ws.Name]; got.String() != ws.Spec.Cluster {
 		if c.shardWorkspaceNameCluster[shard] == nil {
 			c.shardWorkspaceNameCluster[shard] = map[logicalcluster.Name]map[string]logicalcluster.Name{}
 			c.shardClusterWorkspaceName[shard] = map[logicalcluster.Name]string{}
@@ -88,9 +88,9 @@ func (c *State) UpsertWorkspace(shard string, ws *tenancyv1beta1.Workspace) {
 		if c.shardWorkspaceNameCluster[shard][clusterName] == nil {
 			c.shardWorkspaceNameCluster[shard][clusterName] = map[string]logicalcluster.Name{}
 		}
-		c.shardWorkspaceNameCluster[shard][clusterName][ws.Name] = logicalcluster.Name(ws.Status.Cluster)
-		c.shardClusterWorkspaceName[shard][logicalcluster.Name(ws.Status.Cluster)] = ws.Name
-		c.shardClusterParentCluster[shard][logicalcluster.Name(ws.Status.Cluster)] = clusterName
+		c.shardWorkspaceNameCluster[shard][clusterName][ws.Name] = logicalcluster.Name(ws.Spec.Cluster)
+		c.shardClusterWorkspaceName[shard][logicalcluster.Name(ws.Spec.Cluster)] = ws.Name
+		c.shardClusterParentCluster[shard][logicalcluster.Name(ws.Spec.Cluster)] = clusterName
 	}
 }
 
@@ -123,12 +123,12 @@ func (c *State) DeleteWorkspace(shard string, ws *tenancyv1beta1.Workspace) {
 		delete(c.shardWorkspaceNameCluster, shard)
 	}
 
-	delete(c.shardClusterWorkspaceName[shard], logicalcluster.Name(ws.Status.Cluster))
+	delete(c.shardClusterWorkspaceName[shard], logicalcluster.Name(ws.Spec.Cluster))
 	if len(c.shardClusterWorkspaceName[shard]) == 0 {
 		delete(c.shardClusterWorkspaceName, shard)
 	}
 
-	delete(c.shardClusterParentCluster[shard], logicalcluster.Name(ws.Status.Cluster))
+	delete(c.shardClusterParentCluster[shard], logicalcluster.Name(ws.Spec.Cluster))
 	if len(c.shardClusterParentCluster[shard]) == 0 {
 		delete(c.shardClusterParentCluster, shard)
 	}

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -3997,6 +3997,20 @@ func schema_pkg_apis_tenancy_v1beta1_WorkspaceSpec(ref common.ReferenceCallback)
 							Ref:         ref("github.com/kcp-dev/kcp/pkg/apis/tenancy/v1beta1.WorkspaceLocation"),
 						},
 					},
+					"cluster": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cluster is the name of the logical cluster this workspace is stored under.\n\nSet by the system.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"URL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "URL is the address under which the Kubernetes-cluster-like endpoint can be found. This URL can be used to access the workspace with standard Kubernetes client libraries and command line tools.\n\nSet by the system.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -4012,20 +4026,6 @@ func schema_pkg_apis_tenancy_v1beta1_WorkspaceStatus(ref common.ReferenceCallbac
 				Description: "WorkspaceStatus communicates the observed state of the Workspace.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"URL": {
-						SchemaProps: spec.SchemaProps{
-							Description: "url is the address under which the Kubernetes-cluster-like endpoint can be found. This URL can be used to access the workspace with standard Kubernetes client libraries and command line tools.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"cluster": {
-						SchemaProps: spec.SchemaProps{
-							Description: "cluster is the name of the logical cluster this workspace is stored under.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"phase": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Phase of the workspace (Scheduling, Initializing, Ready).",

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_deletion.go
@@ -37,7 +37,7 @@ type deletionReconciler struct {
 
 func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1beta1.Workspace) (reconcileStatus, error) {
 	logger := klog.FromContext(ctx).WithValues("reconciler", "deletion")
-	logger = logger.WithValues("cluster", workspace.Status.Cluster)
+	logger = logger.WithValues("cluster", workspace.Spec.Cluster)
 
 	if workspace.DeletionTimestamp.IsZero() {
 		return reconcileStatusContinue, nil
@@ -49,7 +49,7 @@ func (r *deletionReconciler) reconcile(ctx context.Context, workspace *tenancyv1
 
 	// If the logical cluster hasn't been created yet, we have to look at the annotation to
 	// get the cluster name, instead of looking at status.
-	clusterName := logicalcluster.Name(workspace.Status.Cluster)
+	clusterName := logicalcluster.Name(workspace.Spec.Cluster)
 	if workspace.Status.Phase == corev1alpha1.LogicalClusterPhaseScheduling {
 		a, ok := workspace.Annotations[workspaceClusterAnnotationKey]
 		if !ok {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_phase.go
@@ -43,13 +43,13 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1bet
 
 	switch workspace.Status.Phase {
 	case corev1alpha1.LogicalClusterPhaseScheduling:
-		if workspace.Status.Cluster != "" {
+		if workspace.Spec.URL != "" && workspace.Spec.Cluster != "" {
 			workspace.Status.Phase = corev1alpha1.LogicalClusterPhaseInitializing
 		}
 	case corev1alpha1.LogicalClusterPhaseInitializing:
-		logger = logger.WithValues("cluster", workspace.Status.Cluster)
+		logger = logger.WithValues("cluster", workspace.Spec.Cluster)
 
-		logicalCluster, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Status.Cluster))
+		logicalCluster, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Spec.Cluster))
 		if err != nil && !apierrors.IsNotFound(err) {
 			return reconcileStatusStopAndRequeue, err
 		} else if apierrors.IsNotFound(err) {
@@ -77,9 +77,9 @@ func (r *phaseReconciler) reconcile(ctx context.Context, workspace *tenancyv1bet
 
 	case corev1alpha1.LogicalClusterPhaseReady:
 		if !workspace.DeletionTimestamp.IsZero() {
-			logger = logger.WithValues("cluster", workspace.Status.Cluster)
+			logger = logger.WithValues("cluster", workspace.Spec.Cluster)
 
-			logicalCluster, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Status.Cluster))
+			logicalCluster, err := r.getLogicalCluster(ctx, logicalcluster.NewPath(workspace.Spec.Cluster))
 			if err != nil && !apierrors.IsNotFound(err) {
 				return reconcileStatusStopAndRequeue, err
 			} else if apierrors.IsNotFound(err) {

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -93,8 +93,8 @@ func TestReconcileScheduling(t *testing.T) {
 
 				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
 				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
-				initialWS.Status.URL = `https://root/clusters/root-foo`
-				initialWS.Status.Cluster = "root-foo"
+				initialWS.Spec.URL = `https://root/clusters/root-foo`
+				initialWS.Spec.Cluster = "root-foo"
 				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
 					Type:   tenancyv1alpha1.WorkspaceScheduled,
 					Status: corev1.ConditionTrue,
@@ -127,8 +127,8 @@ func TestReconcileScheduling(t *testing.T) {
 
 				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
 				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
-				initialWS.Status.URL = `https://root/clusters/root-foo`
-				initialWS.Status.Cluster = "root-foo"
+				initialWS.Spec.URL = `https://root/clusters/root-foo`
+				initialWS.Spec.Cluster = "root-foo"
 				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
 					Type:   tenancyv1alpha1.WorkspaceScheduled,
 					Status: corev1.ConditionTrue,
@@ -190,8 +190,8 @@ func TestReconcileScheduling(t *testing.T) {
 
 				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
 				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
-				initialWS.Status.URL = `https://root/clusters/root-foo`
-				initialWS.Status.Cluster = "root-foo"
+				initialWS.Spec.URL = `https://root/clusters/root-foo`
+				initialWS.Spec.Cluster = "root-foo"
 				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
 					Type:   tenancyv1alpha1.WorkspaceScheduled,
 					Status: corev1.ConditionTrue,
@@ -324,6 +324,16 @@ func TestReconcileScheduling(t *testing.T) {
 			status, err := target.reconcile(context.TODO(), scenario.targetWorkspace)
 			if err != nil {
 				t.Fatal(err)
+			}
+
+			if scenario.targetWorkspace.Spec.URL != "" && scenario.targetWorkspace.Spec.Cluster != "" {
+				// If the reconciler has set both url and cluster, call the reconciler again.
+				if status == reconcileStatusStopAndRequeue {
+					status, err = target.reconcile(context.TODO(), scenario.targetWorkspace)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
 			}
 			if status != scenario.expectedStatus {
 				t.Fatalf("unexpected reconciliation status:%v, expected:%v", status, scenario.expectedStatus)

--- a/pkg/server/home_workspaces.go
+++ b/pkg/server/home_workspaces.go
@@ -319,10 +319,11 @@ func (h *homeWorkspaceHandler) ServeHTTP(rw http.ResponseWriter, req *http.Reque
 			Name:              logicalCluster.Name,
 			CreationTimestamp: logicalCluster.CreationTimestamp,
 		},
-		Spec: tenancyv1beta1.WorkspaceSpec{},
+		Spec: tenancyv1beta1.WorkspaceSpec{
+			Cluster: logicalcluster.From(logicalCluster).String(),
+			URL:     logicalCluster.Status.URL,
+		},
 		Status: tenancyv1beta1.WorkspaceStatus{
-			URL:          logicalCluster.Status.URL,
-			Cluster:      logicalcluster.From(logicalCluster).String(),
 			Phase:        logicalCluster.Status.Phase,
 			Conditions:   logicalCluster.Status.Conditions,
 			Initializers: logicalCluster.Status.Initializers,

--- a/test/e2e/reconciler/clusterworkspace/controller_test.go
+++ b/test/e2e/reconciler/clusterworkspace/controller_test.go
@@ -139,10 +139,10 @@ func TestWorkspaceController(t *testing.T) {
 					if isUnschedulable(workspace) {
 						return false, fmt.Sprintf("unschedulable:\n%s", toYAML(t, workspace))
 					}
-					if workspace.Status.Cluster == "" {
-						return false, fmt.Sprintf("status.cluster is empty\n%s", toYAML(t, workspace))
+					if workspace.Spec.Cluster == "" {
+						return false, fmt.Sprintf("spec.cluster is empty\n%s", toYAML(t, workspace))
 					}
-					if expected := previouslyValidShard.Spec.BaseURL + "/clusters/" + workspace.Status.Cluster; workspace.Status.URL != expected {
+					if expected := previouslyValidShard.Spec.BaseURL + "/clusters/" + workspace.Spec.Cluster; workspace.Spec.URL != expected {
 						return false, fmt.Sprintf("URL is not %q:\n%s", expected, toYAML(t, workspace))
 					}
 					return true, ""
@@ -220,8 +220,8 @@ func scheduledAnywhere(object *tenancyv1beta1.Workspace) error {
 	if isUnschedulable(object) {
 		return fmt.Errorf("expected a scheduled workspace, got status.conditions: %#v", object.Status.Conditions)
 	}
-	if object.Status.Cluster == "" {
-		return fmt.Errorf("expected workspace.status.cluster to be anything, got %q", object.Status.Cluster)
+	if object.Spec.Cluster == "" {
+		return fmt.Errorf("expected workspace.spec.cluster to be anything, got %q", object.Spec.Cluster)
 	}
 	return nil
 }

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -363,7 +363,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 			lclusters.Insert(logicalcluster.From(&actual.Items[i]).String())
 		}
 		for i := range expected {
-			expectedClusters.Insert(expected[i].Status.Cluster)
+			expectedClusters.Insert(expected[i].Spec.Cluster)
 		}
 		sort.Slice(actual.Items, func(i, j int) bool {
 			return actual.Items[i].UID < actual.Items[j].UID
@@ -402,16 +402,16 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 
 	ws, err = sourceKcpClusterClient.TenancyV1beta1().Cluster(clusterName.Path()).Workspaces().Get(ctx, ws.Name, metav1.GetOptions{})
 	require.NoError(t, err)
-	wsClusterName := logicalcluster.Name(ws.Status.Cluster)
+	wsClusterName := logicalcluster.Name(ws.Spec.Cluster)
 
-	t.Logf("Waiting for watchers to see the logicalcluster in %s for workspace %s", ws.Status.Cluster, ws.Name)
+	t.Logf("Waiting for watchers to see the logicalcluster in %s for workspace %s", ws.Spec.Cluster, ws.Name)
 	for initializer, watcher := range watchers {
 		for {
 			select {
 			case evt := <-watcher.ResultChan():
 				// there might be other actors doing who-knows-what on the workspaces, so we need to specifically
 				// look for the first event *relating to the new workspace* that we get
-				if logicalcluster.From(evt.Object.(metav1.Object)).String() != ws.Status.Cluster {
+				if logicalcluster.From(evt.Object.(metav1.Object)).String() != ws.Spec.Cluster {
 					continue
 				}
 				require.Equal(t, evt.Type, watch.Added)
@@ -526,7 +526,7 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 				}
 				// there might be other actors doing who-knows-what on the workspaces, so we need to specifically
 				// look for the first event *relating to the new workspace* that we get
-				if logicalcluster.From(evt.Object.(metav1.Object)).String() != ws.Status.Cluster {
+				if logicalcluster.From(evt.Object.(metav1.Object)).String() != ws.Spec.Cluster {
 					continue
 				}
 				require.Equal(t, evt.Type, watch.Deleted)

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -305,10 +305,10 @@ func TestWorkspaceTypes(t *testing.T) {
 
 				t.Logf("Remove initializer")
 				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					logicalCluster, err := server.kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.Name(workspace.Status.Cluster).Path()).Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+					logicalCluster, err := server.kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.Name(workspace.Spec.Cluster).Path()).Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
 					require.NoError(t, err)
 					logicalCluster.Status.Initializers = initialization.EnsureInitializerAbsent(initialization.InitializerForType(cwt), logicalCluster.Status.Initializers)
-					_, err = server.kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.Name(workspace.Status.Cluster).Path()).UpdateStatus(ctx, logicalCluster, metav1.UpdateOptions{})
+					_, err = server.kcpClusterClient.CoreV1alpha1().LogicalClusters().Cluster(logicalcluster.Name(workspace.Spec.Cluster).Path()).UpdateStatus(ctx, logicalCluster, metav1.UpdateOptions{})
 					return err
 				})
 				require.NoError(t, err)


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

In order to preserve the URL field, given that Status may be wiped under a number of conditions and most times URL cannot be easily or at all reconstructured, this changeset moves the field under Spec.

In addition, now the admission code also checks that any modification to the URL is performed by a system user.

Signed-off-by: Vince Prignano <vince@prigna.com>

## Related issue(s)

Fixes #
