### PR TITLE
:bug: server: relax ShardVirtualWorkspace flag validation

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -813,7 +813,7 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 	config = rest.AddUserAgent(config, initialization.ControllerName)
 
 	vwURL := fmt.Sprintf("https://%s", s.GenericConfig.ExternalAddress)
-	if s.Options.Extra.ShardVirtualWorkspaceURL != "" {
+	if !s.Options.Virtual.Enabled && s.Options.Extra.ShardVirtualWorkspaceURL != "" {
 		if s.Options.Extra.ShardVirtualWorkspaceCAFile == "" {
 			// TODO move verification up
 			return fmt.Errorf("s.Options.Extra.ShardVirtualWorkspaceCAFile is required")


### PR DESCRIPTION
## Summary
In #2407 we introduced this validation, but it doesn't handle the case where the VW server is not standalone, but you still want to specify `--shard-virtual-workspace-url`

This scenario is likely when deploying a sharded environment, since you'll want the VW traffic to go via the front-proxy regardless of whether the VW server is standalone or not.

## Related issue(s)
Fixes an issue introduced via #2407


