### PR TITLE
:book: Fix unknown flag --apiexport

### DIFF
--- a/docs/content/en/main/concepts/syncer.md
+++ b/docs/content/en/main/concepts/syncer.md
@@ -118,7 +118,7 @@ kubernetes `APIExport` in workspace of `SyncTarget`, if any of these `APIExport`
 Alternatively, if you would like to bind other `APIExport`s which are supported by the `SyncerTarget`, run:
 
 ```
-kubectl kcp bind compute <workspace of synctarget> --apiexport <apiexport workspace>:<apiexport name>
+kubectl kcp bind compute <workspace of synctarget> --apiexports <apiexport workspace>:<apiexport name>
 ```
 
 In addition, you can specify the certain location or namespace to create placement. e.g.


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
In one of the kcp bind compute --apiexports has been added as --apiexport and if user tries to copy paste the same into his command line it throws an error which reads "unknown flag --apiexport" so fixing the same in docs
## Related issue(s)

Fixes #
