### PR TITLE
:bug: test/e2e: remove a data race

### DIFF
--- a/test/e2e/framework/workspaces.go
+++ b/test/e2e/framework/workspaces.go
@@ -141,6 +141,7 @@ func newWorkspaceFixture[O WorkspaceOption](t *testing.T, clusterClient kcpclien
 		return err == nil, fmt.Sprintf("error creating workspace under %s: %v", parent, err)
 	}, wait.ForeverTestTimeout, time.Millisecond*100, "failed to create %s workspace under %s", tmpl.Spec.Type.Name, parent)
 
+	wsName := ws.Name
 	t.Cleanup(func() {
 		if preserveTestResources() {
 			return
@@ -149,11 +150,11 @@ func newWorkspaceFixture[O WorkspaceOption](t *testing.T, clusterClient kcpclien
 		ctx, cancelFn := context.WithDeadline(context.Background(), time.Now().Add(time.Second*30))
 		defer cancelFn()
 
-		err := clusterClient.Cluster(parent).TenancyV1alpha1().Workspaces().Delete(ctx, ws.Name, metav1.DeleteOptions{})
+		err := clusterClient.Cluster(parent).TenancyV1alpha1().Workspaces().Delete(ctx, wsName, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
 			return // ignore not found and forbidden because this probably means the parent has been deleted
 		}
-		require.NoErrorf(t, err, "failed to delete workspace %s", ws.Name)
+		require.NoErrorf(t, err, "failed to delete workspace %s", wsName)
 	})
 
 	Eventually(t, func() (bool, string) {


### PR DESCRIPTION
The value of `ws` previously would have been mutated by the `Eventually()` call after this cleanup, leading to a race when cleanup occurred during workspace initialization. We don't expect the name of the workspace to ever change, so it's appropriate to capture the name before registering eleanup and simply assuming the name is static.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes #2693 