### PR TITLE
🐛 e2e/reconciler/cluster: temporarily schedule all workspaces on the root shard

### DIFF
--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -164,7 +164,7 @@ func TestClusterController(t *testing.T) {
 	}
 
 	source := framework.SharedKcpServer(t)
-	orgPath, _ := framework.NewOrganizationFixture(t, source)
+	orgPath, _ := framework.NewOrganizationFixture(t, source, framework.WithRootShard())
 
 	for i := range testCases {
 		testCase := testCases[i]
@@ -175,7 +175,7 @@ func TestClusterController(t *testing.T) {
 			t.Cleanup(cancelFunc)
 
 			t.Log("Creating a workspace")
-			wsPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("source"))
+			wsPath, _ := framework.NewWorkspaceFixture(t, source, orgPath, framework.WithName("source"), framework.WithRootShard())
 
 			// clients
 			sourceConfig := source.BaseConfig(t)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the issue will be eventually addressed in kcp-dev#2649

## Related issue(s)

xref: https://github.com/kcp-dev/kcp/pull/2596
