### PR TITLE
:bug: e2e: PrivateKcpServer enable audit-policy

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -104,6 +104,17 @@ func PrivateKcpServer(t *testing.T, options ...KcpConfigOption) RunningServer {
 		cfg = opt(cfg)
 	}
 
+	auditPolicyArg := false
+	for _, arg := range cfg.Args {
+		if arg == "--audit-policy-file" {
+			auditPolicyArg = true
+		}
+	}
+	// Default --audit-policy-file or we get no audit info for CI debugging
+	if !auditPolicyArg {
+		cfg.Args = append(cfg.Args, TestServerWithAuditPolicyFile(WriteEmbedFile(t, "audit-policy.yaml"))...)
+	}
+
 	if len(cfg.ArtifactDir) == 0 || len(cfg.DataDir) == 0 {
 		artifactDir, dataDir, err := ScratchDirs(t)
 		require.NoError(t, err, "failed to create scratch dirs: %v", err)


### PR DESCRIPTION
## Summary

Otherwise we end up with zero-length audit logs in CI...

For example see [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/kcp-dev_kcp/2594/pull-ci-kcp-dev-kcp-main-e2e/1613198333013135360/artifacts/e2e/e2e/artifacts/TestUserHomeWorkspaces/Create_a_workspace_in_the_non-existing_home_and_have_it_created_automatically_through_~/3662491291/artifacts/kcp/main/) - AFAICS all tests using PrivateKcpServer have this problem because we only set the audit-policy flag in the [SharedKcpServer fixture](https://github.com/kcp-dev/kcp/blob/main/test/e2e/framework/kcp.go#L151)
