### PR TITLE
🐛 tmc e2e: fix Syncer virtual workspace e2e test flakes

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -862,7 +862,7 @@ func newPersistentKCPServer(name, kubeconfigPath string, shardKubeconfigPaths ma
 func NewFakeWorkloadServer(t *testing.T, server RunningServer, org logicalcluster.Path, syncTargetName string) RunningServer {
 	t.Helper()
 
-	path, ws := NewWorkspaceFixture(t, server, org, WithName(syncTargetName+"-sink"))
+	path, ws := NewWorkspaceFixture(t, server, org, WithName(syncTargetName+"-sink"), TODO_WithoutMultiShardSupport())
 	logicalClusterName := logicalcluster.Name(ws.Spec.Cluster)
 	rawConfig, err := server.RawConfig()
 	require.NoError(t, err, "failed to read config for server")


### PR DESCRIPTION
## Summary

TMC E2E: Attempt at fixing Syncer virtual workspace e2e test flakes.
Not sure it would fix them all, but at east it fixes a possible cause, and increases log details (through the use of `framework.Eventually` instead of `require.Eventually`

## Related issue(s)

Fixes #
