### PR TITLE
:bug: Fix typo breaking codegen: crds not stored at the right location

### DIFF
--- a/config/crds/core.kcp.io_logicalclusters.yaml
+++ b/config/crds/core.kcp.io_logicalclusters.yaml
@@ -18,7 +18,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: The current phase (e.g. Scheduling, Initializing, Ready, Deleting)
-      jsonPath: .metadata.labels['tenancy\.kcp\.dev/phase']
+      jsonPath: .status.phase
       name: Phase
       type: string
     - description: URL to access the logical cluster

--- a/config/root-phase0/apiresourceschema-logicalclusters.core.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-logicalclusters.core.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v230116-943e458f6.logicalclusters.core.kcp.io
+  name: v230201-b085a04a.logicalclusters.core.kcp.io
 spec:
   group: core.kcp.io
   names:
@@ -16,7 +16,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: The current phase (e.g. Scheduling, Initializing, Ready, Deleting)
-      jsonPath: .metadata.labels['tenancy\.kcp\.dev/phase']
+      jsonPath: .status.phase
       name: Phase
       type: string
     - description: URL to access the logical cluster

--- a/hack/update-codegen-crds.sh
+++ b/hack/update-codegen-crds.sh
@@ -34,7 +34,7 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
         rbac:roleName=manager-role \
         webhook \
         paths="./..." \
-        output:crd:artifacts:config="${REPO_ROOT}"config/crds
+        output:crd:artifacts:config="${REPO_ROOT}"/config/crds
 )
 
 for CRD in "${REPO_ROOT}"/config/crds/*.yaml; do


### PR DESCRIPTION
Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

## Summary

This fixes a typo in codegen, which induces the saving of newly generated crds not in the expected directory.