### PR TITLE
🐛 Add a kcp RequestInfoResolver

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -67,6 +67,7 @@ import (
 	kcpfilters "github.com/kcp-dev/kcp/pkg/server/filters"
 	kcpserveroptions "github.com/kcp-dev/kcp/pkg/server/options"
 	"github.com/kcp-dev/kcp/pkg/server/options/batteries"
+	"github.com/kcp-dev/kcp/pkg/server/requestinfo"
 	"github.com/kcp-dev/kcp/pkg/tunneler"
 )
 
@@ -357,6 +358,9 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		}
 		virtualWorkspaceServerProxyTransport = transport
 	}
+
+	// Make sure to set our RequestInfoResolver that is capable of populating a RequestInfo even for /services/... URLs.
+	c.GenericConfig.RequestInfoResolver = requestinfo.NewKCPRequestInfoResolver()
 
 	// preHandlerChainMux is called before the actual handler chain. Note that BuildHandlerChainFunc below
 	// is called multiple times, but only one of the handler chain will actually be used. Hence, we wrap it

--- a/pkg/server/requestinfo/kcp_request_info_resolver.go
+++ b/pkg/server/requestinfo/kcp_request_info_resolver.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package requestinfo
+
+import (
+	"net/http"
+	"regexp"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type KCPRequestInfoResolver struct {
+	delegate request.RequestInfoResolver
+}
+
+func NewKCPRequestInfoResolver() *KCPRequestInfoResolver {
+	return &KCPRequestInfoResolver{
+		delegate: NewFactory(),
+	}
+}
+
+var clustersRE = regexp.MustCompile(`/clusters/[^/]+/(.*)$`)
+
+func (k *KCPRequestInfoResolver) NewRequestInfo(req *http.Request) (*request.RequestInfo, error) {
+	matches := clustersRE.FindStringSubmatch(req.URL.Path)
+	if len(matches) == 2 {
+		// matches[0] is the leftmost pattern that matches (which includes /clusters/...) - skip over that
+		strippedURL := matches[1]
+		t := req.Clone(req.Context())
+		t.URL.Path = strippedURL
+		return k.delegate.NewRequestInfo(t)
+	}
+	return k.delegate.NewRequestInfo(req)
+}


### PR DESCRIPTION
## Summary
Add a kcp-specific RequestInfoResolver that can populate a RequestInfo from a /services/... URL. This is needed so the code that proxies a virtual workspace request knows if it's a watch request or not. If so, it avoids adding a 1-minute deadline to the request.

## Related issue(s)

Fixes at least one cause of #2479
