### PR TITLE
🌱 Add --labels to kubectl kcp workload sync

### DIFF
--- a/test/e2e/framework/syncer.go
+++ b/test/e2e/framework/syncer.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -184,13 +183,8 @@ func (sf *syncerFixture) CreateSyncTargetAndApplyToDownstream(t *testing.T) *app
 	for _, export := range sf.apiExports {
 		pluginArgs = append(pluginArgs, "--apiexports="+export)
 	}
-	if sf.syncTargetLabels != nil {
-		pairs := []string{}
-		for k, v := range sf.syncTargetLabels {
-			pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
-		}
-		sort.Strings(pairs)
-		pluginArgs = append(pluginArgs, "--labels="+strings.Join(pairs, ","))
+	for k, v := range sf.syncTargetLabels {
+		pluginArgs = append(pluginArgs, fmt.Sprintf("--labels=%s=%s", k, v))
 	}
 
 	syncerYAML := RunKcpCliPlugin(t, kubeconfigPath, pluginArgs)

--- a/test/e2e/reconciler/deployment/deployment_coordinator_test.go
+++ b/test/e2e/reconciler/deployment/deployment_coordinator_test.go
@@ -30,7 +30,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -71,18 +70,14 @@ func TestDeploymentCoordinator(t *testing.T) {
 	eastSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("east"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
+		framework.WithSyncTargetLabels(map[string]string{"region": "east"}),
 	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
-
-	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "east", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"east"}]`), metav1.PatchOptions{})
-	require.NoError(t, err)
 
 	westSyncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
 		framework.WithSyncTargetName("west"),
 		framework.WithSyncedUserWorkspaces(workloadWorkspace1, workloadWorkspace2),
+		framework.WithSyncTargetLabels(map[string]string{"region": "west"}),
 	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
-
-	_, err = kcpClusterClient.Cluster(locationWorkspacePath).WorkloadV1alpha1().SyncTargets().Patch(ctx, "west", types.JSONPatchType, []byte(`[{"op":"add","path":"/metadata/labels/region","value":"west"}]`), metav1.PatchOptions{})
-	require.NoError(t, err)
 
 	eastSyncer.WaitForSyncTargetReady(ctx, t)
 	westSyncer.WaitForSyncTargetReady(ctx, t)


### PR DESCRIPTION
## Summary
This PR adds a --labels flag to be used for setting labels in the SyncTarget created by `kcp workload sync`, thus allowing to easier to test scenarios like the east/west workload placement described in [this PR](https://github.com/kcp-dev/kcp/pull/2336) (it is not required anymore to patch SyncTarget after they are created).

The same capability is added to the `syncerFixture` in the test framework