### PR TITLE
:sparkles: WIP: add network policy blocking cross-tenant pod traffic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0
 	github.com/kcp-dev/client-go v0.0.0-20230126185145-aeff170a288b
+	github.com/kcp-dev/kcp/pkg/apis v0.11.0
 	github.com/kcp-dev/kcp/sdk v0.0.0-00010101000000-000000000000
 	github.com/kcp-dev/logicalcluster/v3 v3.0.2
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -390,6 +390,8 @@ github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0 h1:fb+3CdDlxvnK+o1wm3IcDbD+MJn
 github.com/kcp-dev/apimachinery/v2 v2.0.0-alpha.0/go.mod h1:dn1hXHMY9E6JbyOGa0qXt1Dq4akd/jHMZOpFhJoX7q4=
 github.com/kcp-dev/client-go v0.0.0-20230126185145-aeff170a288b h1:7Raw5C50fye3c7FkltMWI4iAarVI5DQk9fnO6kkWd1s=
 github.com/kcp-dev/client-go v0.0.0-20230126185145-aeff170a288b/go.mod h1:sj0r6sAHNsfEpA37uLTVGZj9TMQQWjBXk4rbpcIDZ7U=
+github.com/kcp-dev/kcp/pkg/apis v0.11.0 h1:K6p+tNHNcvfACCPLcHgY0EMLeaIwR1jS491FyLfXMII=
+github.com/kcp-dev/kcp/pkg/apis v0.11.0/go.mod h1:8cUAmfMJcksauz53UtsLYG8Phhx62rvuCnd/5t/Zihk=
 github.com/kcp-dev/kubernetes v0.0.0-20230217143502-6ebb9f064d8c h1:ZX1WA1XHqOHHVbWv9JhTwGgRwzr2GcXEwNybKu6hNdE=
 github.com/kcp-dev/kubernetes v0.0.0-20230217143502-6ebb9f064d8c/go.mod h1:4QB1cLeQCAsBfp/zCmpPBax3pKOpyGpk+9aO1KqTdMQ=
 github.com/kcp-dev/kubernetes/staging/src/k8s.io/api v0.0.0-20230217143502-6ebb9f064d8c h1:R0wxFaiyjtZT7A/1jgM9LaI9yzqm+G+9OdL5fcSCSq8=

--- a/pkg/cliplugins/workload/plugin/sync_test.go
+++ b/pkg/cliplugins/workload/plugin/sync_test.go
@@ -82,6 +82,8 @@ rules:
   - "create"
   - "list"
   - "watch"
+  - "get"
+  - "update"
 - apiGroups:
   - ""
   resources:
@@ -326,6 +328,8 @@ rules:
   - "create"
   - "list"
   - "watch"
+  - "get"
+  - "update"
 - apiGroups:
   - ""
   resources:

--- a/pkg/cliplugins/workload/plugin/syncer.yaml
+++ b/pkg/cliplugins/workload/plugin/syncer.yaml
@@ -56,6 +56,8 @@ rules:
   - "create"
   - "list"
   - "watch"
+  - "get"
+  - "update"
 {{- range $groupMapping := .GroupMappings}}
 - apiGroups:
   - "{{$groupMapping.APIGroup}}"

--- a/pkg/syncer/shared/networkpolicy.go
+++ b/pkg/syncer/shared/networkpolicy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The KCP Authors.
+Copyright 2023 The KCP Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -49,12 +49,15 @@ func MakeAPIServerNetworkPolicyEgressRule(ctx context.Context, kubeClient kubern
 		}
 	}
 
-	ports := make([]networkingv1.NetworkPolicyPort, len(subset.Ports))
-	for i, port := range subset.Ports {
-		pport := intstr.FromInt(int(port.Port))
-		ports[i].Port = &pport
-		pprotocol := port.Protocol
-		ports[i].Protocol = &pprotocol
+	var ports []networkingv1.NetworkPolicyPort
+	if len(subset.Ports) > 0 {
+		ports = make([]networkingv1.NetworkPolicyPort, len(subset.Ports))
+		for i, port := range subset.Ports {
+			pport := intstr.FromInt(int(port.Port))
+			ports[i].Port = &pport
+			pprotocol := port.Protocol
+			ports[i].Protocol = &pprotocol
+		}
 	}
 
 	return &networkingv1.NetworkPolicyEgressRule{

--- a/pkg/syncer/shared/networkpolicy.go
+++ b/pkg/syncer/shared/networkpolicy.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// MakeAPIServerNetworkPolicyEgressRule creates a network policy egress rule to allow traffic to Kubernetes API Server
+// MakeAPIServerNetworkPolicyEgressRule creates a network policy egress rule to allow traffic to Kubernetes API Server.
 func MakeAPIServerNetworkPolicyEgressRule(ctx context.Context, kubeClient kubernetes.Interface) (*networkingv1.NetworkPolicyEgressRule, error) {
 	var kubeEndpoints *corev1.Endpoints
 

--- a/pkg/syncer/shared/networkpolicy.go
+++ b/pkg/syncer/shared/networkpolicy.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+// MakeAPIServerNetworkPolicyEgressRule creates a network policy egress rule to allow traffic to Kubernetes API Server
+func MakeAPIServerNetworkPolicyEgressRule(ctx context.Context, kubeClient kubernetes.Interface) (*networkingv1.NetworkPolicyEgressRule, error) {
+	var kubeEndpoints *corev1.Endpoints
+
+	kubeEndpoints, err := kubeClient.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if len(kubeEndpoints.Subsets) == 0 || len(kubeEndpoints.Subsets[0].Addresses) == 0 {
+		return nil, errors.New("missing kubernetes API endpoints")
+	}
+
+	subset := kubeEndpoints.Subsets[0]
+	to := make([]networkingv1.NetworkPolicyPeer, len(subset.Addresses))
+	for i, endpoint := range subset.Addresses {
+		to[i] = networkingv1.NetworkPolicyPeer{
+			IPBlock: &networkingv1.IPBlock{
+				CIDR: endpoint.IP + "/32",
+			},
+		}
+	}
+
+	ports := make([]networkingv1.NetworkPolicyPort, len(subset.Ports))
+	for i, port := range subset.Ports {
+		pport := intstr.FromInt(int(port.Port))
+		ports[i].Port = &pport
+		pprotocol := port.Protocol
+		ports[i].Protocol = &pprotocol
+	}
+
+	return &networkingv1.NetworkPolicyEgressRule{
+		To:    to,
+		Ports: ports,
+	}, nil
+}

--- a/pkg/syncer/shared/networkpolicy_test.go
+++ b/pkg/syncer/shared/networkpolicy_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
+	"k8s.io/utils/semantic"
+)
+
+func TestMakeAPIServerNetworkPolicyEgressRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		objects  []runtime.Object
+		wantErr  bool
+		wantRule *networkingv1.NetworkPolicyEgressRule
+	}{
+		{
+			name:    "no kube endpoint",
+			wantErr: true,
+		},
+		{
+			name: "kube endpoint with no subsets",
+			objects: []runtime.Object{
+				endpoints("kubernetes", "default", "", 0),
+			},
+			wantErr: true,
+		},
+		{
+			name: "kube endpoint with at one subset, IP, no ports",
+			objects: []runtime.Object{
+				endpoints("kubernetes", "default", "8.8.8.8", 0),
+			},
+			wantRule: &networkingv1.NetworkPolicyEgressRule{
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "8.8.8.8/32",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "kube endpoint with at one subset, IP, with ports",
+			objects: []runtime.Object{
+				endpoints("kubernetes", "default", "8.8.8.8", 80),
+			},
+			wantRule: &networkingv1.NetworkPolicyEgressRule{
+
+				To: []networkingv1.NetworkPolicyPeer{
+					{
+						IPBlock: &networkingv1.IPBlock{
+							CIDR: "8.8.8.8/32",
+						},
+					},
+				},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{
+						Port:     &intstr.IntOrString{IntVal: 80},
+						Protocol: (*corev1.Protocol)(pointer.StringPtr("TCP")),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := kubefake.NewSimpleClientset(tt.objects...)
+
+			rule, err := MakeAPIServerNetworkPolicyEgressRule(context.Background(), kubeClient)
+
+			if err == nil && tt.wantErr {
+				t.Error("expected an error, got no error")
+			}
+
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+			if !semantic.EqualitiesOrDie().DeepEqual(tt.wantRule, rule) {
+				t.Errorf("got = %v, want %v", rule, tt.wantRule)
+			}
+		})
+	}
+
+}
+
+func endpoints(name, namespace, ip string, port int32) *corev1.Endpoints {
+	endpoint := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if ip != "" {
+		endpoint.Subsets = []corev1.EndpointSubset{{Addresses: []corev1.EndpointAddress{{IP: ip}}}}
+
+		if port != 0 {
+			endpoint.Subsets[0].Ports = []corev1.EndpointPort{{Port: port, Protocol: corev1.ProtocolTCP}}
+		}
+	}
+
+	return endpoint
+}

--- a/pkg/syncer/shared/networkpolicy_test.go
+++ b/pkg/syncer/shared/networkpolicy_test.go
@@ -108,7 +108,6 @@ func TestMakeAPIServerNetworkPolicyEgressRule(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func endpoints(name, namespace, ip string, port int32) *corev1.Endpoints {

--- a/pkg/syncer/spec/networkpolicy_tenant.yaml
+++ b/pkg/syncer/spec/networkpolicy_tenant.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kcp-tenant
+spec:
+  podSelector: {}
+  ingress:
+    - from: # allow ingress traffic from pods in namespaces belonging to TenantID
+      - namespaceSelector:
+          matchLabels:
+            kcp.io/tenant-id: TenantID
+  egress:
+    - to: # allow egress traffic to pods in namespaces belonging to TenantID
+      - namespaceSelector:
+          matchLabels:
+            kcp.io/tenant-id: TenantID
+    - to: # Allow all traffic to the internet
+      - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+    - to: # Allow traffic to the TenantID DNS pods
+      - namespaceSelector:
+          matchLabels:
+            internal.workload.kcp.io/cluster: SyncTargetKey
+        podSelector:
+          matchLabels:
+            kcp.io/tenant-id: TenantID
+      ports:
+        - protocol: TCP
+          port: 5353
+        - protocol: UDP
+          port: 5353
+    - to: # Allow traffic to the Kubernetes API server
+      # one ipBlock per IP (dynamically filled)
+      - ipBlock:
+          cidr: APIServerIP
+      ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress
+    - Ingress

--- a/pkg/syncer/spec/resources.go
+++ b/pkg/syncer/spec/resources.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spec
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	workloadv1alpha1 "github.com/kcp-dev/kcp/pkg/apis/workload/v1alpha1"
+	"github.com/kcp-dev/kcp/pkg/syncer/shared"
+)
+
+//go:embed *.yaml
+var networkPoliciesFiles embed.FS
+
+var (
+	tenantNetworkPolicyTemplate networkingv1.NetworkPolicy
+)
+
+func init() {
+	loadTemplateOrDie("networkpolicy_tenant.yaml", &tenantNetworkPolicyTemplate)
+}
+
+func MakeTenantNetworkPolicy(namespace, tenantID, syncTargetKey string, apiServerRule *networkingv1.NetworkPolicyEgressRule) *networkingv1.NetworkPolicy {
+	np := tenantNetworkPolicyTemplate.DeepCopy()
+
+	np.Namespace = namespace
+	np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels[shared.TenantIDLabel] = tenantID
+
+	np.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels[shared.TenantIDLabel] = tenantID
+
+	np.Spec.Egress[2].To[0].NamespaceSelector.MatchLabels[workloadv1alpha1.InternalDownstreamClusterLabel] = syncTargetKey
+	np.Spec.Egress[2].To[0].PodSelector.MatchLabels[shared.TenantIDLabel] = tenantID
+
+	np.Spec.Egress[3] = *apiServerRule
+
+	return np
+}
+
+// load a YAML resource into a typed kubernetes object.
+func loadTemplateOrDie(filename string, obj interface{}) {
+	raw, err := networkPoliciesFiles.ReadFile(filename)
+	if err != nil {
+		panic(fmt.Sprintf("failed to read file: %v", err))
+	}
+	decoder := yaml.NewYAMLToJSONDecoder(bytes.NewReader(raw))
+
+	var u unstructured.Unstructured
+	err = decoder.Decode(&u)
+	if err != nil {
+		panic(fmt.Sprintf("failed to decode file: %v", err))
+	}
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, obj)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert object: %v", err))
+	}
+}

--- a/pkg/syncer/spec/spec_process.go
+++ b/pkg/syncer/spec/spec_process.go
@@ -285,10 +285,11 @@ func (c *Controller) ensureDownstreamObjectsExists(ctx context.Context, downstre
 	}
 
 	// Check if the namespace already exists, if not create it.
-	namespaceExists := false
+	namespaceExists := true
 	namespace, err := namespaceLister.Get(newNamespace.GetName())
 	if apierrors.IsNotFound(err) {
 		_, err = namespaces.Create(ctx, newNamespace, metav1.CreateOptions{})
+		namespaceExists = false
 
 		if err == nil {
 			logger.Info("Created downstream namespace for upstream namespace")
@@ -296,7 +297,6 @@ func (c *Controller) ensureDownstreamObjectsExists(ctx context.Context, downstre
 	}
 	if apierrors.IsAlreadyExists(err) {
 		namespace, err = namespaces.Get(ctx, newNamespace.GetName(), metav1.GetOptions{})
-		namespaceExists = true
 	}
 	if err != nil {
 		return err
@@ -327,7 +327,6 @@ func (c *Controller) ensureDownstreamObjectsExists(ctx context.Context, downstre
 	}
 
 	// Check the kcp tenant network policy exists
-
 	apiServerRule, err := shared.MakeAPIServerNetworkPolicyEgressRule(ctx, c.downstreamKubeClient)
 	if err != nil {
 		return err

--- a/test/e2e/syncer/networkpolicies/networkpolicies_test.go
+++ b/test/e2e/syncer/networkpolicies/networkpolicies_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2023 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpoints
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kcp-dev/logicalcluster/v3"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kcp-dev/kcp/test/e2e/framework"
+	"github.com/kcp-dev/kcp/test/e2e/syncer/networkpolicies/workspace1"
+)
+
+func TestNetworkPolicies(t *testing.T) {
+	t.Parallel()
+	framework.Suite(t, "transparent-multi-cluster:requires-kind")
+
+	if len(framework.TestConfig.PClusterKubeconfig()) == 0 {
+		t.Skip("Test requires a pcluster")
+	}
+
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	t.Cleanup(cancelFunc)
+
+	upstreamServer := framework.SharedKcpServer(t)
+
+	upstreamConfig := upstreamServer.BaseConfig(t)
+
+	orgPath, _ := framework.NewOrganizationFixture(t, upstreamServer, framework.TODO_WithoutMultiShardSupport())
+
+	locationWorkspacePath, _ := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("location"), framework.TODO_WithoutMultiShardSupport())
+
+	workloadWorkspace1Path, workloadWorkspace1 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload"), framework.TODO_WithoutMultiShardSupport())
+	workloadWorkspace2Path, workloadWorkspace2 := framework.NewWorkspaceFixture(t, upstreamServer, orgPath, framework.WithName("workload"), framework.TODO_WithoutMultiShardSupport())
+
+	syncer := framework.NewSyncerFixture(t, upstreamServer, locationWorkspacePath,
+		framework.WithSyncedUserWorkspaces(workloadWorkspace1),
+		framework.WithSyncedUserWorkspaces(workloadWorkspace2),
+	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
+	syncer.WaitForSyncTargetReady(ctx, t)
+
+	downstreamKubeClient, err := kubernetes.NewForConfig(syncer.DownstreamConfig)
+	require.NoError(t, err)
+
+	upstreamKubeClient, err := kubernetes.NewForConfig(upstreamConfig)
+	require.NoError(t, err)
+
+	t.Logf("Bind workload workspace 1 to location workspace")
+	framework.NewBindCompute(t, workloadWorkspace1Path, upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWorkspacePath),
+	).Bind(t)
+
+	err = framework.CreateResources(ctx, workspace1.FS, upstreamConfig, workloadWorkspace1Path)
+	require.NoError(t, err)
+
+	downstreamNamespace1 := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace1.Spec.Cluster), "default")
+	t.Logf("Downstream namespace for workspace 1 is %s", downstreamNamespace1)
+
+	t.Log("Checking services in workspace 1 have been created downstream")
+	var service corev1.Service
+	framework.Eventually(t, func() (success bool, reason string) {
+		services, err := downstreamKubeClient.CoreV1().Services(downstreamNamespace1).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting services: %v\n", err)
+		}
+		if len(services.Items) != 1 {
+			return false, fmt.Sprintf("expecting 1 service, got: %d\n", len(services.Items))
+		}
+
+		service = services.Items[0]
+		if service.Spec.ClusterIP == "" {
+			return false, "service cluster IP is empty"
+		}
+
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Service in workspace 1 haven't been created")
+
+	t.Logf("Bind workload workspace 2 to location workspace")
+	framework.NewBindCompute(t, workloadWorkspace2Path, upstreamServer,
+		framework.WithLocationWorkspaceWorkloadBindOption(locationWorkspacePath),
+	).Bind(t)
+
+	downstreamNamespace2 := syncer.DownstreamNamespaceFor(t, logicalcluster.Name(workloadWorkspace2.Spec.Cluster), "default")
+	t.Logf("Downstream namespace for workspace 2 is %s", downstreamNamespace2)
+
+	_, err = upstreamKubeClient.CoreV1().ConfigMaps("default").Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "ip"}, Data: map[string]string{"ip": service.Spec.ClusterIP}}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	framework.Eventually(t, func() (success bool, reason string) {
+		deployments, err := upstreamKubeClient.AppsV1().Deployments(downstreamNamespace2).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("error while getting deployments: %v\n", err)
+		}
+		if len(deployments.Items) != 1 {
+			return false, fmt.Sprintf("expecting 1 deployment, got: %d\n", len(deployments.Items))
+		}
+
+		return true, ""
+	}, wait.ForeverTestTimeout, time.Millisecond*500, "Service in workspace 1 haven't been created")
+
+	t.Logf("Check k8s APIServer is reachable")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamNamespace1, "ping-apiserver", "PING"),
+		wait.ForeverTestTimeout, time.Millisecond*500, "APIServer is not reachable")
+
+	t.Logf("Check out-of-cluster host is reachable")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamNamespace1, "ping-external", "PING"),
+		wait.ForeverTestTimeout, time.Millisecond*500, "External host is not reachable")
+
+	t.Logf("Check other tenant pod is not reachable")
+	framework.Eventually(t, checkLogs(ctx, t, downstreamKubeClient, downstreamNamespace2, "ping-other-tenant-fail", "ping: bad"),
+		wait.ForeverTestTimeout, time.Millisecond*500, "Other tenant pod was reachable")
+}
+
+func checkLogs(ctx context.Context, t *testing.T, downstreamKubeClient *kubernetes.Clientset, downstreamNamespace, containerName, expectedPrefix string) func() (success bool, reason string) {
+	t.Helper()
+
+	return func() (success bool, reason string) {
+		pods, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, fmt.Sprintf("Error getting pods: %v", err)
+		}
+
+		for _, pod := range pods.Items {
+			for _, c := range pod.Spec.Containers {
+				if c.Name == containerName {
+					res, err := downstreamKubeClient.CoreV1().Pods(downstreamNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+						Container: c.Name,
+					}).DoRaw(ctx)
+
+					if err != nil {
+						return false, fmt.Sprintf("Failed to get logs for pod %s/%s container %s: %v", pod.Namespace, pod.Name, c.Name, err)
+					}
+
+					for _, line := range strings.Split(string(res), "\n") {
+						t.Logf("Pod %s/%s container %s: %s", pod.Namespace, pod.Name, c.Name, line)
+						if strings.HasPrefix(line, expectedPrefix) {
+							return true, ""
+						}
+					}
+				}
+			}
+		}
+		return false, "no pods"
+	}
+}

--- a/test/e2e/syncer/networkpolicies/workspace1/deployment-ping-apiserver.yaml
+++ b/test/e2e/syncer/networkpolicies/workspace1/deployment-ping-apiserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-apiserver
+spec:
+  selector:
+    matchLabels:
+      app: ping-apiserver
+  template:
+    metadata:
+      labels:
+        app: ping-apiserver
+    spec:
+      containers:
+      - name: ping-apiserver
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping ${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}; do sleep 1; done']

--- a/test/e2e/syncer/networkpolicies/workspace1/deployment-ping-external.yaml
+++ b/test/e2e/syncer/networkpolicies/workspace1/deployment-ping-external.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-external
+spec:
+  selector:
+    matchLabels:
+      app: ping-external
+  template:
+    metadata:
+      labels:
+        app: ping-external
+    spec:
+      containers:
+      - name: ping-external
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping www.ibm.com; do sleep 1; done']

--- a/test/e2e/syncer/networkpolicies/workspace1/embed.go
+++ b/test/e2e/syncer/networkpolicies/workspace1/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace1
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS

--- a/test/e2e/syncer/networkpolicies/workspace1/service-ping-apiserver.yaml
+++ b/test/e2e/syncer/networkpolicies/workspace1/service-ping-apiserver.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ping-apiserver
+spec:
+  selector:
+    app: ping-apiserver
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/test/e2e/syncer/networkpolicies/workspace2/deployment-ping-other-tenant-fail.yaml
+++ b/test/e2e/syncer/networkpolicies/workspace2/deployment-ping-other-tenant-fail.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-other-tenant-fail
+spec:
+  selector:
+    matchLabels:
+      app: ping-other-tenant-fail
+  template:
+    metadata:
+      labels:
+        app: ping-other-tenant-fail
+    spec:
+      containers:
+      - name: ping-other-tenant-fail
+        image: ghcr.io/distroless/alpine-base:latest
+        command: ['sh', '-c', 'until ping ${POD_IP}; do sleep 1; done']
+        env:
+          - name: POD_IP
+            valueFrom:
+              name: ip
+              key: ip
+

--- a/test/e2e/syncer/networkpolicies/workspace2/embed.go
+++ b/test/e2e/syncer/networkpolicies/workspace2/embed.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace2
+
+import (
+	"embed"
+)
+
+//go:embed *.yaml
+var FS embed.FS


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Create a network policy per namespace to prevent traffic between pods belonging to different tenant.

See https://github.com/kcp-dev/kcp/blob/3a5f114b6de2a033dcafe8d7d282d456ce5a70ea/pkg/syncer/spec/networkpolicy_tenant.yaml for more details. 

## Related issue(s)

Fixes kcp-dev/contrib-tmc#113 