### PR TITLE
:bug: cli: honor expanded `~` in kcp ws

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -119,6 +120,7 @@ func (o *UseWorkspaceOptions) BindFlags(cmd *cobra.Command) {
 
 // Run executes the "use workspace" logic based on the supplied options.
 func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
+	home, _ := os.UserHomeDir()
 	rawConfig, err := o.ClientConfig.RawConfig()
 	if err != nil {
 		return err
@@ -208,7 +210,7 @@ func (o *UseWorkspaceOptions) Run(ctx context.Context) error {
 		}()
 		fallthrough
 
-	case "~":
+	case "~", home:
 		homeWorkspace, err := o.kcpClusterClient.Cluster(core.RootCluster.Path()).TenancyV1alpha1().Workspaces().Get(ctx, "~", metav1.GetOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
Today, a user has to write `kubectl kcp ws '~'` to go home, as most shells will expand `~` to the home directory path before passing the argument to our CLI. This is awkward and we can do better.

We know that the literal content of the user's home directory cannot be a valid workspace name, since we don't allow path separators in workspace names. So, we can just handle the case where the argument we got *is* the home directory just like we handle it being `~`.

/assign @mjudeikis 