### PR TITLE
🌱 test/e2e,cmd/test: scrape metrics for test servers and e2e tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,13 +68,19 @@ jobs:
 
       - run: |-
           LOG_DIR=/tmp/e2e/shared-server/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 SUITES=transparent-multi-cluster:requires-kind \
-          make test-e2e-shared
+          ./hack/run-with-prometheus.sh make test-e2e-shared
 
       - uses: cytopia/upload-artifact-retry-action@v0.1.7
         if: ${{ always() }}
         with:
           name: e2e-shared-server
           path: /tmp/e2e/**/artifacts/
+
+      - uses: cytopia/upload-artifact-retry-action@v0.1.7
+        if: ${{ always() }}
+        with:
+          name: e2e-shared-server-metrics
+          path: /tmp/e2e/**/metrics/
 
   e2e-sharded:
     name: e2e-sharded
@@ -109,10 +115,16 @@ jobs:
 
     - run: |-
         LOG_DIR=/tmp/e2e/sharded/artifacts ARTIFACT_DIR=/tmp/e2e COUNT=2 SUITES=transparent-multi-cluster:requires-kind \
-        make test-e2e-sharded
+        ./hack/run-with-prometheus.sh make test-e2e-sharded
 
     - uses: cytopia/upload-artifact-retry-action@v0.1.7
       if: ${{ always() }}
       with:
         name: e2e-sharded
         path: /tmp/e2e/**/artifacts/
+
+    - uses: cytopia/upload-artifact-retry-action@v0.1.7
+      if: ${{ always() }}
+      with:
+        name: e2e-sharded-metrics
+        path: /tmp/e2e/**/metrics/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ tmp
 
 kcp-docs-image
 docs/site
+
+.prometheus_data
+.prometheus-config.yaml
+.prometheus-pid

--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -234,8 +234,12 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 
 	// Wait for shards to be ready
 	shardsErrCh := make(chan indexErrTuple)
-	for i, shard := range shards {
-		terminatedCh, err := shard.WaitForReady(ctx)
+	for i, s := range shards {
+		terminatedCh, err := s.WaitForReady(ctx)
+		if err != nil {
+			return err
+		}
+		err = shard.ScrapeMetrics(ctx, s, workDirPath)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
 	gopkg.in/square/go-jose.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.3
 	k8s.io/apiextensions-apiserver v0.24.3
 	k8s.io/apimachinery v0.24.3
@@ -170,7 +171,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cloud-provider v0.0.0 // indirect
 	k8s.io/component-helpers v0.0.0 // indirect
 	k8s.io/controller-manager v0.0.0 // indirect

--- a/hack/run-with-prometheus.sh
+++ b/hack/run-with-prometheus.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The KCP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+set -o errexit
+
+PROMETHEUS_VER=2.42.0
+ARCH=$(go env GOARCH)
+OS=$(go env GOOS)
+if ! command -v hack/tools/prometheus 1> /dev/null 2>&1; then
+  echo "Downloading Prometheus v${PROMETHEUS_VER}"
+  mkdir -p hack/tools
+  curl -L https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VER}/prometheus-${PROMETHEUS_VER}.${OS}-${ARCH}.tar.gz | tar -xz --strip-components 1 -C hack/tools prometheus-${PROMETHEUS_VER}.${OS}-${ARCH}/prometheus
+fi
+
+touch .prometheus-config.yaml
+./hack/tools/prometheus --storage.tsdb.path=".prometheus_data" --config.file=.prometheus-config.yaml --web.enable-lifecycle &
+PROM_PID=$!
+export PROMETHEUS_URL="http://localhost:9090"
+echo 'Waiting for Prometheus to be ready...'
+while ! curl -s http://localhost:9090/-/ready; do
+  sleep 1
+done
+echo 'Prometheus is ready!'
+
+set -o xtrace
+set +o errexit
+"${@}"
+EXIT_CODE=${?}
+set +o xtrace
+set -o errexit
+echo "Command terminated with ${EXIT_CODE}"
+
+if [ -n "${ARTIFACT_DIR:=}" ]; then
+  kill -TERM ${PROM_PID}
+  echo 'Waiting for Prometheus to shut down...'
+  while [ -f .prometheus_data/lock ]; do sleep 1; done
+  echo 'Prometheus shut down successfully!'
+  mkdir -p ${ARTIFACT_DIR}/metrics
+  tar cvzf ${ARTIFACT_DIR}/metrics/prometheus.tar -C .prometheus_data .
+fi
+
+exit "${EXIT_CODE}"

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -171,6 +171,10 @@ func ScratchDirs(t *testing.T) (string, string, error) {
 	return artifactDir, t.TempDir(), nil
 }
 
+func (c *kcpServer) CADirectory() string {
+	return c.dataDir
+}
+
 func (c *kcpServer) Artifact(t *testing.T, producer func() (runtime.Object, error)) {
 	t.Helper()
 	artifact(t, c, producer)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This adds support for scraping metrics via Prometheus for e2e tests and local shard testing. If the environment variable `PROMETHEUS_URL` is set, scraping targets are being configured automatically.

For e2e tests, `ARTIFACT_DIR` needs to be set additionally.

This is the first part of adding scraping support. The second part will add wiring in CI.

## Related issue(s)
