### PR TITLE
🐛 pkg/reconciler/apis/apibinding: return error in case of conflicts

### DIFF
--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile.go
@@ -262,7 +262,7 @@ func (r *bindingReconciler) reconcile(ctx context.Context, apiBinding *apisv1alp
 					err,
 				)
 			}
-			return reconcileStatusContinue, nil
+			return reconcileStatusStopAndRequeue, err
 		}
 
 		// If there are multiple versions, there must be an APIConversion

--- a/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
+++ b/pkg/reconciler/apis/apibinding/apibinding_reconcile_test.go
@@ -291,6 +291,9 @@ func TestReconcileBinding(t *testing.T) {
 				conflicting.Build(),
 			},
 			wantNamingConflict: true,
+			wantError:          true,
+			wantRequeue:        true,
+			wantNoReady:        true,
 		},
 		"bind existing CRD - other bindings - conflicts": {
 			apiBinding: binding.Build(),
@@ -299,6 +302,9 @@ func TestReconcileBinding(t *testing.T) {
 				conflicting.Build(),
 			},
 			wantNamingConflict: true,
+			wantError:          true,
+			wantRequeue:        true,
+			wantNoReady:        true,
 		},
 		"CRD already exists but isn't established yet": {
 			apiBinding:                binding.Build(),


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This fixes failed local sharded startup failures. The observed symptom was:

```
- apiVersion: apis.kcp.io/v1alpha1
  kind: APIBinding
  metadata:
    annotations:
      kcp.io/cluster: system:shard
    creationTimestamp: "2023-01-18T14:29:39Z"
    finalizers:
    - apis.kcp.io/apibinding-finalizer
    generation: 1
    labels:
      internal.apis.kcp.io/export: bmCdly9xXiUpEHe3ypvDwvXMTfoVZUE92mqAQf
    name: tenancy.kcp.io
    resourceVersion: "195"
    uid: 9cf38f12-663c-4673-84be-b5aae0cb4bdc
  spec:
    reference:
      export:
        name: tenancy.kcp.io
        path: root
  status:
    conditions:
    - lastTransitionTime: "2023-01-18T14:29:42Z"
      message: 'Unable to bind APIs: error checking for naming conflicts for APIBinding
        system:shard|tenancy.kcp.io: error getting CRDs: APIResourceSchema.apis.kcp.io
        "v220628-546034da.negotiatedapiresources.apiresource.kcp.io" not found'
      reason: NamingConflicts
      severity: Error
      status: "False"
      type: Ready
    - lastTransitionTime: "2023-01-18T14:29:41Z"
      message: Invalid APIExport. Please contact the APIExport owner to resolve
      reason: InternalError
      severity: Error
      status: "False"
      type: APIExportValid
    - lastTransitionTime: "2023-01-18T14:29:42Z"
      message: 'Unable to bind APIs: error checking for naming conflicts for APIBinding
        system:shard|tenancy.kcp.io: error getting CRDs: APIResourceSchema.apis.kcp.io
        "v220628-546034da.negotiatedapiresources.apiresource.kcp.io" not found'
      reason: NamingConflicts
      severity: Error
      status: "False"
      type: BindingUpToDate
    - lastTransitionTime: "2023-01-18T14:29:42Z"
      message: 'Unable to bind APIs: error checking for naming conflicts for APIBinding
        system:shard|tenancy.kcp.io: error getting CRDs: APIResourceSchema.apis.kcp.io
        "v220628-546034da.negotiatedapiresources.apiresource.kcp.io" not found'
      reason: NamingConflicts
      severity: Error
      status: "False"
      type: InitialBindingCompleted
    phase: Binding
```

In case of temporary failures the api binding controller didn't retry.

This fixes it.

## Related issue(s)

N/A