### PR TITLE
🐛 e2e/syncer: temporarily schedule all workspaces on the root shard

### DIFF
--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -61,10 +61,10 @@ func TestSyncerLifecycle(t *testing.T) {
 	upstreamServer := framework.SharedKcpServer(t)
 
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.WithRootShard())
 
 	t.Log("Creating a workspace")
-	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithRootShard())
 
 	// The Start method of the fixture will initiate syncer start and then wait for
 	// its sync target to go ready. This implicitly validates the syncer
@@ -569,10 +569,10 @@ func TestSyncWorkload(t *testing.T) {
 	upstreamServer := framework.SharedKcpServer(t)
 
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.WithRootShard())
 
 	t.Log("Creating a workspace")
-	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithRootShard())
 
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()
@@ -600,12 +600,12 @@ func TestCordonUncordonDrain(t *testing.T) {
 	upstreamServer := framework.SharedKcpServer(t)
 
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.WithRootShard())
 
 	upstreamCfg := upstreamServer.BaseConfig(t)
 
 	t.Log("Creating a workspace")
-	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithRootShard())
 
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := upstreamServer.RawConfig()

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -58,9 +58,9 @@ func TestSyncerTunnel(t *testing.T) {
 
 	upstreamServer := framework.PrivateKcpServer(t)
 	t.Log("Creating an organization")
-	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer)
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.WithRootShard())
 	t.Log("Creating a workspace")
-	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath)
+	wsPath, ws := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithRootShard())
 	wsClusterName := logicalcluster.Name(ws.Spec.Cluster)
 
 	// The Start method of the fixture will initiate syncer start and then wait for


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the issue will be eventually addressed in kcp-dev#2649

## Related issue(s)

https://github.com/kcp-dev/kcp/pull/2596
