### PR TITLE
🐛 IndexByLogicalClusterPathAndName should return clusterpath and name

### DIFF
--- a/pkg/indexers/indexers.go
+++ b/pkg/indexers/indexers.go
@@ -109,7 +109,7 @@ func IndexByLogicalClusterPathAndName(obj interface{}) ([]string, error) {
 		}, nil
 	}
 
-	return []string{logicalcluster.From(metaObj).String()}, nil
+	return []string{logicalcluster.From(metaObj).Path().Join(metaObj.GetName()).String()}, nil
 }
 
 // ByIndex returns all instances of T that match indexValue in indexName in indexer.


### PR DESCRIPTION
Signed-off-by: Jian Qiu <jqiu@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

I think IndexByLogicalClusterPathAndName should return clusterPath+Name by default?

## Related issue(s)

Fixes #
