### PR TITLE
🐛 e2e/reconciler/namespace: temporarily schedule all workspaces on the root shard

### DIFF
--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -248,7 +248,7 @@ func TestNamespaceScheduler(t *testing.T) {
 	}
 
 	server := framework.SharedKcpServer(t)
-	orgPath, _ := framework.NewOrganizationFixture(t, server)
+	orgPath, _ := framework.NewOrganizationFixture(t, server, framework.WithRootShard())
 
 	for i := range testCases {
 		testCase := testCases[i]
@@ -263,7 +263,7 @@ func TestNamespaceScheduler(t *testing.T) {
 
 			cfg := server.BaseConfig(t)
 
-			path, _ := framework.NewWorkspaceFixture(t, server, orgPath)
+			path, _ := framework.NewWorkspaceFixture(t, server, orgPath, framework.WithRootShard())
 
 			kubeClusterClient, err := kcpkubernetesclientset.NewForConfig(cfg)
 			require.NoError(t, err)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
the issue will be eventually addressed in kcp-dev#2649

## Related issue(s)

xref: https://github.com/kcp-dev/kcp/pull/2596
