### PR TITLE
🐛 e2e: temporarily schedule all workspaces on the root shard for tmc-related tests

### DIFF
--- a/test/e2e/framework/workspaces.go
+++ b/test/e2e/framework/workspaces.go
@@ -53,6 +53,10 @@ func WithRootShard() UnprivilegedWorkspaceOption {
 	return WithShard(corev1alpha1.RootShard)
 }
 
+func TODO_WithoutMultiShardSupport() UnprivilegedWorkspaceOption {
+	return WithRootShard()
+}
+
 func WithShard(name string) UnprivilegedWorkspaceOption {
 	return WithLocation(tenancyv1alpha1.WorkspaceLocation{Selector: &metav1.LabelSelector{
 		MatchLabels: map[string]string{

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -164,7 +164,7 @@ func TestClusterController(t *testing.T) {
 	}
 
 	source := framework.SharedKcpServer(t)
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
 
 	for i := range testCases {
 		testCase := testCases[i]
@@ -175,7 +175,7 @@ func TestClusterController(t *testing.T) {
 			t.Cleanup(cancelFunc)
 
 			t.Log("Creating a workspace")
-			wsPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("source"))
+			wsPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("source"), framework.TODO_WithoutMultiShardSupport())
 
 			// clients
 			sourceConfig := source.BaseConfig(t)

--- a/test/e2e/reconciler/deployment/deployment_coordinator_test.go
+++ b/test/e2e/reconciler/deployment/deployment_coordinator_test.go
@@ -61,12 +61,12 @@ func TestDeploymentCoordinator(t *testing.T) {
 	kcpClusterClient, err := kcpclientset.NewForConfig(upstreamConfig)
 	require.NoError(t, err)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
 
-	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("synctargets"))
+	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("synctargets"), framework.TODO_WithoutMultiShardSupport())
 
-	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-1"))
-	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-2"))
+	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-1"), framework.TODO_WithoutMultiShardSupport())
+	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-2"), framework.TODO_WithoutMultiShardSupport())
 
 	eastSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("east"),

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -54,8 +54,8 @@ func TestSyncTargetLocalExport(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	computePath, computeWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("compute"))
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	computePath, computeWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("compute"), framework.TODO_WithoutMultiShardSupport())
 	computeClusterName := logicalcluster.Name(computeWorkspace.Spec.Cluster)
 
 	kcpClients, err := kcpclientset.NewForConfig(source.BaseConfig(t))

--- a/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
+++ b/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
@@ -59,8 +59,8 @@ func TestMultipleExports(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	computePath, computeWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	computePath, computeWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 	computeClusterName := logicalcluster.Name(computeWorkspace.Spec.Cluster)
 
 	kcpClients, err := kcpclientset.NewForConfig(source.BaseConfig(t))
@@ -69,7 +69,7 @@ func TestMultipleExports(t *testing.T) {
 	dynamicClients, err := kcpdynamic.NewForConfig(source.BaseConfig(t))
 	require.NoError(t, err, "failed to construct dynamic cluster client for server")
 
-	serviceSchemaPath, serviceSchemaWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	serviceSchemaPath, serviceSchemaWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 	serviceSchemaClusterName := logicalcluster.Name(serviceSchemaWorkspace.Spec.Cluster)
 
 	t.Logf("Install service APIResourceSchema into service schema workspace %q", serviceSchemaPath)
@@ -88,7 +88,7 @@ func TestMultipleExports(t *testing.T) {
 	_, err = kcpClients.Cluster(serviceSchemaPath).ApisV1alpha1().APIExports().Create(ctx, serviceAPIExport, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	ingressSchemaPath, ingressSchemaWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	ingressSchemaPath, ingressSchemaWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 	t.Logf("Install ingress APIResourceSchema into ingress schema workspace %q", ingressSchemaPath)
 	mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(kcpClients.Cluster(ingressSchemaPath).Discovery()))
 	err = helpers.CreateResourceFromFS(ctx, dynamicClients.Cluster(ingressSchemaPath), mapper, sets.NewString("root-compute-workspace"), "apiresourceschema_ingresses.networking.k8s.io.yaml", kube124.KubeComputeFS)

--- a/test/e2e/reconciler/locationworkspace/rootcompute_test.go
+++ b/test/e2e/reconciler/locationworkspace/rootcompute_test.go
@@ -53,9 +53,9 @@ func TestRootComputeWorkspace(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	computePath, _ := framework.NewWorkspaceFixture(t, source, orgPath)
-	consumerPath, consumerWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	computePath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
+	consumerPath, consumerWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	kcpClients, err := kcpclientset.NewForConfig(source.BaseConfig(t))
 	require.NoError(t, err, "failed to construct kcp cluster client for server")

--- a/test/e2e/reconciler/locationworkspace/synctarget_test.go
+++ b/test/e2e/reconciler/locationworkspace/synctarget_test.go
@@ -60,12 +60,12 @@ func TestSyncTargetExport(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
 
-	schemaPath, schemaWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	schemaPath, schemaWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 	schemaClusterName := logicalcluster.Name(schemaWorkspace.Spec.Cluster)
 
-	computePath, computeWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	computePath, computeWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 	computeClusterName := logicalcluster.Name(computeWorkspace.Spec.Cluster)
 
 	kcpClients, err := kcpclientset.NewForConfig(source.BaseConfig(t))

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -248,7 +248,7 @@ func TestNamespaceScheduler(t *testing.T) {
 	}
 
 	server := framework.SharedKcpServer(t)
-	orgPath, _ := framework.NewOrganizationFixture(t, server)
+	orgPath, _ := framework.NewOrganizationFixture(t, server, framework.TODO_WithoutMultiShardSupport())
 
 	for i := range testCases {
 		testCase := testCases[i]
@@ -263,7 +263,7 @@ func TestNamespaceScheduler(t *testing.T) {
 
 			cfg := server.BaseConfig(t)
 
-			path, _ := framework.NewWorkspaceFixture(t, server, orgPath)
+			path, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 			kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
 			require.NoError(t, err)

--- a/test/e2e/reconciler/scheduling/api_compatibility_test.go
+++ b/test/e2e/reconciler/scheduling/api_compatibility_test.go
@@ -45,9 +45,9 @@ func TestSchedulingOnSupportedAPI(t *testing.T) {
 	t.Cleanup(cancelFunc)
 
 	source := framework.SharedKcpServer(t)
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	locationPath, locationWS := framework.NewWorkspaceFixture(t, source, orgPath)
-	userPath, userWS := framework.NewWorkspaceFixture(t, source, orgPath)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	locationPath, locationWS := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
+	userPath, userWS := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	kcpClusterClient, err := kcpclientset.NewForConfig(source.BaseConfig(t))
 	require.NoError(t, err)

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -48,10 +48,10 @@ func TestScheduling(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	negotiationPath, _ := framework.NewWorkspaceFixture(t, source, orgPath)
-	userPath, userWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
-	secondUserPath, secondUserWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	negotiationPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
+	userPath, userWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
+	secondUserPath, secondUserWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(source.BaseConfig(t))
 	require.NoError(t, err)

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -46,9 +46,9 @@ func TestMultiPlacement(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	locationPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("location"))
-	userPath, userWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("user"))
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	locationPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("location"), framework.TODO_WithoutMultiShardSupport())
+	userPath, userWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("user"), framework.TODO_WithoutMultiShardSupport())
 
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(source.BaseConfig(t))
 	require.NoError(t, err)

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -48,9 +48,9 @@ func TestPlacementUpdate(t *testing.T) {
 
 	source := framework.SharedKcpServer(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
-	locationPath, _ := framework.NewWorkspaceFixture(t, source, orgPath)
-	userPath, userWorkspace := framework.NewWorkspaceFixture(t, source, orgPath)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.TODO_WithoutMultiShardSupport())
+	locationPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
+	userPath, userWorkspace := framework.NewWorkspaceFixture(t, source, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(source.BaseConfig(t))
 	require.NoError(t, err)

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -51,12 +51,12 @@ func TestDNSResolution(t *testing.T) {
 
 	upstreamConfig := upstreamServer.BaseConfig(t)
 
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
 
-	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("location"))
+	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("location"), framework.TODO_WithoutMultiShardSupport())
 
-	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-1"))
-	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-2"))
+	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-1"), framework.TODO_WithoutMultiShardSupport())
+	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload-2"), framework.TODO_WithoutMultiShardSupport())
 
 	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -61,10 +61,10 @@ func TestSyncerLifecycle(t *testing.T) {
 	upstreamServer := framework.SharedKcpServer(t)
 
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
 
 	t.Log("Creating a workspace")
-	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	// The Start method of the fixture will initiate syncer start and then wait for
 	// its sync target to go ready. This implicitly validates the syncer
@@ -569,10 +569,10 @@ func TestSyncWorkload(t *testing.T) {
 	upstreamServer := framework.SharedKcpServer(t)
 
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
 
 	t.Log("Creating a workspace")
-	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()
@@ -600,12 +600,12 @@ func TestCordonUncordonDrain(t *testing.T) {
 	upstreamServer := framework.SharedKcpServer(t)
 
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
 
 	upstreamCfg := upstreamServer.BaseConfig(t)
 
 	t.Log("Creating a workspace")
-	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
 
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -58,9 +58,9 @@ func TestSyncerTunnel(t *testing.T) {
 
 	upstreamServer := framework.PrivateKcpServer(t)
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
 	t.Log("Creating a workspace")
-	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.TODO_WithoutMultiShardSupport())
 	wsClusterName := logicalcluster.Name(ws.Spec.Cluster)
 
 	// The Start method of the fixture will initiate syncer start and then wait for


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the issue will be eventually addressed in kcp-dev#2649

## Related issue(s)

https://github.com/kcp-dev/kcp/pull/2596
