### PR TITLE
🌱 test/e2e/virtual/apiexport: make authorizer test self-contained

### DIFF
--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -18,28 +18,33 @@ package apiexport
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	jsonpatch "github.com/evanphx/json-patch"
 	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	kcpapiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/kcp/clientset/versioned"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 
@@ -52,9 +57,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/apis/third_party/conditions/util/conditions"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
-	"github.com/kcp-dev/kcp/test/e2e/fixtures/apifixtures"
 	"github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/apis/wildwest"
-	wildwestclientset "github.com/kcp-dev/kcp/test/e2e/fixtures/wildwest/client/clientset/versioned/cluster"
 	"github.com/kcp-dev/kcp/test/e2e/framework"
 )
 
@@ -73,9 +76,7 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	serviceProvider1Path, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName("provider-a"))
 	serviceProvider2Path, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName("provider-b"))
 	tenantPath, tenantWorkspace := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName("tenant"))
-	tenantClusterName := logicalcluster.Name(tenantWorkspace.Spec.Cluster)
 	tenantShadowCRDPath, tenantShadowCRDWorkspace := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithName("tenant-shadowed-crd"))
-	tenantShadowCRDClusterName := logicalcluster.Name(tenantShadowCRDWorkspace.Spec.Cluster)
 
 	cfg := server.BaseConfig(t)
 
@@ -84,10 +85,6 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	user2KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-2", rest.CopyConfig(cfg)))
 	require.NoError(t, err)
 	user3KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
-	require.NoError(t, err)
-	user2DynamicClusterClient, err := kcpdynamic.NewForConfig(framework.UserConfig("user-2", rest.CopyConfig(cfg)))
-	require.NoError(t, err)
-	user3DynamicClusterClient, err := kcpdynamic.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err)
 	kubeClient, err := kcpkubernetesclientset.NewForConfig(rest.CopyConfig(cfg))
 	require.NoError(t, err)
@@ -98,131 +95,192 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClient, tenantPath, []string{"user-3"}, nil, true)
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClient, tenantShadowCRDPath, []string{"user-3"}, nil, true)
 
-	apifixtures.CreateSheriffsSchemaAndExport(ctx, t, serviceProvider1Path, user1KcpClient, "wild.wild.west", "")
+	t.Logf("install sherriffs API resource schema, API export, permissions for user-3 to be able to bind to the export in service provider workspace %q", serviceProvider1Path)
+	require.NoError(t, apply(t, ctx, serviceProvider1Path, framework.UserConfig("user-1", rest.CopyConfig(cfg)),
+		&apisv1alpha1.APIResourceSchema{
+			ObjectMeta: metav1.ObjectMeta{Name: "today.sheriffs.wild.wild.west"},
+			Spec: apisv1alpha1.APIResourceSchemaSpec{
+				Group: "wild.wild.west",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{Plural: "sheriffs", Singular: "sheriff", Kind: "Sheriff", ListKind: "SheriffList"},
+				Scope: "Namespaced",
+				Versions: []apisv1alpha1.APIResourceVersion{
+					{Name: "v1alpha1", Served: true, Storage: true, Schema: runtime.RawExtension{Raw: []byte(`{"type":"object"}`)}},
+				},
+			},
+		},
+		&apisv1alpha1.APIExport{
+			ObjectMeta: metav1.ObjectMeta{Name: "wild.wild.west"},
+			Spec: apisv1alpha1.APIExportSpec{
+				LatestResourceSchemas:   []string{"today.sheriffs.wild.wild.west"},
+				MaximalPermissionPolicy: &apisv1alpha1.MaximalPermissionPolicy{Local: &apisv1alpha1.LocalAPIExportPolicy{}},
+			},
+		},
 
-	t.Logf("Setting maximal permission policy on APIExport %s|%s", serviceProvider1Path, "wild.wild.west")
-	export, err := user1KcpClient.Cluster(serviceProvider1Path).ApisV1alpha1().APIExports().Get(ctx, "wild.wild.west", metav1.GetOptions{})
-	require.NoError(t, err, "error getting APIExport %s|%s", serviceProvider1Path, export.Name)
-
-	patchedExport := export.DeepCopy()
-	patchedExport.Spec.MaximalPermissionPolicy = &apisv1alpha1.MaximalPermissionPolicy{Local: &apisv1alpha1.LocalAPIExportPolicy{}}
-	mergePatch, err := jsonpatch.CreateMergePatch(encodeJSON(t, export), encodeJSON(t, patchedExport))
-	require.NoError(t, err)
-	_, err = user1KcpClient.Cluster(serviceProvider1Path).ApisV1alpha1().APIExports().Patch(ctx, export.Name, types.MergePatchType, mergePatch, metav1.PatchOptions{})
-	require.NoError(t, err, "error patching APIExport %s|%s", serviceProvider1Path, export.Name)
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-3-bind-apiexport"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"apis.kcp.io"}, ResourceNames: []string{"wild.wild.west"}, Resources: []string{"apiexports"}, Verbs: []string{"bind"}},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-3-bind-apiexport"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "user-3"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.SchemeGroupVersion.Group, Kind: "ClusterRole", Name: "user-3-bind-apiexport"},
+		},
+	))
 
 	t.Logf("get the sheriffs apiexport's generated identity hash")
-	identityHash := ""
+	sherriffsIdentityHash := ""
 	framework.Eventually(t, func() (done bool, str string) {
 		sheriffExport, err := user1KcpClient.Cluster(serviceProvider1Path).ApisV1alpha1().APIExports().Get(ctx, "wild.wild.west", metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Sprintf("error while waiting to get API export: %v", err)
 		}
 		if conditions.IsTrue(sheriffExport, apisv1alpha1.APIExportIdentityValid) {
-			identityHash = sheriffExport.Status.IdentityHash
+			sherriffsIdentityHash = sheriffExport.Status.IdentityHash
 			return true, ""
 		}
 		return false, fmt.Sprintf("waiting for API export identity to be valid: %+v", conditions.Get(sheriffExport, apisv1alpha1.APIExportIdentityValid))
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "could not wait for APIExport to be valid with identity hash")
-	t.Logf("Found identity hash: %v", identityHash)
+	t.Logf("Found identity hash: %v", sherriffsIdentityHash)
 
-	t.Logf("grant user-3 to be able to bind sherriffs API export \"wild.wild.west\" from workspace %q", serviceProvider1Path)
-	cr, crb := createClusterRoleAndBindings(
-		"user-3-bind",
-		"user-3", "User",
-		[]string{"bind"},
-		"apis.kcp.io", "apiexports", "wild.wild.west",
-	)
-	_, err = kubeClient.Cluster(serviceProvider1Path).RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
-	require.NoError(t, err)
-	_, err = kubeClient.Cluster(serviceProvider1Path).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
-	require.NoError(t, err)
-	// create API binding in tenant workspace pointing to the sherriffs export
-	apifixtures.BindToExport(ctx, t, serviceProvider1Path, "wild.wild.west", tenantPath, user3KcpClient)
-
-	t.Logf("Install today cowboys APIResourceSchema into service provider workspace %q", serviceProvider2Path)
-	user2serviceProvider2KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-2", rest.CopyConfig(cfg)))
-	require.NoError(t, err)
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(user2serviceProvider2KcpClient.Cluster(serviceProvider2Path).Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, user2DynamicClusterClient.Cluster(serviceProvider2Path), mapper, nil, "apiresourceschema_cowboys.yaml", testFiles)
-	require.NoError(t, err)
-
-	t.Logf("Create an APIExport for today cowboys APIResourceSchema in service provider %q", serviceProvider2Path)
-	cowboysAPIExport := &apisv1alpha1.APIExport{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "today-cowboys",
-		},
-		Spec: apisv1alpha1.APIExportSpec{
-			LatestResourceSchemas: []string{"today.cowboys.wildwest.dev"},
-			PermissionClaims: []apisv1alpha1.PermissionClaim{
-				{
-					GroupResource: apisv1alpha1.GroupResource{Group: "", Resource: "configmaps"},
-					All:           true,
-				},
-				{
-					GroupResource: apisv1alpha1.GroupResource{Group: "wild.wild.west", Resource: "sheriffs"},
-					IdentityHash:  identityHash,
-					All:           true,
+	t.Logf("install cowboys API resource schema, API export, and permissions for user-3 to be able to bind to the export in second service provider workspace %q", serviceProvider2Path)
+	require.NoError(t, apply(t, ctx, serviceProvider2Path, framework.UserConfig("user-2", rest.CopyConfig(cfg)),
+		&apisv1alpha1.APIResourceSchema{
+			ObjectMeta: metav1.ObjectMeta{Name: "today.cowboys.wildwest.dev"},
+			Spec: apisv1alpha1.APIResourceSchemaSpec{
+				Group: "wildwest.dev",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{Plural: "cowboys", Singular: "cowboy", Kind: "Cowboy", ListKind: "CowboyList"},
+				Scope: "Namespaced",
+				Versions: []apisv1alpha1.APIResourceVersion{
+					{Name: "v1alpha1", Served: true, Storage: true, Schema: runtime.RawExtension{Raw: []byte(`{"type":"object"}`)}},
 				},
 			},
 		},
-	}
-	_, err = user2KcpClient.Cluster(serviceProvider2Path).ApisV1alpha1().APIExports().Create(ctx, cowboysAPIExport, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	t.Logf("grant user-3 to be able to bind cowboys API export \"today-cowboys\" from workspace %q", serviceProvider2Path)
-	cr, crb = createClusterRoleAndBindings(
-		"user-3-bind",
-		"user-3", "User",
-		[]string{"bind"},
-		"apis.kcp.io", "apiexports", "today-cowboys",
-	)
-	_, err = kubeClient.Cluster(serviceProvider2Path).RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
-	require.NoError(t, err)
-	_, err = kubeClient.Cluster(serviceProvider2Path).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
-	require.NoError(t, err)
-
-	t.Logf("Create an APIBinding in consumer workspace %q that points to the today-cowboys export from %q", tenantPath, serviceProvider2Path)
-	apiBinding := &apisv1alpha1.APIBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cowboys",
-		},
-		Spec: apisv1alpha1.APIBindingSpec{
-			Reference: apisv1alpha1.BindingReference{
-				Export: &apisv1alpha1.ExportBindingReference{
-					Path: serviceProvider2Path.String(),
-					Name: "today-cowboys",
+		&apisv1alpha1.APIExport{
+			ObjectMeta: metav1.ObjectMeta{Name: "today-cowboys"},
+			Spec: apisv1alpha1.APIExportSpec{
+				LatestResourceSchemas:   []string{"today.cowboys.wildwest.dev"},
+				MaximalPermissionPolicy: &apisv1alpha1.MaximalPermissionPolicy{Local: &apisv1alpha1.LocalAPIExportPolicy{}},
+				PermissionClaims: []apisv1alpha1.PermissionClaim{
+					{
+						GroupResource: apisv1alpha1.GroupResource{Resource: "configmaps"},
+						All:           true,
+					},
+					{
+						GroupResource: apisv1alpha1.GroupResource{Group: "wild.wild.west", Resource: "sheriffs"},
+						IdentityHash:  sherriffsIdentityHash,
+						All:           true,
+					},
 				},
 			},
 		},
-	}
-	framework.Eventually(t, func() (bool, string) {
-		_, err = user3KcpClient.Cluster(tenantPath).ApisV1alpha1().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
-		if err != nil {
-			return false, fmt.Sprintf("error creating API binding: %v", err)
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "api binding creation failed")
+
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-3-bind"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"apis.kcp.io"}, ResourceNames: []string{"today-cowboys"}, Resources: []string{"apiexports"}, Verbs: []string{"bind"}},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-3-bind"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "user-3"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.SchemeGroupVersion.Group, Kind: "ClusterRole", Name: "user-3-bind"},
+		},
+
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-3-maximum-permission-policy"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"wildwest.dev"}, Resources: []string{"cowboys"}, Verbs: []string{"delete", "create", "list", "watch", "get", "patch"}},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-3-maximum-permission-policy"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "apis.kcp.io:binding:user-3"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.SchemeGroupVersion.Group, Kind: "ClusterRole", Name: "user-3-maximum-permission-policy"},
+		},
+	))
+
+	t.Logf("bind cowboys and claimed sherriffs in the tenant workspace %q", tenantPath)
+	require.NoError(t, apply(t, ctx, tenantPath, framework.UserConfig("user-3", rest.CopyConfig(cfg)),
+		&apisv1alpha1.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "wild.wild.west",
+			},
+			Spec: apisv1alpha1.APIBindingSpec{
+				Reference: apisv1alpha1.BindingReference{
+					Export: &apisv1alpha1.ExportBindingReference{
+						Path: serviceProvider1Path.String(),
+						Name: "wild.wild.west",
+					},
+				},
+			},
+		},
+		&apisv1alpha1.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cowboys",
+			},
+			Spec: apisv1alpha1.APIBindingSpec{
+				PermissionClaims: []apisv1alpha1.AcceptablePermissionClaim{
+					{
+						PermissionClaim: apisv1alpha1.PermissionClaim{
+							GroupResource: apisv1alpha1.GroupResource{Resource: "configmaps"},
+							All:           true,
+						},
+						State: apisv1alpha1.ClaimAccepted,
+					},
+					{
+						PermissionClaim: apisv1alpha1.PermissionClaim{
+							GroupResource: apisv1alpha1.GroupResource{Group: "wild.wild.west", Resource: "sheriffs"},
+							IdentityHash:  sherriffsIdentityHash,
+							All:           true,
+						},
+						State: apisv1alpha1.ClaimAccepted,
+					},
+				},
+				Reference: apisv1alpha1.BindingReference{
+					Export: &apisv1alpha1.ExportBindingReference{
+						Path: serviceProvider2Path.String(),
+						Name: "today-cowboys",
+					},
+				},
+			},
+		},
+	))
 
 	t.Logf("Make sure [%q, %q] API groups shows up in consumer workspace %q group discovery", wildwest.GroupName, "wild.wild.west", tenantPath)
 	user3tenantWorkspaceKcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err)
-	err = wait.PollImmediateWithContext(ctx, 100*time.Millisecond, wait.ForeverTestTimeout, func(c context.Context) (done bool, err error) {
+	framework.Eventually(t, func() (success bool, reason string) {
 		groups, err := user3tenantWorkspaceKcpClient.Cluster(tenantPath).Discovery().ServerGroups()
 		if err != nil {
-			return false, fmt.Errorf("error retrieving consumer workspace %q group discovery: %w", tenantPath, err)
+			return false, fmt.Sprintf("error retrieving consumer workspace %q group discovery: %v", tenantPath, err)
 		}
-		return groupExists(groups, wildwest.GroupName) && groupExists(groups, "wild.wild.west"), nil
-	})
-	require.NoError(t, err)
+		return groupExists(groups, wildwest.GroupName) && groupExists(groups, "wild.wild.west"), ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "discovery failed")
 
-	t.Logf("Install cowboys CRD into tenant workspace %q", tenantShadowCRDPath)
-	user3tenantShadowCRDKubeClient, err := kcpkubernetesclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
-	require.NoError(t, err)
-	mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(user3tenantShadowCRDKubeClient.Cluster(tenantShadowCRDPath).Discovery()))
-	err = helpers.CreateResourceFromFS(ctx, user3DynamicClusterClient.Cluster(tenantShadowCRDPath), mapper, nil, "crd_cowboys.yaml", testFiles)
-	require.NoError(t, err)
+	t.Logf("Install cowboys CRD and also bind the conflicting cowboys API export in tenant workspace %q", tenantShadowCRDPath)
+	require.NoError(t, apply(t, ctx, tenantShadowCRDPath, framework.UserConfig("user-3", rest.CopyConfig(cfg)),
+		&apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "cowboys.wildwest.dev"},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "wildwest.dev",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{Plural: "cowboys", Singular: "cowboy", Kind: "Cowboy", ListKind: "CowboyList"},
+				Scope: "Namespaced",
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name: "v1alpha1", Served: true, Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type: "object",
+							}},
+					},
+				},
+			},
+		},
+	))
 
+	t.Logf("Waiting for cowboys CRD to be ready in tenant workspace %q", tenantShadowCRDPath)
 	user3APIExtensionsClient, err := kcpapiextensionsclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err)
 	framework.Eventually(t, func() (bool, string) {
@@ -236,31 +294,43 @@ func TestAPIExportAuthorizers(t *testing.T) {
 		return false, "waiting for cowboys CRD to become established"
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "waiting for cowboys CRD to become established failed")
 
-	apiBinding = &apisv1alpha1.APIBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cowboys",
-		},
-		Spec: apisv1alpha1.APIBindingSpec{
-			Reference: apisv1alpha1.BindingReference{
-				Export: &apisv1alpha1.ExportBindingReference{
-					Path: serviceProvider2Path.String(),
-					Name: "today-cowboys",
+	t.Logf("Create a cowboys APIBinding in consumer workspace %q that points to the today-cowboys export from %q but shadows a local cowboys CRD at the same time", tenantShadowCRDPath, serviceProvider2Path)
+	require.NoError(t, apply(t, ctx, tenantShadowCRDPath, framework.UserConfig("user-3", rest.CopyConfig(cfg)),
+		&apisv1alpha1.APIBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cowboys",
+			},
+			Spec: apisv1alpha1.APIBindingSpec{
+				PermissionClaims: []apisv1alpha1.AcceptablePermissionClaim{
+					{
+						PermissionClaim: apisv1alpha1.PermissionClaim{
+							GroupResource: apisv1alpha1.GroupResource{Resource: "configmaps"},
+							All:           true,
+						},
+						State: apisv1alpha1.ClaimAccepted,
+					},
+					{
+						PermissionClaim: apisv1alpha1.PermissionClaim{
+							GroupResource: apisv1alpha1.GroupResource{Group: "wild.wild.west", Resource: "sheriffs"},
+							IdentityHash:  sherriffsIdentityHash,
+							All:           true,
+						},
+						State: apisv1alpha1.ClaimAccepted,
+					},
+				},
+				Reference: apisv1alpha1.BindingReference{
+					Export: &apisv1alpha1.ExportBindingReference{
+						Path: serviceProvider2Path.String(),
+						Name: "today-cowboys",
+					},
 				},
 			},
 		},
-	}
-	t.Logf("Create an APIBinding %q in consumer workspace %q that points to the today-cowboys export from %q but shadows a local cowboys CRD at the same time", apiBinding.Name, tenantShadowCRDPath, serviceProvider2Path)
-	framework.Eventually(t, func() (bool, string) {
-		_, err := user3KcpClient.Cluster(tenantShadowCRDPath).ApisV1alpha1().APIBindings().Create(ctx, apiBinding, metav1.CreateOptions{})
-		if err != nil {
-			return false, fmt.Sprintf("error creating API binding: %v", err)
-		}
-		return true, ""
-	}, wait.ForeverTestTimeout, time.Millisecond*100, "api binding creation failed")
+	))
 
-	t.Logf("Waiting for APIBinding %q in consumer workspace %q to have the condition %q mentioning the conflict with the shadowing local cowboys CRD", apiBinding.Name, tenantShadowCRDPath, apisv1alpha1.BindingUpToDate)
+	t.Logf("Waiting for cowboys APIBinding in consumer workspace %q to have the condition %q mentioning the conflict with the shadowing local cowboys CRD", tenantShadowCRDPath, apisv1alpha1.BindingUpToDate)
 	framework.Eventually(t, func() (bool, string) {
-		binding, err := user3KcpClient.Cluster(tenantShadowCRDPath).ApisV1alpha1().APIBindings().Get(ctx, apiBinding.Name, metav1.GetOptions{})
+		binding, err := user3KcpClient.Cluster(tenantShadowCRDPath).ApisV1alpha1().APIBindings().Get(ctx, "cowboys", metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Sprintf("error creating API binding: %v", err)
 		}
@@ -274,17 +344,21 @@ func TestAPIExportAuthorizers(t *testing.T) {
 		return false, fmt.Sprintf("CRD conflict condition not yet met: %q", condition.Message)
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "api binding creation failed")
 
-	user3wildwestClusterClient, err := wildwestclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
-	require.NoError(t, err, "failed to construct wildwest cluster client for server")
-	cowboy := newCowboy("default", "cowboy1")
+	require.NoError(t, apply(t, ctx, tenantPath, framework.UserConfig("user-3", rest.CopyConfig(cfg)), `
+apiVersion: wildwest.dev/v1alpha1
+kind: Cowboy
+metadata:
+  name: cowboy-via-api-binding
+  namespace: default
+`))
 
-	t.Logf("Creating a cowboy resource available via API binding in consumer workspace %q", tenantPath)
-	_, err = user3wildwestClusterClient.Cluster(tenantPath).WildwestV1alpha1().Cowboys("default").Create(ctx, cowboy, metav1.CreateOptions{})
-	require.NoError(t, err, "error creating cowboy in tenant workspace %q", tenantPath)
-
-	t.Logf("Creating a cowboy resource available via CRD in consumer workspace %q", tenantShadowCRDPath)
-	_, err = user3wildwestClusterClient.Cluster(tenantShadowCRDPath).WildwestV1alpha1().Cowboys("default").Create(ctx, cowboy, metav1.CreateOptions{})
-	require.NoError(t, err, "error creating cowboy in shadowing CRD tenant workspace %q", tenantShadowCRDPath)
+	require.NoError(t, apply(t, ctx, tenantShadowCRDPath, framework.UserConfig("user-3", rest.CopyConfig(cfg)), `
+apiVersion: wildwest.dev/v1alpha1
+kind: Cowboy
+metadata:
+  name: cowboy-via-crd
+  namespace: default
+`))
 
 	t.Logf("get virtual workspace client for \"today-cowboys\" APIExport in workspace %q", serviceProvider2Path)
 	var apiExport *apisv1alpha1.APIExport
@@ -305,6 +379,7 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
 	user2ApiExportVWCfg.Host = apiExport.Status.VirtualWorkspaces[0].URL
 	user2DynamicVWClient, err := kcpdynamic.NewForConfig(user2ApiExportVWCfg)
+	require.NoError(t, err)
 
 	t.Logf("verify that user-2 cannot list sherrifs resources via virtual apiexport apiserver because we have no local maximal permissions yet granted")
 	_, err = user2DynamicVWClient.Resource(schema.GroupVersionResource{Version: "v1", Resource: "sheriffs", Group: "wild.wild.west"}).List(ctx, metav1.ListOptions{})
@@ -316,22 +391,24 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	_, err = user2DynamicVWClient.Resource(schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}).List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "user-2 must be allowed to list native types")
 
-	t.Logf("grant access to sherrifs for %q in workspace %q", apisv1alpha1.MaximalPermissionPolicyRBACUserGroupPrefix+"user-2", serviceProvider1Path)
-	cr, crb = createClusterRoleAndBindings(
-		"apiexport-claimed",
-		"apis.kcp.io:binding:user-2", "User",
-		[]string{"create", "list"},
-		"wild.wild.west", "sheriffs", "",
-	)
-	_, err = kubeClient.Cluster(serviceProvider1Path).RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{})
-	require.NoError(t, err)
-	_, err = kubeClient.Cluster(serviceProvider1Path).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
-	require.NoError(t, err)
+	require.NoError(t, apply(t, ctx, serviceProvider1Path, framework.UserConfig("user-1", rest.CopyConfig(cfg)),
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-2-maximum-permission-policy"},
+			Rules: []rbacv1.PolicyRule{
+				{APIGroups: []string{"wild.wild.west"}, Resources: []string{"sheriffs"}, Verbs: []string{"delete", "create", "list", "watch", "get", "patch"}},
+			},
+		},
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-2-maximum-permission-policy"},
+			Subjects:   []rbacv1.Subject{{Kind: "User", Name: "apis.kcp.io:binding:user-2"}},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.SchemeGroupVersion.Group, Kind: "ClusterRole", Name: "user-2-maximum-permission-policy"},
+		},
+	))
 
 	t.Logf("verify that user-2 can lists all claimed resources using a wildcard request")
 	claimedGVRs := []schema.GroupVersionResource{
 		{Version: "v1", Resource: "configmaps"},
-		{Version: "v1", Resource: "sheriffs", Group: "wild.wild.west"},
+		{Version: "v1alpha1", Resource: "sheriffs", Group: "wild.wild.west"},
 	}
 	framework.Eventually(t, func() (success bool, reason string) {
 		for _, gvr := range claimedGVRs {
@@ -345,7 +422,7 @@ func TestAPIExportAuthorizers(t *testing.T) {
 
 	t.Logf("verify that user-2 can lists sherriffs resources in the tenant workspace %q via the virtual apiexport apiserver", tenantPath)
 	framework.Eventually(t, func() (success bool, reason string) {
-		_, err = user2DynamicVWClient.Cluster(tenantClusterName.Path()).Resource(schema.GroupVersionResource{Version: "v1", Resource: "sheriffs", Group: "wild.wild.west"}).List(ctx, metav1.ListOptions{})
+		_, err = user2DynamicVWClient.Cluster(logicalcluster.Name(tenantWorkspace.Spec.Cluster).Path()).Resource(schema.GroupVersionResource{Version: "v1alpha1", Resource: "sheriffs", Group: "wild.wild.west"}).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, fmt.Sprintf("error while waiting to list sherriffs: %v", err)
 		}
@@ -353,9 +430,76 @@ func TestAPIExportAuthorizers(t *testing.T) {
 	}, wait.ForeverTestTimeout, 100*time.Millisecond, "listing claimed resources failed")
 
 	t.Logf("verify that user-2 cannot lists CRD shadowed sherriffs resources in the tenant workspace %q via the virtual apiexport apiserver", tenantShadowCRDPath)
-	_, err = user2DynamicVWClient.Cluster(tenantShadowCRDClusterName.Path()).Resource(schema.GroupVersionResource{Version: "v1alpha1", Resource: "cowboys", Group: "wildwest.dev"}).List(ctx, metav1.ListOptions{})
+	_, err = user2DynamicVWClient.Cluster(logicalcluster.Name(tenantShadowCRDWorkspace.Spec.Cluster).Path()).Resource(schema.GroupVersionResource{Version: "v1alpha1", Resource: "cowboys", Group: "wildwest.dev"}).List(ctx, metav1.ListOptions{})
 	require.Error(t, err, "expected error, got none")
 	require.True(t, errors.IsNotFound(err))
+}
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = apisv1alpha1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
+}
+
+func apply(t *testing.T, ctx context.Context, workspace logicalcluster.Path, cfg *rest.Config, manifests ...any) error {
+	t.Helper()
+	discoveryClient, err := kcpkubernetesclientset.NewForConfig(cfg)
+	require.NoError(t, err)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient.Cluster(workspace).Discovery()))
+
+	for _, manifest := range manifests {
+		obj, gvk := func() (*unstructured.Unstructured, *schema.GroupVersionKind) {
+			switch value := manifest.(type) {
+			case string:
+				result, gvk, err := extensionsapiserver.Codecs.UniversalDeserializer().Decode([]byte(value), nil, &unstructured.Unstructured{})
+				require.NoError(t, err)
+
+				obj, ok := result.(*unstructured.Unstructured)
+				if !ok {
+					t.Fatalf("decoded into incorrect type, got %T, wanted %T", obj, &unstructured.Unstructured{})
+				}
+				return obj, gvk
+			case runtime.Object:
+				ro := manifest.(runtime.Object)
+				gvks, _, err := scheme.ObjectKinds(ro)
+				require.NoError(t, err)
+				ro.GetObjectKind().SetGroupVersionKind(gvks[0])
+				o, err := runtime.DefaultUnstructuredConverter.ToUnstructured(ro)
+				require.NoError(t, err)
+				return &unstructured.Unstructured{Object: o}, &gvks[0]
+			default:
+				panic("unsupported type")
+			}
+		}()
+
+		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		require.NoError(t, err)
+
+		dynamicClient, err := kcpdynamic.NewForConfig(cfg)
+		require.NoError(t, err)
+		var dynamicResource dynamic.ResourceInterface
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+			t.Logf(`applying %q workspace %q namespace %q name %q`, gvk.String(), workspace.String(), obj.GetNamespace(), obj.GetName())
+			dynamicResource = dynamicClient.Cluster(workspace).Resource(mapping.Resource).Namespace(obj.GetNamespace())
+		} else {
+			t.Logf(`applying %q workspace %q name %q`, gvk.String(), workspace.String(), obj.GetName())
+			dynamicResource = dynamicClient.Cluster(workspace).Resource(mapping.Resource)
+		}
+
+		bytes, err := json.Marshal(obj)
+		require.NoError(t, err)
+
+		_, err = dynamicResource.Patch(ctx, obj.GetName(), types.ApplyPatchType, bytes, metav1.PatchOptions{
+			FieldManager: t.Name(),
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func TestRootAPIExportAuthorizers(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This makes the e2e test for virtual apiexport authorizer self-contained. The `apply` method will be used to add new e2e tests asserting existing issues.

## Related issue(s)
