### PR TITLE
🐛 pkg/tunneler: remove non-error verbose log

### DIFF
--- a/pkg/tunneler/podsubresourceproxy_handler.go
+++ b/pkg/tunneler/podsubresourceproxy_handler.go
@@ -110,7 +110,6 @@ func (b *podSubresourceProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.
 	}
 
 	if cluster.Name.Empty() {
-		logger.Error(nil, "no cluster found in the context")
 		b.apiHandler.ServeHTTP(w, req)
 		return
 	}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

When the KCPSyncerTunnel feature is enabled, the podsubresourceproxy_handler outputs an error log line that's not an error and is too verbose:

```
E0208 19:18:24.074484 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:27.150451 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:28.073389 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:28.746808 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:30.579766 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:31.075186 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:32.343049 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:34.562156 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:36.427920 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
E0208 19:18:37.075720 1740192 podsubresourceproxy_handler.go:113] "no cluster found in the context"
```

This PR removes that log line. 
