### PR TITLE
🌱 test/e2e: add support for dynamic users using client certs

### DIFF
--- a/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
+++ b/test/e2e/apibinding/maximalpermissionpolicy_authorizer_test.go
@@ -83,7 +83,7 @@ func TestMaximalPermissionPolicyAuthorizerSystemGroupProtection(t *testing.T) {
 				t.Parallel()
 
 				t.Logf("Creating a WorkspaceType as user-1")
-				userKcpClusterClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-1", server.BaseConfig(t)))
+				userKcpClusterClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", server.BaseConfig(t)))
 				require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 				framework.Eventually(t, func() (bool, string) { // authz makes this eventually succeed
 					_, err = userKcpClusterClient.Cluster(orgPath).TenancyV1alpha1().WorkspaceTypes().Create(ctx, &tenancyv1alpha1.WorkspaceType{
@@ -114,7 +114,7 @@ func TestMaximalPermissionPolicyAuthorizerSystemGroupProtection(t *testing.T) {
 				t.Parallel()
 
 				t.Logf("Creating a APIExport as user-1")
-				userKcpClusterClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-1", server.BaseConfig(t)))
+				userKcpClusterClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", server.BaseConfig(t)))
 				require.NoError(t, err, "failed to construct kcp cluster client for user-1")
 				framework.Eventually(t, func() (bool, string) { // authz makes this eventually succeed
 					_, err := userKcpClusterClient.Cluster(orgPath).ApisV1alpha1().APIExports().Create(ctx, &apisv1alpha1.APIExport{
@@ -169,7 +169,7 @@ func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
-	user3KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
+	user3KcpClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
 	serviceProviderClusterNames := []logicalcluster.Path{rbacServiceProviderPath, serviceProvider2Workspace}
@@ -228,7 +228,7 @@ func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 		t.Logf("Set up user-1 and user-3 as admin for the consumer workspace %q", consumer)
 		framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, consumer, []string{"user-1", "user-3"}, nil, true)
 		bindConsumerToProvider(consumer, serviceProvider)
-		wildwestClusterClient, err := wildwestclientset.NewForConfig(framework.UserConfig("user-1", rest.CopyConfig(cfg)))
+		wildwestClusterClient, err := wildwestclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", rest.CopyConfig(cfg)))
 		cowboyclient := wildwestClusterClient.WildwestV1alpha1().Cluster(consumer).Cowboys("default")
 		require.NoError(t, err)
 		testCRUDOperations(ctx, t, consumer, wildwestClusterClient)
@@ -255,7 +255,7 @@ func TestMaximalPermissionPolicyAuthorizer(t *testing.T) {
 			require.NoError(t, err)
 
 			framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, consumer, []string{"user-2"}, nil, false)
-			user2Client, err := wildwestclientset.NewForConfig(framework.UserConfig("user-2", rest.CopyConfig(cfg)))
+			user2Client, err := wildwestclientset.NewForConfig(framework.StaticTokenUserConfig("user-2", rest.CopyConfig(cfg)))
 			require.NoError(t, err)
 
 			t.Logf("Make sure user 2 can list cowboys in consumer workspace %q", consumer)

--- a/test/e2e/authorizer/authorizer_test.go
+++ b/test/e2e/authorizer/authorizer_test.go
@@ -91,13 +91,13 @@ func TestAuthorizer(t *testing.T) {
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, org2.Join("workspace2"), []string{"user-3"}, nil, false)
 	framework.AdmitWorkspaceAccess(ctx, t, kubeClusterClient, org2.Join("workspace2"), []string{"user-2"}, nil, true)
 
-	user1KubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.UserConfig("user-1", cfg))
+	user1KubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", cfg))
 	require.NoError(t, err)
-	user1KubeDiscoveryClient, err := kcpdiscovery.NewForConfig(framework.UserConfig("user-1", cfg))
+	user1KubeDiscoveryClient, err := kcpdiscovery.NewForConfig(framework.StaticTokenUserConfig("user-1", cfg))
 	require.NoError(t, err)
-	user2KubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.UserConfig("user-2", cfg))
+	user2KubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-2", cfg))
 	require.NoError(t, err)
-	user3KubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.UserConfig("user-3", cfg))
+	user3KubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-3", cfg))
 	require.NoError(t, err)
 
 	t.Logf("Priming the authorization cache")
@@ -169,7 +169,7 @@ func TestAuthorizer(t *testing.T) {
 			// create client talking directly to root shard to test wildcard requests
 			rootKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(rootShardCfg)
 			require.NoError(t, err)
-			user1RootKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.UserConfig("user-1", rootShardCfg))
+			user1RootKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", rootShardCfg))
 			require.NoError(t, err)
 
 			_, err = rootKubeClusterClient.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})

--- a/test/e2e/virtual/apiexport/virtualworkspace_test.go
+++ b/test/e2e/virtual/apiexport/virtualworkspace_test.go
@@ -115,7 +115,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	require.NoError(t, err, "error getting APIExport")
 
 	// create API bindings in consumerWorkspace as user-3 with only bind permissions in serviceProviderWorkspace but not general access.
-	user3KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-3", rest.CopyConfig(cfg)))
+	user3KcpClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig("user-3", rest.CopyConfig(cfg)))
 	require.NoError(t, err, "failed to construct client for user-3")
 	bindConsumerToProvider(ctx, t, consumerPath, serviceProviderPath, user3KcpClient, cfg)
 	createCowboyInConsumer(ctx, t, consumerPath, wildwestClusterClient)
@@ -163,7 +163,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 
 	// Attempt to use VW using user-1 should expect an error
 	t.Logf("Make sure that user-1 is denied")
-	user1VWCfg := framework.UserConfig("user-1", apiExportVWCfg)
+	user1VWCfg := framework.StaticTokenUserConfig("user-1", apiExportVWCfg)
 	wwUser1VC, err := wildwestclientset.NewForConfig(user1VWCfg)
 	require.NoError(t, err)
 	_, err = wwUser1VC.WildwestV1alpha1().Cowboys().List(ctx, metav1.ListOptions{})
@@ -204,7 +204,7 @@ func TestAPIExportVirtualWorkspace(t *testing.T) {
 	_, err = kubeClusterClient.Cluster(serviceProviderPath).RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	user2VWCfg := framework.UserConfig("user-2", apiExportVWCfg)
+	user2VWCfg := framework.StaticTokenUserConfig("user-2", apiExportVWCfg)
 	wwUser2VC, err := wildwestclientset.NewForConfig(user2VWCfg)
 	require.NoError(t, err)
 	t.Logf("Get Cowboy and update status with user-2")

--- a/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
+++ b/test/e2e/virtual/initializingworkspaces/virtualworkspace_test.go
@@ -248,9 +248,9 @@ func TestInitializingWorkspacesVirtualWorkspaceAccess(t *testing.T) {
 	} {
 		virtualWorkspaceConfig := rest.AddUserAgent(rest.CopyConfig(sourceConfig), t.Name()+"-virtual")
 		virtualWorkspaceConfig.Host = workspacetypes[initializer].Status.VirtualWorkspaces[0].URL
-		virtualKcpClusterClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-1", virtualWorkspaceConfig))
+		virtualKcpClusterClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", virtualWorkspaceConfig))
 		require.NoError(t, err)
-		virtualKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.UserConfig("user-1", virtualWorkspaceConfig))
+		virtualKubeClusterClient, err := kcpkubernetesclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", virtualWorkspaceConfig))
 		require.NoError(t, err)
 		user1VwKcpClusterClients[initializer] = virtualKcpClusterClient
 		user1VwKubeClusterClients[initializer] = virtualKubeClusterClient

--- a/test/e2e/workspacetype/controller_test.go
+++ b/test/e2e/workspacetype/controller_test.go
@@ -206,7 +206,7 @@ func TestWorkspaceTypes(t *testing.T) {
 					return server.kcpClusterClient.Cluster(typeSourcePath).TenancyV1alpha1().WorkspaceTypes().Get(ctx, wtName, metav1.GetOptions{})
 				}, "could not wait for readiness on WorkspaceType %s|%s", universalPath.String(), wtName)
 
-				user1KcpClient, err := kcpclientset.NewForConfig(framework.UserConfig("user-1", rest.CopyConfig(cfg)))
+				user1KcpClient, err := kcpclientset.NewForConfig(framework.StaticTokenUserConfig("user-1", rest.CopyConfig(cfg)))
 				require.NoError(t, err, "failed to construct client for user-1")
 				_ = user1KcpClient
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This adds support to generate users on the fly in e2e tests. Currently, only users predefined in a token fixture file can be used. This allows for more descriptive user names and also allows adding groups dynamically.

## Related issue(s)

N/A
