### PR TITLE
:bug: test/e2e/scheduling: don't require kind for upsynced test

### DIFF
--- a/test/e2e/reconciler/scheduling/upsynced_scheduling_test.go
+++ b/test/e2e/reconciler/scheduling/upsynced_scheduling_test.go
@@ -50,7 +50,7 @@ import (
 // 5. Delete the synctarget, and verify that the upsynced pod gets deleted.
 func TestUpsyncedScheduling(t *testing.T) {
 	t.Parallel()
-	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+	framework.Suite(t, "transparent-multi-cluster")
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	t.Cleanup(cancelFunc)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Upsynced test was created, requiring a real k8s cluster to run. This is not truly necessary so we can remove that requirement.

