### PR TITLE
🌱 Make DirectOrGoRunCommand aware of the deployment-coordinator being moved to tmc/cmd

### DIFF
--- a/test/e2e/framework/kcp.go
+++ b/test/e2e/framework/kcp.go
@@ -584,6 +584,9 @@ func DirectOrGoRunCommand(executableName string) []string {
 		return []string{cmdPath}
 	}
 	cmdPath := filepath.Join(RepositoryDir(), "cmd", executableName)
+	if executableName == "deployment-coordinator" {
+		cmdPath = filepath.Join(RepositoryDir(), "tmc", "cmd", executableName)
+	}
 	return []string{"go", "run", cmdPath}
 }
 


### PR DESCRIPTION
## Summary
This PR makes DirectOrGoRunCommand func in the test framework aware of the deployment-coordinator being moved to tmc/cmd.