### PR TITLE
:bug: tunneler: return retry-after when dialer not ready

### DIFF
--- a/pkg/tunneler/podsubresourceproxy_handler.go
+++ b/pkg/tunneler/podsubresourceproxy_handler.go
@@ -252,7 +252,8 @@ func podSubresourceURL(downstreamNamespaceName, podName, subresource string) (*u
 func (tn *tunneler) Proxy(clusterName logicalcluster.Name, syncerName string, rw http.ResponseWriter, req *http.Request) {
 	d := tn.getDialer(clusterName, syncerName)
 	if d == nil || isClosedChan(d.Done()) {
-		http.Error(rw, "syncer tunnels: tunnel closed", http.StatusInternalServerError)
+		rw.Header().Set("Retry-After", "1")
+		http.Error(rw, "syncer tunnels: tunnel closed", http.StatusServiceUnavailable)
 		return
 	}
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

This PR sends a Retry-after to the client when the tunneler handler can't find the reverse connection dialer, this will help in some cases and mitigate the "syncer tunnels: tunnel closed" issues. 

## Related issue(s)

related to https://github.com/kcp-dev/kcp/issues/2886