### PR TITLE
🌱 Debug dns e2e test failures

### DIFF
--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -47,13 +47,10 @@ func TestDNSResolution(t *testing.T) {
 	t.Cleanup(cancelFunc)
 
 	upstreamServer := framework.SharedKcpServer(t)
-
 	upstreamConfig := upstreamServer.BaseConfig(t)
 
 	orgWorkspace := framework.NewOrganizationFixture(t, upstreamServer)
-
 	locationWorkspace := framework.NewWorkspaceFixture(t, upstreamServer, orgWorkspace.Path(), framework.WithName("location"))
-
 	workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgWorkspace.Path(), framework.WithName("workload-1"))
 	workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgWorkspace.Path(), framework.WithName("workload-2"))
 


### PR DESCRIPTION
## Summary

Dummy PR to test / debug failures of the new Syncer DNS e2e test on main

## Related issue(s)

Related to the fact that these e2e tests fail on PR https://github.com/kcp-dev/kcp/pull/2452.
Need to know if it is also the case on top of main.