### PR TITLE
🐛 reconciler/apiexport: use the gloabl informer to get Shards

### DIFF
--- a/pkg/reconciler/apis/apiexport/apiexport_controller.go
+++ b/pkg/reconciler/apis/apiexport/apiexport_controller.go
@@ -58,7 +58,7 @@ const (
 func NewController(
 	kcpClusterClient kcpclientset.ClusterInterface,
 	apiExportInformer apisv1alpha1informers.APIExportClusterInformer,
-	shardInformer corev1alpha1informers.ShardClusterInformer,
+	globalShardInformer corev1alpha1informers.ShardClusterInformer,
 	kubeClusterClient kcpkubernetesclientset.ClusterInterface,
 	namespaceInformer kcpcorev1informers.NamespaceClusterInformer,
 	secretInformer kcpcorev1informers.SecretClusterInformer,
@@ -115,7 +115,7 @@ func NewController(
 		},
 
 		listShards: func() ([]*corev1alpha1.Shard, error) {
-			return shardInformer.Lister().List(labels.Everything())
+			return globalShardInformer.Lister().List(labels.Everything())
 		},
 
 		commit: committer.NewCommitter[*APIExport, Patcher, *APIExportSpec, *APIExportStatus](kcpClusterClient.ApisV1alpha1().APIExports()),
@@ -153,7 +153,7 @@ func NewController(
 		},
 	})
 
-	shardInformer.Informer().AddEventHandler(
+	globalShardInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				c.enqueueAllAPIExports(obj.(*corev1alpha1.Shard))

--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -906,7 +906,7 @@ func (s *Server) installAPIExportController(ctx context.Context, config *rest.Co
 	c, err := apiexport.NewController(
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Apis().V1alpha1().APIExports(),
-		s.KcpSharedInformerFactory.Core().V1alpha1().Shards(),
+		s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
 		kubeClusterClient,
 		s.KubeSharedInformerFactory.Core().V1().Namespaces(),
 		s.KubeSharedInformerFactory.Core().V1().Secrets(),


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
since `Shard` resources are only on the root shard the `apiexport` controller must use the global (cached) informer otherwise the list will always be empty on a non-root shard.

## Related issue(s)

xref: https://github.com/kcp-dev/kcp/pull/2596
