### PR TITLE
:book: fix docs versioning and permissions for gh-pages

### DIFF
--- a/.github/workflows/docs-gen-and-push.yaml
+++ b/.github/workflows/docs-gen-and-push.yaml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -26,6 +26,7 @@ jobs:
     name: Generate and push docs
     runs-on: ubuntu-latest
     steps:
+      # checkout main branch and gh-pages branch on different path
       - uses: actions/checkout@v3
         with:
           submodules: true # Fetch Hugo themes (true OR recursive)
@@ -38,6 +39,8 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: v1.19
+
+      # docsy requires extended version of hugo
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -86,14 +89,17 @@ jobs:
       # config.toml file and mark it as archived, since the tag is also a latest main, the same
       # content is rebuilt using updated config and folder name. The folder thus generated is saved
       # as archive in gh-pages branch.
+      # TODO: refactor this section to a shell script
       - name: Update version info on tag for archive
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           cd kcp/docs
+          IFS='/'
+          read -ra arr <<< "${{ github.ref }}"
           cat <<EOF > temp.txt
           #version-start
           archived_version = true
-          version = "${{ github.ref }}"
+          version = "${arr[2]}"
           EOF
           ed config.toml<<EOF
           /^#version-start
@@ -102,23 +108,24 @@ jobs:
           w
           q
           EOF
-          mkdir -p content/en/${{ github.ref }}
-          mv content/en/main content/en/${{ github.ref }}
+          mv content/en/main content/en/${arr[2]}
           hugo --minify
-          rsync -av public/${{ github.ref }} ../../docs
+          rsync -av public/${arr[2]} ../../docs
 
+      # push older version HTML renders on gh-pages to be included in docs
       - name: Push to gh-pages on tag for archive
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           cd docs
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "Static archive of docs for ${{ github.ref }}"
-          git push
+          git push origin gh-pages
 
+      # copy back older versions to the current docs
       - name: Copy everything from archive to docs
-        run: rsync -av docs public
+        run: rsync -av docs/v* public
 
       - name: Upload build artifact
         uses: actions/upload-pages-artifact@v1

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://kcp-dev.github.io/kcp'
+baseURL = 'https://kcp-dev.github.io/kcp'
 contentDir = "content/en"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
@@ -64,7 +64,7 @@ version = "main"
 #version-end
 version_menu = "Releases"
 version_menu_pagelinks = true
-url_latest_version = "https://kcp-dev.github.io/kcp/main"
+url_latest_version = "/kcp/main"
 github_repo = "https://github.com/kcp-dev/kcp"
 github_project_repo = "https://github.com/kcp-dev/kcp"
 github_subdir = "docs"
@@ -149,7 +149,11 @@ url = "https://github.com/kcp-dev/kcp/blob/main/CONTRIBUTING.md"
 
 
 # release versions
-
+# TODO: find a way to add new versions as soon a new release is available
 [[params.versions]]
 version = "main"
-url = "https://kcp-dev.github.io/kcp/main"
+url = "/kcp/main"
+
+[[params.versions]]
+version = "v0.10.0"
+url = "/kcp/v0.10.0"


### PR DESCRIPTION
## Summary

- fixes the issue where a wrong folder name causes the command to
exit, the expected action is renaming the folder rather than
moving, fixes #2502
- fixes directory names for older versions. the github.ref is
a variable with "refs/tags/$REF" structure, for releases $REF
is of "vMAJOR.MINOR.PATCH" format, the archived docs directory
must be named as version tag
- fixes push permissions for pushing to gh-pages brnach. the
github action by default cannot push to branches, fixes #2655
- changes some links to relative links. this will help test the
docs locally s well as a separate deployments

## Related Pull Request(s)
 No longer needed: #2656

## Test
![image](https://user-images.githubusercontent.com/74113200/214559900-e96e454c-a767-4bbd-a43e-64cb0ef0d304.png)

See the deployment here: https://github.avinal.space/kcp/main/

## Future checklist
- Utilize the homepage of the docs to show all the versions available, currently it shows nothing: https://docs.kcp.io/kcp/
- Refactor workflow config and put long commands into a shell script and reference the script in workflow
- manually build older versions and push them to gh-pages

Signed-off-by: Avinal Kumar <avinal@redhat.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->

