### PR TITLE
:sparkles: Admission for APIExportEndpointSlice

### DIFF
--- a/pkg/admission/apibinding/binding_permissions.go
+++ b/pkg/admission/apibinding/binding_permissions.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apibinding
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func CheckAPIExportAccess(ctx context.Context, user user.Info, apiExportName string, authz authorizer.Authorizer) error {
+	bindAttr := authorizer.AttributesRecord{
+		User:            user,
+		Verb:            "bind",
+		APIGroup:        apisv1alpha1.SchemeGroupVersion.Group,
+		APIVersion:      apisv1alpha1.SchemeGroupVersion.Version,
+		Resource:        "apiexports",
+		Name:            apiExportName,
+		ResourceRequest: true,
+	}
+
+	if decision, _, err := authz.Authorize(ctx, bindAttr); err != nil {
+		return fmt.Errorf("unable to determine access to apiexports: %w", err)
+	} else if decision != authorizer.DecisionAllow {
+		return fmt.Errorf("no permission to bind to export %q", apiExportName)
+	}
+
+	return nil
+}

--- a/pkg/admission/apiexportendpointslice/apiexportendpointslice_admission.go
+++ b/pkg/admission/apiexportendpointslice/apiexportendpointslice_admission.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexportendpointslice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	apibindingadmission "github.com/kcp-dev/kcp/pkg/admission/apibinding"
+	kcpinitializers "github.com/kcp-dev/kcp/pkg/admission/initializers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	"github.com/kcp-dev/kcp/pkg/indexers"
+)
+
+const (
+	PluginName = "apis.kcp.io/APIExportEndpointSlice"
+)
+
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName,
+		func(_ io.Reader) (admission.Interface, error) {
+			p := &apiExportEndpointSliceAdmission{
+				Handler:          admission.NewHandler(admission.Create, admission.Update),
+				createAuthorizer: delegated.NewDelegatedAuthorizer,
+			}
+			p.getAPIExport = func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
+				apiExport, err := indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.localApiExportIndexer, path, name)
+				if apierrors.IsNotFound(err) {
+					apiExport, err = indexers.ByPathAndName[*apisv1alpha1.APIExport](apisv1alpha1.Resource("apiexports"), p.globalApiExportIndexer, path, name)
+				}
+				return apiExport, err
+			}
+
+			return p, nil
+		})
+}
+
+type apiExportEndpointSliceAdmission struct {
+	*admission.Handler
+
+	getAPIExport func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error)
+
+	localApiExportIndexer  cache.Indexer
+	globalApiExportIndexer cache.Indexer
+
+	deepSARClient    kcpkubernetesclientset.ClusterInterface
+	createAuthorizer delegated.DelegatedAuthorizerFactory
+}
+
+// Ensure that the required admission interfaces are implemented.
+var (
+	_ = admission.ValidationInterface(&apiExportEndpointSliceAdmission{})
+	_ = admission.InitializationValidator(&apiExportEndpointSliceAdmission{})
+	_ = kcpinitializers.WantsDeepSARClient(&apiExportEndpointSliceAdmission{})
+	_ = kcpinitializers.WantsKcpInformers(&apiExportEndpointSliceAdmission{})
+)
+
+// Validate validates the creation of APIExportEndpointSlice resources. It also performs a SubjectAccessReview
+// making sure the user is allowed to use the 'bind' verb with the referenced APIExport.
+func (o *apiExportEndpointSliceAdmission) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	clusterName, err := genericapirequest.ClusterNameFrom(ctx)
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
+	if a.GetResource().GroupResource() != apisv1alpha1.Resource("apiexportendpointslices") {
+		return nil
+	}
+
+	u, ok := a.GetObject().(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("unexpected type %T", a.GetObject())
+	}
+
+	slice := &apisv1alpha1.APIExportEndpointSlice{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, slice); err != nil {
+		return fmt.Errorf("failed to convert unstructured to APIExportEndpointSlice: %w", err)
+	}
+
+	// Object validation
+	var errs field.ErrorList
+	var oldSlice *apisv1alpha1.APIExportEndpointSlice
+	switch a.GetOperation() {
+	case admission.Create:
+		errs = ValidateAPIExportEndpointSlice(slice)
+		if len(errs) > 0 {
+			return admission.NewForbidden(a, fmt.Errorf("%v", errs))
+		}
+	case admission.Update:
+		u, ok = a.GetOldObject().(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unexpected type %T", a.GetOldObject())
+		}
+		oldSlice = &apisv1alpha1.APIExportEndpointSlice{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, oldSlice); err != nil {
+			return fmt.Errorf("failed to convert unstructured to APIExportEndpointSlice: %w", err)
+		}
+	}
+
+	switch {
+	case a.GetOperation() == admission.Create,
+		// this may be redundant as APIExportEndpointSlice.Spec.APIExport is immutable
+		a.GetOperation() == admission.Update && !reflect.DeepEqual(slice.Spec.APIExport, oldSlice.Spec.APIExport):
+		// unified forbidden error that does not leak workspace existence
+		// only considering "create" as the APIExport reference is immutable
+		forbidden := admission.NewForbidden(a, fmt.Errorf("unable to create APIExportEndpointSlice: no permission to bind to export %s",
+			logicalcluster.NewPath(slice.Spec.APIExport.Path).Join(slice.Spec.APIExport.Name).String()))
+
+		// get cluster name of export
+		var exportClusterName logicalcluster.Name
+		if slice.Spec.APIExport.Path == "" {
+			exportClusterName = clusterName
+		} else {
+			path := logicalcluster.NewPath(slice.Spec.APIExport.Path)
+			export, err := o.getAPIExport(path, slice.Spec.APIExport.Name)
+			if err != nil {
+				return forbidden
+			}
+			exportClusterName = logicalcluster.From(export)
+		}
+
+		// Access check
+		if err := o.checkAPIExportAccess(ctx, a.GetUserInfo(), exportClusterName, slice.Spec.APIExport.Name); err != nil {
+			return forbidden
+		}
+	}
+
+	return nil
+}
+
+func (o *apiExportEndpointSliceAdmission) checkAPIExportAccess(ctx context.Context, user user.Info, apiExportClusterName logicalcluster.Name, apiExportName string) error {
+	logger := klog.FromContext(ctx)
+	authz, err := o.createAuthorizer(apiExportClusterName, o.deepSARClient, delegated.Options{})
+	if err != nil {
+		// Logging a more specific error for the operator
+		logger.Error(err, "error creating authorizer from delegating authorizer config")
+		// Returning a less specific error to the end user
+		return errors.New("unable to authorize request")
+	}
+
+	return apibindingadmission.CheckAPIExportAccess(ctx, user, apiExportName, authz)
+}
+
+// ValidateInitialization ensures the required injected fields are set.
+func (o *apiExportEndpointSliceAdmission) ValidateInitialization() error {
+	if o.deepSARClient == nil {
+		return fmt.Errorf(PluginName + " plugin needs a deepSARClient")
+	}
+	return nil
+}
+
+// SetDeepSARClient is an admission plugin initializer function that injects a client capable of deep SAR requests into
+// this admission plugin.
+func (o *apiExportEndpointSliceAdmission) SetDeepSARClient(client kcpkubernetesclientset.ClusterInterface) {
+	o.deepSARClient = client
+}
+
+func (o *apiExportEndpointSliceAdmission) SetKcpInformers(local, global kcpinformers.SharedInformerFactory) {
+	localApiExportsReady := local.Apis().V1alpha1().APIExports().Informer().HasSynced
+	globalApiExportsReady := global.Apis().V1alpha1().APIExports().Informer().HasSynced
+	o.SetReadyFunc(func() bool {
+		return localApiExportsReady() && globalApiExportsReady()
+	})
+	o.localApiExportIndexer = local.Apis().V1alpha1().APIExports().Informer().GetIndexer()
+	o.globalApiExportIndexer = global.Apis().V1alpha1().APIExports().Informer().GetIndexer()
+}

--- a/pkg/admission/apiexportendpointslice/apiexportendpointslice_admission_test.go
+++ b/pkg/admission/apiexportendpointslice/apiexportendpointslice_admission_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexportendpointslice
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/kcp-dev/kcp/pkg/admission/helpers"
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/apis/core"
+	"github.com/kcp-dev/kcp/pkg/authorization/delegated"
+)
+
+func createAttr(slice *apisv1alpha1.APIExportEndpointSlice) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(slice),
+		nil,
+		apisv1alpha1.Kind("APIExportEndpointSlice").WithVersion("v1alpha1"),
+		"",
+		slice.Name,
+		apisv1alpha1.Resource("apiexportendpointslices").WithVersion("v1alpha1"),
+		"",
+		admission.Create,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func updateAttr(newSlice, oldSlice *apisv1alpha1.APIExportEndpointSlice) admission.Attributes {
+	return admission.NewAttributesRecord(
+		helpers.ToUnstructuredOrDie(newSlice),
+		helpers.ToUnstructuredOrDie(oldSlice),
+		apisv1alpha1.Kind("APIExportEndpointSlice").WithVersion("v1alpha1"),
+		"",
+		newSlice.Name,
+		apisv1alpha1.Resource("apiexportendpointslices").WithVersion("v1alpha1"),
+		"",
+		admission.Update,
+		&metav1.CreateOptions{},
+		false,
+		&user.DefaultInfo{},
+	)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name           string
+		attr           admission.Attributes
+		authzDecision  authorizer.Decision
+		authzError     error
+		expectedErrors []string
+	}{
+		{
+			name: "Create: fails without reference",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").APIExportEndpointSlice,
+			),
+			expectedErrors: []string{"spec.export.name: Required value"},
+		},
+		{
+			name: "Create: missing workspace reference exportName fails",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root-org-workspaceName"), "").APIExportEndpointSlice,
+			),
+			expectedErrors: []string{"spec.export.name: Required value"},
+		},
+		{
+			name: "Create: complete workspaceName reference passes when authorized",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision: authorizer.DecisionAllow,
+		},
+		{
+			name: "Create: root reference passes when authorized",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision: authorizer.DecisionAllow,
+		},
+		{
+			name: "Create: complete root absolute workspace reference passes when authorized",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision: authorizer.DecisionAllow,
+		},
+		{
+			name: "Create: complete non-root absolute workspace reference passes when authorized",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:aunt"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision: authorizer.DecisionAllow,
+		},
+		{
+			name: "Create: complete workspace reference fails with no authorization decision",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision:  authorizer.DecisionNoOpinion,
+			expectedErrors: []string{`no permission to bind to export root:org:workspaceName:someExport`},
+		},
+		{
+			name: "Create: complete workspace reference fails when denied",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision:  authorizer.DecisionDeny,
+			expectedErrors: []string{`no permission to bind to export root:org:workspaceName:someExport`},
+		},
+		{
+			name: "Create: complete workspace reference fails when there's an error checking authorization",
+			attr: createAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+			),
+			authzError:     errors.New("some error here"),
+			expectedErrors: []string{"no permission to bind to export root:org:workspaceName:someExport"},
+		},
+		{
+			name: "Update: complete workspace reference passes when authorized",
+			attr: updateAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+			),
+			authzDecision: authorizer.DecisionAllow,
+		},
+		{
+			name: "Update: complete workspace reference fails with no authorization decision",
+			attr: updateAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "anotherExport").APIExportEndpointSlice,
+			),
+			authzDecision:  authorizer.DecisionNoOpinion,
+			expectedErrors: []string{`no permission to bind to export root:org:workspaceName:someExport`},
+		},
+		{
+			name: "Update: complete workspace reference fails when denied",
+			attr: updateAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "anotherExport").APIExportEndpointSlice,
+			),
+			authzDecision:  authorizer.DecisionDeny,
+			expectedErrors: []string{`no permission to bind to export root:org:workspaceName:someExport`},
+		},
+		{
+			name: "Update: complete workspace reference fails when there's an error checking authorization",
+			attr: updateAttr(
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "someExport").APIExportEndpointSlice,
+				newAPIExportEndpointSlice().withName("test").withReference(logicalcluster.NewPath("root:org:workspaceName"), "anotherExport").APIExportEndpointSlice,
+			),
+			authzError:     errors.New("some error here"),
+			expectedErrors: []string{"no permission to bind to export root:org:workspaceName:someExport"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &apiExportEndpointSliceAdmission{
+				Handler: admission.NewHandler(admission.Create, admission.Update),
+				createAuthorizer: func(clusterName logicalcluster.Name, client kcpkubernetesclientset.ClusterInterface, opts delegated.Options) (authorizer.Authorizer, error) {
+					return &fakeAuthorizer{
+						tc.authzDecision,
+						tc.authzError,
+					}, nil
+				},
+				getAPIExport: func(path logicalcluster.Path, name string) (*apisv1alpha1.APIExport, error) {
+					switch path.Join(name).String() {
+					case "root:org:workspaceName:someExport", "root-org-workspaceName:someExport":
+						return newExport(logicalcluster.NewPath("root:org:workspaceName"), name).APIExport, nil
+					case "root:aunt:someExport", "root-aunt:someExport":
+						return newExport(logicalcluster.NewPath("root:aunt"), name).APIExport, nil
+					case "root:org:sibling:someExport", "root-org-sibling:someExport":
+						return newExport(logicalcluster.NewPath("root:org:sibling"), name).APIExport, nil
+					case "root:org:someExport", "root-org:someExport":
+						return newExport(logicalcluster.NewPath("root:org"), name).APIExport, nil
+					case "root:some-other-org:bla:someExport", "root-some-other-org-bla:someExport":
+						return newExport(logicalcluster.NewPath("root:some-other-org:bla"), name).APIExport, nil
+					case "root:someExport":
+						return newExport(logicalcluster.NewPath("root"), name).APIExport, nil
+					}
+					return nil, apierrors.NewNotFound(apisv1alpha1.Resource("apiexports"), path.Join(name).String())
+				},
+			}
+
+			ctx := request.WithCluster(context.Background(), request.Cluster{Name: logicalcluster.From(tc.attr.GetObject().(metav1.Object))})
+
+			err := o.Validate(ctx, tc.attr, nil)
+
+			wantErr := len(tc.expectedErrors) > 0
+			require.Equal(t, wantErr, err != nil, "err: %v", err)
+
+			if err != nil {
+				t.Logf("Got admission errors: %v", err)
+				for _, expected := range tc.expectedErrors {
+					require.Contains(t, err.Error(), expected)
+				}
+			}
+		})
+	}
+}
+
+type fakeAuthorizer struct {
+	authorized authorizer.Decision
+	err        error
+}
+
+func (a *fakeAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	return a.authorized, "reason", a.err
+}
+
+type bindingBuilder struct {
+	*apisv1alpha1.APIExportEndpointSlice
+}
+
+func newAPIExportEndpointSlice() *bindingBuilder {
+	return &bindingBuilder{
+		APIExportEndpointSlice: &apisv1alpha1.APIExportEndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					logicalcluster.AnnotationKey: "root-org-ws",
+				},
+			},
+		},
+	}
+}
+
+func (b *bindingBuilder) withName(name string) *bindingBuilder {
+	b.Name = name
+	return b
+}
+
+func (b *bindingBuilder) withReference(path logicalcluster.Path, exportName string) *bindingBuilder {
+	b.Spec.APIExport = apisv1alpha1.ExportBindingReference{
+		Path: path.String(),
+		Name: exportName,
+	}
+	return b
+}
+
+type apiExportBuilder struct {
+	*apisv1alpha1.APIExport
+}
+
+func newExport(path logicalcluster.Path, name string) apiExportBuilder {
+	clusterName := strings.ReplaceAll(path.String(), ":", "-")
+	return apiExportBuilder{APIExport: &apisv1alpha1.APIExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				logicalcluster.AnnotationKey:         clusterName,
+				core.LogicalClusterPathAnnotationKey: path.String(),
+			},
+		},
+	}}
+}

--- a/pkg/admission/apiexportendpointslice/validation.go
+++ b/pkg/admission/apiexportendpointslice/validation.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexportendpointslice
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+// ValidateAPIExportEndpointSlice validates an APIExport.
+func ValidateAPIExportEndpointSlice(slice *apisv1alpha1.APIExportEndpointSlice) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, ValidateAPIExportEndpointSliceReference(slice.Spec.APIExport, field.NewPath("spec", "export"))...)
+
+	return allErrs
+}
+
+// ValidateAPIExportEndpointSliceReference validates an APIExportEndpointSlice's APIExport reference.
+func ValidateAPIExportEndpointSliceReference(reference apisv1alpha1.ExportBindingReference, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if reference.Name == "" {
+		allErrs = append(allErrs, field.Required(path.Child("name"), ""))
+	}
+
+	return allErrs
+}

--- a/pkg/admission/plugins.go
+++ b/pkg/admission/plugins.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/admission/apibinding"
 	"github.com/kcp-dev/kcp/pkg/admission/apibindingfinalizer"
 	"github.com/kcp-dev/kcp/pkg/admission/apiexport"
+	"github.com/kcp-dev/kcp/pkg/admission/apiexportendpointslice"
 	"github.com/kcp-dev/kcp/pkg/admission/apiresourceschema"
 	"github.com/kcp-dev/kcp/pkg/admission/crdnooverlappinggvr"
 	"github.com/kcp-dev/kcp/pkg/admission/kubequota"
@@ -76,6 +77,7 @@ var AllOrderedPlugins = beforeWebhooks(kubeapiserveroptions.AllOrderedPlugins,
 	apiexport.PluginName,
 	apibinding.PluginName,
 	apibindingfinalizer.PluginName,
+	apiexportendpointslice.PluginName,
 	kcpvalidatingwebhook.PluginName,
 	kcpmutatingwebhook.PluginName,
 	kcplimitranger.PluginName,
@@ -114,6 +116,7 @@ func RegisterAllKcpAdmissionPlugins(plugins *admission.Plugins) {
 	apiexport.Register(plugins)
 	apibinding.Register(plugins)
 	apibindingfinalizer.Register(plugins)
+	apiexportendpointslice.Register(plugins)
 	workspacenamespacelifecycle.Register(plugins)
 	kcpvalidatingwebhook.Register(plugins)
 	kcpmutatingwebhook.Register(plugins)
@@ -146,6 +149,7 @@ var defaultOnPluginsInKcp = sets.NewString(
 	apiexport.PluginName,
 	apibinding.PluginName,
 	apibindingfinalizer.PluginName,
+	apiexportendpointslice.PluginName,
 	kcpvalidatingwebhook.PluginName,
 	kcpmutatingwebhook.PluginName,
 	reservedcrdannotations.PluginName,

--- a/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_reconcile.go
+++ b/pkg/reconciler/apis/apiexportendpointslice/apiexportendpointslice_reconcile.go
@@ -57,7 +57,7 @@ func (c *controller) reconcile(ctx context.Context, apiExportEndpointSlice *apis
 
 func (r *endpointsReconciler) reconcile(ctx context.Context, apiExportEndpointSlice *apisv1alpha1.APIExportEndpointSlice) error {
 	// TODO (fgiloux): When the information is available in the cache server
-	// check if at least one APIBinding is bound in the shard to the APIExport referenced by the APIExportEndpointSLice.
+	// check if at least one APIBinding is bound in the shard to the APIExport referenced by the APIExportEndpointSlice.
 	// If so, add the respective endpoint to the status.
 	// For now the unfiltered list is added.
 


### PR DESCRIPTION
## Summary

check for binding authorization against the referenced APIExport.

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

## Related issue(s)

Contributes to #2332
