### PR TITLE
🌱 cluster workspace rename

### DIFF
--- a/pkg/admission/kubequota/kubequota_admission.go
+++ b/pkg/admission/kubequota/kubequota_admission.go
@@ -144,7 +144,7 @@ func (k *KubeResourceQuota) Validate(ctx context.Context, a admission.Attributes
 	}
 
 	k.clusterWorkspaceDeletionMonitorStarter.Do(func() {
-		m := newClusterWorkspaceDeletionMonitor(k.logicalClusterInformer, k.stopQuotaAdmissionForCluster)
+		m := newLogicalClusterDeletionMonitor(k.logicalClusterInformer, k.stopQuotaAdmissionForCluster)
 		go m.Start(k.serverDone)
 	})
 

--- a/pkg/proxy/index/index_controller.go
+++ b/pkg/proxy/index/index_controller.go
@@ -52,12 +52,12 @@ type Index interface {
 	LookupURL(path logicalcluster.Path) (url string, found bool)
 }
 
-type ClusterWorkspaceClientGetter func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error)
+type ClusterClientGetter func(shard *corev1alpha1.Shard) (kcpclientset.ClusterInterface, error)
 
 func NewController(
 	ctx context.Context,
 	shardInformer corev1alpha1informers.ShardInformer,
-	clientGetter ClusterWorkspaceClientGetter,
+	clientGetter ClusterClientGetter,
 ) *Controller {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName)
 
@@ -112,7 +112,7 @@ func NewController(
 type Controller struct {
 	queue workqueue.RateLimitingInterface
 
-	clientGetter ClusterWorkspaceClientGetter
+	clientGetter ClusterClientGetter
 
 	shardIndexer cache.Indexer
 	shardLister  corev1alpha1listers.ShardLister

--- a/pkg/reconciler/garbagecollector/garbagecollector_controller.go
+++ b/pkg/reconciler/garbagecollector/garbagecollector_controller.go
@@ -196,7 +196,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	ws, err := c.logicalClusterLister.Cluster(clusterName).Get(name)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
-			logger.V(2).Info("ClusterWorkspace not found - stopping garbage collector controller for it (if needed)")
+			logger.V(2).Info("LogicalCluster not found - stopping garbage collector controller for it (if needed)")
 
 			c.lock.Lock()
 			cancel, ok := c.cancelFuncs[clusterName]
@@ -230,7 +230,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	ctx = klog.NewContext(ctx, logger)
 	c.cancelFuncs[clusterName] = cancel
 
-	if err := c.startGarbageCollectorForClusterWorkspace(ctx, clusterName); err != nil {
+	if err := c.startGarbageCollectorForLogicalCluster(ctx, clusterName); err != nil {
 		cancel()
 		return fmt.Errorf("error starting garbage collector controller for cluster %q: %w", clusterName, err)
 	}
@@ -238,7 +238,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *Controller) startGarbageCollectorForClusterWorkspace(ctx context.Context, clusterName logicalcluster.Name) error {
+func (c *Controller) startGarbageCollectorForLogicalCluster(ctx context.Context, clusterName logicalcluster.Name) error {
 	logger := klog.FromContext(ctx)
 
 	kubeClient := c.kubeClusterClient.Cluster(clusterName.Path())

--- a/pkg/reconciler/kubequota/kubequota_controller.go
+++ b/pkg/reconciler/kubequota/kubequota_controller.go
@@ -239,7 +239,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	ctx = klog.NewContext(ctx, logger)
 	c.cancelFuncs[clusterName] = cancel
 
-	if err := c.startQuotaForClusterWorkspace(ctx, clusterName); err != nil {
+	if err := c.startQuotaForLogicalCluster(ctx, clusterName); err != nil {
 		cancel()
 		return fmt.Errorf("error starting quota controller for cluster %q: %w", clusterName, err)
 	}
@@ -247,7 +247,7 @@ func (c *Controller) process(ctx context.Context, key string) error {
 	return nil
 }
 
-func (c *Controller) startQuotaForClusterWorkspace(ctx context.Context, clusterName logicalcluster.Name) error {
+func (c *Controller) startQuotaForLogicalCluster(ctx context.Context, clusterName logicalcluster.Name) error {
 	logger := klog.FromContext(ctx)
 	resourceQuotaControllerClient := c.kubeClusterClient.Cluster(clusterName.Path())
 

--- a/pkg/virtual/initializingworkspaces/builder/build.go
+++ b/pkg/virtual/initializingworkspaces/builder/build.go
@@ -127,7 +127,7 @@ func BuildVirtualWorkspace(
 				dynamicClusterClient: dynamicClusterClient,
 				exposeSubresources:   false,
 				resource:             &logicalClusterResource,
-				storageProvider:      provideFilteredClusterWorkspacesReadOnlyRestStorage(getTenancyIdentity),
+				storageProvider:      provideFilteredLogicalClusterReadOnlyRestStorage(getTenancyIdentity),
 			}, nil
 		},
 	}
@@ -164,7 +164,7 @@ func BuildVirtualWorkspace(
 				dynamicClusterClient: dynamicClusterClient,
 				exposeSubresources:   true,
 				resource:             &logicalClusterResource,
-				storageProvider:      provideDelegatingClusterWorkspacesRestStorage(getTenancyIdentity),
+				storageProvider:      provideDelegatingLogicalClusterRestStorage(getTenancyIdentity),
 			}, nil
 		},
 	}

--- a/pkg/virtual/initializingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/initializingworkspaces/builder/forwarding.go
@@ -60,7 +60,7 @@ func initializingWorkspaceRequirements(initializer corev1alpha1.LogicalClusterIn
 	return requirements, nil
 }
 
-func provideFilteredClusterWorkspacesReadOnlyRestStorage(getTenancyIdentity func() (string, error)) func(
+func provideFilteredLogicalClusterReadOnlyRestStorage(getTenancyIdentity func() (string, error)) func(
 	ctx context.Context,
 	clusterClient kcpdynamic.ClusterInterface,
 	initializer corev1alpha1.LogicalClusterInitializer,
@@ -89,7 +89,7 @@ func provideFilteredClusterWorkspacesReadOnlyRestStorage(getTenancyIdentity func
 	}
 }
 
-func provideDelegatingClusterWorkspacesRestStorage(getTenancyIdentity func() (string, error)) func(
+func provideDelegatingLogicalClusterRestStorage(getTenancyIdentity func() (string, error)) func(
 	ctx context.Context,
 	clusterClient kcpdynamic.ClusterInterface,
 	initializer corev1alpha1.LogicalClusterInitializer,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This renames a couple of occurences of clusterworkspace to logicalcluster.

some more text.
some more text.
some more text.
some more text.
some more text.
some more text.
some more text.
some more text.

## Related issue(s)
https://github.com/kcp-dev/kcp/pull/2510
