### PR TITLE
🐛 Fix API binding privilege escalation

### DIFF
--- a/pkg/virtual/apiexport/builder/build.go
+++ b/pkg/virtual/apiexport/builder/build.go
@@ -27,14 +27,17 @@ import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
 	apisv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/apis/v1alpha1"
 	"github.com/kcp-dev/kcp/pkg/authorization"
+	"github.com/kcp-dev/kcp/pkg/authorization/bootstrap"
 	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
 	kcpinformers "github.com/kcp-dev/kcp/pkg/client/informers/externalversions"
 	virtualapiexportauth "github.com/kcp-dev/kcp/pkg/virtual/apiexport/authorizer"
@@ -53,8 +56,8 @@ const VirtualWorkspaceName string = "apiexport"
 
 func BuildVirtualWorkspace(
 	rootPathPrefix string,
+	cfg *rest.Config,
 	kubeClusterClient, deepSARClient kcpkubernetesclientset.ClusterInterface,
-	dynamicClusterClient kcpdynamic.ClusterInterface,
 	kcpClusterClient kcpclientset.ClusterInterface,
 	cachedKcpInformers kcpinformers.SharedInformerFactory,
 ) ([]rootapiserver.NamedVirtualWorkspace, error) {
@@ -86,6 +89,37 @@ func BuildVirtualWorkspace(
 		}),
 
 		BootstrapAPISetManagement: func(mainConfig genericapiserver.CompletedConfig) (apidefinition.APIDefinitionSetGetter, error) {
+			dynamicClient, err := kcpdynamic.NewForConfig(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("error creating privileged dynamic kcp client: %w", err)
+			}
+
+			impersonatedDynamicClientGetter := func(ctx context.Context) (kcpdynamic.ClusterInterface, error) {
+				cluster, err := genericapirequest.ValidClusterFrom(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("error getting valid cluster from context: %w", err)
+				}
+
+				// Wildcard requests cannot be impersonated against a concrete cluster.
+				if cluster.Wildcard {
+					return dynamicClient, nil
+				}
+
+				impersonationConfig := rest.CopyConfig(cfg)
+				impersonationConfig.Impersonate = rest.ImpersonationConfig{
+					UserName: "system:serviceaccount:default:rest",
+					Groups:   []string{bootstrap.SystemKcpAdminGroup},
+					Extra: map[string][]string{
+						serviceaccount.ClusterNameKey: {cluster.Name.Path().String()},
+					},
+				}
+				impersonatedClient, err := kcpdynamic.NewForConfig(impersonationConfig)
+				if err != nil {
+					return nil, fmt.Errorf("error generating dynamic client: %w", err)
+				}
+				return impersonatedClient, nil
+			}
+
 			apiReconciler, err := apireconciler.NewAPIReconciler(
 				kcpClusterClient,
 				cachedKcpInformers.Apis().V1alpha1().APIResourceSchemas(),
@@ -100,7 +134,7 @@ func BuildVirtualWorkspace(
 						})
 					}
 
-					storageBuilder := provideDelegatingRestStorage(ctx, dynamicClusterClient, identityHash, wrapper)
+					storageBuilder := provideDelegatingRestStorage(ctx, impersonatedDynamicClientGetter, identityHash, wrapper)
 					def, err := apiserver.CreateServingInfoFor(mainConfig, apiResourceSchema, version, storageBuilder)
 					if err != nil {
 						cancelFn()
@@ -112,7 +146,7 @@ func BuildVirtualWorkspace(
 					}, nil
 				},
 				func(ctx context.Context, clusterName logicalcluster.Name, apiExportName string) (apidefinition.APIDefinition, error) {
-					restProvider, err := provideAPIExportFilteredRestStorage(ctx, dynamicClusterClient, clusterName, apiExportName)
+					restProvider, err := provideAPIExportFilteredRestStorage(ctx, impersonatedDynamicClientGetter, clusterName, apiExportName)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/virtual/apiexport/options/options.go
+++ b/pkg/virtual/apiexport/options/options.go
@@ -19,7 +19,6 @@ package options
 import (
 	"path"
 
-	kcpdynamic "github.com/kcp-dev/client-go/dynamic"
 	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
 	"github.com/spf13/pflag"
 
@@ -67,14 +66,10 @@ func (o *APIExport) NewVirtualWorkspaces(
 	if err != nil {
 		return nil, err
 	}
-	dynamicClusterClient, err := kcpdynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
 	deepSARClient, err := kcpkubernetesclientset.NewForConfig(authorization.WithDeepSARConfig(rest.CopyConfig(config)))
 	if err != nil {
 		return nil, err
 	}
 
-	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), kubeClusterClient, deepSARClient, dynamicClusterClient, kcpClusterClient, cachedKcpInformers)
+	return builder.BuildVirtualWorkspace(path.Join(rootPathPrefix, builder.VirtualWorkspaceName), config, kubeClusterClient, deepSARClient, kcpClusterClient, cachedKcpInformers)
 }

--- a/pkg/virtual/framework/forwardingregistry/rest_test.go
+++ b/pkg/virtual/framework/forwardingregistry/rest_test.go
@@ -112,7 +112,7 @@ func newStorage(t *testing.T, clusterClient kcpdynamic.ClusterInterface, apiExpo
 		nil,
 		table,
 		nil,
-		clusterClient,
+		func(ctx context.Context) (kcpdynamic.ClusterInterface, error) { return clusterClient, nil },
 		patchConflictRetryBackoff,
 		forwardingregistry.StorageWrapperFunc(func(_ schema.GroupResource, store *forwardingregistry.StoreFuncs) {
 		}))

--- a/pkg/virtual/initializingworkspaces/builder/forwarding.go
+++ b/pkg/virtual/initializingworkspaces/builder/forwarding.go
@@ -72,7 +72,7 @@ func filteredLogicalClusterReadOnlyRestStorage(
 
 	return registry.ProvideReadOnlyRestStorage(
 		ctx,
-		clusterClient,
+		func(ctx context.Context) (kcpdynamic.ClusterInterface, error) { return clusterClient, nil },
 		registry.WithStaticLabelSelector(requirements),
 		nil,
 	)
@@ -130,7 +130,7 @@ func delegatingLogicalClusterReadOnlyRestStorage(
 			nil,
 			tableConvertor,
 			nil,
-			clusterClient,
+			func(ctx context.Context) (kcpdynamic.ClusterInterface, error) { return clusterClient, nil },
 			nil,
 			&registry.StorageWrappers{
 				registry.WithStaticLabelSelector(requirements),

--- a/pkg/virtual/syncer/builder/forwarding.go
+++ b/pkg/virtual/syncer/builder/forwarding.go
@@ -71,7 +71,7 @@ func NewSyncerRestProvider(ctx context.Context, clusterClient kcpdynamic.Cluster
 			nil,
 			tableConvertor,
 			nil,
-			clusterClient,
+			func(ctx context.Context) (kcpdynamic.ClusterInterface, error) { return clusterClient, nil },
 			nil,
 			wrapper,
 		)
@@ -167,7 +167,7 @@ func NewUpSyncerRestProvider(ctx context.Context, clusterClient kcpdynamic.Clust
 			nil,
 			tableConvertor,
 			nil,
-			clusterClient,
+			func(ctx context.Context) (kcpdynamic.ClusterInterface, error) { return clusterClient, nil },
 			nil,
 			wrapper,
 		)

--- a/test/e2e/virtual/apiexport/authorizer_test.go
+++ b/test/e2e/virtual/apiexport/authorizer_test.go
@@ -479,7 +479,9 @@ func apply(t *testing.T, ctx context.Context, workspace logicalcluster.Path, cfg
 		}()
 
 		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-		require.NoError(t, err)
+		if err != nil {
+			return fmt.Errorf("error getting REST mapping: %w", err)
+		}
 
 		dynamicClient, err := kcpdynamic.NewForConfig(cfg)
 		require.NoError(t, err)

--- a/test/e2e/virtual/apiexport/binding_test.go
+++ b/test/e2e/virtual/apiexport/binding_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiexport
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	kcpkubernetesclientset "github.com/kcp-dev/client-go/kubernetes"
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+
+	kcpclientset "github.com/kcp-dev/kcp/pkg/client/clientset/versioned/cluster"
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+)
+
+func TestBinding(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "control-plane")
+
+	server := framework.SharedKcpServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	org, _ := framework.NewOrganizationFixture(t, server)
+	serviceWorkspacePath, _ := framework.NewWorkspaceFixture(t, server, org, framework.WithName("service"))
+	restrictedWorkspacePath, _ := framework.NewWorkspaceFixture(t, server, org, framework.WithName("restricted-service"))
+	consumerWorkspacePath, consumerWorkspace := framework.NewWorkspaceFixture(t, server, org, framework.WithName("consumer-workspace"))
+	cfg := server.BaseConfig(t)
+
+	kubeClient, err := kcpkubernetesclientset.NewForConfig(rest.CopyConfig(cfg))
+	require.NoError(t, err)
+	kcpClient, err := kcpclientset.NewForConfig(rest.CopyConfig(cfg))
+	require.NoError(t, err)
+	serviceProviderUser := server.ClientCAUserConfig(t, rest.CopyConfig(cfg), "service-provider")
+
+	framework.AdmitWorkspaceAccess(ctx, t, kubeClient, serviceWorkspacePath, []string{"service-provider"}, nil, true)
+
+	require.NoError(t, apply(t, ctx, serviceWorkspacePath, cfg, `
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  name: api-manager
+spec:
+  permissionClaims:
+    - group: "apis.kcp.io"
+      resource: "apibindings"
+      all: true
+`, `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-manager-role
+rules:
+- apiGroups:
+  - apis.kcp.io
+  resources:
+  - apiexports/content
+  verbs:
+  - '*'
+  resourceNames:
+  - 'api-manager'
+`, `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: api-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: api-manager-role
+subjects:
+- kind: User
+  name: service-provider
+`))
+
+	require.NoError(t, apply(t, ctx, restrictedWorkspacePath, cfg, `
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  name: restricted-service
+spec: {}
+`))
+
+	framework.Eventually(t, func() (bool, string) {
+		err := apply(t, ctx, consumerWorkspacePath, cfg, fmt.Sprintf(`
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  name: api-manager
+spec:
+  permissionClaims:
+  - group: apis.kcp.io
+    resource: apibindings
+    state: Accepted
+    all: true
+  reference:
+    export:
+      name: api-manager
+      path: %v
+`, serviceWorkspacePath.String()))
+		if err != nil {
+			return false, fmt.Sprintf("error creating API binding %v", err.Error())
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 1000*time.Millisecond, "waiting on virtual workspace to be ready")
+
+	serviceProviderVirtualWorkspaceConfig := rest.CopyConfig(serviceProviderUser)
+	framework.Eventually(t, func() (bool, string) {
+		apiExport, err := kcpClient.Cluster(serviceWorkspacePath).ApisV1alpha1().APIExports().Get(ctx, "api-manager", metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("waiting on apiexport to be available %v", err.Error())
+		}
+		var found bool
+		serviceProviderVirtualWorkspaceConfig.Host, found, err = framework.VirtualWorkspaceURL(ctx, kcpClient, consumerWorkspace, framework.ExportVirtualWorkspaceURLs(apiExport))
+		require.NoError(t, err)
+		//nolint:staticcheck // SA1019 VirtualWorkspaces is deprecated but not removed yet
+		return found, fmt.Sprintf("waiting for virtual workspace URLs to be available: %v", apiExport.Status.VirtualWorkspaces)
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting on virtual workspace to be ready")
+
+	framework.Eventually(t, func() (success bool, reason string) {
+		err = apply(t, ctx, logicalcluster.Name(consumerWorkspace.Spec.Cluster).Path(), serviceProviderVirtualWorkspaceConfig, fmt.Sprintf(`
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  name: should-fail
+spec:
+  reference:
+    export:
+      name: restricted-service
+      path: %v`, restrictedWorkspacePath.String()))
+		require.Error(t, err)
+		want := "unable to create APIBinding: no permission to bind to export"
+		if got := err.Error(); !strings.Contains(got, want) {
+			return false, fmt.Sprintf("want %q, got %q", want, got)
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 1000*time.Millisecond, "waiting on virtual workspace to be ready")
+
+	require.NoError(t, apply(t, ctx, restrictedWorkspacePath, cfg, `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: anonymous-binder
+rules:
+- apiGroups:
+  - apis.kcp.io
+  resources:
+  - apiexports
+  verbs:
+  - 'bind'
+  resourceNames:
+  - 'restricted-service'
+`, `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: anonymous-binder
+subjects:
+- kind: User
+  name: system:anonymous
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: anonymous-binder
+`))
+
+	framework.Eventually(t, func() (bool, string) {
+		err := apply(t, ctx, logicalcluster.Name(consumerWorkspace.Spec.Cluster).Path(), serviceProviderVirtualWorkspaceConfig, fmt.Sprintf(`
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIBinding
+metadata:
+  name: should-not-fail
+spec:
+  reference:
+    export:
+      name: restricted-service
+      path: %v`, restrictedWorkspacePath.String()))
+		if err != nil {
+			return false, fmt.Sprintf("waiting on being able to bind: %v", err.Error())
+		}
+		return true, ""
+	}, wait.ForeverTestTimeout, 100*time.Millisecond, "waiting on being able to bind")
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
Currently, privilege escalation can be provoked when creating APIBindings
for exported resources.

This fixes it by impersonating virtual API export requests with a
service account that is bound to the requested workspace.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/2239
