### PR TITLE
🌱 Switch workload/namespace controller to use committer

### DIFF
--- a/pkg/reconciler/workload/namespace/namespace_reconcile_placementbind.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile_placementbind.go
@@ -18,73 +18,54 @@ package namespace
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/kcp-dev/logicalcluster/v3"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/scheduling/v1alpha1"
 	"github.com/kcp-dev/kcp/sdk/apis/third_party/conditions/util/conditions"
 )
 
-// bindNamespaceReconciler updates the existing annotation and creates an empty one if
-// at least one placement matches and there is no annotation. It delete the annotation
+// reconcilePlacementBind updates the existing scheduling.kcp.io/placement annotation and creates an
+// empty one if at least one placement matches and there is no annotation. It deletes the annotation
 // if there is no matched placement.
+//
 // TODO this should be reconsidered when we want lazy binding.
-type bindNamespaceReconciler struct {
-	listPlacement func(clusterName logicalcluster.Name) ([]*schedulingv1alpha1.Placement, error)
-
-	patchNamespace func(ctx context.Context, clusterName logicalcluster.Path, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*corev1.Namespace, error)
-}
-
-func (r *bindNamespaceReconciler) reconcile(ctx context.Context, ns *corev1.Namespace) (reconcileStatus, *corev1.Namespace, error) {
-	logger := klog.FromContext(ctx)
+func (c *controller) reconcilePlacementBind(
+	_ context.Context,
+	_ string,
+	ns *corev1.Namespace,
+) (reconcileResult, error) {
 	clusterName := logicalcluster.From(ns)
 
-	_, foundPlacement := ns.Annotations[schedulingv1alpha1.PlacementAnnotationKey]
-
-	validPlacements, err := r.validPlacements(clusterName, ns)
+	validPlacements, err := c.validPlacements(clusterName, ns)
 	if err != nil {
-		return reconcileStatusContinue, ns, err
+		return reconcileResult{stop: true}, err
 	}
 
-	expectedAnnotations := map[string]interface{}{} // nil means to remove the key
-	if len(validPlacements) > 0 && !foundPlacement {
-		expectedAnnotations[schedulingv1alpha1.PlacementAnnotationKey] = ""
-	} else if len(validPlacements) == 0 && foundPlacement {
-		expectedAnnotations[schedulingv1alpha1.PlacementAnnotationKey] = nil
+	_, hasPlacement := ns.Annotations[schedulingv1alpha1.PlacementAnnotationKey]
+	shouldHavePlacement := len(validPlacements) > 0
+
+	switch {
+	case shouldHavePlacement && hasPlacement, !shouldHavePlacement && !hasPlacement:
+		return reconcileResult{}, nil
+	case shouldHavePlacement && !hasPlacement:
+		if ns.Annotations == nil {
+			ns.Annotations = make(map[string]string)
+		}
+		ns.Annotations[schedulingv1alpha1.PlacementAnnotationKey] = ""
+	case !shouldHavePlacement && hasPlacement:
+		delete(ns.Annotations, schedulingv1alpha1.PlacementAnnotationKey)
 	}
 
-	if len(expectedAnnotations) == 0 {
-		return reconcileStatusContinue, ns, nil
-	}
-
-	patch := map[string]interface{}{}
-	if err := unstructured.SetNestedField(patch, expectedAnnotations, "metadata", "annotations"); err != nil {
-		return reconcileStatusStop, ns, err
-	}
-
-	patchBytes, err := json.Marshal(patch)
-	if err != nil {
-		return reconcileStatusStop, ns, err
-	}
-	logger.WithValues("patch", string(patchBytes)).V(3).Info("patching Namespace to update placement annotation")
-	updated, err := r.patchNamespace(ctx, clusterName.Path(), ns.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-	if err != nil {
-		return reconcileStatusStop, ns, err
-	}
-
-	return reconcileStatusContinue, updated, nil
+	return reconcileResult{stop: true}, nil
 }
 
-func (r *bindNamespaceReconciler) validPlacements(clusterName logicalcluster.Name, ns *corev1.Namespace) ([]*schedulingv1alpha1.Placement, error) {
-	placements, err := r.listPlacement(clusterName)
+func (c *controller) validPlacements(clusterName logicalcluster.Name, ns *corev1.Namespace) ([]*schedulingv1alpha1.Placement, error) {
+	placements, err := c.listPlacements(clusterName)
 
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/workload/namespace/namespace_reconcile_status_test.go
+++ b/pkg/reconciler/workload/namespace/namespace_reconcile_status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package namespace
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,13 +65,18 @@ func TestSetScheduledCondition(t *testing.T) {
 					Annotations: testCase.annotations,
 				},
 			}
-			updatedNs := setScheduledCondition(ns)
+
+			c := &controller{}
+			result, err := c.reconcileStatus(context.Background(), "key", ns)
+			require.NoError(t, err)
+			require.False(t, result.stop)
+			require.Zero(t, result.requeueAfter)
 
 			if !testCase.scheduled && testCase.reason == "" {
-				c := conditions.Get(&NamespaceConditionsAdapter{updatedNs}, NamespaceScheduled)
+				c := conditions.Get(&NamespaceConditionsAdapter{ns}, NamespaceScheduled)
 				require.Nil(t, c)
 			} else {
-				c := conditions.Get(&NamespaceConditionsAdapter{updatedNs}, NamespaceScheduled)
+				c := conditions.Get(&NamespaceConditionsAdapter{ns}, NamespaceScheduled)
 				require.NotNil(t, c)
 				scheduled := c.Status == corev1.ConditionTrue
 				require.Equal(t, testCase.scheduled, scheduled, "unexpected value for scheduled")

--- a/sdk/apis/scheduling/v1alpha1/types_location.go
+++ b/sdk/apis/scheduling/v1alpha1/types_location.go
@@ -25,7 +25,8 @@ const (
 	// representation of the location labels in order to use them in a table column in the CLI.
 	LocationLabelsStringAnnotationKey = "scheduling.kcp.io/labels"
 
-	// PlacementAnnotationKey is the label key for the label holding a PlacementAnnotation struct.
+	// PlacementAnnotationKey is the label key for a namespace that indicates the namespace's labels match the selector
+	// in at least one ready Placement.
 	PlacementAnnotationKey = "scheduling.kcp.io/placement"
 )
 


### PR DESCRIPTION
## Summary
1. Switch committer to allow changes to both spec/meta and status in the same reconcile loop. If both were changed, only the spec/meta patch is sent. If nothing else changes, the presumption is the status patch will go through on the next reconcile iteration.
2. Switch workload/namespace controller to use committer. This involved removing the individual places where it was sending namespace patches directly and replacing them with calculating the desired state of the namespace in the reconcile logic. Then, after reconcile() is done, the committer will send a patch if needed.

## Related issue(s)

Part of #2635