### PR TITLE
🐛 Fix the spec.URL in workspace using canonicalPath

### DIFF
--- a/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_reconcile_scheduling_test.go
@@ -92,7 +92,7 @@ func TestReconcileScheduling(t *testing.T) {
 
 				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
 				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
-				initialWS.Spec.URL = `https://root/clusters/root-foo`
+				initialWS.Spec.URL = `https://root/clusters/root:foo`
 				initialWS.Spec.Cluster = "root-foo"
 				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
 					Type:   tenancyv1alpha1.WorkspaceScheduled,
@@ -126,7 +126,7 @@ func TestReconcileScheduling(t *testing.T) {
 
 				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
 				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
-				initialWS.Spec.URL = `https://root/clusters/root-foo`
+				initialWS.Spec.URL = `https://root/clusters/root:foo`
 				initialWS.Spec.Cluster = "root-foo"
 				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
 					Type:   tenancyv1alpha1.WorkspaceScheduled,
@@ -189,7 +189,7 @@ func TestReconcileScheduling(t *testing.T) {
 
 				clearLastTransitionTimeOnWsConditions(wsAfterReconciliation)
 				initialWS.CreationTimestamp = wsAfterReconciliation.CreationTimestamp
-				initialWS.Spec.URL = `https://root/clusters/root-foo`
+				initialWS.Spec.URL = `https://root/clusters/root:foo`
 				initialWS.Spec.Cluster = "root-foo"
 				initialWS.Status.Conditions = append(initialWS.Status.Conditions, conditionsapi.Condition{
 					Type:   tenancyv1alpha1.WorkspaceScheduled,

--- a/test/e2e/reconciler/workspace/controller_test.go
+++ b/test/e2e/reconciler/workspace/controller_test.go
@@ -18,6 +18,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -131,7 +132,10 @@ func TestWorkspaceController(t *testing.T) {
 
 				workspace, err = server.orgWorkspaceKcpClient.TenancyV1alpha1().Workspaces().Get(ctx, workspace.Name, metav1.GetOptions{})
 				require.NoError(t, err)
-				require.Emptyf(t, cmp.Diff(previouslyValidShard.Spec.BaseURL+"/clusters/"+workspace.Spec.Cluster, workspace.Spec.URL), "incorrect URL")
+				orgLogicalCluster, err := server.orgWorkspaceKcpClient.CoreV1alpha1().LogicalClusters().Get(ctx, corev1alpha1.LogicalClusterName, metav1.GetOptions{})
+				require.NoError(t, err)
+				path := fmt.Sprintf("%s:%s", orgLogicalCluster.Annotations[core.LogicalClusterPathAnnotationKey], workspace.Name)
+				require.Emptyf(t, cmp.Diff(previouslyValidShard.Spec.BaseURL+"/clusters/"+path, workspace.Spec.URL), "incorrect URL")
 			},
 		},
 	}


### PR DESCRIPTION
The spec.URL in workspace should use canonicalPath

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
The spec.URL of workspace should use canonicalPath instead of absolute path.

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/2737
