### PR TITLE
🐛 controller: use the global informer to get Shards

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -485,7 +485,7 @@ func (s *Server) installWorkspaceScheduler(ctx context.Context, config *rest.Con
 	workspaceTypeController, err := workspacetype.NewController(
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Tenancy().V1alpha1().WorkspaceTypes(),
-		s.KcpSharedInformerFactory.Core().V1alpha1().Shards(),
+		s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
 	)
 	if err != nil {
 		return err
@@ -1274,6 +1274,8 @@ func (s *Server) installSyncTargetController(ctx context.Context, config *rest.C
 	c := synctargetcontroller.NewController(
 		kcpClusterClient,
 		s.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
+		// TODO: change to s.CacheKcpSharedInformerFactory.Core().V1alpha1().Shards(),
+		// once https://github.com/kcp-dev/kcp/issues/2649 is resolved
 		s.KcpSharedInformerFactory.Core().V1alpha1().Shards(),
 	)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

since Shard resources are only on the root shard all controllers must use the global (cached) informer otherwise the list will always be empty on a non-root shard.

## Related issue(s)

xref: https://github.com/kcp-dev/kcp/pull/2596
