### PR TITLE
:bug: server: revert non-standalone VW URL

### DIFF
--- a/pkg/server/controllers.go
+++ b/pkg/server/controllers.go
@@ -811,9 +811,10 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 	// Client used to create APIBindings within the initializing workspace
 	config = rest.CopyConfig(config)
 	config = rest.AddUserAgent(config, initialization.ControllerName)
+	config.Host += initializingworkspacesbuilder.URLFor(tenancyv1alpha1.WorkspaceAPIBindingsInitializer)
 
-	vwURL := fmt.Sprintf("https://%s", s.GenericConfig.ExternalAddress)
 	if !s.Options.Virtual.Enabled && s.Options.Extra.ShardVirtualWorkspaceURL != "" {
+		vwURL := fmt.Sprintf("https://%s", s.GenericConfig.ExternalAddress)
 		if s.Options.Extra.ShardVirtualWorkspaceCAFile == "" {
 			// TODO move verification up
 			return fmt.Errorf("s.Options.Extra.ShardVirtualWorkspaceCAFile is required")
@@ -829,9 +830,9 @@ func (s *Server) installAPIBinderController(ctx context.Context, config *rest.Co
 		config.TLSClientConfig.CAFile = s.Options.Extra.ShardVirtualWorkspaceCAFile
 		config.TLSClientConfig.CertFile = s.Options.Extra.ShardClientCertFile
 		config.TLSClientConfig.KeyFile = s.Options.Extra.ShardClientKeyFile
+		config.Host = fmt.Sprintf("%v%v", vwURL, initializingworkspacesbuilder.URLFor(tenancyv1alpha1.WorkspaceAPIBindingsInitializer))
 	}
 
-	config.Host = fmt.Sprintf("%v%v", vwURL, initializingworkspacesbuilder.URLFor(tenancyv1alpha1.WorkspaceAPIBindingsInitializer))
 	initializingWorkspacesKcpClusterClient, err := kcpclientset.NewForConfig(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
Partially reverts logic introduced in #2407 so we don't unconditionally use the external URL - when non-standalone VW mode is used we still need the old behavior, or the loopback client can't access the non-standalone VW server.

This breaks shard bootstrapping (evidently not in our e2e scenarios, but in a real deployment where probes mean the proxy isn't ready until the shard bootstrap is complete)

I suspect further work will be required to make standalone VW mode work when deployed on a real cluster, since the ExternalAddress will go via the proxy, which depends on proxy bootstrapping (when the shard is deployed via a Service)