### PR TITLE
🌱 tmc e2e : Split SyncerFixture

### DIFF
--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -402,12 +402,12 @@ func StartSyncer(ctx context.Context, cfg *SyncerConfig, numSyncerThreads int, i
 		go startSyncerTunnel(ctx, upstreamConfig, downstreamConfig, logicalcluster.From(syncTarget), cfg.SyncTargetName)
 	}
 
-	StartHeartbeatKeeper(ctx, kcpSyncTargetClient, cfg.SyncTargetName, cfg.SyncTargetUID)
+	StartHeartbeat(ctx, kcpSyncTargetClient, cfg.SyncTargetName, cfg.SyncTargetUID)
 
 	return nil
 }
 
-func StartHeartbeatKeeper(ctx context.Context, kcpSyncTargetClient kcpclientset.Interface, syncTargetName, syncTargetUID string) {
+func StartHeartbeat(ctx context.Context, kcpSyncTargetClient kcpclientset.Interface, syncTargetName, syncTargetUID string) {
 	logger := klog.FromContext(ctx)
 
 	// Attempt to heartbeat every interval

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -130,10 +130,10 @@ func WithDownstreamPreparation(prepare func(config *rest.Config, isFakePCluster 
 	}
 }
 
-// Create creates a SyncTarget resource through the `workload sync` CLI command,
+// CreateSyncTargetAndApplyToDownstream creates a SyncTarget resource through the `workload sync` CLI command,
 // applies the syncer-related resources in the physical cluster.
 // No resource will be effectively synced after calling this method.
-func (sf *syncerFixture) Create(t *testing.T) *appliedSyncerFixture {
+func (sf *syncerFixture) CreateSyncTargetAndApplyToDownstream(t *testing.T) *appliedSyncerFixture {
 	t.Helper()
 
 	artifactDir, _, err := ScratchDirs(t)

--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -143,12 +143,6 @@ func (sf *syncerFixture) Create(t *testing.T) *appliedSyncerFixture {
 
 	useDeployedSyncer := len(TestConfig.PClusterKubeconfig()) > 0
 
-	var (
-		downstreamConfig         *rest.Config
-		downstreamKubeconfigPath string
-		syncerID                 string
-	)
-
 	// Write the upstream logical cluster config to disk for the workspace plugin
 	upstreamRawConfig, err := sf.upstreamServer.RawConfig()
 	require.NoError(t, err)
@@ -183,6 +177,8 @@ func (sf *syncerFixture) Create(t *testing.T) *appliedSyncerFixture {
 	}
 	syncerYAML := RunKcpCliPlugin(t, kubeconfigPath, pluginArgs)
 
+	var downstreamConfig *rest.Config
+	var downstreamKubeconfigPath string
 	if useDeployedSyncer {
 		// The syncer will target the pcluster identified by `--pcluster-kubeconfig`.
 		downstreamKubeconfigPath = TestConfig.PClusterKubeconfig()
@@ -273,6 +269,7 @@ func (sf *syncerFixture) Create(t *testing.T) *appliedSyncerFixture {
 	// Extract the configuration for an in-process syncer from the resources that were
 	// applied to the downstream server. This maximizes the parity between the
 	// configuration of a deployed and in-process syncer.
+	var syncerID string
 	for _, doc := range strings.Split(string(syncerYAML), "\n---\n") {
 		var manifest struct {
 			metav1.ObjectMeta `json:"metadata"`

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -195,7 +195,7 @@ func TestClusterController(t *testing.T) {
 					require.NoError(t, err)
 					t.Log("Installing test CRDs into sink cluster...")
 					fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
-				})).CreateAndStart(t)
+				})).Create(t).StartSyncer(t)
 
 			t.Logf("Bind second user workspace to location workspace")
 			framework.NewBindCompute(t, wsPath, source).Bind(t)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -195,7 +195,7 @@ func TestClusterController(t *testing.T) {
 					require.NoError(t, err)
 					t.Log("Installing test CRDs into sink cluster...")
 					fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
-				})).Create(t).StartSyncer(t)
+				})).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 			t.Logf("Bind second user workspace to location workspace")
 			framework.NewBindCompute(t, wsPath, source).Bind(t)

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -195,7 +195,7 @@ func TestClusterController(t *testing.T) {
 					require.NoError(t, err)
 					t.Log("Installing test CRDs into sink cluster...")
 					fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
-				})).Start(t)
+				})).CreateAndStart(t)
 
 			t.Logf("Bind second user workspace to location workspace")
 			framework.NewBindCompute(t, wsPath, source).Bind(t)

--- a/test/e2e/reconciler/deployment/deployment_coordinator_test.go
+++ b/test/e2e/reconciler/deployment/deployment_coordinator_test.go
@@ -71,7 +71,7 @@ func TestDeploymentCoordinator(t *testing.T) {
 	eastSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("east"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "east", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"east"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestDeploymentCoordinator(t *testing.T) {
 	westSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("west"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "west", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"west"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)

--- a/test/e2e/reconciler/deployment/deployment_coordinator_test.go
+++ b/test/e2e/reconciler/deployment/deployment_coordinator_test.go
@@ -71,7 +71,7 @@ func TestDeploymentCoordinator(t *testing.T) {
 	eastSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("east"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).Start(t)
+	).CreateAndStart(t)
 
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "east", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"east"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestDeploymentCoordinator(t *testing.T) {
 	westSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("west"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).Start(t)
+	).CreateAndStart(t)
 
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "west", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"west"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)

--- a/test/e2e/reconciler/deployment/deployment_coordinator_test.go
+++ b/test/e2e/reconciler/deployment/deployment_coordinator_test.go
@@ -71,7 +71,7 @@ func TestDeploymentCoordinator(t *testing.T) {
 	eastSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("east"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "east", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"east"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
@@ -79,7 +79,7 @@ func TestDeploymentCoordinator(t *testing.T) {
 	westSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("west"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "west", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"west"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)

--- a/test/e2e/reconciler/deployment/deployment_coordinator_test.go
+++ b/test/e2e/reconciler/deployment/deployment_coordinator_test.go
@@ -84,8 +84,8 @@ func TestDeploymentCoordinator(t *testing.T) {
 	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "west", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"west"}]`), metav1.PatchOptions{})
 	require.NoError(t, err)
 
-	eastSyncer.WaitForClusterReady(ctx, t)
-	westSyncer.WaitForClusterReady(ctx, t)
+	eastSyncer.WaitForSyncTargetReady(ctx, t)
+	westSyncer.WaitForSyncTargetReady(ctx, t)
 
 	t.Logf("Create 2 locations, one for each SyncTargets")
 	err = framework.CreateResources(ctx, locations.FS, upstreamConfig, locationWorkspacePath)

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -70,7 +70,7 @@ func TestSyncTargetLocalExport(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(syncTargetName),
 		framework.WithSyncedUserWorkspaces(computeWorkspace),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	framework.Eventually(t, func() (bool, string) {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -70,7 +70,7 @@ func TestSyncTargetLocalExport(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(syncTargetName),
 		framework.WithSyncedUserWorkspaces(computeWorkspace),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	framework.Eventually(t, func() (bool, string) {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -70,7 +70,7 @@ func TestSyncTargetLocalExport(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(syncTargetName),
 		framework.WithSyncedUserWorkspaces(computeWorkspace),
-	).Start(t)
+	).CreateAndStart(t)
 
 	framework.Eventually(t, func() (bool, string) {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
+++ b/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
@@ -123,7 +123,7 @@ func TestMultipleExports(t *testing.T) {
 			)
 			require.NoError(t, err)
 		}),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	t.Logf("syncTarget should have one resource to sync")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
+++ b/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
@@ -123,7 +123,7 @@ func TestMultipleExports(t *testing.T) {
 			)
 			require.NoError(t, err)
 		}),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	t.Logf("syncTarget should have one resource to sync")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
+++ b/test/e2e/reconciler/locationworkspace/multiple_apiexports_test.go
@@ -123,7 +123,7 @@ func TestMultipleExports(t *testing.T) {
 			)
 			require.NoError(t, err)
 		}),
-	).Start(t)
+	).CreateAndStart(t)
 
 	t.Logf("syncTarget should have one resource to sync")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/locationworkspace/rootcompute_test.go
+++ b/test/e2e/reconciler/locationworkspace/rootcompute_test.go
@@ -80,7 +80,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 			)
 			require.NoError(t, err)
 		}),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/rootcompute_test.go
+++ b/test/e2e/reconciler/locationworkspace/rootcompute_test.go
@@ -80,7 +80,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 			)
 			require.NoError(t, err)
 		}),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/rootcompute_test.go
+++ b/test/e2e/reconciler/locationworkspace/rootcompute_test.go
@@ -80,7 +80,7 @@ func TestRootComputeWorkspace(t *testing.T) {
 			)
 			require.NoError(t, err)
 		}),
-	).Start(t)
+	).CreateAndStart(t)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/synctarget_test.go
+++ b/test/e2e/reconciler/locationworkspace/synctarget_test.go
@@ -98,7 +98,7 @@ func TestSyncTargetExport(t *testing.T) {
 	syncTarget := framework.NewSyncerFixture(t, source, computePath,
 		framework.WithAPIExports(fmt.Sprintf("%s:%s", schemaPath.String(), cowboysAPIExport.Name)),
 		framework.WithSyncTargetName(syncTargetName),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/synctarget_test.go
+++ b/test/e2e/reconciler/locationworkspace/synctarget_test.go
@@ -98,7 +98,7 @@ func TestSyncTargetExport(t *testing.T) {
 	syncTarget := framework.NewSyncerFixture(t, source, computePath,
 		framework.WithAPIExports(fmt.Sprintf("%s:%s", schemaPath.String(), cowboysAPIExport.Name)),
 		framework.WithSyncTargetName(syncTargetName),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/locationworkspace/synctarget_test.go
+++ b/test/e2e/reconciler/locationworkspace/synctarget_test.go
@@ -98,7 +98,7 @@ func TestSyncTargetExport(t *testing.T) {
 	syncTarget := framework.NewSyncerFixture(t, source, computePath,
 		framework.WithAPIExports(fmt.Sprintf("%s:%s", schemaPath.String(), cowboysAPIExport.Name)),
 		framework.WithSyncTargetName(syncTargetName),
-	).Start(t)
+	).CreateAndStart(t)
 
 	require.Eventually(t, func() bool {
 		syncTarget, err := kcpClients.Cluster(computePath).WorkloadV1alpha1().SyncTargets().Get(ctx, syncTargetName, metav1.GetOptions{})

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -92,12 +92,9 @@ func TestNamespaceScheduler(t *testing.T) {
 
 				t.Log("Deploy a syncer")
 				// Create and Start a syncer against a workload cluster so that there's a ready cluster to schedule to.
-				//
-				// TODO(marun) Extract the heartbeater out of the syncer for reuse in a test fixture. The namespace
-				// controller just needs ready clusters which can be accomplished without a syncer by having the
-				// heartbeater update the sync target so the heartbeat controller can set the cluster ready.
 				syncerFixture := framework.NewSyncerFixture(t, server, server.path,
-					framework.WithExtraResources("services")).Start(t)
+					framework.WithExtraResources("services"),
+				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
 				syncTargetName := syncerFixture.SyncerConfig.SyncTargetName
 
 				t.Logf("Bind to location workspace")

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -95,7 +95,7 @@ func TestNamespaceScheduler(t *testing.T) {
 				// so that there's a ready cluster to schedule to.
 				syncerFixture := framework.NewSyncerFixture(t, server, server.path,
 					framework.WithExtraResources("services"),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 				syncTargetName := syncerFixture.SyncerConfig.SyncTargetName
 
 				t.Logf("Bind to location workspace")

--- a/test/e2e/reconciler/namespace/controller_test.go
+++ b/test/e2e/reconciler/namespace/controller_test.go
@@ -90,8 +90,9 @@ func TestNamespaceScheduler(t *testing.T) {
 					return &workloadnamespace.NamespaceConditionsAdapter{Namespace: ns}, err
 				}, framework.IsNot(workloadnamespace.NamespaceScheduled).WithReason(workloadnamespace.NamespaceReasonUnschedulable))
 
-				t.Log("Deploy a syncer")
-				// Create and Start a syncer against a workload cluster so that there's a ready cluster to schedule to.
+				t.Log("Create the SyncTarget and start both the Syncer APIImporter and Syncer HeartBeat")
+				// Create the SyncTarget and start both the Syncer APIImporter and Syncer HeartBeat against a workload cluster
+				// so that there's a ready cluster to schedule to.
 				syncerFixture := framework.NewSyncerFixture(t, server, server.path,
 					framework.WithExtraResources("services"),
 				).Create(t).StartAPIImporter(t).StartHeartBeat(t)

--- a/test/e2e/reconciler/scheduling/api_compatibility_test.go
+++ b/test/e2e/reconciler/scheduling/api_compatibility_test.go
@@ -50,7 +50,7 @@ func TestSchedulingOnSupportedAPI(t *testing.T) {
 	require.NoError(t, err)
 
 	firstSyncTargetName := fmt.Sprintf("firstsynctarget-%d", +rand.Intn(1000000))
-	t.Logf("Creating a SyncTarget with no supported APIExports and syncer in %s", locationPath)
+	t.Logf("Creating a SyncTarget with no supported APIExports in %s, and start both the Syncer APIImporter and Syncer HeartBeat", locationPath)
 	_ = framework.NewSyncerFixture(t, source, locationPath,
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWS),
@@ -58,7 +58,7 @@ func TestSchedulingOnSupportedAPI(t *testing.T) {
 	).Create(t).StartAPIImporter(t).StartHeartBeat(t)
 
 	secondSyncTargetName := fmt.Sprintf("secondsynctarget-%d", +rand.Intn(1000000))
-	t.Logf("Creating a SyncTarget with global kubernetes APIExports and syncer in %s", locationPath)
+	t.Logf("Creating a SyncTarget with global kubernetes APIExports in %s,and start both the Syncer APIImporter and Syncer HeartBeat", locationPath)
 	_ = framework.NewSyncerFixture(t, source, locationPath,
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWS),

--- a/test/e2e/reconciler/scheduling/api_compatibility_test.go
+++ b/test/e2e/reconciler/scheduling/api_compatibility_test.go
@@ -55,14 +55,14 @@ func TestSchedulingOnSupportedAPI(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWS),
 		framework.WithAPIExports(""),
-	).Start(t)
+	).Create(t).StartAPIImporter(t).StartHeartBeat(t)
 
 	secondSyncTargetName := fmt.Sprintf("secondsynctarget-%d", +rand.Intn(1000000))
 	t.Logf("Creating a SyncTarget with global kubernetes APIExports and syncer in %s", locationPath)
 	_ = framework.NewSyncerFixture(t, source, locationPath,
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWS),
-	).Start(t)
+	).Create(t).StartAPIImporter(t).StartHeartBeat(t)
 
 	placementName := "placement-test-supportedapi"
 	t.Logf("Bind to location workspace")

--- a/test/e2e/reconciler/scheduling/api_compatibility_test.go
+++ b/test/e2e/reconciler/scheduling/api_compatibility_test.go
@@ -55,14 +55,14 @@ func TestSchedulingOnSupportedAPI(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWS),
 		framework.WithAPIExports(""),
-	).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 	secondSyncTargetName := fmt.Sprintf("secondsynctarget-%d", +rand.Intn(1000000))
 	t.Logf("Creating a SyncTarget with global kubernetes APIExports in %s,and start both the Syncer APIImporter and Syncer HeartBeat", locationPath)
 	_ = framework.NewSyncerFixture(t, source, locationPath,
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWS),
-	).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 	placementName := "placement-test-supportedapi"
 	t.Logf("Bind to location workspace")

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -72,7 +72,7 @@ func TestScheduling(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(syncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace, secondUserWorkspace),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	t.Logf("Wait for APIResourceImports to show up in the negotiation workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -72,7 +72,7 @@ func TestScheduling(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(syncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace, secondUserWorkspace),
-	).Start(t)
+	).CreateAndStart(t)
 
 	t.Logf("Wait for APIResourceImports to show up in the negotiation workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/controller_test.go
+++ b/test/e2e/reconciler/scheduling/controller_test.go
@@ -72,7 +72,7 @@ func TestScheduling(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(syncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace, secondUserWorkspace),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	t.Logf("Wait for APIResourceImports to show up in the negotiation workspace")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -65,7 +65,7 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithExtraResources("services"),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	secondSyncTargetName := "second-synctarget"
 	t.Logf("Creating a SyncTarget and syncer in %s", locationPath)
@@ -73,7 +73,7 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	t.Log("Label synctarget")
 	patchData1 := `{"metadata":{"labels":{"loc":"loc1"}}}`

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -65,7 +65,7 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithExtraResources("services"),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-	).Start(t)
+	).CreateAndStart(t)
 
 	secondSyncTargetName := "second-synctarget"
 	t.Logf("Creating a SyncTarget and syncer in %s", locationPath)
@@ -73,7 +73,7 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-	).Start(t)
+	).CreateAndStart(t)
 
 	t.Log("Label synctarget")
 	patchData1 := `{"metadata":{"labels":{"loc":"loc1"}}}`

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -65,7 +65,7 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithExtraResources("services"),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	secondSyncTargetName := "second-synctarget"
 	t.Logf("Creating a SyncTarget and syncer in %s", locationPath)
@@ -73,7 +73,7 @@ func TestMultiPlacement(t *testing.T) {
 		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	t.Log("Label synctarget")
 	patchData1 := `{"metadata":{"labels":{"loc":"loc1"}}}`

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -67,7 +67,7 @@ func TestPlacementUpdate(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
 		framework.WithExtraResources("services"),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	t.Log("Wait for \"default\" location")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -67,7 +67,7 @@ func TestPlacementUpdate(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
 		framework.WithExtraResources("services"),
-	).Start(t)
+	).CreateAndStart(t)
 
 	t.Log("Wait for \"default\" location")
 	require.Eventually(t, func() bool {

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -67,7 +67,7 @@ func TestPlacementUpdate(t *testing.T) {
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
 		framework.WithExtraResources("services"),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	t.Log("Wait for \"default\" location")
 	require.Eventually(t, func() bool {

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -61,7 +61,7 @@ func TestDNSResolution(t *testing.T) {
 	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
 	).CreateAndStart(t)
-	syncer.WaitForClusterReady(ctx, t)
+	syncer.WaitForSyncTargetReady(ctx, t)
 
 	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)
 	require.NoError(t, err)

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -60,7 +60,7 @@ func TestDNSResolution(t *testing.T) {
 
 	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 	syncer.WaitForSyncTargetReady(ctx, t)
 
 	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -60,7 +60,7 @@ func TestDNSResolution(t *testing.T) {
 
 	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).Start(t)
+	).CreateAndStart(t)
 	syncer.WaitForClusterReady(ctx, t)
 
 	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)

--- a/test/e2e/syncer/dns/dns_test.go
+++ b/test/e2e/syncer/dns/dns_test.go
@@ -60,7 +60,7 @@ func TestDNSResolution(t *testing.T) {
 
 	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 	syncer.WaitForSyncTargetReady(ctx, t)
 
 	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -85,7 +85,7 @@ func TestSyncerLifecycle(t *testing.T) {
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "persistentvolumes"},
 			)
 			require.NoError(t, err)
-		})).Start(t)
+		})).CreateAndStart(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
@@ -620,7 +620,7 @@ func TestCordonUncordonDrain(t *testing.T) {
 	// heartbeating and the heartbeat controller setting the sync target ready in
 	// response.
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsPath,
-		framework.WithExtraResources("services")).Start(t)
+		framework.WithExtraResources("services")).CreateAndStart(t)
 	syncTargetName := syncerFixture.SyncerConfig.SyncTargetName
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -85,7 +85,7 @@ func TestSyncerLifecycle(t *testing.T) {
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "persistentvolumes"},
 			)
 			require.NoError(t, err)
-		})).CreateAndStart(t)
+		})).Create(t).StartSyncer(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
@@ -620,7 +620,8 @@ func TestCordonUncordonDrain(t *testing.T) {
 	// heartbeating and the heartbeat controller setting the sync target ready in
 	// response.
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsPath,
-		framework.WithExtraResources("services")).CreateAndStart(t)
+		framework.WithExtraResources("services"),
+	).Create(t).StartSyncer(t)
 	syncTargetName := syncerFixture.SyncerConfig.SyncTargetName
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/test/e2e/syncer/syncer_test.go
+++ b/test/e2e/syncer/syncer_test.go
@@ -85,7 +85,7 @@ func TestSyncerLifecycle(t *testing.T) {
 				metav1.GroupResource{Group: "core.k8s.io", Resource: "persistentvolumes"},
 			)
 			require.NoError(t, err)
-		})).Create(t).StartSyncer(t)
+		})).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)
@@ -621,7 +621,7 @@ func TestCordonUncordonDrain(t *testing.T) {
 	// response.
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, wsPath,
 		framework.WithExtraResources("services"),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 	syncTargetName := syncerFixture.SyncerConfig.SyncTargetName
 
 	ctx, cancelFunc := context.WithCancel(context.Background())

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -73,7 +73,7 @@ func TestSyncerTunnel(t *testing.T) {
 
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, synctargetWsName.Path(),
 		framework.WithSyncedUserWorkspaces(userWs),
-	).Create(t).StartSyncer(t)
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	syncerFixture.WaitForSyncTargetReady(ctx, t)
 

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -73,7 +73,7 @@ func TestSyncerTunnel(t *testing.T) {
 
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, synctargetWsName.Path(),
 		framework.WithSyncedUserWorkspaces(userWs),
-	).Start(t)
+	).CreateAndStart(t)
 
 	syncerFixture.WaitForClusterReady(ctx, t)
 

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -75,7 +75,7 @@ func TestSyncerTunnel(t *testing.T) {
 		framework.WithSyncedUserWorkspaces(userWs),
 	).CreateAndStart(t)
 
-	syncerFixture.WaitForClusterReady(ctx, t)
+	syncerFixture.WaitForSyncTargetReady(ctx, t)
 
 	t.Log("Binding the consumer workspace to the location workspace")
 	framework.NewBindCompute(t, userWsName.Path(), upstreamServer,

--- a/test/e2e/syncer/tunnels_test.go
+++ b/test/e2e/syncer/tunnels_test.go
@@ -73,7 +73,7 @@ func TestSyncerTunnel(t *testing.T) {
 
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, synctargetWsName.Path(),
 		framework.WithSyncedUserWorkspaces(userWs),
-	).CreateAndStart(t)
+	).Create(t).StartSyncer(t)
 
 	syncerFixture.WaitForSyncTargetReady(ctx, t)
 

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -232,7 +232,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						)
 						require.NoError(t, err)
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				kubelikeSyncer.StopHeartBeat(t)
 				kubelikeSyncer.StartHeartBeat(t)
@@ -254,7 +254,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				kubelikeVWDiscoverClusterClient, err := kcpdiscovery.NewForConfig(kubelikeSyncer.SyncerVirtualWorkspaceConfig)
 				require.NoError(t, err)
@@ -341,7 +341,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				logWithTimestampf(t, "Create two service accounts")
 				_, err := kubeClusterClient.Cluster(wildwestLocationPath).CoreV1().ServiceAccounts("default").Create(ctx, &corev1.ServiceAccount{
@@ -461,7 +461,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				logWithTimestampf(t, "Bind wildwest location workspace to itself")
 				framework.NewBindCompute(t, wildwestLocationPath, server,
@@ -619,7 +619,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				logWithTimestampf(t, "Bind consumer workspace to wildwest location workspace")
 				framework.NewBindCompute(t, consumerPath, server,
@@ -774,7 +774,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				_, err = kcpClusterClient.Cluster(wildwestLocationPath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "wildwest-north", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"north"}]`), metav1.PatchOptions{})
 				require.NoError(t, err)
@@ -793,7 +793,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				_, err = kcpClusterClient.Cluster(wildwestLocationPath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "wildwest-south", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"south"}]`), metav1.PatchOptions{})
 				require.NoError(t, err)
@@ -997,7 +997,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				_, err = kcpClusterClient.Cluster(wildwestLocationPath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "wildwest-north", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"north"}]`), metav1.PatchOptions{})
 				require.NoError(t, err)
@@ -1018,7 +1018,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				_, err = kcpClusterClient.Cluster(wildwestLocationPath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "wildwest-south", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"south"}]`), metav1.PatchOptions{})
 				require.NoError(t, err)
@@ -1325,7 +1325,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				logWithTimestampf(t, "Bind consumer workspace to wildwest location workspace")
 				framework.NewBindCompute(t, consumerPath, server,
@@ -1433,7 +1433,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 						logWithTimestampf(t, "Installing test CRDs into sink cluster...")
 						fixturewildwest.FakePClusterCreate(t, sinkCrdClient.ApiextensionsV1().CustomResourceDefinitions(), metav1.GroupResource{Group: wildwest.GroupName, Resource: "cowboys"})
 					}),
-				).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 				logWithTimestampf(t, "Bind consumer workspace to wildwest location workspace")
 				framework.NewBindCompute(t, consumerPath, server,
@@ -1948,7 +1948,7 @@ func TestUpsyncerVirtualWorkspace(t *testing.T) {
 					)
 					require.NoError(t, err)
 				}),
-			).Create(t).StartAPIImporter(t).StartHeartBeat(t)
+			).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 			logWithTimestampf(t, "Bind upsyncer workspace")
 			framework.NewBindCompute(t, upsyncerPath, server,


### PR DESCRIPTION
## Summary

Split the `SyncerFixture` start method to provide a way to only maintain Synctarget heartbeat and import apis, without
effectively syncing upstream resources.

## Related issue(s)

No related issue, but this is required in order to avoid conflicting with the e2e tests of the Upsyncer virtual workspace with the implementation of the Upsyncer controller (on the Syncer side) is merged.
This will also allow lighter e2e tests for all the tests that don't need effective syncing of resources to the downstream cluster.  