### PR TITLE
WIP pkg/authorization: remove deep SAR check from maximal permission policy

### DIFF
--- a/pkg/authorization/maximal_permission_policy_authorizer.go
+++ b/pkg/authorization/maximal_permission_policy_authorizer.go
@@ -112,11 +112,6 @@ type MaximalPermissionPolicyAuthorizer struct {
 }
 
 func (a *MaximalPermissionPolicyAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
-	if IsDeepSubjectAccessReviewFrom(ctx, attr) {
-		// this is a deep SAR request, we have to skip the checks here and delegate to the subsequent authorizer.
-		return DelegateAuthorization("deep SAR request", a.delegate).Authorize(ctx, attr)
-	}
-
 	// get the cluster from the ctx.
 	lcluster, err := genericapirequest.ClusterNameFrom(ctx)
 	if err != nil {

--- a/pkg/server/options/authorization.go
+++ b/pkg/server/options/authorization.go
@@ -114,8 +114,6 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, kubeInformers, 
 	globalAuth, _ := authz.NewGlobalAuthorizer(kubeInformers, globalKubeInformers)
 	globalAuth = authz.NewDecorator("global.authorization.kcp.io", globalAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
 
-	// everything below - skipped for Deep SAR
-
 	// enforce maximal permission policy
 	maxPermissionPolicyAuth := authz.NewMaximalPermissionPolicyAuthorizer(kubeInformers, globalKubeInformers, kcpInformers, globalKcpInformers, union.New(bootstrapAuth, localAuth, globalAuth))
 	maxPermissionPolicyAuth = authz.NewDecorator("maxpermissionpolicy.authorization.kcp.io", maxPermissionPolicyAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
@@ -123,6 +121,8 @@ func (s *Authorization) ApplyTo(config *genericapiserver.Config, kubeInformers, 
 	// protect status updates to apiexport and apibinding
 	systemCRDAuth := authz.NewSystemCRDAuthorizer(maxPermissionPolicyAuth)
 	systemCRDAuth = authz.NewDecorator("systemcrd.authorization.kcp.io", systemCRDAuth).AddAuditLogging().AddAnonymization().AddReasonAnnotation()
+
+	// everything below - skipped for Deep SAR
 
 	// content auth deteremines if users have access to the workspace itself - by default, in Kube there is a set
 	// of default permissions given even to system:authenticated (like access to discovery) - this authorizer allows


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Currently, deep SAR is ommitted in maximal permission policy authorizer. That was done in order to fix https://github.com/kcp-dev/kcp/issues/2384. This fix is not right according to @sttts hence the removal here.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/2568