### PR TITLE
:bug:  Add verb `access`to syncer

### DIFF
--- a/pkg/cliplugins/workload/plugin/sync.go
+++ b/pkg/cliplugins/workload/plugin/sync.go
@@ -548,6 +548,10 @@ func (o *SyncOptions) enableSyncerForWorkspace(ctx context.Context, config *rest
 			APIGroups: []string{apiresourcev1alpha1.SchemeGroupVersion.Group},
 			Resources: []string{"apiresourceimports"},
 		},
+		{
+			Verbs:           []string{"access"},
+			NonResourceURLs: []string{"/"},
+		},
 	}
 
 	cr, err := kubeClient.RbacV1().ClusterRoles().Get(ctx,


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add `access` verb to default syncer cluster role for `NonResourceURLs: /` 

