### PR TITLE
🐛 Fix workspace output when enter into home workspace

### DIFF
--- a/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
+++ b/pkg/cliplugins/workspace/plugin/kubeconfig_test.go
@@ -1232,6 +1232,25 @@ func TestUse(t *testing.T) {
 				return false, nil, nil
 			})
 
+			client.PrependReactor("get", "logicalclusters", func(action kcptesting.Action) (handled bool, ret runtime.Object, err error) {
+				getAction := action.(kcptesting.GetAction)
+				if getAction.GetCluster() != homeWorkspaceLogicalCluster {
+					return false, nil, nil
+				}
+				if getAction.GetName() == corev1alpha1.LogicalClusterName {
+					logicalCluster := &corev1alpha1.LogicalCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: corev1alpha1.LogicalClusterName,
+							Annotations: map[string]string{
+								core.LogicalClusterPathAnnotationKey: homeWorkspaceLogicalCluster.String(),
+							},
+						},
+					}
+					return true, logicalCluster, nil
+				}
+				return false, nil, nil
+			})
+
 			// return nothing in the default case.
 			getAPIBindings := func(ctx context.Context, kcpClusterClient kcpclientset.ClusterInterface, host string) ([]apisv1alpha1.APIBinding, error) {
 				return nil, nil


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

the workspace output when run `kubectl ws "~"` is not user friendly. 

I was 

```
$ k ws "~"
Current workspace is "kvdk2spgmbix".
```

with the fix, it is changed to

$ kubectl ws "~"
Current workspace is "user:kcp-admin". 

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/2737
