### PR TITLE
:book: document kcp bind commmand to allow to sync deployment in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ local `kind` cluster.
 Run the following command to tell kcp about the `kind` cluster (replace the syncer image tag as needed):
 
 ```shell
-$ kubectl kcp workload sync kind --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.8.0 -o syncer-kind-main.yaml
+$ kubectl kcp workload sync kind --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.10.0 -o syncer-kind-main.yaml
 Creating synctarget "kind"
 Creating service account "kcp-syncer-kind-25coemaz"
 Creating cluster role "kcp-syncer-kind-25coemaz" to give service account "kcp-syncer-kind-25coemaz"
@@ -98,6 +98,15 @@ clusterrole.rbac.authorization.k8s.io/kcp-syncer-kind-25coemaz created
 clusterrolebinding.rbac.authorization.k8s.io/kcp-syncer-kind-25coemaz created
 secret/kcp-syncer-kind-25coemaz created
 deployment.apps/kcp-syncer-kind-25coemaz created
+```
+
+### Bind to workload APIs and create default placement
+
+If you are running kcp version v0.10.0 and higher, you will need to run the following commmand 
+to create a binding to the workload APIs export and a default placement for your physical cluster:
+
+```shell
+$ kubectl kcp bind compute root
 ```
 
 ### Create a deployment in kcp


### PR DESCRIPTION
Signed-off-by: Paolo Dettori <dettori@us.ibm.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Update the Quickstart guide to add the `kcp bind compute` command so that first time users can successfully sync a deployment to a sync cluster. Also, update example command for syncer to use the latest release (v0.10.0)

## Related issue(s)
#2697 
#2655

