### PR TITLE
📖 Update link for investigations directory

### DIFF
--- a/docs/content/en/GOALS.md
+++ b/docs/content/en/GOALS.md
@@ -116,7 +116,7 @@ Not every idea below may bear fruit, but it's never the wrong time to look for n
 
 ### Process
 
-Right now we are interested in assessing how these goals fit within the larger ecosystem. The [investigations directory](https://github.com/kcp-dev/kcp/tree/main/docs/content/en/investigations) is where we will capture specific deep dive details.
+Right now we are interested in assessing how these goals fit within the larger ecosystem.
 
 
 ### Terminology

--- a/docs/content/en/GOALS.md
+++ b/docs/content/en/GOALS.md
@@ -116,7 +116,7 @@ Not every idea below may bear fruit, but it's never the wrong time to look for n
 
 ### Process
 
-Right now we are interested in assessing how these goals fit within the larger ecosystem. The [investigations directory](docs/investigations) is where we will capture specific deep dive details.
+Right now we are interested in assessing how these goals fit within the larger ecosystem. The [investigations directory](https://github.com/kcp-dev/kcp/tree/main/docs/content/en/investigations) is where we will capture specific deep dive details.
 
 
 ### Terminology


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The link for `investigations directory` in [docs website](https://docs.kcp.io/kcp/main/en/GOALS/#process) is pointing to a 404 page. It might be good to point to the investigations folder in GitHub instead of 404 page. 

