### PR TITLE
:sparkles: Add Ready column to `APIBinding` and `APIExport`

### DIFF
--- a/config/crds/apis.kcp.io_apibindings.yaml
+++ b/config/crds/apis.kcp.io_apibindings.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crds/apis.kcp.io_apiexports.yaml
+++ b/config/crds/apis.kcp.io_apiexports.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    - jsonPath: .status.conditions[?(@.type=="VirtualWorkspaceURLsReady")].status
+      name: Ready
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/pkg/apis/apis/v1alpha1/types_apibinding.go
+++ b/pkg/apis/apis/v1alpha1/types_apibinding.go
@@ -40,6 +40,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=kcp
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 type APIBinding struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/pkg/apis/apis/v1alpha1/types_apiexport.go
+++ b/pkg/apis/apis/v1alpha1/types_apiexport.go
@@ -53,6 +53,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories=kcp
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="VirtualWorkspaceURLsReady")].status`
 type APIExport struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Adds column for readiness of apibinding and apiexport:
```
[mjudeikis@unknown2 kcp]$ k get apiexport 
NAME                 AGE   READY
apiresource.kcp.io   13d   True
scheduling.kcp.io    13d   True
shards.core.kcp.io   13d   True
tenancy.kcp.io       13d   True
topology.kcp.io      13d   True
workload.kcp.io      13d   True
[mjudeikis@unknown2 kcp]$ k get apibinding
NAME                 AGE   READY
apiresource.kcp.io   13d   True
scheduling.kcp.io    13d   True
shards.core.kcp.io   13d   True
tenancy.kcp.io       13d   True
topology.kcp.io      13d   True
workload.kcp.io      13d   True
```

## Related issue(s)

Fixes #2182
