### PR TITLE
🐛 Fix APIExport virtual workspace API bug

### DIFF
--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller.go
@@ -69,6 +69,9 @@ func NewAPIReconciler(
 
 		apiExportLister:  apiExportInformer.Lister(),
 		apiExportIndexer: apiExportInformer.Informer().GetIndexer(),
+		listAPIExports: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
+			return apiExportInformer.Lister().Cluster(clusterName).List(labels.Everything())
+		},
 
 		queue: queue,
 
@@ -121,6 +124,7 @@ type APIReconciler struct {
 
 	apiExportLister  apisv1alpha1listers.APIExportClusterLister
 	apiExportIndexer cache.Indexer
+	listAPIExports   func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error)
 
 	queue workqueue.RateLimitingInterface
 
@@ -143,7 +147,7 @@ func (c *APIReconciler) enqueueAPIResourceSchema(obj interface{}, logger logr.Lo
 		runtime.HandleError(err)
 		return
 	}
-	exports, err := c.apiExportLister.Cluster(clusterName).List(labels.Everything())
+	exports, err := c.listAPIExports(clusterName)
 	if err != nil {
 		runtime.HandleError(err)
 		return
@@ -154,13 +158,13 @@ func (c *APIReconciler) enqueueAPIResourceSchema(obj interface{}, logger logr.Lo
 	}
 
 	if len(exports) == 0 {
-		logger.V(2).Info("No kubernetes APIExport found for APIResourceSchema")
+		logger.V(2).Info("No APIExports found")
 		return
 	}
 
 	for _, export := range exports {
 		logger.WithValues("apiexport", export.Name).V(2).Info("Queueing APIExport for APIResourceSchema")
-		c.enqueueAPIExport(obj, logger.WithValues("reason", "APIResourceSchema change", "apiResourceSchema", name))
+		c.enqueueAPIExport(export, logger.WithValues("reason", "APIResourceSchema change", "apiResourceSchema", name))
 	}
 }
 

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller_test.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_controller_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apireconciler
+
+import (
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2/ktesting"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+)
+
+func TestEnqueueAPIResourceSchema(t *testing.T) {
+	c := &APIReconciler{
+		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), ControllerName),
+		listAPIExports: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIExport, error) {
+			return []*apisv1alpha1.APIExport{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "export1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "export2",
+					},
+				},
+			}, nil
+		},
+	}
+
+	schema := &apisv1alpha1.APIResourceSchema{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				logicalcluster.AnnotationKey: "mycluster",
+			},
+			Name: "schema1",
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	c.enqueueAPIResourceSchema(schema, logger)
+
+	require.Equal(t, c.queue.Len(), 2)
+
+	// get the queue keys
+	actual := sets.NewString()
+	item, _ := c.queue.Get()
+	actual.Insert(item.(string))
+	item, _ = c.queue.Get()
+	actual.Insert(item.(string))
+
+	expected := sets.NewString("export1", "export2")
+	require.True(t, expected.Equal(actual))
+}

--- a/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
+++ b/pkg/virtual/apiexport/controllers/apireconciler/apiexport_apireconciler_reconcile.go
@@ -276,15 +276,16 @@ func (c *APIReconciler) getSchemasFromAPIExport(ctx context.Context, apiExport *
 	logger := klog.FromContext(ctx)
 	apiResourceSchemas := map[schema.GroupResource]*apisv1alpha1.APIResourceSchema{}
 	for _, schemaName := range apiExport.Spec.LatestResourceSchemas {
-		apiResourceSchema, err := c.apiResourceSchemaLister.Cluster(logicalcluster.From(apiExport)).Get(schemaName)
+		apiExportClusterName := logicalcluster.From(apiExport)
+		apiResourceSchema, err := c.apiResourceSchemaLister.Cluster(apiExportClusterName).Get(schemaName)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}
 		if apierrors.IsNotFound(err) {
 			logger.WithValues(
 				"schema", schemaName,
-				"exportNamespace", apiExport.Namespace,
-				"export", apiExport.Name,
+				"exportClusterName", apiExportClusterName,
+				"exportName", apiExport.Name,
 			).V(3).Info("APIResourceSchema for APIExport not found")
 			continue
 		}


### PR DESCRIPTION
## Summary
Fix bug in the APIExport virtual workspace where the APIDefinitionSet was sometimes calculated incorrectly. When an APIResourceSchema informer event came in, we were supposed to enqueue all APIExports in the same logical cluster, but instead it was accidentally trying to enqueue the APIResourceSchema itself.

## Related issue(s)

Fixes #2501