### PR TITLE
🌱 run replication tests on a shared kcp instance

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -700,7 +700,7 @@ func (c *kcpServer) loadCfg() error {
 	var lastError error
 	if err := wait.PollImmediateWithContext(c.ctx, 100*time.Millisecond, 1*time.Minute, func(ctx context.Context) (bool, error) {
 		c.kubeconfigPath = filepath.Join(c.dataDir, "admin.kubeconfig")
-		config, err := loadKubeConfig(c.kubeconfigPath)
+		config, err := LoadKubeConfig(c.kubeconfigPath, "base")
 		if err != nil {
 			// A missing file is likely caused by the server not
 			// having started up yet. Ignore these errors for the
@@ -791,11 +791,11 @@ func unreadyComponentsFromError(err error) string {
 	return strings.Join(unreadyComponents, ", ")
 }
 
-// loadKubeConfig loads a kubeconfig from disk. This method is
+// LoadKubeConfig loads a kubeconfig from disk. This method is
 // intended to be common between fixture for servers whose lifecycle
 // is test-managed and fixture for servers whose lifecycle is managed
 // separately from a test run.
-func loadKubeConfig(kubeconfigPath string) (clientcmd.ClientConfig, error) {
+func LoadKubeConfig(kubeconfigPath, contextName string) (clientcmd.ClientConfig, error) {
 	fs, err := os.Stat(kubeconfigPath)
 	if err != nil {
 		return nil, err
@@ -809,7 +809,7 @@ func loadKubeConfig(kubeconfigPath string) (clientcmd.ClientConfig, error) {
 		return nil, fmt.Errorf("failed to load admin kubeconfig: %w", err)
 	}
 
-	return clientcmd.NewNonInteractiveClientConfig(*rawConfig, "base", nil, nil), nil
+	return clientcmd.NewNonInteractiveClientConfig(*rawConfig, contextName, nil, nil), nil
 }
 
 type unmanagedKCPServer struct {
@@ -825,12 +825,12 @@ type unmanagedKCPServer struct {
 // the configuration can be loaded synchronously and no locking is
 // required to subsequently access it.
 func newPersistentKCPServer(name, kubeconfigPath, rootShardKubeconfigPath string) (RunningServer, error) {
-	cfg, err := loadKubeConfig(kubeconfigPath)
+	cfg, err := LoadKubeConfig(kubeconfigPath, "base")
 	if err != nil {
 		return nil, err
 	}
 
-	rootShardCfg, err := loadKubeConfig(rootShardKubeconfigPath)
+	rootShardCfg, err := LoadKubeConfig(rootShardKubeconfigPath, "base")
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -76,12 +77,11 @@ func replicateAPIResourceSchemaScenario(ctx context.Context, t *testing.T, serve
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		"",
-		"today.sheriffs.wild.wild.west",
 		"APIResourceSchema",
 		apisv1alpha1.SchemeGroupVersion.WithResource("apiresourceschemas"),
 		&apisv1alpha1.APIResourceSchema{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("today.sheriffs.%s", "wild.wild.west"),
+				Name: fmt.Sprintf("%s.%s", withPseudoRandomSuffix("today"), "sheriffs.wild.wild.west"),
 			},
 			Spec: apisv1alpha1.APIResourceSchemaSpec{
 				Group: "wild.wild.west",
@@ -126,12 +126,11 @@ func replicateAPIResourceSchemaNegativeScenario(ctx context.Context, t *testing.
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		"",
-		"juicy.mangodbs.db.io",
 		"APIResourceSchema",
 		apisv1alpha1.SchemeGroupVersion.WithResource("apiresourceschemas"),
 		&apisv1alpha1.APIResourceSchema{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "juicy.mangodbs.db.io",
+				Name: fmt.Sprintf("%s.%s", withPseudoRandomSuffix("juicy"), "mangodbs.db.io"),
 			},
 			Spec: apisv1alpha1.APIResourceSchemaSpec{
 				Group: "db.io",
@@ -178,11 +177,10 @@ func replicateAPIExportScenario(ctx context.Context, t *testing.T, server framew
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		"",
-		"wild.wild.west",
 		"APIExport",
 		apisv1alpha1.SchemeGroupVersion.WithResource("apiexports"),
 		&apisv1alpha1.APIExport{
-			ObjectMeta: metav1.ObjectMeta{Name: "wild.wild.west"},
+			ObjectMeta: metav1.ObjectMeta{Name: withPseudoRandomSuffix("wild.wild.west")},
 		},
 		&apisv1alpha1.APIExport{
 			Spec: apisv1alpha1.APIExportSpec{LatestResourceSchemas: []string{"foo.bar"}},
@@ -200,12 +198,11 @@ func replicateAPIExportNegativeScenario(ctx context.Context, t *testing.T, serve
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		"",
-		"mangodb",
 		"APIExport",
 		apisv1alpha1.SchemeGroupVersion.WithResource("apiexports"),
 		&apisv1alpha1.APIExport{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "mangodb",
+				Name: withPseudoRandomSuffix("mangodb"),
 			},
 		},
 		&apisv1alpha1.APIExport{
@@ -224,11 +221,10 @@ func replicateShardScenario(ctx context.Context, t *testing.T, server framework.
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		core.RootCluster,
-		"test-shard",
 		"Shard",
 		corev1alpha1.SchemeGroupVersion.WithResource("shards"),
 		&corev1alpha1.Shard{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-shard"},
+			ObjectMeta: metav1.ObjectMeta{Name: withPseudoRandomSuffix("test-shard")},
 			Spec:       corev1alpha1.ShardSpec{BaseURL: "https://base.kcp.test.dev"},
 		},
 		&corev1alpha1.Shard{
@@ -247,12 +243,11 @@ func replicateShardNegativeScenario(ctx context.Context, t *testing.T, server fr
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		core.RootCluster,
-		"test-shard-2",
 		"Shard",
 		corev1alpha1.SchemeGroupVersion.WithResource("shards"),
 		&corev1alpha1.Shard{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-shard-2",
+				Name: withPseudoRandomSuffix("test-shard"),
 			},
 			Spec: corev1alpha1.ShardSpec{
 				BaseURL: "https://base.kcp.test.dev",
@@ -274,11 +269,10 @@ func replicateWorkspaceTypeScenario(ctx context.Context, t *testing.T, server fr
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		"",
-		"replicate-workspace-type",
 		"WorkspaceType",
 		tenancyv1alpha1.SchemeGroupVersion.WithResource("workspacetypes"),
 		&tenancyv1alpha1.WorkspaceType{
-			ObjectMeta: metav1.ObjectMeta{Name: "replicate-workspace-type"},
+			ObjectMeta: metav1.ObjectMeta{Name: withPseudoRandomSuffix("replicate-workspace-type")},
 			Spec:       tenancyv1alpha1.WorkspaceTypeSpec{},
 		},
 		&tenancyv1alpha1.WorkspaceType{
@@ -297,11 +291,10 @@ func replicateWorkspaceTypeNegativeScenario(ctx context.Context, t *testing.T, s
 		kcpShardClusterDynamicClient,
 		cacheKcpClusterDynamicClient,
 		"",
-		"replicate-workspace-type-negative",
 		"WorkspaceType",
 		tenancyv1alpha1.SchemeGroupVersion.WithResource("workspacetypes"),
 		&tenancyv1alpha1.WorkspaceType{
-			ObjectMeta: metav1.ObjectMeta{Name: "replicate-workspace-type-negative"},
+			ObjectMeta: metav1.ObjectMeta{Name: withPseudoRandomSuffix("replicate-workspace-type-negative")},
 			Spec:       tenancyv1alpha1.WorkspaceTypeSpec{},
 		},
 		&tenancyv1alpha1.WorkspaceType{
@@ -319,7 +312,6 @@ func replicateWorkspaceTypeNegativeScenario(ctx context.Context, t *testing.T, s
 //	replicateResource(
 //	  ...
 //	  "root:org:rh", // clusterName
-//	  "my-awesome-resource" // resName
 //	  "APIExports", // kind
 //	  apisv1alpha1.SchemeGroupVersion.WithResource("apiexports"), // gvr
 //	  &apisv1alpha1.APIExport{...}, // the resource
@@ -328,7 +320,6 @@ func replicateWorkspaceTypeNegativeScenario(ctx context.Context, t *testing.T, s
 func replicateResource(ctx context.Context, t *testing.T,
 	server framework.RunningServer, kcpShardClusterDynamicClient kcpdynamic.ClusterInterface, cacheKcpClusterDynamicClient kcpdynamic.ClusterInterface,
 	clusterName logicalcluster.Name, /*cluster for hosting the provided resource, can be empty*/
-	resourceName string, /*a resource name*/
 	kind string, /*kind for the given resource*/
 	gvr schema.GroupVersionResource, /*gvr for the given resource*/
 	res runtime.Object, /*a strongly typed resource object that will be created*/
@@ -340,6 +331,9 @@ func replicateResource(ctx context.Context, t *testing.T,
 		_, ws := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithRootShard())
 		clusterName = logicalcluster.Name(ws.Spec.Cluster)
 	}
+	resMeta, err := meta.Accessor(res)
+	require.NoError(t, err)
+	resourceName := resMeta.GetName()
 	scenario := &replicateResourceScenario{resourceName: resourceName, kind: kind, gvr: gvr, cluster: clusterName, server: server, kcpShardClusterDynamicClient: kcpShardClusterDynamicClient, cacheKcpClusterDynamicClient: cacheKcpClusterDynamicClient}
 
 	t.Logf("Create source %s %s/%s on the root shard for replication", kind, clusterName, resourceName)
@@ -379,7 +373,6 @@ func replicateResource(ctx context.Context, t *testing.T,
 func replicateResourceNegative(ctx context.Context, t *testing.T,
 	server framework.RunningServer, kcpShardClusterDynamicClient kcpdynamic.ClusterInterface, cacheKcpClusterDynamicClient kcpdynamic.ClusterInterface,
 	clusterName logicalcluster.Name, /*cluster for hosting the provided resource, can be empty*/
-	resourceName string, /*a resource name*/
 	kind string, /*kind for the given resource*/
 	gvr schema.GroupVersionResource, /*gvr for the given resource*/
 	res runtime.Object, /*a strongly typed resource object that will be created*/
@@ -391,6 +384,9 @@ func replicateResourceNegative(ctx context.Context, t *testing.T,
 		_, ws := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithRootShard())
 		clusterName = logicalcluster.Name(ws.Spec.Cluster)
 	}
+	resMeta, err := meta.Accessor(res)
+	require.NoError(t, err)
+	resourceName := resMeta.GetName()
 	scenario := &replicateResourceScenario{resourceName: resourceName, kind: kind, gvr: gvr, cluster: clusterName, server: server, kcpShardClusterDynamicClient: kcpShardClusterDynamicClient, cacheKcpClusterDynamicClient: cacheKcpClusterDynamicClient}
 
 	t.Logf("Create source %s %s/%s on the root shard for replication", kind, clusterName, resourceName)
@@ -709,4 +705,8 @@ func toUnstructured(obj interface{}, kind string, gvr schema.GroupVersionResourc
 	unstructured.SetKind(kind)
 	unstructured.SetAPIVersion(gvr.GroupVersion().String())
 	return unstructured, nil
+}
+
+func withPseudoRandomSuffix(name string) string {
+	return fmt.Sprintf("%s-%d", name, rand.Int())
 }

--- a/test/e2e/reconciler/cache/replication_test.go
+++ b/test/e2e/reconciler/cache/replication_test.go
@@ -415,15 +415,12 @@ func replicateResourceNegative(ctx context.Context, t *testing.T,
 	scenario.VerifyReplication(ctx, t)
 }
 
-// TestCacheServerInProcess runs all test scenarios against a cache server that runs with a kcp server.
-func TestCacheServerInProcess(t *testing.T) {
+// TestReplication runs all test scenarios against a default setup possibly with the cache server running within kcp server.
+func TestReplication(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")
 
-	// TODO(p0lyn0mial): switch to framework.SharedKcpServer when caching is turned on by default
-	tokenAuthFile := framework.WriteTokenAuthFile(t)
-	server := framework.PrivateKcpServer(t,
-		framework.WithCustomArguments(framework.TestServerArgsWithTokenAuthFile(tokenAuthFile)...))
+	server := framework.SharedKcpServer(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -444,6 +441,7 @@ func TestCacheServerInProcess(t *testing.T) {
 }
 
 // TestCacheServerStandalone runs all test scenarios against a standalone cache server.
+// TODO(p0lyn0mial): remove the following flavour in https://github.com/kcp-dev/kcp/pull/2596.
 func TestCacheServerStandalone(t *testing.T) {
 	t.Parallel()
 	framework.Suite(t, "control-plane")


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
previously all scenarios were run in a private environment. After the change only the scenarios that are disruptive run in a sandbox, the rest is run on a shared kcp instance (either on a single or multi-shard env)

This change allows us to run non-disruptive scenarios on a multi-shard cluster.

## Related issue(s)

https://github.com/kcp-dev/kcp/pull/2596
https://github.com/kcp-dev/kcp/issues/2269
