### PR TITLE
:book: Brush up TMC quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.3+kcp-v0.8
 ### Configure kcp to sync to your cluster
 
 kcp can't run pods by itself - it needs at least one physical cluster for that. For this example, we'll be using a
-local `kind` cluster.
+local `kind` cluster.  It does not have to exist yet.
 
-Run the following command to tell kcp about the `kind` cluster (replace the syncer image tag as needed):
+In this recipe we use the root workspace to hold the description of the workload and where it goes.  These usually would go elsewhere, but we use the root workspace here for simplicity.
+
+Run the following command to tell kcp about the `kind` cluster (replace the syncer image tag as needed; CI now puts built images in https://github.com/orgs/kcp-dev/packages):
 
 ```shell
 $ kubectl kcp workload sync kind --syncer-image ghcr.io/kcp-dev/kcp/syncer:v0.10.0 -o syncer-kind-main.yaml
@@ -87,7 +89,7 @@ to verify the syncer pod is running.
 ```
 
 Next, we need to install the syncer pod on our `kind` cluster - this is what actually syncs content from kcp to the
-physical cluster. Run the following command:
+physical cluster. The kind cluster needs to be running by now. Run the following command:
 
 ```shell
 $ KUBECONFIG=</path/to/kind/kubeconfig> kubectl apply -f "syncer-kind-main.yaml"
@@ -102,11 +104,14 @@ deployment.apps/kcp-syncer-kind-25coemaz created
 
 ### Bind to workload APIs and create default placement
 
-If you are running kcp version v0.10.0 and higher, you will need to run the following commmand 
+If you are running kcp version v0.10.0 or higher, you will need to run the following commmand (continuing in the `root` workspace)
 to create a binding to the workload APIs export and a default placement for your physical cluster:
 
 ```shell
 $ kubectl kcp bind compute root
+Binding APIExport "root:compute:kubernetes".
+placement placement-1pfxsevk created.
+Placement "placement-1pfxsevk" is ready.
 ```
 
 ### Create a deployment in kcp


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
1. Show the output of `kubectl kcp bind`.

2. Be clear about when the kind cluster needs to be running.

3. Warn that the use of the root workspace to hold workload source is unusual.

4. s/and/or/ where needed.

5. Note one of the places (the one with a web UI) where CI puts built images.

## Related issue(s)

Fixes #
