### PR TITLE
:sparkles: server: wire cache informers instead of root informers

### DIFF
--- a/cmd/sharded-test-server/cache.go
+++ b/cmd/sharded-test-server/cache.go
@@ -40,11 +40,11 @@ import (
 )
 
 func startCacheServer(ctx context.Context, logDirPath, workingDir string) (<-chan error, string, error) {
-	red := color.New(color.BgHiRed, color.FgHiWhite).SprintFunc()
-	inverse := color.New(color.BgHiWhite, color.FgHiRed).SprintFunc()
+	cyan := color.New(color.BgHiCyan, color.FgHiWhite).SprintFunc()
+	inverse := color.New(color.BgHiWhite, color.FgHiCyan).SprintFunc()
 	out := lineprefix.New(
-		lineprefix.Prefix(red(strings.ToUpper("cache"))),
-		lineprefix.Color(color.New(color.FgHiRed)),
+		lineprefix.Prefix(cyan(strings.ToUpper("cache"))),
+		lineprefix.Color(color.New(color.FgHiCyan)),
 	)
 	loggerOut := lineprefix.New(
 		lineprefix.Prefix(inverse(strings.ToUpper("cache"))),

--- a/pkg/cache/server/bootstrap/bootstrap.go
+++ b/pkg/cache/server/bootstrap/bootstrap.go
@@ -47,6 +47,7 @@ func Bootstrap(ctx context.Context, apiExtensionsClusterClient kcpapiextensionsc
 		{"apis.kcp.io", "apiresourceschemas"},
 		{"apis.kcp.io", "apiexports"},
 		{"core.kcp.io", "shards"},
+		{"tenancy.kcp.io", "workspacetypes"},
 	} {
 		crd := &apiextensionsv1.CustomResourceDefinition{}
 		if err := configcrds.Unmarshal(fmt.Sprintf("%s_%s.yaml", gr.group, gr.resource), crd); err != nil {

--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -573,7 +573,7 @@ func (o *CreateWorkspaceOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	workspaceReference := fmt.Sprintf("Workspace %q (type %s)", o.Name, ws.Spec.Type)
+	workspaceReference := fmt.Sprintf("Workspace %q (type %s)", o.Name, logicalcluster.NewPath(ws.Spec.Type.Path).Join(string(ws.Spec.Type.Name)).String())
 	if preExisting {
 		if ws.Spec.Type.Name != "" && ws.Spec.Type.Name != structuredWorkspaceType.Name || ws.Spec.Type.Path != structuredWorkspaceType.Path {
 			wsTypeString := logicalcluster.NewPath(ws.Spec.Type.Path).Join(string(ws.Spec.Type.Name)).String()

--- a/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_controller.go
@@ -58,7 +58,7 @@ const (
 // for the given GRs when making requests to the server.
 func NewApiExportIdentityProviderController(
 	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
-	cacheAPIExportInformer apisv1alpha1informers.APIExportClusterInformer,
+	globalAPIExportInformer apisv1alpha1informers.APIExportClusterInformer,
 	configMapInformer kcpcorev1informers.ConfigMapClusterInformer,
 ) (*controller, error) {
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName)
@@ -74,12 +74,12 @@ func NewApiExportIdentityProviderController(
 		updateConfigMap: func(ctx context.Context, cluster logicalcluster.Path, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 			return kubeClusterClient.Cluster(cluster).CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
 		},
-		listCacheAPIExports: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
-			return cacheAPIExportInformer.Lister().Cluster(clusterName).List(labels.Everything())
+		listGlobalAPIExports: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
+			return globalAPIExportInformer.Lister().Cluster(clusterName).List(labels.Everything())
 		},
 	}
 
-	cacheAPIExportInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	globalAPIExportInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
 			key, err := kcpcache.DeletionHandlingMetaClusterNamespaceKeyFunc(obj)
 			if err != nil {
@@ -172,9 +172,9 @@ func (c *controller) processNextWorkItem(ctx context.Context) bool {
 }
 
 type controller struct {
-	queue               workqueue.RateLimitingInterface
-	createConfigMap     func(ctx context.Context, cluster logicalcluster.Path, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
-	getConfigMap        func(clusterName logicalcluster.Name, namespace, name string) (*corev1.ConfigMap, error)
-	updateConfigMap     func(ctx context.Context, cluster logicalcluster.Path, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
-	listCacheAPIExports func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error)
+	queue                workqueue.RateLimitingInterface
+	createConfigMap      func(ctx context.Context, cluster logicalcluster.Path, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	getConfigMap         func(clusterName logicalcluster.Name, namespace, name string) (*corev1.ConfigMap, error)
+	updateConfigMap      func(ctx context.Context, cluster logicalcluster.Path, namespace string, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	listGlobalAPIExports func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error)
 }

--- a/pkg/reconciler/apis/identitycache/api_export_identity_reconcile.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_reconcile.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (c *controller) reconcile(ctx context.Context) error {
-	apiExports, err := c.listCacheAPIExports(core.RootCluster)
+	apiExports, err := c.listGlobalAPIExports(core.RootCluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/apis/identitycache/api_export_identity_reconcile.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_reconcile.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (c *controller) reconcile(ctx context.Context) error {
-	apiExports, err := c.listAPIExportsFromRemoteShard(core.RootCluster)
+	apiExports, err := c.listCacheAPIExports(core.RootCluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/apis/identitycache/api_export_identity_reconcile_test.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_reconcile_test.go
@@ -142,17 +142,17 @@ func TestReconcile(t *testing.T) {
 						return nil, err
 					},
 				},
-				listCacheAPIExports: listCacheAPIExportsRecord{
+				listGlobalAPIExports: listGlobalAPIExportsRecord{
 					defaulted: func(name logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
 						return scenario.initialApiExports, nil
 					},
 				},
 			}
 			target := &controller{
-				createConfigMap:     calls.createConfigMap.call,
-				updateConfigMap:     calls.updateConfigMap.call,
-				getConfigMap:        calls.getConfigMap.call,
-				listCacheAPIExports: calls.listCacheAPIExports.call,
+				createConfigMap:      calls.createConfigMap.call,
+				updateConfigMap:      calls.updateConfigMap.call,
+				getConfigMap:         calls.getConfigMap.call,
+				listGlobalAPIExports: calls.listGlobalAPIExports.call,
 			}
 			if err := target.reconcile(context.TODO()); err != nil {
 				t.Error(err)
@@ -165,10 +165,10 @@ func TestReconcile(t *testing.T) {
 }
 
 type callContext struct {
-	createConfigMap     createConfigMapRecord
-	getConfigMap        getConfigMapRecord
-	updateConfigMap     updateConfigMapRecord
-	listCacheAPIExports listCacheAPIExportsRecord
+	createConfigMap      createConfigMapRecord
+	getConfigMap         getConfigMapRecord
+	updateConfigMap      updateConfigMapRecord
+	listGlobalAPIExports listGlobalAPIExportsRecord
 }
 
 type createConfigMapRecord struct {
@@ -213,12 +213,12 @@ func (r *updateConfigMapRecord) call(ctx context.Context, cluster logicalcluster
 	return delegate(ctx, cluster, namespace, configMap)
 }
 
-type listCacheAPIExportsRecord struct {
+type listGlobalAPIExportsRecord struct {
 	called              bool
 	delegate, defaulted func(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error)
 }
 
-func (r *listCacheAPIExportsRecord) call(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
+func (r *listGlobalAPIExportsRecord) call(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
 	r.called = true
 	delegate := r.delegate
 	if delegate == nil {

--- a/pkg/reconciler/apis/identitycache/api_export_identity_reconcile_test.go
+++ b/pkg/reconciler/apis/identitycache/api_export_identity_reconcile_test.go
@@ -142,17 +142,17 @@ func TestReconcile(t *testing.T) {
 						return nil, err
 					},
 				},
-				listAPIExportsFromRemoteShard: listAPIExportsFromRemoteShardRecord{
+				listCacheAPIExports: listCacheAPIExportsRecord{
 					defaulted: func(name logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
 						return scenario.initialApiExports, nil
 					},
 				},
 			}
 			target := &controller{
-				createConfigMap:               calls.createConfigMap.call,
-				updateConfigMap:               calls.updateConfigMap.call,
-				getConfigMap:                  calls.getConfigMap.call,
-				listAPIExportsFromRemoteShard: calls.listAPIExportsFromRemoteShard.call,
+				createConfigMap:     calls.createConfigMap.call,
+				updateConfigMap:     calls.updateConfigMap.call,
+				getConfigMap:        calls.getConfigMap.call,
+				listCacheAPIExports: calls.listCacheAPIExports.call,
 			}
 			if err := target.reconcile(context.TODO()); err != nil {
 				t.Error(err)
@@ -165,10 +165,10 @@ func TestReconcile(t *testing.T) {
 }
 
 type callContext struct {
-	createConfigMap               createConfigMapRecord
-	getConfigMap                  getConfigMapRecord
-	updateConfigMap               updateConfigMapRecord
-	listAPIExportsFromRemoteShard listAPIExportsFromRemoteShardRecord
+	createConfigMap     createConfigMapRecord
+	getConfigMap        getConfigMapRecord
+	updateConfigMap     updateConfigMapRecord
+	listCacheAPIExports listCacheAPIExportsRecord
 }
 
 type createConfigMapRecord struct {
@@ -213,12 +213,12 @@ func (r *updateConfigMapRecord) call(ctx context.Context, cluster logicalcluster
 	return delegate(ctx, cluster, namespace, configMap)
 }
 
-type listAPIExportsFromRemoteShardRecord struct {
+type listCacheAPIExportsRecord struct {
 	called              bool
 	delegate, defaulted func(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error)
 }
 
-func (r *listAPIExportsFromRemoteShardRecord) call(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
+func (r *listCacheAPIExportsRecord) call(cluster logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
 	r.called = true
 	delegate := r.delegate
 	if delegate == nil {

--- a/pkg/reconciler/cache/replication/replication_reconcile.go
+++ b/pkg/reconciler/cache/replication/replication_reconcile.go
@@ -34,6 +34,7 @@ import (
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	corev1alpha1 "github.com/kcp-dev/kcp/pkg/apis/core/v1alpha1"
+	tenancyv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/tenancy/v1alpha1"
 )
 
 func (c *controller) reconcile(ctx context.Context, gvrKey string) error {
@@ -74,6 +75,17 @@ func (c *controller) reconcile(ctx context.Context, gvrKey string) error {
 			},
 			func(cluster logicalcluster.Name, _, name string) (interface{}, error) {
 				return c.localShardLister.Cluster(cluster).Get(name)
+			})
+	case tenancyv1alpha1.SchemeGroupVersion.WithResource("workspacetypes").String():
+		return c.reconcileObject(ctx,
+			keyParts[1],
+			tenancyv1alpha1.SchemeGroupVersion.WithResource("workspacetypes"),
+			tenancyv1alpha1.SchemeGroupVersion.WithKind("WorkspaceType"),
+			func(gvr schema.GroupVersionResource, cluster logicalcluster.Name, namespace, name string) (interface{}, error) {
+				return retrieveCacheObject(&gvr, c.globalWorkspaceTypeIndexer, c.shardName, cluster, namespace, name)
+			},
+			func(cluster logicalcluster.Name, _, name string) (interface{}, error) {
+				return c.localWorkspaceTypeLister.Cluster(cluster).Get(name)
 			})
 	default:
 		return fmt.Errorf("unsupported resource %v", keyParts[0])

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -181,7 +181,7 @@ func (b *APIBinder) enqueueAPIBinding(obj interface{}, logger logr.Logger) {
 	logicalCluster, err := b.getLogicalCluster(clusterName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// The workspace was deleted or is no longer initializing, so we can safely ignore this event.
+			// The workspace was deleted, or is no longer initializing, or is not actually a workspace, so we can safely ignore this event.
 			return
 		}
 		logger.Error(err, "failed to get LogicalCluster from lister", "cluster", clusterName)

--- a/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
+++ b/pkg/reconciler/tenancy/initialization/apibinder_initializer_controller.go
@@ -58,9 +58,9 @@ const (
 func NewAPIBinder(
 	kcpClusterClient kcpclientset.ClusterInterface,
 	logicalClusterInformer corev1alpha1informers.LogicalClusterClusterInformer,
-	workspaceTypeInformer tenancyv1alpha1informers.WorkspaceTypeClusterInformer,
+	workspaceTypeInformer, globalWorkspaceTypeInformer tenancyv1alpha1informers.WorkspaceTypeClusterInformer,
 	apiBindingsInformer apisv1alpha1informers.APIBindingClusterInformer,
-	apiExportsInformer apisv1alpha1informers.APIExportClusterInformer,
+	apiExportsInformer, globalAPIExportsInformer apisv1alpha1informers.APIExportClusterInformer,
 ) (*APIBinder, error) {
 	c := &APIBinder{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName),
@@ -69,7 +69,11 @@ func NewAPIBinder(
 			return logicalClusterInformer.Lister().Cluster(clusterName).Get(corev1alpha1.LogicalClusterName)
 		},
 		getWorkspaceType: func(path logicalcluster.Path, name string) (*tenancyv1alpha1.WorkspaceType, error) {
-			return indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), workspaceTypeInformer.Informer().GetIndexer(), path, name)
+			t, err := indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), workspaceTypeInformer.Informer().GetIndexer(), path, name)
+			if apierrors.IsNotFound(err) {
+				return indexers.ByPathAndName[*tenancyv1alpha1.WorkspaceType](tenancyv1alpha1.Resource("workspacetypes"), globalWorkspaceTypeInformer.Informer().GetIndexer(), path, name)
+			}
+			return t, err
 		},
 		listLogicalClusters: func() ([]*corev1alpha1.LogicalCluster, error) {
 			return logicalClusterInformer.Lister().List(labels.Everything())
@@ -86,7 +90,11 @@ func NewAPIBinder(
 		},
 
 		getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
-			return indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), path, name)
+			export, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), apiExportsInformer.Informer().GetIndexer(), path, name)
+			if apierrors.IsNotFound(err) {
+				return indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), globalAPIExportsInformer.Informer().GetIndexer(), path, name)
+			}
+			return export, err
 		},
 
 		commit: committer.NewCommitter[*corev1alpha1.LogicalCluster, corev1alpha1client.LogicalClusterInterface, *corev1alpha1.LogicalClusterSpec, *corev1alpha1.LogicalClusterStatus](kcpClusterClient.CoreV1alpha1().LogicalClusters()),
@@ -97,6 +105,10 @@ func NewAPIBinder(
 	logger := logging.WithReconciler(klog.Background(), ControllerName)
 
 	indexers.AddIfNotPresentOrDie(workspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
+		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
+	})
+
+	indexers.AddIfNotPresentOrDie(globalWorkspaceTypeInformer.Informer().GetIndexer(), cache.Indexers{
 		indexers.ByLogicalClusterPathAndName: indexers.IndexByLogicalClusterPathAndName,
 	})
 
@@ -119,6 +131,15 @@ func NewAPIBinder(
 	})
 
 	workspaceTypeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.enqueueWorkspaceTypes(obj, logger)
+		},
+		UpdateFunc: func(_, obj interface{}) {
+			c.enqueueWorkspaceTypes(obj, logger)
+		},
+	})
+
+	globalWorkspaceTypeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueueWorkspaceTypes(obj, logger)
 		},

--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling.go
@@ -170,7 +170,6 @@ func (r *schedulingReconciler) reconcile(ctx context.Context, workspace *tenancy
 
 func (r *schedulingReconciler) chooseShardAndMarkCondition(logger klog.Logger, workspace *tenancyv1beta1.Workspace) (shard string, reason string, err error) {
 	selector := labels.Everything()
-	var shards []*corev1alpha1.Shard
 	if workspace.Spec.Location != nil {
 		if workspace.Spec.Location.Selector != nil {
 			var err error
@@ -181,34 +180,27 @@ func (r *schedulingReconciler) chooseShardAndMarkCondition(logger klog.Logger, w
 		}
 	}
 
-	if len(shards) == 0 {
-		var err error
-		shards, err = r.listShards(selector)
-		if err != nil {
-			return "", "", err
-		}
+	shards, err := r.listShards(selector)
+	if err != nil {
+		return "", "", err
+	}
 
-		// if no specific shard was required,
-		// we are going to schedule the given ws onto the root shard
-		// this step is temporary until working with multi-shard env works
-		// until then we need to assign ws to the root shard otherwise all e2e test will break
-		//
-		// note if there are no shards just let it run, at the end, we set a proper condition.
-		if len(shards) > 0 && (workspace.Spec.Location == nil || workspace.Spec.Location.Selector == nil) {
-			// trim the list to contain only the "root" shard so that we always schedule onto it
+	// schedule onto the root shard. This step is temporary until working with multi-shard env works
+	// until then we need to assign ws to the root shard otherwise all e2e test will break
+	if len(shards) > 0 && (workspace.Spec.Location == nil || workspace.Spec.Location.Selector == nil) {
+		// trim the list to contain only the "root" shard so that we always schedule onto it
+		for _, shard := range shards {
+			if shard.Name == "root" {
+				shards = []*corev1alpha1.Shard{shard}
+				break
+			}
+		}
+		if len(shards) == 0 {
+			names := make([]string, 0, len(shards))
 			for _, shard := range shards {
-				if shard.Name == "root" {
-					shards = []*corev1alpha1.Shard{shard}
-					break
-				}
+				names = append(names, shard.Name)
 			}
-			if len(shards) == 0 {
-				names := make([]string, 0, len(shards))
-				for _, shard := range shards {
-					names = append(names, shard.Name)
-				}
-				return "", "", fmt.Errorf("since no specific shard was requested we default to schedule onto the root shard, but the root shard wasn't found, found shards: %v", names)
-			}
+			return "", "", fmt.Errorf("since no specific shard was requested we default to schedule onto the root shard, but the root shard wasn't found, found shards: %v", names)
 		}
 	}
 

--- a/pkg/server/bootstrap/identity.go
+++ b/pkg/server/bootstrap/identity.go
@@ -98,7 +98,7 @@ func NewConfigWithWildcardIdentities(config *rest.Config,
 }
 
 // NewWildcardIdentitiesWrappingRoundTripper creates an HTTP RoundTripper
-// that injected resource identities for individual group or group resources.
+// that injects resource identities for individual groups or group resources.
 // Each group or resource is coming from one APIExport whose names are passed in as a map.
 // The RoundTripper is exposed as a function that allows wrapping the RoundTripper
 //

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -119,14 +119,6 @@ type ExtraConfig struct {
 	ApiExtensionsSharedInformerFactory      kcpapiextensionsinformers.SharedInformerFactory
 	DiscoveringDynamicSharedInformerFactory *informer.DiscoveringDynamicSharedInformerFactory
 	CacheKcpSharedInformerFactory           kcpinformers.SharedInformerFactory
-	// TODO(p0lyn0mial):  get rid of TemporaryRootShardKcpSharedInformerFactory, in the future
-	//                    we should have multi-shard aware informers
-	//
-	// TODO(p0lyn0mial): wire it to the root shard, this will be needed to get bindings,
-	//                   eventually it will be replaced by replication
-	//
-	// TemporaryRootShardKcpSharedInformerFactory bring data from the root shard
-	TemporaryRootShardKcpSharedInformerFactory kcpinformers.SharedInformerFactory
 }
 
 type completedConfig struct {
@@ -233,10 +225,6 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		c.TemporaryRootShardKcpSharedInformerFactory = kcpinformers.NewSharedInformerFactoryWithOptions(
-			c.RootShardKcpClusterClient,
-			resyncPeriod,
-		)
 
 		c.identityConfig = rest.CopyConfig(c.GenericConfig.LoopbackClientConfig)
 		c.identityConfig.Wrap(kcpShardIdentityRoundTripper)
@@ -245,9 +233,6 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 			return nil, err
 		}
 	} else {
-		// create an empty non-functional factory so that code that uses it but doesn't need it, doesn't have to check against the nil value
-		c.TemporaryRootShardKcpSharedInformerFactory = kcpinformers.NewSharedInformerFactory(nil, resyncPeriod)
-
 		// The informers here are not used before the informers are actually started (i.e. no race).
 
 		c.identityConfig, c.resolveIdentities = bootstrap.NewConfigWithWildcardIdentities(c.GenericConfig.LoopbackClientConfig, bootstrap.KcpRootGroupExportNames, bootstrap.KcpRootGroupResourceExportNames, nil)

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -828,8 +828,10 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 		initializingWorkspacesKcpClusterClient,
 		initializingWorkspacesKcpInformers.Core().V1alpha1().LogicalClusters(),
 		s.KcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes(),
+		s.CacheKcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 	)
 	if err != nil {
 		return err
@@ -1404,4 +1406,3 @@ func (s *Server) waitForSync(stop <-chan struct{}) error {
 		return nil
 	}
 }
-

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -667,8 +667,8 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
-		s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
-		s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
+		s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas(),
 		s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions(),
 	)
 	if err != nil {
@@ -683,8 +683,11 @@ func (s *Server) installAPIBindingController(ctx context.Context, config *rest.C
 		if err := wait.PollImmediateInfiniteWithContext(goContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
 			crdsSynced := s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced()
 			exportsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
+			cacheExportsSynced := s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
+			schemasSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
+			cacheSchemasSynced := s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIResourceSchemas().Informer().HasSynced()
 			bindingsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
-			return crdsSynced && exportsSynced && bindingsSynced, nil
+			return crdsSynced && exportsSynced && cacheExportsSynced && schemasSynced && cacheSchemasSynced && bindingsSynced, nil
 		}); err != nil {
 			logger.Error(err, "failed to finish post-start-hook")
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
@@ -913,8 +916,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 		if err := wait.PollImmediateInfiniteWithContext(goContext(hookContext), time.Millisecond*100, func(ctx context.Context) (bool, error) {
 			crdsSynced := s.ApiExtensionsSharedInformerFactory.Apiextensions().V1().CustomResourceDefinitions().Informer().HasSynced()
 			exportsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports().Informer().HasSynced()
-			bindingsSynced := s.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings().Informer().HasSynced()
-			return crdsSynced && exportsSynced && bindingsSynced, nil
+			return crdsSynced && exportsSynced, nil
 		}); err != nil {
 			logger.Error(err, "failed to finish post-start-hook")
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
@@ -949,10 +951,6 @@ func (s *Server) installAPIExportEndpointSliceController(ctx context.Context, co
 	return s.AddPostStartHook(postStartHookName(apiexportendpointslice.ControllerName), func(hookContext genericapiserver.PostStartHookContext) error {
 		logger := klog.FromContext(ctx).WithValues("postStartHook", postStartHookName(apiexportendpointslice.ControllerName))
 		if err := s.waitForSync(hookContext.StopCh); err != nil {
-			logger.Error(err, "failed to finish post-start-hook")
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-		if err := s.waitForOptionalSync(hookContext.StopCh); err != nil {
 			logger.Error(err, "failed to finish post-start-hook")
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
@@ -1311,7 +1309,7 @@ func (s *Server) installApiExportIdentityController(ctx context.Context, config 
 	if err != nil {
 		return err
 	}
-	c, err := identitycache.NewApiExportIdentityProviderController(kubeClusterClient, s.TemporaryRootShardKcpSharedInformerFactory.Apis().V1alpha1().APIExports(), s.KubeSharedInformerFactory.Core().V1().ConfigMaps())
+	c, err := identitycache.NewApiExportIdentityProviderController(kubeClusterClient, s.CacheKcpSharedInformerFactory.Apis().V1alpha1().APIExports(), s.KubeSharedInformerFactory.Core().V1().ConfigMaps())
 	if err != nil {
 		return err
 	}
@@ -1341,10 +1339,6 @@ func (s *Server) installReplicationController(ctx context.Context, config *rest.
 	return server.AddPostStartHook(postStartHookName(replication.ControllerName), func(hookContext genericapiserver.PostStartHookContext) error {
 		logger := klog.FromContext(ctx).WithValues("postStartHook", postStartHookName(replication.ControllerName))
 		if err := s.waitForSync(hookContext.StopCh); err != nil {
-			logger.Error(err, "failed to finish post-start-hook")
-			return nil // don't klog.Fatal. This only happens when context is cancelled.
-		}
-		if err := s.waitForOptionalSync(hookContext.StopCh); err != nil {
 			logger.Error(err, "failed to finish post-start-hook")
 			return nil // don't klog.Fatal. This only happens when context is cancelled.
 		}
@@ -1411,13 +1405,3 @@ func (s *Server) waitForSync(stop <-chan struct{}) error {
 	}
 }
 
-// waitForOptionalSync waits until optional informers have been synced.
-// use this method before starting controllers that require additional informers.
-func (s *Server) waitForOptionalSync(stop <-chan struct{}) error {
-	select {
-	case <-stop:
-		return errors.New("timed out waiting for optional informers to sync")
-	case <-s.syncedOptionalCh:
-		return nil
-	}
-}


### PR DESCRIPTION
- wire the cache informers into the relevant controllers that are needed to create and initialize a workspace.
- add workspace types to replication to the cache server
- fix workspace initialization VW on a non-root shard
- add `--location-selector` flag to `kubectl ws create` plugin