### PR TITLE
🌱 Fix git in Prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,14 @@
 # We need bash for some conditional logic below.
 SHELL := /usr/bin/env bash -e
 
+#-----------------------------------------------------------------------------
+# Workaround git issues on OpenShift Prow CI, where the user running in the
+# job is not guaranteed to own the repo checkout.
+#-----------------------------------------------------------------------------
+ifeq ($(CI),true)
+   $(shell git config --global --add safe.directory '*')
+endif
+
 GO_INSTALL = ./hack/go-install.sh
 
 TOOLS_DIR=hack/tools


### PR DESCRIPTION
## Summary
Newer versions of git have a security measure in place to prevent git from parsing the .git/config file or running any hooks if the user running git is not the owner of the repository files. Prow runs as a random UID, which is not guaranteed to be the same as the UID that owns the cloned files, so this change disables the ownership check and considers all cloned repositories "safe" regardless of owner.

## Related issue(s)

Fixes #
