### PR TITLE
🐛 Drop non-existent workspace get command from help output

### DIFF
--- a/pkg/cliplugins/workspace/cmd/cmd.go
+++ b/pkg/cliplugins/workspace/cmd/cmd.go
@@ -38,9 +38,6 @@ var (
 	# short-hand for the use syntax
 	%[1]s workspace my-workspace
 
-	# list sub-workspaces in the current workspace
-	%[1]s get workspaces
-
 	# enter a given absolute workspace
 	%[1]s workspace root:default:my-workspace
 


### PR DESCRIPTION


<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Drops the kubectl kcp workspace get example from help output as it is not a valid command.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

## Related issue(s)

n/a
