### PR TITLE
🐛 Do not look up APIExports in the generic webhook

### DIFF
--- a/pkg/admission/webhook/generic_webhook_test.go
+++ b/pkg/admission/webhook/generic_webhook_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -266,14 +265,6 @@ func TestDispatch(t *testing.T) {
 				informersHaveSynced: tc.informersHaveSynced,
 				getAPIBindings: func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error) {
 					return tc.apiBindings, nil
-				},
-				getAPIExport: func(clusterName logicalcluster.Name, name string) (*apisv1alpha1.APIExport, error) {
-					for _, export := range tc.apiExports {
-						if export.Name == name && clusterName == logicalcluster.Name(export.Annotations[logicalcluster.AnnotationKey]) {
-							return export, nil
-						}
-					}
-					return nil, errors.NewNotFound(apisv1alpha1.Resource("APIExport"), name)
 				},
 			}
 

--- a/pkg/reconciler/workload/resource/resource_controller.go
+++ b/pkg/reconciler/workload/resource/resource_controller.go
@@ -335,6 +335,9 @@ func (c *Controller) processResource(ctx context.Context, key string) error {
 		return nil
 	}
 	obj, err := inf.Lister().ByCluster(lclusterName).ByNamespace(namespace).Get(name)
+	if errors.IsNotFound(err) {
+		return nil
+	}
 	if err != nil {
 		logger.Error(err, "error getting object from indexer")
 		return err


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The generic webhook was still using an APIExport lookup to determine cluster name, when all it needed to do was return a value off the APIBinding.

Also cleaned up some NotFound noise from the resource controller.

## Related issue(s)

Fixes #2622
