### PR TITLE
🐛 Prevent gc/quota workqueue backlogs

### DIFF
--- a/pkg/reconciler/garbagecollector/garbagecollector_controller.go
+++ b/pkg/reconciler/garbagecollector/garbagecollector_controller.go
@@ -290,10 +290,13 @@ func (c *Controller) startGarbageCollectorForLogicalCluster(ctx context.Context,
 		}
 	}()
 
-	// Make sure the GC monitors are synced at least once
-	garbageCollector.ResyncMonitors(ctx, c.dynamicDiscoverySharedInformerFactory)
+	// Do this in a goroutine to avoid holding up a worker in the event ResyncMonitors stalls for whatever reason
+	go func() {
+		// Make sure the GC monitors are synced at least once
+		garbageCollector.ResyncMonitors(ctx, c.dynamicDiscoverySharedInformerFactory)
 
-	go garbageCollector.Run(ctx, c.workersPerLogicalCluster)
+		go garbageCollector.Run(ctx, c.workersPerLogicalCluster)
+	}()
 
 	return nil
 }

--- a/pkg/reconciler/kubequota/kubequota_controller.go
+++ b/pkg/reconciler/kubequota/kubequota_controller.go
@@ -309,10 +309,13 @@ func (c *Controller) startQuotaForLogicalCluster(ctx context.Context, clusterNam
 		}
 	}()
 
-	// Make sure the monitors are synced at least once
-	resourceQuotaController.UpdateMonitors(ctx, c.dynamicDiscoverySharedInformerFactory.ServerPreferredResources)
+	// Do this in a goroutine to avoid holding up a worker in the event UpdateMonitors stalls for whatever reason
+	go func() {
+		// Make sure the monitors are synced at least once
+		resourceQuotaController.UpdateMonitors(ctx, c.dynamicDiscoverySharedInformerFactory.ServerPreferredResources)
 
-	go resourceQuotaController.Run(ctx, c.workersPerLogicalCluster)
+		go resourceQuotaController.Run(ctx, c.workersPerLogicalCluster)
+	}()
 
 	return nil
 }


### PR DESCRIPTION
## Summary
Run the initial monitor syncing in a goroutine to avoid any stalling here to block a worker.

## Related issue(s)

Maybe #1878 #2665
