### PR TITLE
🌱 pkg/authorization: enable audit logging for SAR requests

### DIFF
--- a/pkg/authorization/requiredgroups_authorizer_test.go
+++ b/pkg/authorization/requiredgroups_authorizer_test.go
@@ -44,7 +44,7 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 			requestingUser:     newUser("user-unknown"),
 			deepSARHeader:      true,
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to deep SAR request: allowed",
+			wantReason:         "delegating due to deep SAR request",
 		},
 		"missing cluster in request": {
 			requestingUser: newUser("user-unknown"),
@@ -55,26 +55,26 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newUser("lcluster-admin", "system:kcp:logical-cluster-admin"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to logical cluster admin access: allowed",
+			wantReason:         "delegating due to logical cluster admin access",
 		},
 		"service account from other cluster is granted access": {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newServiceAccountWithCluster("sa", "anotherws"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to service account access to logical cluster: allowed",
+			wantReason:         "delegating due to service account access to logical cluster",
 		},
 		"service account from same cluster is granted access": {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newServiceAccountWithCluster("sa", "root:ready"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to service account access to logical cluster: allowed",
+			wantReason:         "delegating due to service account access to logical cluster",
 		},
 		"permitted user is granted access to logical cluster without required groups": {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newUser("user-access", "system:authenticated"),
 			wantDecision:       authorizer.DecisionAllow,
 			logicalCluster:     &v1alpha1.LogicalCluster{},
-			wantReason:         "delegating due to logical cluster does not require groups: allowed",
+			wantReason:         "delegating due to logical cluster does not require groups",
 		},
 		"permitted user is denied access to logical cluster with required groups": {
 			requestedWorkspace: "root:ready",
@@ -100,7 +100,7 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 					},
 				},
 			},
-			wantReason: "delegating due to user is member of required groups: special-group-1;special-group-2: allowed",
+			wantReason: "delegating due to user is member of required groups: special-group-1;special-group-2",
 		},
 		"permitted user is allowed access to logical cluster with matching one of multiple disjunctive groups": {
 			requestedWorkspace: "root:ready",
@@ -113,7 +113,7 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 					},
 				},
 			},
-			wantReason: "delegating due to user is member of required groups: special-group-1;special-group-2: allowed",
+			wantReason: "delegating due to user is member of required groups: special-group-1;special-group-2",
 		},
 		"permitted user is allowed access to logical cluster with multiple conjunctive groups": {
 			requestedWorkspace: "root:ready",
@@ -126,7 +126,7 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 					},
 				},
 			},
-			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2: allowed",
+			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2",
 		},
 		"permitted user is denied access to logical cluster with multiple conjunctive groups": {
 			requestedWorkspace: "root:ready",
@@ -152,7 +152,7 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 					},
 				},
 			},
-			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2;special-group-3: allowed",
+			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2;special-group-3",
 		},
 		"permitted user is allowed access to logical cluster with matching one of multiple conjunctive and disjunctive groups": {
 			requestedWorkspace: "root:ready",
@@ -165,7 +165,7 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 					},
 				},
 			},
-			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2;special-group-3: allowed",
+			wantReason: "delegating due to user is member of required groups: special-group-1,special-group-2;special-group-3",
 		},
 		"permitted user is denied access to logical cluster with matching only one of multiple conjunctive and disjunctive groups": {
 			requestedWorkspace: "root:ready",

--- a/pkg/authorization/workspace_content_authorizer_test.go
+++ b/pkg/authorization/workspace_content_authorizer_test.go
@@ -95,7 +95,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "rootwithoutparent",
 			requestingUser:     newUser("user-access"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to user logical cluster access: allowed",
+			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
 			testName: "non-permitted user is not allowed",
@@ -111,7 +111,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newUser("user-access", "system:authenticated"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to user logical cluster access: allowed",
+			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
 			testName: "service account from other cluster is denied",
@@ -127,7 +127,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newServiceAccountWithCluster("sa", "root:ready"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to local service account access: allowed",
+			wantReason:         "delegating due to local service account access",
 		},
 		{
 			testName: "user is granted access on root",
@@ -135,7 +135,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root",
 			requestingUser:     newUser("somebody", "system:authenticated"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to user logical cluster access: allowed",
+			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
 			testName: "service account from other cluster is denied on root",
@@ -151,7 +151,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root",
 			requestingUser:     newServiceAccountWithCluster("somebody", "root", "system:authenticated"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to local service account access: allowed",
+			wantReason:         "delegating due to local service account access",
 		},
 		{
 			testName: "service account of same workspace is not allowed access to scheduling workspace",
@@ -167,7 +167,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root:initializing",
 			requestingUser:     newServiceAccountWithCluster("somebody", "root:initializing", "system:authenticated"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to local service account access: allowed",
+			wantReason:         "delegating due to local service account access",
 		},
 		{
 			testName: "system:kcp:logical-cluster-admin can always pass",
@@ -175,7 +175,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root:non-existent",
 			requestingUser:     newUser("lcluster-admin", "system:kcp:logical-cluster-admin"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to logical cluster admin access: allowed",
+			wantReason:         "delegating due to logical cluster admin access",
 		},
 		{
 			testName: "permitted user is granted access to initializing workspace",
@@ -183,7 +183,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestedWorkspace: "root:initializing",
 			requestingUser:     newUser("user-access", "system:authenticated"),
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to user logical cluster access: allowed",
+			wantReason:         "delegating due to user logical cluster access",
 		},
 		{
 			testName: "any user passed for deep SAR",
@@ -192,7 +192,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestingUser:     newUser("user-unknown"),
 			deepSARHeader:      true,
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to deep SAR request: allowed",
+			wantReason:         "delegating due to deep SAR request",
 		},
 		{
 			testName: "any service account passed for deep SAR",
@@ -201,7 +201,7 @@ func TestWorkspaceContentAuthorizer(t *testing.T) {
 			requestingUser:     newServiceAccountWithCluster("somebody", "root", "system:authenticated"),
 			deepSARHeader:      true,
 			wantDecision:       authorizer.DecisionAllow,
-			wantReason:         "delegating due to deep SAR request: allowed",
+			wantReason:         "delegating due to deep SAR request",
 		},
 	} {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -365,6 +365,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 	c.GenericConfig.BuildHandlerChainFunc = func(apiHandler http.Handler, genericConfig *genericapiserver.Config) (secure http.Handler) {
 		apiHandler = WithWildcardListWatchGuard(apiHandler)
 		apiHandler = WithRequestIdentity(apiHandler)
+		apiHandler = authorization.WithSubjectAccessReviewAuditAnnotations(apiHandler)
 		apiHandler = authorization.WithDeepSubjectAccessReview(apiHandler)
 
 		// The following ensures that only the default main api handler chain executes authorizers which log audit messages.
@@ -373,7 +374,7 @@ func NewConfig(opts *kcpserveroptions.CompletedOptions) (*Config, error) {
 		// First, remember authorizer chain with audit logging disabled.
 		authorizerWithoutAudit := genericConfig.Authorization.Authorizer
 		// configure audit logging enabled authorizer chain and build the apiHandler using this configuration.
-		genericConfig.Authorization.Authorizer = authorization.EnableAuditLogging(genericConfig.Authorization.Authorizer)
+		genericConfig.Authorization.Authorizer = authorization.WithAuditLogging("request.auth.kcp.io", genericConfig.Authorization.Authorizer)
 		apiHandler = genericapiserver.DefaultBuildHandlerChainFromAuthz(apiHandler, genericConfig)
 		// reset authorizer chain with audit logging disabled.
 		genericConfig.Authorization.Authorizer = authorizerWithoutAudit

--- a/test/e2e/audit/audit_log_test.go
+++ b/test/e2e/audit/audit_log_test.go
@@ -73,18 +73,17 @@ func TestAuditLogs(t *testing.T) {
 	require.Equal(t, workspaceNameSent, responseAuditEvent.Annotations["tenancy.kcp.io/workspace"])
 
 	for _, annotation := range []string{
-		"authorization.k8s.io",
-		"bootstrap.authorization.kcp.io",
-		"content.authorization.kcp.io",
-		"maxpermissionpolicy.authorization.kcp.io",
-		"requiredgroups.authorization.kcp.io",
-		"systemcrd.authorization.kcp.io",
+		"request.auth.kcp.io/01-requiredgroups",
+		"request.auth.kcp.io/02-content",
+		"request.auth.kcp.io/03-systemcrd",
+		"request.auth.kcp.io/04-maxpermissionpolicy",
+		"request.auth.kcp.io/05-bootstrap",
 	} {
-		if _, ok := responseAuditEvent.Annotations[annotation+"/decision"]; !ok {
-			t.Errorf("expected annotation %v/decision but got none", annotation)
+		if _, ok := responseAuditEvent.Annotations[annotation+"-decision"]; !ok {
+			t.Errorf("expected annotation %v-decision but got none", annotation)
 		}
-		if _, ok := responseAuditEvent.Annotations[annotation+"/reason"]; !ok {
-			t.Errorf("expected annotation %v/reason but got none", annotation)
+		if _, ok := responseAuditEvent.Annotations[annotation+"-reason"]; !ok {
+			t.Errorf("expected annotation %v-reason but got none", annotation)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR:

- adds domain annotation for audit logging: this allows separating regular workspace requests (`request.auth.kcp.io` domain) vs. SAR requests (`sar.auth.kcp.io`)
- in case of SAR request: audit are created for the actual SAR authorization review and not for the create authorization request. This allows debugging why a SAR denies.
- adds numbering of authorizers in audit logs so the ordering is clear
- removes audit logging of delegation reasons for more concise audit log entries. Reasons of delegated authorizers can be inspected in the corresponding audit annotation of the delegated authorizer.

Audit example for a SAR request:
```
  "annotations": {
    "apiserver.latency.k8s.io/response-write": "3µs",
    "apiserver.latency.k8s.io/serialize-response-object": "155.625µs",
    "apiserver.latency.k8s.io/total": "48.648838125s",
    "apiserver.latency.k8s.io/transform-response-object": "9.709µs",
    "authorization.k8s.io/decision": "allow",
    "authorization.k8s.io/reason": "access granted",
    "request.auth.kcp.io/01-requiredgroups-decision": "Allowed",
    "request.auth.kcp.io/01-requiredgroups-reason": "delegating due to logical cluster does not require groups",
    "request.auth.kcp.io/02-content-decision": "Allowed",
    "request.auth.kcp.io/02-content-reason": "delegating due to user logical cluster access",
    "request.auth.kcp.io/03-systemcrd-decision": "Allowed",
    "request.auth.kcp.io/03-systemcrd-reason": "delegating due to no system CRD violation",
    "request.auth.kcp.io/04-maxpermissionpolicy-decision": "Allowed",
    "request.auth.kcp.io/04-maxpermissionpolicy-reason": "05-local: access granted",
    "request.auth.kcp.io/05-bootstrap-decision": "NoOpinion",
    "request.auth.kcp.io/05-bootstrap-reason": "bootstrap policy: ",
    "request.auth.kcp.io/05-local-decision": "Allowed",
    "request.auth.kcp.io/05-local-reason": "local cluster \"2tgmp7irk229vwdu\" policy: RBAC: allowed by ClusterRoleBinding \"workspace-admin-fhvwv\" of ClusterRole \"cluster-admin\" to User \"user-1\"",
    "sar.auth.kcp.io/01-requiredgroups-decision": "Allowed",
    "sar.auth.kcp.io/01-requiredgroups-reason": "delegating due to logical cluster does not require groups",
    "sar.auth.kcp.io/02-content-decision": "Allowed",
    "sar.auth.kcp.io/02-content-reason": "delegating due to user logical cluster access",
    "sar.auth.kcp.io/03-systemcrd-decision": "Allowed",
    "sar.auth.kcp.io/03-systemcrd-reason": "delegating due to no system CRD violation",
    "sar.auth.kcp.io/04-maxpermissionpolicy-decision": "Allowed",
    "sar.auth.kcp.io/04-maxpermissionpolicy-reason": "05-local: access granted",
    "sar.auth.kcp.io/05-bootstrap-decision": "NoOpinion",
    "sar.auth.kcp.io/05-bootstrap-reason": "bootstrap policy: ",
    "sar.auth.kcp.io/05-local-decision": "Allowed",
    "sar.auth.kcp.io/05-local-reason": "local cluster \"2tgmp7irk229vwdu\" policy: RBAC: allowed by ClusterRoleBinding \"user-1-configmap-reader\" of ClusterRole \"configmap-reader\" to User \"user-1\"",
    "tenancy.kcp.io/workspace": "2tgmp7irk229vwdu"
  }
```

## Related issue(s)

N/A