### PR TITLE
[WIP] :bug: Fixes RestMapper issue for Syncer

### DIFF
--- a/pkg/crdpuller/discovery.go
+++ b/pkg/crdpuller/discovery.go
@@ -106,7 +106,8 @@ func (sp *schemaPuller) PullCRDs(ctx context.Context, resourceNames ...string) (
 	for _, resourceToPull := range resourceNames {
 		gr := schema.ParseGroupResource(resourceToPull)
 		grToPull, err := sp.resourceFor(gr)
-		if err != nil {
+		// Check the group.resource equals to that provided by the user
+		if err != nil && grToPull.String() == resourceToPull {
 			logger.Error(err, "error mapping", "resource", resourceToPull)
 			continue
 		}


### PR DESCRIPTION
## Summary
Adds validation for `syncer` command to validate resource name to be either core resources or have `<group>.<resource>` syntax. 
Adds tests on CRDPuller to check if the resolved `<group>.<resource>` value equals to the user-supplied value.

Fixes #
Fixes Issue https://github.com/kcp-dev/kcp/issues/2718

Screenshot: 
![Screenshot from 2023-03-20 18-15-11](https://user-images.githubusercontent.com/54092533/226339328-66ddbdea-509d-4896-a3ad-917067b1f30f.png)
