### PR TITLE
✨ Synctarget: Have URLs for both syncer and upsyncer

### DIFF
--- a/config/crds/workload.kcp.io_synctargets.yaml
+++ b/config/crds/workload.kcp.io_synctargets.yaml
@@ -230,16 +230,21 @@ spec:
                   type: object
                 type: array
               virtualWorkspaces:
-                description: VirtualWorkspaces contains all syncer virtual workspace
-                  URLs.
+                description: VirtualWorkspaces contains all virtual workspace URLs.
                 items:
                   properties:
-                    url:
-                      description: URL is the URL of the syncer virtual workspace.
+                    syncerURL:
+                      description: SyncerURL is the URL of the syncer virtual workspace.
+                      minLength: 1
+                      type: string
+                    upsyncerURL:
+                      description: UpsyncerURL is the URL of the upsyncer virtual
+                        workspace.
                       minLength: 1
                       type: string
                   required:
-                  - url
+                  - syncerURL
+                  - upsyncerURL
                   type: object
                 type: array
             type: object

--- a/config/root-phase0/apiexport-workload.kcp.io.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.io.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.io
 spec:
   latestResourceSchemas:
-  - v221219-20c08164c.synctargets.workload.kcp.io
+  - v230109-773b219c.synctargets.workload.kcp.io
 status: {}

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v221219-20c08164c.synctargets.workload.kcp.io
+  name: v230109-773b219c.synctargets.workload.kcp.io
 spec:
   group: workload.kcp.io
   names:
@@ -224,16 +224,20 @@ spec:
                 type: object
               type: array
             virtualWorkspaces:
-              description: VirtualWorkspaces contains all syncer virtual workspace
-                URLs.
+              description: VirtualWorkspaces contains all virtual workspace URLs.
               items:
                 properties:
-                  url:
-                    description: URL is the URL of the syncer virtual workspace.
+                  syncerURL:
+                    description: SyncerURL is the URL of the syncer virtual workspace.
+                    minLength: 1
+                    type: string
+                  upsyncerURL:
+                    description: UpsyncerURL is the URL of the upsyncer virtual workspace.
                     minLength: 1
                     type: string
                 required:
-                - url
+                - syncerURL
+                - upsyncerURL
                 type: object
               type: array
           type: object

--- a/pkg/apis/workload/v1alpha1/synctarget_types.go
+++ b/pkg/apis/workload/v1alpha1/synctarget_types.go
@@ -107,7 +107,7 @@ type SyncTargetStatus struct {
 	// +optional
 	LastSyncerHeartbeatTime *metav1.Time `json:"lastSyncerHeartbeatTime,omitempty"`
 
-	// VirtualWorkspaces contains all syncer virtual workspace URLs.
+	// VirtualWorkspaces contains all virtual workspace URLs.
 	// +optional
 	VirtualWorkspaces []VirtualWorkspace `json:"virtualWorkspaces,omitempty"`
 }
@@ -150,12 +150,19 @@ const (
 )
 
 type VirtualWorkspace struct {
-	// URL is the URL of the syncer virtual workspace.
+	// SyncerURL is the URL of the syncer virtual workspace.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:format:URL
 	// +required
-	URL string `json:"url"`
+	SyncerURL string `json:"syncerURL"`
+
+	// UpsyncerURL is the URL of the upsyncer virtual workspace.
+	//
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:format:URL
+	// +required
+	UpsyncerURL string `json:"upsyncerURL"`
 }
 
 // SyncTargetList is a list of SyncTarget resources

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -4406,7 +4406,7 @@ func schema_pkg_apis_workload_v1alpha1_SyncTargetStatus(ref common.ReferenceCall
 					},
 					"virtualWorkspaces": {
 						SchemaProps: spec.SchemaProps{
-							Description: "VirtualWorkspaces contains all syncer virtual workspace URLs.",
+							Description: "VirtualWorkspaces contains all virtual workspace URLs.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4432,16 +4432,24 @@ func schema_pkg_apis_workload_v1alpha1_VirtualWorkspace(ref common.ReferenceCall
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"url": {
+					"syncerURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "URL is the URL of the syncer virtual workspace.",
+							Description: "SyncerURL is the URL of the syncer virtual workspace.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"upsyncerURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UpsyncerURL is the URL of the upsyncer virtual workspace.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"url"},
+				Required: []string{"syncerURL", "upsyncerURL"},
 			},
 		},
 	}

--- a/pkg/reconciler/workload/synctarget/synctarget_reconcile_test.go
+++ b/pkg/reconciler/workload/synctarget/synctarget_reconcile_test.go
@@ -19,7 +19,6 @@ package synctarget
 import (
 	"context"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -82,7 +81,8 @@ func TestReconciler(t *testing.T) {
 				Status: workloadv1alpha1.SyncTargetStatus{
 					VirtualWorkspaces: []workloadv1alpha1.VirtualWorkspace{
 						{
-							URL: "http://external-host/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 					},
 				},
@@ -91,15 +91,6 @@ func TestReconciler(t *testing.T) {
 		},
 		"SyncTarget and multiple Shards": {
 			workspaceShards: []*corev1alpha1.Shard{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "root",
-					},
-					Spec: corev1alpha1.ShardSpec{
-						BaseURL:     "http://1.2.3.4/",
-						ExternalURL: "http://external-host/",
-					},
-				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "root2",
@@ -118,6 +109,15 @@ func TestReconciler(t *testing.T) {
 						ExternalURL: "http://external-host-3/",
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "root",
+					},
+					Spec: corev1alpha1.ShardSpec{
+						BaseURL:     "http://1.2.3.4/",
+						ExternalURL: "http://external-host-1/",
+					},
+				},
 			},
 			syncTarget: &workloadv1alpha1.SyncTarget{
 				ObjectMeta: metav1.ObjectMeta{
@@ -151,13 +151,16 @@ func TestReconciler(t *testing.T) {
 				Status: workloadv1alpha1.SyncTargetStatus{
 					VirtualWorkspaces: []workloadv1alpha1.VirtualWorkspace{
 						{
-							URL: "http://external-host/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-1/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-1/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 						{
-							URL: "http://external-host-2/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-2/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-2/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 						{
-							URL: "http://external-host-3/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-3/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-3/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 					},
 				},
@@ -172,7 +175,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1alpha1.ShardSpec{
 						BaseURL:     "http://1.2.3.4/",
-						ExternalURL: "http://external-host/",
+						ExternalURL: "http://external-host-1/",
 					},
 				},
 				{
@@ -181,7 +184,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1alpha1.ShardSpec{
 						BaseURL:     "http://1.2.3.4/",
-						ExternalURL: "http://external-host/",
+						ExternalURL: "http://external-host-1/",
 					},
 				},
 				{
@@ -226,11 +229,13 @@ func TestReconciler(t *testing.T) {
 				Status: workloadv1alpha1.SyncTargetStatus{
 					VirtualWorkspaces: []workloadv1alpha1.VirtualWorkspace{
 						{
-							URL: "http://external-host/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-1/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-1/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 
 						{
-							URL: "http://external-host-3/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-3/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-3/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 					},
 				},
@@ -278,7 +283,7 @@ func TestReconciler(t *testing.T) {
 					},
 					Spec: corev1alpha1.ShardSpec{
 						BaseURL:     "http://1.2.3.4/",
-						ExternalURL: "http://external-host/",
+						ExternalURL: "http://external-host-1/",
 					},
 				},
 			},
@@ -296,13 +301,16 @@ func TestReconciler(t *testing.T) {
 				Status: workloadv1alpha1.SyncTargetStatus{
 					VirtualWorkspaces: []workloadv1alpha1.VirtualWorkspace{
 						{
-							URL: "http://external-host/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-1/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-1/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 						{
-							URL: "http://external-host-2/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-2/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-2/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 						{
-							URL: "http://external-host-3/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-3/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-3/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 					},
 				},
@@ -324,7 +332,8 @@ func TestReconciler(t *testing.T) {
 				Status: workloadv1alpha1.SyncTargetStatus{
 					VirtualWorkspaces: []workloadv1alpha1.VirtualWorkspace{
 						{
-							URL: "http://external-host/services/syncer/demo:root:yourworkspace/test-cluster",
+							SyncerURL:   "http://external-host-1/services/syncer/demo:root:yourworkspace/test-cluster",
+							UpsyncerURL: "http://external-host-1/services/upsyncer/demo:root:yourworkspace/test-cluster",
 						},
 					},
 				},
@@ -339,9 +348,6 @@ func TestReconciler(t *testing.T) {
 			if err != nil && !tc.expectError {
 				t.Errorf("unexpected error: %v", err)
 			}
-			sort.Slice(tc.expectedSyncTarget.Status.VirtualWorkspaces, func(i, j int) bool {
-				return tc.expectedSyncTarget.Status.VirtualWorkspaces[i].URL < tc.expectedSyncTarget.Status.VirtualWorkspaces[j].URL
-			})
 			if !reflect.DeepEqual(returnedSyncTarget, tc.expectedSyncTarget) {
 				t.Errorf("expected diff: %s", cmp.Diff(tc.expectedSyncTarget, returnedSyncTarget))
 			}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -125,7 +125,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		if len(syncTarget.Status.VirtualWorkspaces) > 1 {
 			logger.Error(fmt.Errorf("SyncTarget should not have several Syncer virtual workspace URLs: not supported for now, ignoring additional URLs"), "error processing SyncTarget")
 		}
-		syncerVirtualWorkspaceURL = syncTarget.Status.VirtualWorkspaces[0].URL
+		syncerVirtualWorkspaceURL = syncTarget.Status.VirtualWorkspaces[0].SyncerURL
 		return true, nil
 	})
 	if err != nil {

--- a/pkg/virtual/framework/internalapis/fixtures/synctargets.yaml
+++ b/pkg/virtual/framework/internalapis/fixtures/synctargets.yaml
@@ -172,15 +172,18 @@ spec:
                 type: object
               type: array
             virtualWorkspaces:
-              description: VirtualWorkspaces contains all syncer virtual workspace
-                URLs.
+              description: VirtualWorkspaces contains all virtual workspace URLs.
               items:
                 properties:
-                  url:
-                    description: URL is the URL of the syncer virtual workspace.
+                  syncerURL:
+                    description: SyncerURL is the URL of the syncer virtual workspace.
+                    type: string
+                  upsyncerURL:
+                    description: UpsyncerURL is the URL of the upsyncer virtual workspace.
                     type: string
                 required:
-                - url
+                - syncerURL
+                - upsyncerURL
                 type: object
               type: array
           type: object

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -467,7 +467,7 @@ func (sf *syncerFixture) Start(t *testing.T) *StartedSyncerFixture {
 		if len(syncTarget.Status.VirtualWorkspaces) != 1 {
 			return false, ""
 		}
-		virtualWorkspaceURL = syncTarget.Status.VirtualWorkspaces[0].URL
+		virtualWorkspaceURL = syncTarget.Status.VirtualWorkspaces[0].SyncerURL
 		syncTargetClusterName = logicalcluster.From(syncTarget)
 		return true, "Virtual workspace URL is available"
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "Syncer Virtual Workspace URL not available")


### PR DESCRIPTION
## Summary

To prepare for the Upsyncing support, on the Synctarget we should have distinct URLs for the both syncer and upsyncer
virtual workspaces.

## Related issue(s)

Pre-requisite to PR https://github.com/kcp-dev/kcp/pull/2452