### PR TITLE
WIP 🌱 pkg/virtual/apiexport: add permission claims authorizer

### DIFF
--- a/pkg/virtual/apiexport/authorizer/permission_claims_authorizer.go
+++ b/pkg/virtual/apiexport/authorizer/permission_claims_authorizer.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/authorization"
+	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+func NewPermissionClaimsAuthorizer(kcpInformers kcpinformers.SharedInformerFactory, delegate authorizer.Authorizer) authorizer.Authorizer {
+	apiBindingLister := kcpInformers.Apis().V1alpha1().APIBindings().Lister()
+	apiExportLister := kcpInformers.Apis().V1alpha1().APIExports().Lister()
+
+	return &permissionClaimsAuthorizer{
+		getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+			return apiExportLister.Cluster(logicalcluster.Name(clusterName)).Get(apiExportName)
+		},
+		listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
+			return apiBindingLister.Cluster(clusterName).List(labels.Everything())
+		},
+		listAllAPIBindings: func() ([]*apisv1alpha1.APIBinding, error) {
+			return apiBindingLister.List(labels.Everything())
+		},
+		delegate: delegate,
+	}
+}
+
+type permissionClaimsAuthorizer struct {
+	getAPIExport       func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error)
+	listAllAPIBindings func() ([]*apisv1alpha1.APIBinding, error)
+	listAPIBindings    func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error)
+	delegate           authorizer.Authorizer
+}
+
+func (a *permissionClaimsAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
+	if !attr.IsResourceRequest() {
+		return authorization.DelegateAuthorization("non-resource request", a.delegate).Authorize(ctx, attr)
+	}
+
+	clusterName, isWildcardRequest, err := genericapirequest.ClusterNameOrWildcardFrom(ctx)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error getting cluster from request: %w", err)
+	}
+
+	apiDomainKey := dynamiccontext.APIDomainKeyFrom(ctx)
+	parts := strings.Split(string(apiDomainKey), "/")
+	if len(parts) < 2 {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("invalid API domain key")
+	}
+
+	claimingAPIExportCluster := parts[0]
+	claimingAPIExportName := parts[1]
+
+	apiExport, err := a.getAPIExport(claimingAPIExportCluster, claimingAPIExportName)
+	if err != nil {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error finding API export %q/%q: %w", claimingAPIExportCluster, claimingAPIExportName, err)
+	}
+
+	// if the requested resource is a bound resource it cannot be claimed.
+	if isBoundResource(attr, apiExport) {
+		return authorization.DelegateAuthorization("bound resource", a.delegate).Authorize(ctx, attr)
+	}
+
+	// Find binding that matches the requested API export in the requested workspace.
+	// If the requested API export has no corresponding API binding then the access must be denied
+	// as the user did not accept any permission claims.
+	allBindings, err := func() ([]*apisv1alpha1.APIBinding, error) {
+		if isWildcardRequest {
+			return a.listAllAPIBindings()
+		}
+		return a.listAPIBindings(clusterName)
+	}()
+	if err != nil {
+		return authorizer.DecisionNoOpinion, "", fmt.Errorf("error finding API bindings for API export %q/%q: %w", claimingAPIExportCluster, claimingAPIExportName, err)
+	}
+	for _, binding := range allBindings {
+		if binding.Spec.Reference.Export == nil {
+			continue
+		}
+
+		if binding.Spec.Reference.Export.Name != apiExport.Name ||
+			binding.Spec.Reference.Export.Path != logicalcluster.From(apiExport).String() {
+			continue
+		}
+
+		for _, claim := range binding.Spec.PermissionClaims {
+			if claim.Group != attr.GetAPIGroup() || claim.Resource != attr.GetResource() {
+				continue
+			}
+			// If at least one claimed resource is not accepted by the user, access must be denied
+			if claim.State != apisv1alpha1.ClaimAccepted {
+				return authorizer.DecisionNoOpinion, fmt.Sprintf("claim %v of API export %q/%q is not accepted", claim, logicalcluster.From(apiExport), apiExport.Name), nil
+			}
+			requestingAllResources := attr.GetName() == "" && attr.GetNamespace() == ""
+			resourceSelectorMatches := claim.All || requestingAllResources
+			for _, claimedResource := range claim.ResourceSelector {
+				var ns string
+				if claimedResource.Namespace != "" {
+					ns = attr.GetNamespace()
+				}
+				var name string
+				if claimedResource.Name != "" {
+					name = attr.GetName()
+				}
+				if claimedResource.Name == name && claimedResource.Namespace == ns {
+					resourceSelectorMatches = true
+					break
+				}
+			}
+
+			if !resourceSelectorMatches {
+				continue
+			}
+
+			return authorization.DelegateAuthorization(fmt.Sprintf("claimed resource in API binding name=%q", binding.GetName()), a.delegate).Authorize(ctx, attr)
+		}
+	}
+
+	return authorizer.DecisionNoOpinion, "unclaimed resource", nil
+}
+
+func isBoundResource(attr authorizer.Attributes, apiExport *apisv1alpha1.APIExport) bool {
+	for _, schema := range apiExport.Spec.LatestResourceSchemas {
+		_, resource, group, ok := split3(schema, ".")
+		if !ok {
+			continue
+		}
+		if group == attr.GetAPIGroup() && resource == attr.GetResource() {
+			return true
+		}
+	}
+	return false
+}
+
+func split3(s string, sep string) (string, string, string, bool) {
+	comps := strings.SplitN(s, sep, 3)
+	if len(comps) != 3 {
+		return "", "", "", false
+	}
+	return comps[0], comps[1], comps[2], true
+}

--- a/pkg/virtual/apiexport/authorizer/permission_claims_authorizer_test.go
+++ b/pkg/virtual/apiexport/authorizer/permission_claims_authorizer_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
+	dynamiccontext "github.com/kcp-dev/kcp/pkg/virtual/framework/dynamic/context"
+)
+
+func TestPermissionClaimsAuthorizer(t *testing.T) {
+	// Default permission claim and request attributes fixtures match
+	newPermissionClaimFixture := func() *apisv1alpha1.AcceptablePermissionClaim {
+		return &apisv1alpha1.AcceptablePermissionClaim{
+			PermissionClaim: apisv1alpha1.PermissionClaim{
+				GroupResource: apisv1alpha1.GroupResource{Resource: "configmaps"},
+				ResourceSelector: []apisv1alpha1.ResourceSelector{
+					{Name: "foo", Namespace: "bar"},
+				},
+			},
+			State: apisv1alpha1.ClaimAccepted,
+		}
+	}
+	newAttributesFixture := func() *authorizer.AttributesRecord {
+		return &authorizer.AttributesRecord{
+			Verb:            "get",
+			Namespace:       "bar",
+			Resource:        "configmaps",
+			Name:            "foo",
+			ResourceRequest: true,
+		}
+	}
+
+	for _, tt := range []struct {
+		name         string
+		attrFunc     func(*authorizer.AttributesRecord)
+		claimFunc    func(*apisv1alpha1.AcceptablePermissionClaim)
+		wantDecision authorizer.Decision
+		wantReason   string
+		wantError    string
+	}{
+		{
+			name:         "match",
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "delegating due to claimed resource in API binding name=\"binding\": allowed",
+		},
+		{
+			name:         "non-resource request",
+			wantDecision: authorizer.DecisionAllow,
+			attrFunc: func(record *authorizer.AttributesRecord) {
+				record.ResourceRequest = false
+			},
+			wantReason: "delegating due to non-resource request: allowed",
+		},
+		{
+			name: "requested resource differs",
+			attrFunc: func(a *authorizer.AttributesRecord) {
+				a.Resource = "DIFFERENT"
+			},
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "unclaimed resource",
+		},
+		{
+			name: "requested name differs",
+			attrFunc: func(a *authorizer.AttributesRecord) {
+				a.Name = "DIFFERENT"
+			},
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "unclaimed resource",
+		},
+		{
+			name: "claimed resource differs",
+			claimFunc: func(c *apisv1alpha1.AcceptablePermissionClaim) {
+				c.GroupResource = apisv1alpha1.GroupResource{Resource: "DIFFERENT"}
+			},
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "unclaimed resource",
+		},
+		{
+			name: "claimed name differs",
+			claimFunc: func(c *apisv1alpha1.AcceptablePermissionClaim) {
+				c.ResourceSelector = []apisv1alpha1.ResourceSelector{
+					{Name: "DIFFERENT", Namespace: "bar"},
+				}
+			},
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "unclaimed resource",
+		},
+		{
+			name: "claimed namespace differs",
+			claimFunc: func(c *apisv1alpha1.AcceptablePermissionClaim) {
+				c.ResourceSelector = []apisv1alpha1.ResourceSelector{
+					{Name: "foo", Namespace: "DIFFERENT"},
+				}
+			},
+			wantDecision: authorizer.DecisionNoOpinion,
+			wantReason:   "unclaimed resource",
+		},
+		{
+			name: "claimed name unset",
+			claimFunc: func(c *apisv1alpha1.AcceptablePermissionClaim) {
+				c.ResourceSelector = []apisv1alpha1.ResourceSelector{
+					{Name: "", Namespace: "bar"},
+				}
+			},
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "delegating due to claimed resource in API binding name=\"binding\": allowed",
+		},
+		{
+			name: "claimed namespace unset",
+			claimFunc: func(c *apisv1alpha1.AcceptablePermissionClaim) {
+				c.ResourceSelector = []apisv1alpha1.ResourceSelector{
+					{Name: "foo", Namespace: ""},
+				}
+			},
+			wantDecision: authorizer.DecisionAllow,
+			wantReason:   "delegating due to claimed resource in API binding name=\"binding\": allowed",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := newPermissionClaimFixture()
+			if tt.claimFunc != nil {
+				tt.claimFunc(claim)
+			}
+			attr := newAttributesFixture()
+			if tt.attrFunc != nil {
+				tt.attrFunc(attr)
+			}
+			auth := &permissionClaimsAuthorizer{
+				getAPIExport: func(clusterName, apiExportName string) (*apisv1alpha1.APIExport, error) {
+					return &apisv1alpha1.APIExport{
+						ObjectMeta: v1.ObjectMeta{
+							Name: apiExportName,
+						},
+						Spec: apisv1alpha1.APIExportSpec{},
+					}, nil
+				},
+				listAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
+					return []*apisv1alpha1.APIBinding{{
+						ObjectMeta: v1.ObjectMeta{Name: "binding"},
+						Spec: apisv1alpha1.APIBindingSpec{
+							Reference: apisv1alpha1.BindingReference{
+								Export: &apisv1alpha1.ExportBindingReference{
+									Name: "bar",
+								},
+							},
+							PermissionClaims: []apisv1alpha1.AcceptablePermissionClaim{*claim},
+						},
+						Status: apisv1alpha1.APIBindingStatus{},
+					}}, nil
+				},
+				delegate: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+					return authorizer.DecisionAllow, "allowed", nil
+				}),
+			}
+			ctx := request.WithCluster(context.Background(), request.Cluster{Name: "cluster"})
+			ctx = dynamiccontext.WithAPIDomainKey(ctx, "foo/bar")
+			dec, reason, err := auth.Authorize(ctx, attr)
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+			if gotErr != tt.wantError {
+				t.Errorf("want error %q, got %q", tt.wantError, gotErr)
+			}
+			if dec != tt.wantDecision {
+				t.Errorf("want decision %v, got %v", tt.wantDecision, dec)
+			}
+			if reason != tt.wantReason {
+				t.Errorf("want reason %q, got %q", tt.wantReason, reason)
+			}
+		})
+	}
+}

--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -227,7 +227,10 @@ func newAuthorizer(kubeClusterClient, deepSARClient kcpkubernetesclientset.Clust
 	maximalPermissionAuth := virtualapiexportauth.NewMaximalPermissionAuthorizer(deepSARClient, kcpinformers.Apis().V1alpha1().APIExports())
 	maximalPermissionAuth = authorization.NewDecorator("virtual.apiexport.maxpermissionpolicy.authorization.kcp.io", maximalPermissionAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
-	apiExportsContentAuth := virtualapiexportauth.NewAPIExportsContentAuthorizer(maximalPermissionAuth, kubeClusterClient)
+	permissionClaimAuth := virtualapiexportauth.NewPermissionClaimsAuthorizer(kcpinformers, maximalPermissionAuth)
+	permissionClaimAuth = authorization.NewDecorator("virtual.apiexport.permission.authorization.kcp.io", permissionClaimAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+
+	apiExportsContentAuth := virtualapiexportauth.NewAPIExportsContentAuthorizer(permissionClaimAuth, kubeClusterClient)
 	apiExportsContentAuth = authorization.NewDecorator("virtual.apiexport.content.authorization.kcp.io", apiExportsContentAuth).AddAuditLogging().AddAnonymization()
 
 	return apiExportsContentAuth


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This adds a permission claims authorizer which respects a permission claim's resource selector.

It partially backports functionality from https://github.com/kcp-dev/kcp/pull/2089 (reverse permission claims)

/cc @nrb 

TODOS:
- [ ] Add e2e tests

## Related issue(s)

https://github.com/kcp-dev/kcp/pull/2456
