### PR TITLE
🐛 Remove root:compute deps in controller

### DIFF
--- a/config/crds/workload.kcp.io_synctargets.yaml
+++ b/config/crds/workload.kcp.io_synctargets.yaml
@@ -78,14 +78,10 @@ spec:
                 format: date-time
                 type: string
               supportedAPIExports:
-                default:
-                - export: kubernetes
                 description: SupportedAPIExports defines a set of APIExports supposed
                   to be supported by this SyncTarget. The SyncTarget will be selected
                   to deploy the workload only when the resource schema on the SyncTarget
                   is compatible with the resource schema included in the exports.
-                  If it is not set, the kubernetes export in the same workspace will
-                  be used by default.
                 items:
                   description: APIExportReference provides the fields necessary to
                     resolve an APIExport.

--- a/config/root-phase0/apiexport-workload.kcp.io.yaml
+++ b/config/root-phase0/apiexport-workload.kcp.io.yaml
@@ -5,5 +5,5 @@ metadata:
   name: workload.kcp.io
 spec:
   latestResourceSchemas:
-  - v230109-773b219c.synctargets.workload.kcp.io
+  - v230329-c41ff68c.synctargets.workload.kcp.io
 status: {}

--- a/config/root-phase0/apiresourceschema-synctargets.workload.kcp.io.yaml
+++ b/config/root-phase0/apiresourceschema-synctargets.workload.kcp.io.yaml
@@ -2,7 +2,7 @@ apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
   creationTimestamp: null
-  name: v230109-773b219c.synctargets.workload.kcp.io
+  name: v230329-c41ff68c.synctargets.workload.kcp.io
 spec:
   group: workload.kcp.io
   names:
@@ -75,14 +75,10 @@ spec:
               format: date-time
               type: string
             supportedAPIExports:
-              default:
-              - export: kubernetes
               description: SupportedAPIExports defines a set of APIExports supposed
                 to be supported by this SyncTarget. The SyncTarget will be selected
                 to deploy the workload only when the resource schema on the SyncTarget
-                is compatible with the resource schema included in the exports. If
-                it is not set, the kubernetes export in the same workspace will be
-                used by default.
+                is compatible with the resource schema included in the exports.
               items:
                 description: APIExportReference provides the fields necessary to resolve
                   an APIExport.

--- a/docs/content/concepts/registering-kubernetes-clusters-using-syncer.md
+++ b/docs/content/concepts/registering-kubernetes-clusters-using-syncer.md
@@ -96,8 +96,8 @@ kubectl kcp workload sync <mycluster> --syncer-image <image name> --resources ro
 ```
 
 And apply the generated manifests to the physical cluster. The syncer will then import the API schema of `foo.bar`
-to the workspace of the SyncTarget, followed by an auto generated kubernetes APIExport and APIBinding in the same workspace.
-You can then create `foo.bar` in this workspace, or create an APIBinding in another workspace to bind this APIExport.
+to the workspace of the SyncTarget, followed by an auto generated kubernetes APIExport in the same workspace.
+The auto generated APIExport name is `imported-apis`, and you can then create an APIBinding to bind this APIExport.
 
 To synchronize resource from another existing APIExport in the KCP server, run:
 
@@ -105,7 +105,8 @@ To synchronize resource from another existing APIExport in the KCP server, run:
 kubectl kcp workload sync <mycluster> --syncer-image <image name> --apiexports another-workspace:another-apiexport -o syncer.yaml
 ```
 
-Syncer will start synchronizing the resources in this `APIExport` as long as the `SyncTarget` has compatible API schemas.
+Syncer will start synchronizing the resources in this `APIExport` as long as the `SyncTarget` has compatible API schemas. The auto generated
+APIExport `imported-apis` is a reserved APIExport name and should not be set in the `--apiexports`
 
 To see if a certain resource is synchronized by the syncer, you can check the `state` of the `syncedResources` in `SyncTarget` status:
 
@@ -121,8 +122,13 @@ After the `SyncTarget` is ready, switch to any workspace containing some workloa
 kubectl kcp bind compute <workspace of synctarget>
 ```
 
-This command will create a `Placement` in the workspace. By default, it will also create `APIBinding`s for global kubernetes `APIExport` and
-kubernetes `APIExport` in workspace of `SyncTarget`, if any of these `APIExport`s are supported by the `SyncTarget`.
+This command will create a `Placement` in the workspace. By default, it will also create `APIBinding`s for global kubernetes `APIExport`.
+
+You can also bind to the auto generated `imported-apis` APIExport by running
+
+```sh
+kubectl kcp bind compute <workspace of synctarget> --apiexports <workspace of synctarget>:imported-apis
+```
 
 Alternatively, if you would like to bind other `APIExport`s which are supported by the `SyncerTarget`, run:
 

--- a/pkg/openapi/zz_generated.openapi.go
+++ b/pkg/openapi/zz_generated.openapi.go
@@ -4562,7 +4562,7 @@ func schema_sdk_apis_workload_v1alpha1_SyncTargetSpec(ref common.ReferenceCallba
 					},
 					"supportedAPIExports": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SupportedAPIExports defines a set of APIExports supposed to be supported by this SyncTarget. The SyncTarget will be selected to deploy the workload only when the resource schema on the SyncTarget is compatible with the resource schema included in the exports. If it is not set, the kubernetes export in the same workspace will be used by default.",
+							Description: "SupportedAPIExports defines a set of APIExports supposed to be supported by this SyncTarget. The SyncTarget will be selected to deploy the workload only when the resource schema on the SyncTarget is compatible with the resource schema included in the exports.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/reconciler/workload/apiexport/apiresourceschema.go
+++ b/pkg/reconciler/workload/apiexport/apiresourceschema.go
@@ -17,9 +17,12 @@ limitations under the License.
 package apiexport
 
 import (
+	"strings"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apiresourcev1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apiresource/v1alpha1"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
@@ -71,4 +74,13 @@ func toAPIResourceSchema(r *apiresourcev1alpha1.NegotiatedAPIResource, name stri
 	}
 
 	return schema
+}
+
+// ParseAPIResourceSchemaName parses name of APIResourceSchema to a gr and schema if it is valid.
+func ParseAPIResourceSchemaName(name string) (schema.GroupResource, bool) {
+	comps := strings.SplitN(name, ".", 3)
+	if len(comps) < 3 {
+		return schema.GroupResource{}, false
+	}
+	return schema.GroupResource{Resource: comps[1], Group: comps[2]}, true
 }

--- a/pkg/reconciler/workload/apiexport/workload_apiexport_controller.go
+++ b/pkg/reconciler/workload/apiexport/workload_apiexport_controller.go
@@ -46,9 +46,6 @@ import (
 
 const (
 	ControllerName = "kcp-workload-apiexport"
-
-	// TemporaryComputeServiceExportName is a temporary singleton name of compute service exports.
-	TemporaryComputeServiceExportName = "kubernetes"
 )
 
 // NewController returns a new controller instance.
@@ -82,7 +79,7 @@ func NewController(
 		FilterFunc: func(obj interface{}) bool {
 			switch t := obj.(type) {
 			case *apisv1alpha1.APIExport:
-				return t.Name == TemporaryComputeServiceExportName
+				return t.Name == workloadv1alpha1.ImportedAPISExportName
 			}
 			return false
 		},
@@ -133,11 +130,11 @@ func (c *controller) enqueueNegotiatedAPIResource(obj interface{}) {
 		return
 	}
 
-	export, err := c.apiExportsLister.Cluster(logicalcluster.From(resource)).Get(TemporaryComputeServiceExportName)
+	export, err := c.apiExportsLister.Cluster(logicalcluster.From(resource)).Get(workloadv1alpha1.ImportedAPISExportName)
 	if errors.IsNotFound(err) {
 		return // it's gone
 	} else if err != nil {
-		runtime.HandleError(fmt.Errorf("failed to get APIExport %s|%s: %w", logicalcluster.From(resource), TemporaryComputeServiceExportName, err))
+		runtime.HandleError(fmt.Errorf("failed to get APIExport %s|%s: %w", logicalcluster.From(resource), workloadv1alpha1.ImportedAPISExportName, err))
 		return
 	}
 
@@ -158,11 +155,11 @@ func (c *controller) enqueueSyncTarget(obj interface{}) {
 		return
 	}
 
-	export, err := c.apiExportsLister.Cluster(logicalcluster.From(resource)).Get(TemporaryComputeServiceExportName)
+	export, err := c.apiExportsLister.Cluster(logicalcluster.From(resource)).Get(workloadv1alpha1.ImportedAPISExportName)
 	if errors.IsNotFound(err) {
 		return // it's gone
 	} else if err != nil {
-		runtime.HandleError(fmt.Errorf("failed to get APIExport %s|%s: %w", logicalcluster.From(resource), TemporaryComputeServiceExportName, err))
+		runtime.HandleError(fmt.Errorf("failed to get APIExport %s|%s: %w", logicalcluster.From(resource), workloadv1alpha1.ImportedAPISExportName, err))
 		return
 	}
 

--- a/pkg/reconciler/workload/synctargetexports/synctarget_indexes.go
+++ b/pkg/reconciler/workload/synctargetexports/synctarget_indexes.go
@@ -22,7 +22,6 @@ import (
 	kcpcache "github.com/kcp-dev/apimachinery/v2/pkg/cache"
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	reconcilerapiexport "github.com/kcp-dev/kcp/pkg/reconciler/workload/apiexport"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
 )
@@ -49,10 +48,6 @@ func indexSyncTargetsByExports(obj interface{}) ([]string, error) {
 	}
 
 	clusterName := logicalcluster.From(synctarget)
-	if len(synctarget.Spec.SupportedAPIExports) == 0 {
-		return []string{clusterName.Path().Join(reconcilerapiexport.TemporaryComputeServiceExportName).String()}, nil
-	}
-
 	keys := make([]string, 0, len(synctarget.Spec.SupportedAPIExports))
 	for _, export := range synctarget.Spec.SupportedAPIExports {
 		if len(export.Path) == 0 {

--- a/pkg/virtual/framework/internalapis/fixtures/synctargets.yaml
+++ b/pkg/virtual/framework/internalapis/fixtures/synctargets.yaml
@@ -48,9 +48,7 @@ spec:
               description: SupportedAPIExports defines a set of APIExports supposed
                 to be supported by this SyncTarget. The SyncTarget will be selected
                 to deploy the workload only when the resource schema on the SyncTarget
-                is compatible with the resource schema included in the exports. If
-                it is not set, the kubernetes export in the same workspace will be
-                used by default.
+                is compatible with the resource schema included in the exports.
               items:
                 description: APIExportReference provides the fields necessary to resolve
                   an APIExport.

--- a/sdk/apis/workload/v1alpha1/synctarget_types.go
+++ b/sdk/apis/workload/v1alpha1/synctarget_types.go
@@ -73,8 +73,6 @@ type SyncTargetSpec struct {
 	// SupportedAPIExports defines a set of APIExports supposed to be supported by this SyncTarget. The SyncTarget
 	// will be selected to deploy the workload only when the resource schema on the SyncTarget is compatible
 	// with the resource schema included in the exports.
-	// If it is not set, the kubernetes export in the same workspace will be used by default.
-	// +kubebuilder:default={{export: kubernetes}}
 	SupportedAPIExports []tenancyv1alpha1.APIExportReference `json:"supportedAPIExports,omitempty"`
 
 	// Cells is a set of labels to identify the cells the SyncTarget belongs to. SyncTargets with the same cells run as
@@ -174,6 +172,9 @@ type SyncTargetList struct {
 
 	Items []SyncTarget `json:"items"`
 }
+
+// ImportedAPISExportName is singleton name of compute service exports in location workspace.
+const ImportedAPISExportName = "imported-apis"
 
 // Conditions and ConditionReasons for the kcp SyncTarget object.
 const (

--- a/test/e2e/reconciler/cluster/controller_test.go
+++ b/test/e2e/reconciler/cluster/controller_test.go
@@ -187,7 +187,7 @@ func TestClusterController(t *testing.T) {
 			require.NoError(t, err)
 
 			syncerFixture := framework.NewSyncerFixture(t, source, wsPath,
-				framework.WithExtraResources("cowboys.wildwest.dev", "services"),
+				framework.WithExtraResources("cowboys.wildwest.dev"),
 				framework.WithDownstreamPreparation(func(config *rest.Config, isFakePCluster bool) {
 					// Always install the crd regardless of whether the target is
 					// logical or not since cowboys is not a native type.
@@ -198,7 +198,7 @@ func TestClusterController(t *testing.T) {
 				})).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 			t.Logf("Bind second user workspace to location workspace")
-			framework.NewBindCompute(t, wsPath, source).Bind(t)
+			framework.NewBindCompute(t, wsPath, source, framework.WithAPIExportsWorkloadBindOption(workloadv1alpha1.ImportedAPISExportName)).Bind(t)
 
 			sinkWildwestClient, err := wildwestclientset.NewForConfig(syncerFixture.DownstreamConfig)
 			require.NoError(t, err)

--- a/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
+++ b/test/e2e/reconciler/locationworkspace/local_apiexport_test.go
@@ -121,7 +121,7 @@ func TestSyncTargetLocalExport(t *testing.T) {
 
 	t.Logf("Bind to location workspace")
 	framework.NewBindCompute(t, computePath, source,
-		framework.WithAPIExportsWorkloadBindOption("kubernetes"),
+		framework.WithAPIExportsWorkloadBindOption(workloadv1alpha1.ImportedAPISExportName),
 	).Bind(t)
 
 	t.Logf("Wait for being able to list Services in the user workspace")

--- a/test/e2e/reconciler/scheduling/multi_placements_test.go
+++ b/test/e2e/reconciler/scheduling/multi_placements_test.go
@@ -63,14 +63,12 @@ func TestMultiPlacement(t *testing.T) {
 	t.Logf("Creating a SyncTarget and syncer in %s", locationPath)
 	firstSyncerFixture := framework.NewSyncerFixture(t, source, locationPath,
 		framework.WithSyncTargetName(firstSyncTargetName),
-		framework.WithExtraResources("services"),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
 	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	secondSyncTargetName := "second-synctarget"
 	t.Logf("Creating a SyncTarget and syncer in %s", locationPath)
 	secondSyncerFixture := framework.NewSyncerFixture(t, source, locationPath,
-		framework.WithExtraResources("services"),
 		framework.WithSyncTargetName(secondSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
 	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)

--- a/test/e2e/reconciler/scheduling/placement_scheduler_test.go
+++ b/test/e2e/reconciler/scheduling/placement_scheduler_test.go
@@ -66,7 +66,6 @@ func TestPlacementUpdate(t *testing.T) {
 	syncerFixture := framework.NewSyncerFixture(t, source, locationPath,
 		framework.WithSyncTargetName(firstSyncTargetName),
 		framework.WithSyncedUserWorkspaces(userWorkspace),
-		framework.WithExtraResources("services"),
 	).CreateSyncTargetAndApplyToDownstream(t).StartSyncer(t)
 
 	t.Log("Wait for \"default\" location")

--- a/test/e2e/reconciler/scheduling/upsynced_scheduling_test.go
+++ b/test/e2e/reconciler/scheduling/upsynced_scheduling_test.go
@@ -67,14 +67,13 @@ func TestUpsyncedScheduling(t *testing.T) {
 	syncerFixture := framework.NewSyncerFixture(t, upstreamServer, synctargetWsName.Path(),
 		framework.WithExtraResources("pods"),
 		framework.WithExtraResources("deployments.apps"),
-		framework.WithAPIExports("kubernetes"),
 		framework.WithSyncedUserWorkspaces(userWs),
 	).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
 	t.Log("Binding the consumer workspace to the location workspace")
 	framework.NewBindCompute(t, userWsName.Path(), upstreamServer,
 		framework.WithLocationWorkspaceWorkloadBindOption(synctargetWsName.Path()),
-		framework.WithAPIExportsWorkloadBindOption(synctargetWsName.String()+":kubernetes"),
+		framework.WithAPIExportsWorkloadBindOption(synctargetWsName.String()+":"+workloadv1alpha1.ImportedAPISExportName),
 	).Bind(t)
 
 	upstreamConfig := upstreamServer.BaseConfig(t)

--- a/test/e2e/virtual/syncer/virtualworkspace_test.go
+++ b/test/e2e/virtual/syncer/virtualworkspace_test.go
@@ -353,6 +353,11 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 					}),
 				).CreateSyncTargetAndApplyToDownstream(t).StartAPIImporter(t).StartHeartBeat(t)
 
+				logWithTimestampf(t, "Bind wildwest location workspace to itself")
+				framework.NewBindCompute(t, wildwestLocationPath, server,
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
+				).Bind(t)
+
 				logWithTimestampf(t, "Create two service accounts")
 				_, err := kubeClusterClient.Cluster(wildwestLocationPath).CoreV1().ServiceAccounts("default").Create(ctx, &corev1.ServiceAccount{
 					ObjectMeta: metav1.ObjectMeta{
@@ -475,7 +480,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 				logWithTimestampf(t, "Bind wildwest location workspace to itself")
 				framework.NewBindCompute(t, wildwestLocationPath, server,
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join("kubernetes").String()),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 				).Bind(t)
 
 				wildwestClusterClient, err := wildwestclientset.NewForConfig(server.BaseConfig(t))
@@ -626,7 +631,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 				logWithTimestampf(t, "Bind consumer workspace to wildwest location workspace")
 				framework.NewBindCompute(t, consumerPath, server,
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.String()+":kubernetes"),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 				).Bind(t)
 
@@ -849,7 +854,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				logWithTimestampf(t, "Create 2 placements, one for each SyncTarget")
 				framework.NewBindCompute(t, consumerPath, server,
 					framework.WithPlacementNameBindOption("north"),
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.String()+":kubernetes"),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 					framework.WithLocationSelectorWorkloadBindOption(metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -860,7 +865,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 				framework.NewBindCompute(t, consumerPath, server,
 					framework.WithPlacementNameBindOption("south"),
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.String()+":kubernetes"),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 					framework.WithLocationSelectorWorkloadBindOption(metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1085,7 +1090,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				logWithTimestampf(t, "Create the north placement, for the north SyncTarget")
 				framework.NewBindCompute(t, consumerPath, server,
 					framework.WithPlacementNameBindOption("north"),
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.String()+":kubernetes"),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 					framework.WithLocationSelectorWorkloadBindOption(metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1193,7 +1198,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 				logWithTimestampf(t, "Create the south placement, for the south SyncTarget")
 				framework.NewBindCompute(t, consumerPath, server,
 					framework.WithPlacementNameBindOption("south"),
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.String()+":kubernetes"),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 					framework.WithLocationSelectorWorkloadBindOption(metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -1338,7 +1343,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 				logWithTimestampf(t, "Bind consumer workspace to wildwest location workspace")
 				framework.NewBindCompute(t, consumerPath, server,
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join("kubernetes").String()),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 				).Bind(t)
 
@@ -1446,7 +1451,7 @@ func TestSyncerVirtualWorkspace(t *testing.T) {
 
 				logWithTimestampf(t, "Bind consumer workspace to wildwest location workspace")
 				framework.NewBindCompute(t, consumerPath, server,
-					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.String()+":kubernetes"),
+					framework.WithAPIExportsWorkloadBindOption(wildwestLocationPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 					framework.WithLocationWorkspaceWorkloadBindOption(wildwestLocationPath),
 				).Bind(t)
 
@@ -1961,7 +1966,7 @@ func TestUpsyncerVirtualWorkspace(t *testing.T) {
 
 			logWithTimestampf(t, "Bind upsyncer workspace")
 			framework.NewBindCompute(t, upsyncerPath, server,
-				framework.WithAPIExportsWorkloadBindOption(upsyncerPath.Join("kubernetes").String()),
+				framework.WithAPIExportsWorkloadBindOption(upsyncerPath.Join(workloadv1alpha1.ImportedAPISExportName).String()),
 			).Bind(t)
 
 			logWithTimestampf(t, "Waiting for the persistentvolumes crd to be imported and available in the upsyncer source cluster...")

--- a/tmc/pkg/server/server.go
+++ b/tmc/pkg/server/server.go
@@ -127,7 +127,7 @@ func (s *Server) Run(ctx context.Context) error {
 			if err := s.installWorkloadsAPIExportController(ctx, controllerConfig); err != nil {
 				return err
 			}
-			if err := s.installWorkloadsAPIExportCreateController(ctx, controllerConfig); err != nil {
+			if err := s.installWorkloadsDefaultLocationController(ctx, controllerConfig); err != nil {
 				return err
 			}
 		}

--- a/tmc/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_indexes.go
+++ b/tmc/pkg/virtual/syncer/controllers/apireconciler/syncer_apireconciler_indexes.go
@@ -19,7 +19,6 @@ package apireconciler
 import (
 	"github.com/kcp-dev/logicalcluster/v3"
 
-	reconcilerapiexport "github.com/kcp-dev/kcp/pkg/reconciler/workload/apiexport"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
 	"github.com/kcp-dev/kcp/sdk/client"
@@ -41,10 +40,6 @@ func IndexSyncTargetsByExports(obj interface{}) ([]string, error) {
 	syncTarget := obj.(*workloadv1alpha1.SyncTarget)
 
 	clusterName := logicalcluster.From(syncTarget)
-	if len(syncTarget.Spec.SupportedAPIExports) == 0 {
-		return []string{client.ToClusterAwareKey(clusterName.Path(), reconcilerapiexport.TemporaryComputeServiceExportName)}, nil
-	}
-
 	keys := make([]string, 0, len(syncTarget.Spec.SupportedAPIExports))
 	for _, export := range syncTarget.Spec.SupportedAPIExports {
 		path := export.Path


### PR DESCRIPTION
1. create imported-api APIExport during sync cmd if resources flag is set
2. controller updated imported-api APIExport with updated APIResourceSchema

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes https://github.com/kcp-dev/kcp/issues/2625
