### PR TITLE
:sparkles: Add Upsync controller (replaces PR #2214)

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -53,6 +53,7 @@ import (
 	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
 	"github.com/kcp-dev/kcp/pkg/syncer/spec"
 	"github.com/kcp-dev/kcp/pkg/syncer/status"
+	"github.com/kcp-dev/kcp/pkg/syncer/upsync"
 	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
 )
 
@@ -283,6 +284,12 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		return err
 	}
 
+	logger.Info("Creating resource upsyncer")
+	upSyncer, err := upsync.NewUpSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamUpsyncerClusterClient, downstreamDynamicClient, ddsifForUpstreamSyncer, ddsifForUpstreamUpsyncer, ddsifForDownstream, syncTarget.GetUID())
+	if err != nil {
+		return err
+	}
+
 	// Start and sync informer factories
 	var cacheSyncsForAlwaysRequiredGVRs []cache.InformerSynced
 	for _, alwaysRequired := range []string{"secrets", "namespaces"} {
@@ -318,7 +325,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	go syncTargetGVRSource.Start(ctx, 1)
 	go specSyncer.Start(ctx, numSyncerThreads)
 	go statusSyncer.Start(ctx, numSyncerThreads)
-
+	go upSyncer.Start(ctx, numSyncerThreads)
 	go downstreamNamespaceController.Start(ctx, numSyncerThreads)
 
 	// Create and start GVR-specific controllers through controller managers

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -285,7 +285,7 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 	}
 
 	logger.Info("Creating resource upsyncer")
-	upSyncer, err := upsync.NewUpSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamUpsyncerClusterClient, downstreamDynamicClient, ddsifForUpstreamSyncer, ddsifForUpstreamUpsyncer, ddsifForDownstream, syncTarget.GetUID())
+	upSyncer, err := upsync.NewUpSyncer(logger, logicalcluster.From(syncTarget), cfg.SyncTargetName, syncTargetKey, upstreamUpsyncerClusterClient, downstreamDynamicClient, ddsifForUpstreamUpsyncer, ddsifForDownstream, syncTarget.GetUID())
 	if err != nil {
 		return err
 	}

--- a/pkg/syncer/upsync/upsync_controller.go
+++ b/pkg/syncer/upsync/upsync_controller.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/logging"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const (
+	controllerName = "kcp-resource-upsycner"
+	labelKey       = "kcp.resource.upsync"
+	syncValue      = "sync"
+)
+
+type Controller struct {
+	queue                     workqueue.RateLimitingInterface
+	upstreamClient            kcpdynamic.ClusterInterface
+	downstreamClient          dynamic.Interface
+	downstreamNamespaceLister cache.GenericLister
+
+	getDownstreamLister func(gvr schema.GroupVersionResource) (cache.GenericLister, error)
+
+	syncTargetName      string
+	syncTargetWorkspace logicalcluster.Name
+	syncTargetUID       types.UID
+	syncTargetKey       string
+}
+
+type Keysource uint
+type UpdateType uint
+
+const (
+	Upstream Keysource = iota
+	Downstream
+)
+
+const (
+	SpecUpdate UpdateType = iota
+	StatusUpdate
+	MetadataUpdate
+)
+
+// Upstream resource key generation
+// Add the cluster name/namespace#cluster-name
+func getKey(obj interface{}, keySource Keysource) (string, error) {
+	if keySource == Upstream {
+		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+		if err != nil {
+			return key, err
+		}
+		clusterName := logicalcluster.From(obj.(metav1.Object)).String()
+		keyWithClusterName := key + "#" + clusterName
+		return keyWithClusterName, nil
+	}
+	return cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+}
+
+func ParseUpstreamKey(key string) (clusterName, namespace, name string, err error) {
+	parts := strings.Split(key, "#")
+	clusterName = parts[1]
+	namespace, name, err = cache.SplitMetaNamespaceKey(parts[0])
+	if err != nil {
+		return clusterName, namespace, name, err
+	}
+	return clusterName, namespace, name, nil
+}
+
+//Queue handles keys for both upstream and downstream resources. Key Source identifies if it's a downstream or an upstream object
+type queueKey struct {
+	gvr schema.GroupVersionResource
+	key string
+	// Differentiate between upstream and downstream keys
+	keysource Keysource
+	// Update type
+	updateType []UpdateType
+}
+
+func getUpdateType(oldObj *unstructured.Unstructured, newObj *unstructured.Unstructured) []UpdateType {
+	newStatus := newObj.UnstructuredContent()["status"]
+	oldStatus := oldObj.UnstructuredContent()["status"]
+	isStatusUpdated := equality.Semantic.DeepEqual(newStatus, oldStatus)
+
+	newSpec := newObj.UnstructuredContent()["spec"]
+	oldSpec := oldObj.UnstructuredContent()["spec"]
+	isSpecUpdated := equality.Semantic.DeepEqual(newSpec, oldSpec)
+
+	newMeta := newObj.UnstructuredContent()["metadata"]
+	oldMeta := oldObj.UnstructuredContent()["metadata"]
+	isMetadataUpdated := equality.Semantic.DeepEqual(newMeta, oldMeta)
+
+	updatedValues := []UpdateType{}
+	if isSpecUpdated {
+		updatedValues = append(updatedValues, SpecUpdate)
+	}
+	if isStatusUpdated {
+		updatedValues = append(updatedValues, StatusUpdate)
+	}
+	if isMetadataUpdated {
+		updatedValues = append(updatedValues, StatusUpdate)
+	}
+	return updatedValues
+}
+
+func (c *Controller) AddToQueue(gvr schema.GroupVersionResource, obj interface{}, logger logr.Logger, keysource Keysource, updateType []UpdateType) {
+	key, err := getKey(obj, keysource)
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	logging.WithQueueKey(logger, key).V(2).Info("queueing GVR", "gvr", gvr.String())
+	c.queue.Add(
+		queueKey{
+			gvr:       gvr,
+			key:       key,
+			keysource: keysource,
+		},
+	)
+}
+
+func NewUpSyncer(syncerLogger logr.Logger, syncTargetWorkspace logicalcluster.Name,
+	syncTargetName, syncTargetKey string,
+	upstreamClient kcpdynamic.ClusterInterface, downstreamClient dynamic.Interface,
+	ddsifForUpstreamSyncer *ddsif.DiscoveringDynamicSharedInformerFactory,
+	ddsifForUpstreamUpyncer *ddsif.DiscoveringDynamicSharedInformerFactory,
+	ddsifForDownstream *ddsif.GenericDiscoveringDynamicSharedInformerFactory[cache.SharedIndexInformer, cache.GenericLister, informers.GenericInformer],
+	syncTargetUID types.UID) (*Controller, error) {
+	c := &Controller{
+		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+		upstreamClient:   upstreamClient,
+		downstreamClient: downstreamClient,
+		getDownstreamLister: func(gvr schema.GroupVersionResource) (cache.GenericLister, error) {
+			informers, notSynced := ddsifForDownstream.Informers()
+			informer, ok := informers[gvr]
+			if !ok {
+				if shared.ContainsGVR(notSynced, gvr) {
+					return nil, fmt.Errorf("informer for gvr %v not synced in the downstream informer factory", gvr)
+				}
+				return nil, fmt.Errorf("gvr %v should be known in the downstream informer factory", gvr)
+			}
+			return informer.Lister(), nil
+		},
+
+		downstreamUpsyncInformer: downstreamUpsyncInformer,
+		syncTargetName:           syncTargetKey,
+		syncTargetWorkspace:      syncTargetWorkspace,
+		syncTargetUID:            syncTargetUID,
+		syncTargetKey:            syncTargetKey,
+		upstreamInformer:         upstreamInformer,
+	}
+	logger := logging.WithReconciler(syncerLogger, controllerName)
+
+	downstreamUpsyncInformer.AddDownstreamEventHandler(
+		func(gvr schema.GroupVersionResource) cache.ResourceEventHandler {
+			logger.V(2).Info("Set up downstream resources informer", "gvr", gvr.String())
+			return cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					c.AddToQueue(gvr, obj, logger, Downstream, []UpdateType{})
+				},
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					updateType := getUpdateType(oldObj.(*unstructured.Unstructured), newObj.(*unstructured.Unstructured))
+					if len(updateType) > 0 {
+						c.AddToQueue(gvr, newObj, logger, Downstream, updateType)
+					}
+				},
+				DeleteFunc: func(obj interface{}) {
+					c.AddToQueue(gvr, obj, logger, Downstream, []UpdateType{})
+				},
+			}
+		},
+	)
+
+	downstreamUpsyncInformer.AddUpstreamEventHandler(
+		func(gvr schema.GroupVersionResource) cache.ResourceEventHandler {
+			logger.V(2).Info("Set up upstream resources informer", "gvr", gvr.String())
+			return cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					c.AddToQueue(gvr, obj, logger, Upstream, []UpdateType{})
+				},
+			}
+		},
+	)
+	return c, nil
+}
+
+func (c *Controller) Start(ctx context.Context, numThreads int) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	logger := logging.WithReconciler(klog.FromContext(ctx), controllerName)
+	ctx = klog.NewContext(ctx, logger)
+	logger.Info("Starting upsync workers")
+	defer logger.Info("Stopping upsync workers")
+
+	for i := 0; i < numThreads; i++ {
+		go wait.UntilWithContext(ctx, c.startWorker, time.Second)
+	}
+	<-ctx.Done()
+}
+
+func (c *Controller) startWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context) bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	qk := key.(queueKey)
+	ks := qk.keysource
+	updateType := qk.updateType
+	keySource := "Downstream"
+	if ks == Upstream {
+		keySource = "Upstream"
+	}
+
+	logger := logging.WithQueueKey(klog.FromContext(ctx), qk.key).WithValues("gvr", qk.gvr.String(), "Key for:", keySource)
+	ctx = klog.NewContext(ctx, logger)
+	logger.V(1).Info("Processing key")
+	defer c.queue.Done(key)
+
+	if err := c.process(ctx, qk.gvr, qk.key, qk.keysource == Upstream, updateType); err != nil {
+		runtime.HandleError(fmt.Errorf("%s failed to upsync %q, err: %w", controllerName, key, err))
+		c.queue.AddRateLimited(key)
+		return true
+	}
+
+	c.queue.Forget(key)
+
+	return true
+}

--- a/pkg/syncer/upsync/upsync_process.go
+++ b/pkg/syncer/upsync/upsync_process.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+	. "github.com/kcp-dev/kcp/tmc/pkg/logging"
+	"github.com/kcp-dev/logicalcluster/v3"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+const (
+	ResourceVersionAnnotation = "kcp.dev/resource-version"
+)
+
+func (c *Controller) pruneUpstreamResource(ctx context.Context, gvr schema.GroupVersionResource, key string) error {
+	clusterNameString, upstreamNamespace, upstreamName, err := ParseUpstreamKey(key)
+	if err != nil {
+		return err
+	}
+	clusterName := logicalcluster.New(clusterNameString)
+	err = c.upstreamClient.Cluster(clusterName).Resource(gvr).Namespace(upstreamNamespace).Delete(ctx, upstreamName, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) processUpstreamResource(ctx context.Context, gvr schema.GroupVersionResource, key string) error {
+	logger := klog.FromContext(ctx)
+	clusterNameString, upstreamNamespace, upstreamName, err := ParseUpstreamKey(key)
+	// ClusterFromContext can be used here???
+	clusterName := logicalcluster.New(clusterNameString)
+	if err != nil {
+		logger.Error(err, "Invalid key")
+		return nil
+	}
+	// Get upstream resource
+	desiredNSLocator := shared.NewNamespaceLocator(clusterName, c.syncTargetWorkspace, c.syncTargetUID, c.syncTargetName, upstreamNamespace)
+	if upstreamNamespace != "" {
+		downstreamNamespace, err := shared.PhysicalClusterNamespaceName(desiredNSLocator)
+		if err != nil {
+			return err
+		}
+		// Check namespace exists
+		_, err = c.downstreamNamespaceLister.Get(downstreamNamespace)
+		if err != nil && k8serror.IsNotFound(err) {
+			// Downstream namespace not present; assume object is not present as well and return upstream object
+			// Prune resource upstream
+			return c.pruneUpstreamResource(ctx, gvr, key)
+		}
+		if err != nil && !k8serror.IsNotFound(err) {
+			return err
+		}
+		_, err = c.downstreamNamespaceLister.ByNamespace(downstreamNamespace).Get(upstreamName)
+		if err != nil && k8serror.IsNotFound(err) {
+			// Resource not found downstream prune it
+			return c.pruneUpstreamResource(ctx, gvr, key)
+		}
+		if err != nil && !k8serror.IsNotFound(err) {
+			return err
+		}
+	} else {
+		_, err := c.downstreamClient.Resource(gvr).Get(context.TODO(), upstreamName, metav1.GetOptions{})
+		if err != nil && k8serror.IsNotFound(err) {
+			// Downstream namespace not present; assume object is not present as well and return upstream object
+			// Prune resource upstream
+			return c.pruneUpstreamResource(ctx, gvr, key)
+		}
+		if err != nil && !k8serror.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Controller) updateResourceContent(ctx context.Context, gvr schema.GroupVersionResource, upstreamCluster logicalcluster.Name, namespace string, upstreamResource, downstreamResource *unstructured.Unstructured, field string) error {
+	if field == "metadata" {
+		annotations := downstreamResource.GetAnnotations()
+		delete(annotations, shared.NamespaceLocatorAnnotation)
+		downstreamResource.SetAnnotations(annotations)
+	}
+	err := unstructured.SetNestedField(upstreamResource.UnstructuredContent(), downstreamResource.UnstructuredContent()[field], field)
+	if err != nil {
+		return err
+	}
+	if field == "metadata" {
+		annotations := upstreamResource.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[ResourceVersionAnnotation] = downstreamResource.GetResourceVersion()
+		upstreamResource.SetAnnotations(annotations)
+	}
+	_, err = c.upstreamClient.Cluster(upstreamCluster).Resource(gvr).Namespace(namespace).Update(ctx, upstreamResource, metav1.UpdateOptions{}, field)
+	return err
+}
+
+func (c *Controller) processDownstreamResource(ctx context.Context, gvr schema.GroupVersionResource, key string, updateType []UpdateType) error {
+	logger := klog.FromContext(ctx)
+	downstreamNamespace, downstreamName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Error(err, "Invalid key")
+		return nil
+	}
+
+	logger = logger.WithValues(DownstreamNamespace, downstreamNamespace, DownstreamName, downstreamName)
+
+	var upstreamLocator *shared.NamespaceLocator
+	var locatorExists bool
+	var downstreamObject interface{}
+	// Namespace scoped resource
+	if downstreamNamespace != "" {
+		var nsObj runtime.Object
+		if nsObj, err = c.downstreamNamespaceLister.Get(downstreamNamespace); err != nil {
+			logger.Error(err, "Error getting downstream Namespace from downstream namespace lister", "ns", downstreamNamespace)
+		}
+		nsMeta, ok := nsObj.(metav1.Object)
+		if !ok {
+			logger.Info(fmt.Sprintf("Error: downstream ns expected to be metav1.Object got %T", nsObj))
+		}
+
+		upstreamLocator, locatorExists, err = shared.LocatorFromAnnotations(nsMeta.GetAnnotations())
+		if err != nil {
+			logger.Error(err, "Error ")
+		}
+
+		if !locatorExists || upstreamLocator == nil {
+			return nil
+		}
+		downstreamObject, err = c.downstreamClient.Resource(gvr).Namespace(downstreamNamespace).Get(ctx, downstreamName, metav1.GetOptions{})
+		if err != nil {
+			logger.Error(err, "Could not find the resource downstream")
+		}
+	}
+	if downstreamNamespace == "" {
+		downstreamObject, err = c.downstreamClient.Resource(gvr).Get(ctx, downstreamName, metav1.GetOptions{})
+		if err != nil {
+			logger.Error(err, "Could not find the resource downstream")
+		}
+		objMeta, ok := downstreamObject.(metav1.Object)
+		if !ok {
+			logger.Info("Error: downstream cluster-wide res not of metav1 type")
+		}
+		if upstreamLocator, locatorExists, err = shared.LocatorFromAnnotations(objMeta.GetAnnotations()); err != nil {
+			logger.Error(err, "Error decoding annotations on DS cluster-wide res")
+		}
+
+		if !locatorExists || upstreamLocator == nil {
+			return nil
+		}
+	}
+
+	downstreamResource, ok := downstreamObject.(*unstructured.Unstructured)
+	if !ok {
+		logger.Info(fmt.Sprintf("Type mismatch of resource object. Recieved %T", downstreamResource))
+		return nil
+	}
+
+	if upstreamLocator.SyncTarget.UID != c.syncTargetUID || upstreamLocator.SyncTarget.Workspace != c.syncTargetWorkspace.String() {
+		return nil
+	}
+
+	upstreamNamespace := upstreamLocator.Namespace
+	upstreamWorkspace := upstreamLocator.Workspace
+
+	upstreamResource, err := c.upstreamInformer.ForResource(gvr).Lister().ByCluster(upstreamWorkspace).ByNamespace(upstreamNamespace).Get(downstreamResource.GetName())
+	unstructuredUpstreamResource := upstreamResource.(*unstructured.Unstructured)
+	resourceVersionUpstream := ""
+	if k8serror.IsNotFound(err) {
+		// Resource doesn't exist upstream
+		logger.Info("Creating resource upstream", upstreamNamespace, upstreamWorkspace, downstreamResource.GetName())
+		resource, err := c.createResourceInUpstream(ctx, gvr, upstreamNamespace, upstreamWorkspace, downstreamResource)
+		if err != nil {
+			return err
+		}
+		c.updateResourceContent(ctx, gvr, upstreamWorkspace, upstreamNamespace, resource, downstreamResource, "spec")
+		c.updateResourceContent(ctx, gvr, upstreamWorkspace, upstreamNamespace, resource, downstreamResource, "status")
+	} else {
+		resourceVersionUpstream = unstructuredUpstreamResource.GetAnnotations()[ResourceVersionAnnotation]
+	}
+	if !k8serror.IsNotFound(err) && err != nil {
+		return err
+	}
+
+	resourceVersionDownstream := downstreamResource.GetResourceVersion()
+	if unstructuredUpstreamResource != nil && resourceVersionDownstream != resourceVersionUpstream {
+		// Update Resource upstream
+		logger.Info("Updating upstream resource", upstreamNamespace, upstreamWorkspace, downstreamResource)
+		for _, update := range updateType {
+			if update == SpecUpdate {
+				c.updateResourceContent(ctx, gvr, upstreamWorkspace, upstreamNamespace, unstructuredUpstreamResource, downstreamResource, "spec")
+			}
+			if update == StatusUpdate {
+				c.updateResourceContent(ctx, gvr, upstreamWorkspace, upstreamNamespace, unstructuredUpstreamResource, downstreamResource, "status")
+			}
+			if update == MetadataUpdate {
+				c.updateResourceContent(ctx, gvr, upstreamWorkspace, upstreamNamespace, unstructuredUpstreamResource, downstreamResource, "metadata")
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) process(ctx context.Context, gvr schema.GroupVersionResource, key string, isUpstream bool, updateType []UpdateType) error {
+	// Upstream resources are only present upstream and not downstream; so we prune them
+	if isUpstream {
+		return c.processUpstreamResource(ctx, gvr, key)
+	} else {
+		// triggers updated on upstream resource or creation of upstream resource
+		return c.processDownstreamResource(ctx, gvr, key, updateType)
+	}
+}
+
+// Only add the metadata part
+func (c *Controller) createResourceInUpstream(ctx context.Context, gvr schema.GroupVersionResource, upstreamNS string, upstreamLogicalCluster logicalcluster.Name, downstreamObj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	// Make a deepcopy
+	downstreamObject := downstreamObj.DeepCopy()
+	annotations := downstreamObject.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, 5)
+	} else {
+
+		delete(annotations, shared.NamespaceLocatorAnnotation)
+	}
+	annotations[ResourceVersionAnnotation] = downstreamObj.GetResourceVersion()
+	if (len(annotations)) == 0 {
+		downstreamObject.SetAnnotations(nil)
+	} else {
+		downstreamObject.SetAnnotations(annotations)
+	}
+	// Create the resource
+	return c.upstreamClient.Cluster(upstreamLogicalCluster).Resource(gvr).Namespace(upstreamNS).Create(ctx, downstreamObject, metav1.CreateOptions{})
+}

--- a/pkg/syncer/upsync/upsync_process_test.go
+++ b/pkg/syncer/upsync/upsync_process_test.go
@@ -1,0 +1,492 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upsync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
+	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
+	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
+	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
+	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+var scheme *runtime.Scheme
+
+func init() {
+	scheme = runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+}
+
+func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstructured {
+	var result unstructured.Unstructured
+	err := scheme.Convert(obj, &result, nil)
+	require.NoError(t, err)
+
+	return &result
+}
+func TestUpsyncerprocess(t *testing.T) {
+	tests := map[string]struct {
+		fromNamespace *corev1.Namespace
+		gvr           schema.GroupVersionResource
+		fromResource  runtime.Object
+		toResources   []runtime.Object
+
+		resourceToProcessName string
+
+		upstreamURL            string
+		upstreamLogicalCluster string
+		syncTargetName         string
+		syncTargetWorkspace    logicalcluster.Name
+		syncTargetUID          types.UID
+		expectError            bool
+		expectActionsOnFrom    []clienttesting.Action
+		expectActionsOnTo      []kcptesting.Action
+		isUpstream             bool
+		updateType             []UpdateType
+	}{
+		"StatusSyncer upsyncs namespaced resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			},
+				map[string]string{
+					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+				},
+			),
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+			fromResource: getPVC("test-pvc", "test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
+			}, nil, nil, "1"),
+			toResources:           []runtime.Object{},
+			resourceToProcessName: "test-pvc",
+			syncTargetName:        "us-west1",
+			expectActionsOnFrom: []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "",
+				Version:  "v1",
+				Resource: "persistentvolumeclaims"}, "test", "test-pvc")},
+			expectActionsOnTo: []kcptesting.Action{
+				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
+				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
+					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
+				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "spec", "test",
+					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
+						"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+						workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
+					}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "status", "test",
+					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
+						"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+						workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
+					}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
+			},
+			isUpstream: false,
+			updateType: []UpdateType{MetadataUpdate, SpecUpdate},
+		},
+		"StatusSyncer upsyncs cluster-wide resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace:          nil,
+			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
+			fromResource: getPV(getPVC("test", "test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			},
+				map[string]string{
+					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":""}`,
+				}, nil, "1")),
+			toResources:           []runtime.Object{},
+			resourceToProcessName: "test-pv",
+			syncTargetName:        "us-west1",
+			expectActionsOnFrom:   []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, "", "test-pv")},
+			expectActionsOnTo: []kcptesting.Action{
+				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
+				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
+					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "spec", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
+					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "status", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
+					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
+			},
+			isUpstream: false,
+			updateType: []UpdateType{MetadataUpdate},
+		},
+
+		"Status Syncer udpates namespaced resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			},
+				map[string]string{
+					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+				},
+			),
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+			fromResource: getPVC("test-pvc", "test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			}, nil, nil, "2"),
+			toResources: []runtime.Object{
+				getPVC("test-pvc", "test", "root:org:ws", map[string]string{
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"),
+			},
+			resourceToProcessName: "test-pvc",
+			syncTargetName:        "us-west1",
+			expectActionsOnFrom:   []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, "test", "test-pvc")},
+			expectActionsOnTo: []kcptesting.Action{
+				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "metadata", "test",
+					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
+						"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+						workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+					}, map[string]string{"kcp.dev/resource-version": "2"}, nil, "2"))),
+			},
+			isUpstream: false,
+			updateType: []UpdateType{MetadataUpdate},
+		},
+		"StatusSyncer updates cluster-wide resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace:          nil,
+			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
+			fromResource: getPV(getPVC("test", "test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			},
+				map[string]string{
+					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":""}`,
+				}, nil, "2")),
+			toResources: []runtime.Object{
+				getPV(getPVC("test", "test", "root:org:ws", map[string]string{
+					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				}, map[string]string{
+					"kcp.dev/resource-version": "1",
+				}, nil, "1")),
+			},
+			resourceToProcessName: "test-pv",
+			syncTargetName:        "us-west1",
+			expectActionsOnFrom:   []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, "", "test-pv")},
+			expectActionsOnTo: []kcptesting.Action{
+				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "metadata", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
+					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				}, map[string]string{"kcp.dev/resource-version": "2"}, nil, "2")))),
+			},
+			isUpstream: false,
+			updateType: []UpdateType{MetadataUpdate},
+		},
+		"StatusSyncer deletes upstream namespaced resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace: namespace("test", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			},
+				map[string]string{
+					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+				},
+			),
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+			fromResource: namespace("kcp-1dtzz0tyij19", "", map[string]string{
+				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			},
+				map[string]string{
+					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+				},
+			),
+			toResources: []runtime.Object{
+				getPVC("test-pvc", "test", "root:org:ws", map[string]string{
+					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
+				}, nil, nil, "1"),
+			},
+			resourceToProcessName: "test-pvc",
+			syncTargetName:        "us-west1",
+			expectActionsOnFrom:   []clienttesting.Action{},
+			expectActionsOnTo: []kcptesting.Action{
+				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
+			},
+			isUpstream: true,
+			updateType: []UpdateType{},
+		},
+		"StatusSyncer deletes upstream cluster-wide resources": {
+			upstreamLogicalCluster: "root:org:ws",
+			fromNamespace:          nil,
+			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
+			fromResource:           nil,
+			toResources: []runtime.Object{
+				getPV(getPVC("test", "test", "root:org:ws", map[string]string{
+					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
+				}, nil, nil, "1")),
+			},
+			resourceToProcessName: "test-pv",
+			syncTargetName:        "us-west1",
+			expectActionsOnFrom: []clienttesting.Action{
+				clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, "", "test-pv"),
+			},
+			expectActionsOnTo: []kcptesting.Action{
+				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
+			},
+			isUpstream: true,
+			updateType: []UpdateType{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger := klog.FromContext(ctx)
+
+			kcpLogicalCluster := logicalcluster.New(tc.upstreamLogicalCluster)
+			if tc.syncTargetUID == "" {
+				tc.syncTargetUID = types.UID("syncTargetUID")
+			}
+			if tc.syncTargetWorkspace.Empty() {
+				tc.syncTargetWorkspace = logicalcluster.New("root:org:ws")
+			}
+
+			var allFromResources []runtime.Object
+			if tc.fromNamespace != nil {
+				allFromResources = append(allFromResources, tc.fromNamespace)
+			}
+
+			if tc.fromResource != nil {
+				allFromResources = append(allFromResources, tc.fromResource)
+			}
+			fromClient := dynamicfake.NewSimpleDynamicClient(scheme, allFromResources...)
+			toClusterClient := kcpfakedynamic.NewSimpleDynamicClient(scheme, tc.toResources...)
+
+			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(tc.syncTargetWorkspace, tc.syncTargetName)
+			fromInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fromClient, time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
+				o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+			})
+			toInformers := kcpdynamicinformer.NewFilteredDynamicSharedInformerFactory(toClusterClient, time.Hour, func(o *metav1.ListOptions) {
+				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + syncTargetKey + "=" + "Upsync"
+			})
+
+			setupServersideApplyPatchReactor(toClusterClient)
+			fromClientResourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClient)
+			toClientResourceWatcherStarted := setupClusterWatchReactor(tc.gvr.Resource, toClusterClient)
+
+			fakeInformers := newFakeSyncerInformers(tc.gvr, toInformers, fromInformers)
+
+			// upstream => to (kcp)
+			// downstream => from (physical cluster)
+			// to === kcp
+			// from === physiccal
+			controller, err := NewUpSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, toClusterClient, fromClient, toInformers, fromInformers, fakeInformers, tc.syncTargetUID)
+
+			require.NoError(t, err)
+
+			toInformers.ForResource(tc.gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+
+			fromInformers.Start(ctx.Done())
+			toInformers.Start(ctx.Done())
+
+			fromInformers.WaitForCacheSync(ctx.Done())
+			toInformers.WaitForCacheSync(ctx.Done())
+
+			<-fromClientResourceWatcherStarted
+			<-toClientResourceWatcherStarted
+
+			fromClient.ClearActions()
+			toClusterClient.ClearActions()
+
+			var key string
+			if tc.fromNamespace != nil {
+				key = tc.fromNamespace.Name + "/" + tc.resourceToProcessName
+			} else {
+				key = tc.resourceToProcessName
+			}
+			if tc.isUpstream {
+				key += "#" + kcpLogicalCluster.String()
+			}
+
+			err = controller.process(context.Background(), tc.gvr, key, tc.isUpstream, tc.updateType)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnFrom, fromClient.Actions()))
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClusterClient.Actions(), cmp.AllowUnexported(logicalcluster.Name{})))
+		})
+	}
+}
+
+type fakeSyncerInformers struct {
+	upstreamInformer   kcpkubernetesinformers.GenericClusterInformer
+	downStreamInformer informers.GenericInformer
+}
+
+func newFakeSyncerInformers(gvr schema.GroupVersionResource, upstreamInformers kcpdynamicinformer.DynamicSharedInformerFactory, downStreamInformers dynamicinformer.DynamicSharedInformerFactory) *fakeSyncerInformers {
+	return &fakeSyncerInformers{
+		upstreamInformer:   upstreamInformers.ForResource(gvr),
+		downStreamInformer: downStreamInformers.ForResource(gvr),
+	}
+}
+
+func (f *fakeSyncerInformers) AddUpstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
+}
+func (f *fakeSyncerInformers) AddDownstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
+}
+func (f *fakeSyncerInformers) InformerForResource(gvr schema.GroupVersionResource) (*resourcesync.SyncerInformer, bool) {
+	return &resourcesync.SyncerInformer{
+		UpstreamInformer:   f.upstreamInformer,
+		DownstreamInformer: f.downStreamInformer,
+	}, true
+}
+func (f *fakeSyncerInformers) Start(ctx context.Context, numThreads int) {}
+func (f *fakeSyncerInformers) SyncableGVRs() (map[schema.GroupVersionResource]*resourcesync.SyncerInformer, error) {
+	gvrs := map[schema.GroupVersionResource]*resourcesync.SyncerInformer{{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}: nil, {Group: "", Version: "v1", Resource: "persistentvolumes"}: nil}
+	return gvrs, nil
+}
+
+func setupWatchReactor(resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+	watcherStarted := make(chan struct{})
+	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+	return watcherStarted
+}
+
+func setupClusterWatchReactor(resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+	watcherStarted := make(chan struct{})
+	client.PrependWatchReactor(resource, func(action kcptesting.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := client.Tracker().Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		close(watcherStarted)
+		return true, watch, nil
+	})
+	return watcherStarted
+}
+
+func setupServersideApplyPatchReactor(toClient *kcpfakedynamic.FakeDynamicClusterClientset) {
+	toClient.PrependReactor("patch", "*", func(action kcptesting.Action) (handled bool, ret runtime.Object, err error) {
+		patchAction := action.(kcptesting.PatchAction)
+		if patchAction.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		return true, nil, err
+	})
+}
+
+func namespace(name, clusterName string, labels, annotations map[string]string) *corev1.Namespace {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+	}
+
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
+}
+
+func getPVC(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.PersistentVolumeClaim {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: resourceVersion,
+				Name:            name,
+				Namespace:       namespace,
+				Labels:          labels,
+				Annotations:     annotations,
+				Finalizers:      finalizers,
+			},
+		}
+	}
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: resourceVersion,
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			Annotations:     annotations,
+			Finalizers:      finalizers,
+		},
+	}
+
+}
+
+func getPV(pvc *corev1.PersistentVolumeClaim) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: pvc.GetResourceVersion(),
+			Name:            pvc.GetName() + "-pv",
+			Labels:          pvc.GetLabels(),
+			Annotations:     pvc.GetAnnotations(),
+			Finalizers:      pvc.GetFinalizers(),
+		},
+	}
+}

--- a/pkg/syncer/upsync/upsync_process_test.go
+++ b/pkg/syncer/upsync/upsync_process_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KCP Authors.
+Copyright 2023 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,32 +19,30 @@ package upsync
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-	kcpdynamicinformer "github.com/kcp-dev/client-go/dynamic/dynamicinformer"
-	kcpkubernetesinformers "github.com/kcp-dev/client-go/informers"
-	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
-	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
-	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
-	"github.com/kcp-dev/kcp/pkg/syncer/resourcesync"
-	"github.com/kcp-dev/logicalcluster/v2"
+	"github.com/kcp-dev/logicalcluster/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
+
+	kcpfakedynamic "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/dynamic/fake"
+	kcptesting "github.com/kcp-dev/client-go/third_party/k8s.io/client-go/testing"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/informers"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	ddsif "github.com/kcp-dev/kcp/pkg/informer"
+	"github.com/kcp-dev/kcp/pkg/syncer/indexers"
 )
 
 var scheme *runtime.Scheme
@@ -52,7 +50,6 @@ var scheme *runtime.Scheme
 func init() {
 	scheme = runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
 }
 
 func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstructured {
@@ -62,6 +59,56 @@ func toUnstructured(t require.TestingT, obj metav1.Object) *unstructured.Unstruc
 
 	return &result
 }
+
+var _ ddsif.GVRSource = (*mockedGVRSource)(nil)
+
+type mockedGVRSource struct {
+	upsyncer bool
+}
+
+func (s *mockedGVRSource) GVRs() map[schema.GroupVersionResource]ddsif.GVRPartialMetadata {
+	return map[schema.GroupVersionResource]ddsif.GVRPartialMetadata{
+		{
+			Version:  "v1",
+			Resource: "namespaces",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "namespace",
+				Kind:     "Namespace",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "persistentvolumes",
+		}: {
+			Scope: apiextensionsv1.ClusterScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "persistentvolume",
+				Kind:     "PersistentVolume",
+			},
+		},
+		{
+			Version:  "v1",
+			Resource: "pods",
+		}: {
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Singular: "pod",
+				Kind:     "Pod",
+			},
+		},
+	}
+}
+
+func (s *mockedGVRSource) Ready() bool {
+	return true
+}
+
+func (s *mockedGVRSource) Subscribe() <-chan struct{} {
+	return make(<-chan struct{})
+}
+
 func TestUpsyncerprocess(t *testing.T) {
 	tests := map[string]struct {
 		fromNamespace *corev1.Namespace
@@ -85,38 +132,37 @@ func TestUpsyncerprocess(t *testing.T) {
 		"Upsyncer upsyncs namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
-			fromResource: getPVC("test-pvc", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			fromResource: createPod("test-pod", "test", "", map[string]string{
+				"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 				workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
 			}, nil, nil, "1"),
 			toResources:           []runtime.Object{},
-			resourceToProcessName: "test-pvc",
+			resourceToProcessName: "test-pod",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
-				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "test", toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+					"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "spec", "test",
-					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-						"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "spec", "test",
+					toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+						"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 						workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-					}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "status", "test",
-					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-						"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+					}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "status", "test",
+					toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+						"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 						workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-					}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"))),
+					}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate, SpecUpdate},
@@ -125,31 +171,31 @@ func TestUpsyncerprocess(t *testing.T) {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace:          nil,
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
-			fromResource: getPV(getPVC("test", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			fromResource: createPV("test-pv", "", "", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":""}`,
-				}, nil, "1")),
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":""}`,
+				}, nil, "1"),
 			toResources:           []runtime.Object{},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
-				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "spec", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "status", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1")))),
+				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "spec", "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "status", "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate},
@@ -158,33 +204,32 @@ func TestUpsyncerprocess(t *testing.T) {
 		"Status Syncer udpates namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
-			fromResource: getPVC("test-pvc", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			fromResource: createPod("test-pod", "test", "", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			}, nil, nil, "2"),
 			toResources: []runtime.Object{
-				getPVC("test-pvc", "test", "root:org:ws", map[string]string{
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "1"}, nil, "1"),
+				createPod("test-pod", "test", "root:org:ws", map[string]string{
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "1"}, nil, "1"),
 			},
-			resourceToProcessName: "test-pvc",
+			resourceToProcessName: "test-pod",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "metadata", "test",
-					toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
-						"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-						workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-					}, map[string]string{"kcp.dev/resource-version": "2"}, nil, "2"))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "metadata", "test",
+					toUnstructured(t, createPod("test-pod", "test", "", map[string]string{
+						"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+						workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+					}, map[string]string{"kcp.io/resource-version": "2"}, nil, "2"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate},
@@ -193,30 +238,30 @@ func TestUpsyncerprocess(t *testing.T) {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace:          nil,
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
-			fromResource: getPV(getPVC("test", "test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+			fromResource: createPV("test-pv", "", "", map[string]string{
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":""}`,
-				}, nil, "2")),
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":""}`,
+				}, nil, "2"),
 			toResources: []runtime.Object{
-				getPV(getPVC("test", "test", "root:org:ws", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				createPV("test-pv", "", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 				}, map[string]string{
-					"kcp.dev/resource-version": "1",
-				}, nil, "1")),
+					"kcp.io/resource-version": "1",
+				}, nil, "1"),
 			},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
-				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "metadata", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
-					"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-					workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
-				}, map[string]string{"kcp.dev/resource-version": "2"}, nil, "2")))),
+				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "metadata", "", toUnstructured(t, createPV("test-pv", "", "", map[string]string{
+					"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+					workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
+				}, map[string]string{"kcp.io/resource-version": "2"}, nil, "2"))),
 			},
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate},
@@ -224,33 +269,33 @@ func TestUpsyncerprocess(t *testing.T) {
 		"StatusSyncer deletes upstream namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
-			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+			gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
 			fromResource: namespace("kcp-1dtzz0tyij19", "", map[string]string{
-				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
-				workloadv1alpha1.ClusterResourceStateLabelPrefix + "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5": "Upsync",
+				"internal.workload.kcp.io/cluster": "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
+				workloadv1alpha1.ClusterResourceStateLabelPrefix + "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g": "Upsync",
 			},
 				map[string]string{
-					"kcp.dev/namespace-locator": `{"syncTarget": {"workspace":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "workspace":"root:org:ws","namespace":"test"}`,
+					"kcp.io/namespace-locator": `{"syncTarget": {"cluster":"root:org:ws", "name":"us-west1", "uid":"syncTargetUID"}, "cluster":"root:org:ws","namespace":"test"}`,
 				},
 			),
 			toResources: []runtime.Object{
-				getPVC("test-pvc", "test", "root:org:ws", map[string]string{
-					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				createPod("test-pod", "test", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
 				}, nil, nil, "1"),
 			},
-			resourceToProcessName: "test-pvc",
+			resourceToProcessName: "test-pod",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
-				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
+				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, logicalcluster.NewPath("root:org:ws"), "test", "test-pod"),
 			},
 			isUpstream: true,
 			updateType: []UpdateType{},
@@ -261,16 +306,16 @@ func TestUpsyncerprocess(t *testing.T) {
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
 			fromResource:           nil,
 			toResources: []runtime.Object{
-				getPV(getPVC("test", "test", "root:org:ws", map[string]string{
-					"internal.workload.kcp.dev/cluster":                              "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
+				createPV("test-pv", "", "root:org:ws", map[string]string{
+					"internal.workload.kcp.io/cluster":                               "6ohB8yeXhwqTQVuBzJRgqcRJTpRjX7yTZu5g5g",
 					workloadv1alpha1.ClusterResourceStateLabelPrefix + "root:org:ws": "Upsync",
-				}, nil, nil, "1")),
+				}, nil, nil, "1"),
 			},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
 			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
-				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
+				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.NewPath("root:org:ws"), "", "test-pv"),
 			},
 			isUpstream: true,
 			updateType: []UpdateType{},
@@ -283,12 +328,12 @@ func TestUpsyncerprocess(t *testing.T) {
 			defer cancel()
 			logger := klog.FromContext(ctx)
 
-			kcpLogicalCluster := logicalcluster.New(tc.upstreamLogicalCluster)
+			kcpLogicalCluster := logicalcluster.Name(tc.upstreamLogicalCluster)
 			if tc.syncTargetUID == "" {
 				tc.syncTargetUID = types.UID("syncTargetUID")
 			}
 			if tc.syncTargetWorkspace.Empty() {
-				tc.syncTargetWorkspace = logicalcluster.New("root:org:ws")
+				tc.syncTargetWorkspace = logicalcluster.Name("root:org:ws")
 			}
 
 			var allFromResources []runtime.Object
@@ -303,50 +348,103 @@ func TestUpsyncerprocess(t *testing.T) {
 			toClusterClient := kcpfakedynamic.NewSimpleDynamicClient(scheme, tc.toResources...)
 
 			syncTargetKey := workloadv1alpha1.ToSyncTargetKey(tc.syncTargetWorkspace, tc.syncTargetName)
-			fromInformers := dynamicinformer.NewFilteredDynamicSharedInformerFactory(fromClient, time.Hour, metav1.NamespaceAll, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
-			})
-			toInformers := kcpdynamicinformer.NewFilteredDynamicSharedInformerFactory(toClusterClient, time.Hour, func(o *metav1.ListOptions) {
-				o.LabelSelector = workloadv1alpha1.ClusterResourceStateLabelPrefix + syncTargetKey + "=" + "Upsync"
-			})
+
+			ddsifForUpstreamUpsyncer, err := ddsif.NewDiscoveringDynamicSharedInformerFactory(toClusterClient, nil, nil, &mockedGVRSource{true}, cache.Indexers{})
+			require.NoError(t, err)
+
+			ddsifForDownstream, err := ddsif.NewScopedDiscoveringDynamicSharedInformerFactory(fromClient, nil,
+				func(o *metav1.ListOptions) {
+					o.LabelSelector = workloadv1alpha1.InternalDownstreamClusterLabel + "=" + syncTargetKey
+				},
+				&mockedGVRSource{},
+				cache.Indexers{
+					indexers.ByNamespaceLocatorIndexName: indexers.IndexByNamespaceLocator,
+				},
+			)
+			require.NoError(t, err)
+
+			var cacheSyncsForAlwaysRequiredGVRs []cache.InformerSynced
+			if informer, err := ddsifForUpstreamUpsyncer.ForResource(corev1.SchemeGroupVersion.WithResource("namespaces")); err != nil {
+				require.NoError(t, err)
+			} else {
+				cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+			}
+			if informer, err := ddsifForDownstream.ForResource(corev1.SchemeGroupVersion.WithResource("namespaces")); err != nil {
+				require.NoError(t, err)
+			} else {
+				cacheSyncsForAlwaysRequiredGVRs = append(cacheSyncsForAlwaysRequiredGVRs, informer.Informer().HasSynced)
+			}
 
 			setupServersideApplyPatchReactor(toClusterClient)
-			fromClientResourceWatcherStarted := setupWatchReactor(tc.gvr.Resource, fromClient)
-			toClientResourceWatcherStarted := setupClusterWatchReactor(tc.gvr.Resource, toClusterClient)
-
-			fakeInformers := newFakeSyncerInformers(tc.gvr, toInformers, fromInformers)
+			fromClientResourceWatcherStarted := setupWatchReactor(t, tc.gvr.Resource, fromClient)
+			toClientResourceWatcherStarted := setupClusterWatchReactor(t, tc.gvr.Resource, toClusterClient)
 
 			// upstream => to (kcp)
 			// downstream => from (physical cluster)
 			// to === kcp
 			// from === physiccal
-			controller, err := NewUpSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, toClusterClient, fromClient, toInformers, fromInformers, fakeInformers, tc.syncTargetUID)
-
+			controller, err := NewUpSyncer(logger, kcpLogicalCluster, tc.syncTargetName, syncTargetKey, toClusterClient, fromClient, ddsifForUpstreamUpsyncer, ddsifForDownstream, tc.syncTargetUID)
 			require.NoError(t, err)
 
-			toInformers.ForResource(tc.gvr).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{})
+			gvrsUpdated := make(chan struct{})
+			upstreamUpsyncerDDSIFUpdated := ddsifForUpstreamUpsyncer.Subscribe("upstreamUpsyncer")
+			downstreamDDSIFUpdated := ddsifForDownstream.Subscribe("downstream")
+			go func() {
+				<-upstreamUpsyncerDDSIFUpdated
+				t.Logf("%s: upstream ddsif synced", t.Name())
+				<-downstreamDDSIFUpdated
+				t.Logf("%s: downstream ddsif synced", t.Name())
 
-			fromInformers.Start(ctx.Done())
-			toInformers.Start(ctx.Done())
+				_, unsynced := ddsifForUpstreamUpsyncer.Informers()
+				for _, gvr := range unsynced {
+					informer, _ := ddsifForUpstreamUpsyncer.ForResource(gvr)
+					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
+					t.Logf("%s: upstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
+				}
+				_, unsynced = ddsifForDownstream.Informers()
+				for _, gvr := range unsynced {
+					informer, _ := ddsifForDownstream.ForResource(gvr)
+					cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced)
+					t.Logf("%s: downstream ddsif informer synced for gvr %s", t.Name(), gvr.String())
+				}
+				t.Logf("%s: gvrs updated", t.Name())
+				gvrsUpdated <- struct{}{}
+			}()
 
-			fromInformers.WaitForCacheSync(ctx.Done())
-			toInformers.WaitForCacheSync(ctx.Done())
+			ddsifForUpstreamUpsyncer.Start(ctx.Done())
+			ddsifForDownstream.Start(ctx.Done())
+
+			go ddsifForUpstreamUpsyncer.StartWorker(ctx)
+			go ddsifForDownstream.StartWorker(ctx)
 
 			<-fromClientResourceWatcherStarted
 			<-toClientResourceWatcherStarted
 
+			cache.WaitForCacheSync(ctx.Done(), cacheSyncsForAlwaysRequiredGVRs...)
+
+			<-gvrsUpdated
+
 			fromClient.ClearActions()
 			toClusterClient.ClearActions()
 
-			var key string
+			obj := &metav1.ObjectMeta{
+				Name: tc.resourceToProcessName,
+			}
+
 			if tc.fromNamespace != nil {
-				key = tc.fromNamespace.Name + "/" + tc.resourceToProcessName
-			} else {
-				key = tc.resourceToProcessName
+				obj.Namespace = tc.fromNamespace.Name
 			}
+
+			var key string
 			if tc.isUpstream {
-				key += "#" + kcpLogicalCluster.String()
+				obj.Annotations = map[string]string{
+					logicalcluster.AnnotationKey: kcpLogicalCluster.String(),
+				}
+				key, err = getKey(obj, Upstream)
+			} else {
+				key, err = getKey(obj, Downstream)
 			}
+			require.NoError(t, err)
 
 			err = controller.process(context.Background(), tc.gvr, key, tc.isUpstream, tc.updateType)
 			if tc.expectError {
@@ -355,40 +453,13 @@ func TestUpsyncerprocess(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Empty(t, cmp.Diff(tc.expectActionsOnFrom, fromClient.Actions()))
-			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClusterClient.Actions(), cmp.AllowUnexported(logicalcluster.Name{})))
+			assert.Empty(t, cmp.Diff(tc.expectActionsOnTo, toClusterClient.Actions()))
 		})
 	}
 }
 
-type fakeSyncerInformers struct {
-	upstreamInformer   kcpkubernetesinformers.GenericClusterInformer
-	downStreamInformer informers.GenericInformer
-}
-
-func newFakeSyncerInformers(gvr schema.GroupVersionResource, upstreamInformers kcpdynamicinformer.DynamicSharedInformerFactory, downStreamInformers dynamicinformer.DynamicSharedInformerFactory) *fakeSyncerInformers {
-	return &fakeSyncerInformers{
-		upstreamInformer:   upstreamInformers.ForResource(gvr),
-		downStreamInformer: downStreamInformers.ForResource(gvr),
-	}
-}
-
-func (f *fakeSyncerInformers) AddUpstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
-}
-func (f *fakeSyncerInformers) AddDownstreamEventHandler(handler resourcesync.ResourceEventHandlerPerGVR) {
-}
-func (f *fakeSyncerInformers) InformerForResource(gvr schema.GroupVersionResource) (*resourcesync.SyncerInformer, bool) {
-	return &resourcesync.SyncerInformer{
-		UpstreamInformer:   f.upstreamInformer,
-		DownstreamInformer: f.downStreamInformer,
-	}, true
-}
-func (f *fakeSyncerInformers) Start(ctx context.Context, numThreads int) {}
-func (f *fakeSyncerInformers) SyncableGVRs() (map[schema.GroupVersionResource]*resourcesync.SyncerInformer, error) {
-	gvrs := map[schema.GroupVersionResource]*resourcesync.SyncerInformer{{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}: nil, {Group: "", Version: "v1", Resource: "persistentvolumes"}: nil}
-	return gvrs, nil
-}
-
-func setupWatchReactor(resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+func setupWatchReactor(t *testing.T, resource string, client *dynamicfake.FakeDynamicClient) chan struct{} {
+	t.Helper()
 	watcherStarted := make(chan struct{})
 	client.PrependWatchReactor(resource, func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -397,23 +468,31 @@ func setupWatchReactor(resource string, client *dynamicfake.FakeDynamicClient) c
 		if err != nil {
 			return false, nil, err
 		}
+		t.Logf("%s: watcher started", t.Name())
 		close(watcherStarted)
 		return true, watch, nil
 	})
 	return watcherStarted
 }
 
-func setupClusterWatchReactor(resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+func setupClusterWatchReactor(t *testing.T, resource string, client *kcpfakedynamic.FakeDynamicClusterClientset) chan struct{} {
+	t.Helper()
 	watcherStarted := make(chan struct{})
-	client.PrependWatchReactor(resource, func(action kcptesting.Action) (handled bool, ret watch.Interface, err error) {
+	client.PrependWatchReactor(resource, func(action kcptesting.Action) (bool, watch.Interface, error) {
+		cluster := action.GetCluster()
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
-		watch, err := client.Tracker().Watch(gvr, ns)
-		if err != nil {
-			return false, nil, err
+		var watcher watch.Interface
+		var err error
+		switch cluster {
+		case logicalcluster.Wildcard:
+			watcher, err = client.Tracker().Watch(gvr, ns)
+		default:
+			watcher, err = client.Tracker().Cluster(cluster).Watch(gvr, ns)
 		}
+		t.Logf("%s: cluster watcher started", t.Name())
 		close(watcherStarted)
-		return true, watch, nil
+		return true, watcher, err
 	})
 	return watcherStarted
 }
@@ -445,13 +524,13 @@ func namespace(name, clusterName string, labels, annotations map[string]string) 
 	}
 }
 
-func getPVC(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.PersistentVolumeClaim {
+func createPV(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.PersistentVolume {
 	if clusterName != "" {
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}
 		annotations[logicalcluster.AnnotationKey] = clusterName
-		return &corev1.PersistentVolumeClaim{
+		return &corev1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				ResourceVersion: resourceVersion,
 				Name:            name,
@@ -462,7 +541,7 @@ func getPVC(name, namespace, clusterName string, labels, annotations map[string]
 			},
 		}
 	}
-	return &corev1.PersistentVolumeClaim{
+	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: resourceVersion,
 			Name:            name,
@@ -472,17 +551,33 @@ func getPVC(name, namespace, clusterName string, labels, annotations map[string]
 			Finalizers:      finalizers,
 		},
 	}
-
 }
 
-func getPV(pvc *corev1.PersistentVolumeClaim) *corev1.PersistentVolume {
-	return &corev1.PersistentVolume{
+func createPod(name, namespace, clusterName string, labels, annotations map[string]string, finalizers []string, resourceVersion string) *corev1.Pod {
+	if clusterName != "" {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[logicalcluster.AnnotationKey] = clusterName
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: resourceVersion,
+				Name:            name,
+				Namespace:       namespace,
+				Labels:          labels,
+				Annotations:     annotations,
+				Finalizers:      finalizers,
+			},
+		}
+	}
+	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			ResourceVersion: pvc.GetResourceVersion(),
-			Name:            pvc.GetName() + "-pv",
-			Labels:          pvc.GetLabels(),
-			Annotations:     pvc.GetAnnotations(),
-			Finalizers:      pvc.GetFinalizers(),
+			ResourceVersion: resourceVersion,
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			Annotations:     annotations,
+			Finalizers:      finalizers,
 		},
 	}
 }

--- a/pkg/syncer/upsync/upsync_process_test.go
+++ b/pkg/syncer/upsync/upsync_process_test.go
@@ -82,7 +82,7 @@ func TestUpsyncerprocess(t *testing.T) {
 		isUpstream             bool
 		updateType             []UpdateType
 	}{
-		"StatusSyncer upsyncs namespaced resources": {
+		"Upsyncer upsyncs namespaced resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace: namespace("test", "", map[string]string{
 				"internal.workload.kcp.dev/cluster": "2gzO8uuQmIoZ2FE95zoOPKtrtGGXzzjAvtl6q5",
@@ -100,9 +100,7 @@ func TestUpsyncerprocess(t *testing.T) {
 			toResources:           []runtime.Object{},
 			resourceToProcessName: "test-pvc",
 			syncTargetName:        "us-west1",
-			expectActionsOnFrom: []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "",
-				Version:  "v1",
-				Resource: "persistentvolumeclaims"}, "test", "test-pvc")},
+			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
 				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", toUnstructured(t, getPVC("test-pvc", "test", "", map[string]string{
@@ -123,7 +121,7 @@ func TestUpsyncerprocess(t *testing.T) {
 			isUpstream: false,
 			updateType: []UpdateType{MetadataUpdate, SpecUpdate},
 		},
-		"StatusSyncer upsyncs cluster-wide resources": {
+		"Upsyncer upsyncs cluster-wide resources": {
 			upstreamLogicalCluster: "root:org:ws",
 			fromNamespace:          nil,
 			gvr:                    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
@@ -137,7 +135,7 @@ func TestUpsyncerprocess(t *testing.T) {
 			toResources:           []runtime.Object{},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
-			expectActionsOnFrom:   []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, "", "test-pv")},
+			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
 				kcptesting.NewCreateAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
@@ -179,7 +177,7 @@ func TestUpsyncerprocess(t *testing.T) {
 			},
 			resourceToProcessName: "test-pvc",
 			syncTargetName:        "us-west1",
-			expectActionsOnFrom:   []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, "test", "test-pvc")},
+			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "test", "test-pvc"),
 				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}, logicalcluster.New("root:org:ws"), "metadata", "test",
@@ -212,7 +210,7 @@ func TestUpsyncerprocess(t *testing.T) {
 			},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
-			expectActionsOnFrom:   []clienttesting.Action{clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, "", "test-pv")},
+			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				// kcptesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
 				kcptesting.NewUpdateSubresourceAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "metadata", "", toUnstructured(t, getPV(getPVC("test", "test", "", map[string]string{
@@ -270,9 +268,7 @@ func TestUpsyncerprocess(t *testing.T) {
 			},
 			resourceToProcessName: "test-pv",
 			syncTargetName:        "us-west1",
-			expectActionsOnFrom: []clienttesting.Action{
-				clienttesting.NewGetAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, "", "test-pv"),
-			},
+			expectActionsOnFrom:   []clienttesting.Action{},
 			expectActionsOnTo: []kcptesting.Action{
 				kcptesting.NewDeleteAction(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}, logicalcluster.New("root:org:ws"), "", "test-pv"),
 			},

--- a/pkg/virtual/syncer/builder/build.go
+++ b/pkg/virtual/syncer/builder/build.go
@@ -99,7 +99,7 @@ func BuildVirtualWorkspace(
 				restProviderBuilder:   NewUpSyncerRestProvider,
 				allowedAPIFilter: func(apiGroupResource schema.GroupResource) bool {
 					// Only allow persistentvolumes to be Upsynced.
-					return apiGroupResource.Group == "" && apiGroupResource.Resource == "persistentvolumes"
+					return apiGroupResource.Group == "" && (apiGroupResource.Resource == "persistentvolumes" || apiGroupResource.Resource == "pods")
 				},
 				transformer:           &upsyncer.UpsyncerResourceTransformer{},
 				storageWrapperBuilder: upsyncer.WithStaticLabelSelectorAndInWriteCallsCheck,


### PR DESCRIPTION
## Summary

This PR implements the Upsyncer controller inside the Syncer.
It is a replacement of the [initial PR](https://github.com/kcp-dev/kcp/pull/2214) that had to be reworked and rebased.

## Related issue(s)

Fixes #1980
