### PR TITLE
🐛 Use APIExport cluster names within webhooks

### DIFF
--- a/config/crds/apis.kcp.io_apibindings.yaml
+++ b/config/crds/apis.kcp.io_apibindings.yaml
@@ -400,6 +400,10 @@ spec:
                       != "logicalclusters" || (has(self.identityHash) && self.identityHash
                       != "")'
                 type: array
+              logicalCluster:
+                description: logicalCluster records the name (not path) of the logical
+                  cluster that contains the APIExport.
+                type: string
               phase:
                 description: 'phase is the current phase of the APIBinding: - "":
                   the APIBinding has just been created, waiting to be bound. - Binding:
@@ -410,6 +414,8 @@ spec:
                 - Binding
                 - Bound
                 type: string
+            required:
+            - logicalCluster
             type: object
         type: object
     served: true

--- a/config/crds/apis.kcp.io_apibindings.yaml
+++ b/config/crds/apis.kcp.io_apibindings.yaml
@@ -152,6 +152,10 @@ spec:
           status:
             description: Status communicates the observed state.
             properties:
+              apiExportClusterName:
+                description: APIExportClusterName records the name (not path) of the
+                  logical cluster that contains the APIExport.
+                type: string
               appliedPermissionClaims:
                 description: appliedPermissionClaims is a list of the permission claims
                   the system has seen and applied, according to the requests of the
@@ -400,10 +404,6 @@ spec:
                       != "logicalclusters" || (has(self.identityHash) && self.identityHash
                       != "")'
                 type: array
-              logicalCluster:
-                description: logicalCluster records the name (not path) of the logical
-                  cluster that contains the APIExport.
-                type: string
               phase:
                 description: 'phase is the current phase of the APIBinding: - "":
                   the APIBinding has just been created, waiting to be bound. - Binding:
@@ -414,8 +414,6 @@ spec:
                 - Binding
                 - Bound
                 type: string
-            required:
-            - logicalCluster
             type: object
         type: object
     served: true

--- a/pkg/admission/webhook/generic_webhook.go
+++ b/pkg/admission/webhook/generic_webhook.go
@@ -147,8 +147,8 @@ func (p *WebhookDispatcher) getAPIExportCluster(attr admission.Attributes, clust
 	for _, apiBinding := range objs {
 		for _, br := range apiBinding.Status.BoundResources {
 			if br.Group == attr.GetResource().Group && br.Resource == attr.GetResource().Resource {
-				name := logicalcluster.Name(apiBinding.Status.APIExportClusterName)
-				export, err := p.getAPIExport(name, apiBinding.Spec.Reference.Export.Name)
+				clusterName := logicalcluster.Name(apiBinding.Status.APIExportClusterName)
+				export, err := p.getAPIExport(clusterName, apiBinding.Spec.Reference.Export.Name)
 				if err != nil {
 					return "", false, err
 				}

--- a/pkg/admission/webhook/generic_webhook.go
+++ b/pkg/admission/webhook/generic_webhook.go
@@ -160,10 +160,7 @@ func (p *WebhookDispatcher) getAPIExportCluster(attr admission.Attributes, clust
 	for _, apiBinding := range objs {
 		for _, br := range apiBinding.Status.BoundResources {
 			if br.Group == attr.GetResource().Group && br.Resource == attr.GetResource().Resource {
-				path := logicalcluster.NewPath(apiBinding.Spec.Reference.Export.Path)
-				if path.Empty() {
-					path = clusterName.Path()
-				}
+				path := logicalcluster.NewPath(apiBinding.Status.LogicalCluster)
 				export, err := p.getAPIExport(path, apiBinding.Spec.Reference.Export.Name)
 				if err != nil {
 					return "", false, err

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -138,6 +138,13 @@ const (
 
 // APIBindingStatus records which schemas are bound.
 type APIBindingStatus struct {
+	// logicalCluster records the name (not path) of the logical cluster that contains the APIExport.
+	//
+	// +required
+	// +kubebuilder:validation:Required
+	// +kube:validation:MinLength=1
+	LogicalCluster string `json:"logicalCluster"`
+
 	// boundResources records the state of bound APIs.
 	//
 	// +optional

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -138,12 +138,10 @@ const (
 
 // APIBindingStatus records which schemas are bound.
 type APIBindingStatus struct {
-	// logicalCluster records the name (not path) of the logical cluster that contains the APIExport.
+	// APIExportClusterName records the name (not path) of the logical cluster that contains the APIExport.
 	//
-	// +required
-	// +kubebuilder:validation:Required
-	// +kube:validation:MinLength=1
-	LogicalCluster string `json:"logicalCluster"`
+	// +optional
+	APIExportClusterName string `json:"apiExportClusterName,omitempty"`
 
 	// boundResources records the state of bound APIs.
 	//

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1218,10 +1218,9 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 				Description: "APIBindingStatus records which schemas are bound.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"logicalCluster": {
+					"apiExportClusterName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "logicalCluster records the name (not path) of the logical cluster that contains the APIExport.",
-							Default:     "",
+							Description: "APIExportClusterName records the name (not path) of the logical cluster that contains the APIExport.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1299,7 +1298,6 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"logicalCluster"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -1218,6 +1218,14 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 				Description: "APIBindingStatus records which schemas are bound.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"logicalCluster": {
+						SchemaProps: spec.SchemaProps{
+							Description: "logicalCluster records the name (not path) of the logical cluster that contains the APIExport.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"boundResources": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -1291,6 +1299,7 @@ func schema_pkg_apis_apis_v1alpha1_APIBindingStatus(ref common.ReferenceCallback
 						},
 					},
 				},
+				Required: []string{"logicalCluster"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -204,6 +204,9 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		return reconcileStatusContinue, nil
 	}
 
+	clusterName := logicalcluster.From(apiExport)
+	apiBinding.Status.LogicalCluster = clusterName.String()
+
 	var needToWaitForRequeueWhenEstablished []string
 
 	// Process all APIResourceSchemas

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -204,8 +204,10 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 		return reconcileStatusContinue, nil
 	}
 
+	// Record the APIExport's host cluster name for lookup in webhooks.
+	// The full path is unreliable for this purpose.
 	clusterName := logicalcluster.From(apiExport)
-	apiBinding.Status.LogicalCluster = clusterName.String()
+	apiBinding.Status.APIExportClusterName = clusterName.String()
 
 	var needToWaitForRequeueWhenEstablished []string
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Look up APIExports by name, not path, within the generic webhook.

Adds a new required field that the APIBinding reconciler sets: `APIBinding.Status.LogicalCluster`.

## Related issue(s)

Fixes #2622
