### PR TITLE
:bug: Decouple internal and external logical-cluster-admin access

### DIFF
--- a/cmd/sharded-test-server/main.go
+++ b/cmd/sharded-test-server/main.go
@@ -135,7 +135,21 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 		365,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create kcp-logical-cluster client cert: %w", err)
+		return fmt.Errorf("failed to create logical-cluster-admin client cert: %w", err)
+	}
+
+	// client cert for external-logical-cluster-admin
+	_, _, err = clientCA.EnsureClientCertificate(
+		filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.crt"),
+		filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.key"),
+		&kuser.DefaultInfo{
+			Name:   "external-logical-cluster-admin",
+			Groups: []string{bootstrap.SystemExternalLogicalClusterAdmin},
+		},
+		365,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create external-logical-cluster-admin client cert: %w", err)
 	}
 
 	// TODO:(p0lyn0mial): in the future we need a separate group valid only for the proxy
@@ -199,6 +213,10 @@ func start(proxyFlags, shardFlags []string, logDirPath, workDirPath string, numb
 	}()
 
 	if err := writeLogicalClusterAdminKubeConfig(hostIP.String(), workDirPath); err != nil {
+		return err
+	}
+
+	if err := writeExternalLogicalClusterAdminKubeConfig(hostIP.String(), workDirPath); err != nil {
 		return err
 	}
 

--- a/cmd/sharded-test-server/shard.go
+++ b/cmd/sharded-test-server/shard.go
@@ -95,6 +95,7 @@ func newShard(ctx context.Context, n int, args []string, standaloneVW bool, serv
 		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(workDirPath, fmt.Sprintf(".kcp-%d/apiserver.key", n))),
 		fmt.Sprintf("--secure-port=%d", 6444+n),
 		fmt.Sprintf("--logical-cluster-admin-kubeconfig=%s", filepath.Join(workDirPath, ".kcp/logical-cluster-admin.kubeconfig")),
+		fmt.Sprintf("--external-logical-cluster-admin-kubeconfig=%s", filepath.Join(workDirPath, ".kcp/external-logical-cluster-admin.kubeconfig")),
 		fmt.Sprintf("--shard-client-cert-file=%s", shardClientCert),
 		fmt.Sprintf("--shard-client-key-file=%s", shardClientCertKey),
 		fmt.Sprintf("--shard-virtual-workspace-ca-file=%s", filepath.Join(workDirPath, ".kcp", "serving-ca.crt")),

--- a/pkg/admission/logicalcluster/admission.go
+++ b/pkg/admission/logicalcluster/admission.go
@@ -190,8 +190,7 @@ func (o *plugin) Validate(ctx context.Context, a admission.Attributes, _ admissi
 		if err != nil {
 			return fmt.Errorf("LogicalCluster cannot be deleted: %w", err)
 		}
-		groups := sets.NewString(a.GetUserInfo().GetGroups()...)
-		if !logicalCluster.Spec.DirectlyDeletable && !groups.Has(kuser.SystemPrivilegedGroup) && !groups.Has(bootstrap.SystemLogicalClusterAdmin) {
+		if !logicalCluster.Spec.DirectlyDeletable {
 			return admission.NewForbidden(a, fmt.Errorf("LogicalCluster cannot be deleted"))
 		}
 

--- a/pkg/admission/logicalcluster/admission.go
+++ b/pkg/admission/logicalcluster/admission.go
@@ -127,7 +127,7 @@ func (o *plugin) Validate(ctx context.Context, a admission.Attributes, _ admissi
 	}
 
 	groups := sets.NewString(a.GetUserInfo().GetGroups()...)
-	if groups.Has(kuser.SystemPrivilegedGroup) || groups.Has(bootstrap.SystemLogicalClusterAdmin) || groups.Has(bootstrap.SystemKcpWorkspaceBootstrapper) {
+	if groups.Has(kuser.SystemPrivilegedGroup) || groups.Has(bootstrap.SystemLogicalClusterAdmin) || groups.Has(bootstrap.SystemExternalLogicalClusterAdmin) || groups.Has(bootstrap.SystemKcpWorkspaceBootstrapper) {
 		return nil
 	}
 

--- a/pkg/admission/logicalcluster/admission_test.go
+++ b/pkg/admission/logicalcluster/admission_test.go
@@ -337,6 +337,14 @@ func TestValidate(t *testing.T) {
 			),
 		},
 		{
+			name:        "passed deletion as system:kcp:external-logical-cluster-admin",
+			clusterName: "root:org:ws",
+			attr: deleteAttr(
+				newLogicalCluster("root:org:ws").LogicalCluster,
+				&kuser.DefaultInfo{Groups: []string{"system:kcp:external-logical-cluster-admin"}},
+			),
+		},
+		{
 			name:        "passed deletion as another user if directly deletable",
 			clusterName: "root:org:ws",
 			logicalClusters: []*corev1alpha1.LogicalCluster{

--- a/pkg/authorization/requiredgroups_authorizer.go
+++ b/pkg/authorization/requiredgroups_authorizer.go
@@ -101,6 +101,11 @@ func (a *requiredGroupsAuthorizer) Authorize(ctx context.Context, attr authorize
 			return authorizer.DecisionNoOpinion, "", err
 		}
 
+		// always let external-logical-cluster-admins through
+		if sets.NewString(attr.GetUser().GetGroups()...).Has(bootstrap.SystemExternalLogicalClusterAdmin) {
+			return DelegateAuthorization("external logical cluster admin access", a.delegate).Authorize(ctx, attr)
+		}
+
 		// check required groups
 		value, found := logicalCluster.Annotations[RequiredGroupsAnnotationKey]
 		if !found {

--- a/pkg/authorization/requiredgroups_authorizer_test.go
+++ b/pkg/authorization/requiredgroups_authorizer_test.go
@@ -57,6 +57,12 @@ func TestRequiredGroupsAuthorizer(t *testing.T) {
 			wantDecision:       authorizer.DecisionAllow,
 			wantReason:         "delegating due to logical cluster admin access",
 		},
+		"system:kcp:external-logical-cluster-admin can always pass": {
+			requestedWorkspace: "root:ready",
+			requestingUser:     newUser("external-lcluster-admin", "system:kcp:external-logical-cluster-admin"),
+			wantDecision:       authorizer.DecisionAllow,
+			wantReason:         "delegating due to external logical cluster admin access",
+		},
 		"service account from other cluster is granted access": {
 			requestedWorkspace: "root:ready",
 			requestingUser:     newServiceAccountWithCluster("sa", "anotherws"),

--- a/pkg/reconciler/tenancy/workspace/workspace_controller.go
+++ b/pkg/reconciler/tenancy/workspace/workspace_controller.go
@@ -51,10 +51,10 @@ const (
 
 func NewController(
 	shardName string,
-	shardExternalURL func() string,
 	kcpClusterClient kcpclientset.ClusterInterface,
 	kubeClusterClient kubernetes.ClusterInterface,
 	logicalClusterAdminConfig *rest.Config,
+	externalLogicalClusterAdminConfig *rest.Config,
 	workspaceInformer tenancyv1alpha1informers.WorkspaceClusterInformer,
 	globalShardInformer corev1alpha1informers.ShardClusterInformer,
 	globalWorkspaceTypeInformer tenancyv1alpha1informers.WorkspaceTypeClusterInformer,
@@ -65,10 +65,9 @@ func NewController(
 	c := &Controller{
 		queue: queue,
 
-		shardName:        shardName,
-		shardExternalURL: shardExternalURL,
-
-		logicalClusterAdminConfig: logicalClusterAdminConfig,
+		shardName:                         shardName,
+		logicalClusterAdminConfig:         logicalClusterAdminConfig,
+		externalLogicalClusterAdminConfig: externalLogicalClusterAdminConfig,
 
 		kcpClusterClient:  kcpClusterClient,
 		kubeClusterClient: kubeClusterClient,
@@ -119,9 +118,9 @@ type workspaceResource = committer.Resource[*tenancyv1alpha1.WorkspaceSpec, *ten
 type Controller struct {
 	queue workqueue.RateLimitingInterface
 
-	shardName                 string
-	shardExternalURL          func() string
-	logicalClusterAdminConfig *rest.Config
+	shardName                         string
+	logicalClusterAdminConfig         *rest.Config // for direct shard connections used during scheduling
+	externalLogicalClusterAdminConfig *rest.Config // for front-proxy connections used during initialization
 
 	kcpClusterClient  kcpclientset.ClusterInterface
 	kubeClusterClient kubernetes.ClusterInterface
@@ -191,8 +190,7 @@ func (c *Controller) Start(ctx context.Context, numThreads int) {
 	defer c.queue.ShutDown()
 
 	// create external client that goes through the front-proxy
-	externalConfig := rest.CopyConfig(c.logicalClusterAdminConfig)
-	externalConfig.Host = c.shardExternalURL()
+	externalConfig := rest.CopyConfig(c.externalLogicalClusterAdminConfig)
 	kcpExternalClient, err := kcpclientset.NewForConfig(externalConfig)
 	if err != nil {
 		runtime.HandleError(err)

--- a/pkg/server/options/options.go
+++ b/pkg/server/options/options.go
@@ -51,22 +51,22 @@ type Options struct {
 }
 
 type ExtraOptions struct {
-	ProfilerAddress                    string
-	ShardKubeconfigFile                string
-	RootShardKubeconfigFile            string
-	ShardBaseURL                       string
-	ShardExternalURL                   string
-	ShardName                          string
-	ShardVirtualWorkspaceURL           string
-	ShardClientCertFile                string
-	ShardClientKeyFile                 string
-	ShardVirtualWorkspaceCAFile        string
-	DiscoveryPollInterval              time.Duration
-	ExperimentalBindFreePort           bool
-	LogicalClusterAdminKubeconfig      string
-	ConversionCELTransformationTimeout time.Duration
-
-	BatteriesIncluded []string
+	ProfilerAddress                       string
+	ShardKubeconfigFile                   string
+	RootShardKubeconfigFile               string
+	ShardBaseURL                          string
+	ShardExternalURL                      string
+	ShardName                             string
+	ShardVirtualWorkspaceURL              string
+	ShardClientCertFile                   string
+	ShardClientKeyFile                    string
+	ShardVirtualWorkspaceCAFile           string
+	DiscoveryPollInterval                 time.Duration
+	ExperimentalBindFreePort              bool
+	LogicalClusterAdminKubeconfig         string
+	ExternalLogicalClusterAdminKubeconfig string
+	ConversionCELTransformationTimeout    time.Duration
+	BatteriesIncluded                     []string
 }
 
 type completedOptions struct {
@@ -166,7 +166,8 @@ func (o *Options) AddFlags(fss *cliflag.NamedFlagSets) {
 	fs.StringVar(&o.Extra.ShardVirtualWorkspaceURL, "shard-virtual-workspace-url", o.Extra.ShardVirtualWorkspaceURL, "An external URL address of a virtual workspace server associated with this shard. Defaults to shard's base address.")
 	fs.StringVar(&o.Extra.ShardClientCertFile, "shard-client-cert-file", o.Extra.ShardClientCertFile, "Path to a client certificate file the shard uses to communicate with other system components.")
 	fs.StringVar(&o.Extra.ShardClientKeyFile, "shard-client-key-file", o.Extra.ShardClientKeyFile, "Path to a client certificate key file the shard uses to communicate with other system components.")
-	fs.StringVar(&o.Extra.LogicalClusterAdminKubeconfig, "logical-cluster-admin-kubeconfig", o.Extra.LogicalClusterAdminKubeconfig, "Kubeconfig holding admin(!) credentials to other shards. Defaults to the loopback client")
+	fs.StringVar(&o.Extra.LogicalClusterAdminKubeconfig, "logical-cluster-admin-kubeconfig", o.Extra.LogicalClusterAdminKubeconfig, "Kubeconfig holding system:kcp:logical-cluster-admin credentials for connecting to other shards. Defaults to the loopback client")
+	fs.StringVar(&o.Extra.ExternalLogicalClusterAdminKubeconfig, "external-logical-cluster-admin-kubeconfig", o.Extra.ExternalLogicalClusterAdminKubeconfig, "Kubeconfig holding system:kcp:external-logical-cluster-admin credentials for connecting to the external address (e.g. the front-proxy). Defaults to the loopback client")
 
 	fs.BoolVar(&o.Extra.ExperimentalBindFreePort, "experimental-bind-free-port", o.Extra.ExperimentalBindFreePort, "Bind to a free port. --secure-port must be 0. Use the admin.kubeconfig to extract the chosen port.")
 	fs.MarkHidden("experimental-bind-free-port") //nolint:errcheck
@@ -265,6 +266,12 @@ func (o *Options) Complete(rootDir string) (*CompletedOptions, error) {
 	}
 	if len(o.Extra.LogicalClusterAdminKubeconfig) > 0 && !filepath.IsAbs(o.Extra.LogicalClusterAdminKubeconfig) {
 		o.Extra.LogicalClusterAdminKubeconfig, err = filepath.Abs(o.Extra.LogicalClusterAdminKubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(o.Extra.ExternalLogicalClusterAdminKubeconfig) > 0 && !filepath.IsAbs(o.Extra.ExternalLogicalClusterAdminKubeconfig) {
+		o.Extra.ExternalLogicalClusterAdminKubeconfig, err = filepath.Abs(o.Extra.ExternalLogicalClusterAdminKubeconfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -378,13 +378,13 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	if s.Options.Controllers.EnableAll || enabled.Has("workspace-scheduler") {
-		if err := s.installWorkspaceScheduler(ctx, controllerConfig, s.LogicalClusterAdminConfig); err != nil {
+		if err := s.installWorkspaceScheduler(ctx, controllerConfig, s.LogicalClusterAdminConfig, s.ExternalLogicalClusterAdminConfig); err != nil {
 			return err
 		}
 		if err := s.installTenancyLogicalClusterController(ctx, controllerConfig); err != nil {
 			return err
 		}
-		if err := s.installLogicalClusterDeletionController(ctx, controllerConfig, s.LogicalClusterAdminConfig, s.CompletedConfig.ShardExternalURL); err != nil {
+		if err := s.installLogicalClusterDeletionController(ctx, controllerConfig, s.LogicalClusterAdminConfig, s.ExternalLogicalClusterAdminConfig); err != nil {
 			return err
 		}
 		if err := s.installLogicalCluster(ctx, controllerConfig); err != nil {


### PR DESCRIPTION
## Summary
Currently the logical cluster admin kubeconfig is used to access both the [external front-proxy endpoint](https://github.com/kcp-dev/kcp/blob/main/pkg/reconciler/tenancy/workspace/workspace_controller.go#L194..L195), and also the [shard directly via the baseURL](https://github.com/kcp-dev/kcp/blob/main/pkg/reconciler/tenancy/workspace/workspace_reconcile.go#L71..L72) - this won't work in the case where different CA certs are used for shard and front-proxy (such as in the [helm-charts](https://github.com/kcp-dev/helm-charts))

This only works in CI because we use the same serving-ca.crt for both shard and front-proxy, (in a future PR I will propose a change which better reflects the likely scenario in production deployments).

Fixes #2872