### PR TITLE
:bug: Fix Makefile clean target and add .kcp cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,9 +382,14 @@ verify-modules: modules  ## Verify go modules are up to date
 	hack/verify-go-modules.sh
 
 .PHONY: clean
-clean:
+clean: clean-workdir
 	rm -fr $(TOOLS_DIR)
 	rm -f $(GOBIN_DIR)/*
+
+.PHONY: clean-workdir
+clean-workdir: WORK_DIR ?= .
+clean-workdir:
+	rm -fr $(WORK_DIR)/.kcp*
 
 .PHONY: help
 help: ## Show this help.

--- a/Makefile
+++ b/Makefile
@@ -383,8 +383,8 @@ verify-modules: modules  ## Verify go modules are up to date
 
 .PHONY: clean
 clean:
-	! test -e $(TOOLS_DIR) || rm -r $(TOOLS_DIR)
-	! test -e $(GOBIN_DIR)/* || rm $(GOBIN_DIR)/*
+	rm -fr $(TOOLS_DIR)
+	rm -f $(GOBIN_DIR)/*
 
 .PHONY: help
 help: ## Show this help.


### PR DESCRIPTION
## Summary
The `clean` target was added in https://github.com/kcp-dev/kcp/pull/2562 but doesn't currently work due to the wildcard in the `GOBIN_DIR` test.

Also following some discussion on slack about cleanup for the `.kcp*` directories I added cleanup so we can more easily switch between e.g shared/sharded e2e tests locally e.g `make clean test-e2e-sharded-minimal`

