### PR TITLE
✨ Syncer: also mutate `StatefulSet`s and `ReplicaSet`s

### DIFF
--- a/pkg/syncer/spec/mutators/podspecable_test.go
+++ b/pkg/syncer/spec/mutators/podspecable_test.go
@@ -941,7 +941,7 @@ func TestDeploymentMutate(t *testing.T) {
 				require.NoError(t, err, "Service Add() = %v", err)
 				svcLister := listerscorev1.NewServiceLister(serviceIndexer)
 
-				dm := NewDeploymentMutator(upstreamURL, secretLister, svcLister, clusterName, "syncTargetUID", "syncTargetName", "dnsNamespace", c.upsyncPods)
+				dm := NewPodspecableMutator(upstreamURL, secretLister, svcLister, clusterName, "syncTargetUID", "syncTargetName", "dnsNamespace", c.upsyncPods)
 
 				unstrOriginalDeployment, err := toUnstructured(c.originalDeployment)
 				require.NoError(t, err, "toUnstructured() = %v", err)

--- a/pkg/syncer/spec/mutators/secrets.go
+++ b/pkg/syncer/spec/mutators/secrets.go
@@ -25,11 +25,13 @@ import (
 type SecretMutator struct {
 }
 
-func (sm *SecretMutator) GVR() schema.GroupVersionResource {
-	return schema.GroupVersionResource{
-		Group:    "",
-		Version:  "v1",
-		Resource: "secrets",
+func (sm *SecretMutator) GVRs() []schema.GroupVersionResource {
+	return []schema.GroupVersionResource{
+		{
+			Group:    "",
+			Version:  "v1",
+			Resource: "secrets",
+		},
 	}
 }
 

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -51,8 +51,6 @@ const (
 	syncerApplyManager = "syncer"
 )
 
-type mutatorGvrMap map[schema.GroupVersionResource]func(obj *unstructured.Unstructured) error
-
 func deepEqualApartFromStatus(logger logr.Logger, oldUnstrob, newUnstrob *unstructured.Unstructured) bool {
 	// TODO(jmprusi): Remove this after switching to virtual workspaces.
 	// remove status annotation from oldObj and newObj before comparing
@@ -443,7 +441,7 @@ func (c *Controller) applyToDownstream(ctx context.Context, gvr schema.GroupVers
 
 	// Run any transformations on the object before we apply it to the downstream cluster.
 	if mutator, ok := c.mutators[gvr]; ok {
-		if err := mutator(downstreamObj); err != nil {
+		if err := mutator.Mutate(downstreamObj); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- Also mutate the `StatefulSet`s and the `ReplicaSet`s as it is done for the `Deployment`s
- Extract the mutators from the SpecSyncer (will make it easier to disable them in alternate syncers)

## Related issue(s)

Fixes #2844
