### PR TITLE
🌱 /pkg/proxy/server: handle /readyz and /livez outside of the auth chain

### DIFF
--- a/pkg/proxy/mapping.go
+++ b/pkg/proxy/mapping.go
@@ -59,18 +59,6 @@ func NewHandler(ctx context.Context, o *proxyoptions.Options, index index.Index)
 
 	mux := http.NewServeMux()
 
-	// TODO: implement proper readyz handler
-	mux.Handle("/readyz", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("OK")) //nolint:errcheck
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	// TODO: implement proper livez handler
-	mux.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("OK")) //nolint:errcheck
-		w.WriteHeader(http.StatusOK)
-	}))
-
 	mux.Handle("/metrics", legacyregistry.Handler())
 
 	logger := klog.FromContext(ctx)


### PR DESCRIPTION

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
To simplify deployment we want the `/readyz` and `/livez` not be handled by the regular auth chain. This allows us to use simple httpGet kube probes.

## Related issue(s)

Related helm chart update: https://github.com/kcp-dev/helm-charts/pull/24