### PR TITLE
🌱 Add cache informers for synctargets/locations in placement controller

### DIFF
--- a/pkg/reconciler/workload/placement/placement_reconcile.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile.go
@@ -27,7 +27,6 @@ import (
 	utilserrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog/v2"
 
-	"github.com/kcp-dev/kcp/pkg/indexers"
 	apisv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/apis/v1alpha1"
 	schedulingv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/scheduling/v1alpha1"
 	workloadv1alpha1 "github.com/kcp-dev/kcp/sdk/apis/workload/v1alpha1"
@@ -71,14 +70,6 @@ func (c *controller) reconcile(ctx context.Context, placement *schedulingv1alpha
 	}
 
 	return requeue, utilserrors.NewAggregate(errs)
-}
-
-func (c *controller) listSyncTarget(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
-	return c.syncTargetLister.Cluster(clusterName).List(labels.Everything())
-}
-
-func (c *controller) getLocation(path logicalcluster.Path, name string) (*schedulingv1alpha1.Location, error) {
-	return indexers.ByPathAndName[*schedulingv1alpha1.Location](schedulingv1alpha1.Resource("locations"), c.locationIndexer, path, name)
 }
 
 func (c *controller) patchPlacement(ctx context.Context, clusterName logicalcluster.Path, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*schedulingv1alpha1.Placement, error) {

--- a/pkg/reconciler/workload/placement/placement_reconcile.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile.go
@@ -46,7 +46,7 @@ type reconciler interface {
 func (c *controller) reconcile(ctx context.Context, placement *schedulingv1alpha1.Placement) (bool, error) {
 	reconcilers := []reconciler{
 		&placementSchedulingReconciler{
-			listSyncTarget:          c.listSyncTarget,
+			listSyncTargets:         c.listSyncTargets,
 			getLocation:             c.getLocation,
 			patchPlacement:          c.patchPlacement,
 			listWorkloadAPIBindings: c.listWorkloadAPIBindings,

--- a/pkg/reconciler/workload/placement/placement_reconcile_scheduling.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile_scheduling.go
@@ -43,7 +43,7 @@ import (
 // It considers only valid SyncTargets and updates the internal.workload.kcp.io/synctarget
 // annotation with the selected one on the placement object.
 type placementSchedulingReconciler struct {
-	listSyncTarget          func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error)
+	listSyncTargets         func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error)
 	listWorkloadAPIBindings func(clusterName logicalcluster.Name) ([]*apisv1alpha1.APIBinding, error)
 	getLocation             func(path logicalcluster.Path, name string) (*schedulingv1alpha1.Location, error)
 	patchPlacement          func(ctx context.Context, clusterName logicalcluster.Path, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*schedulingv1alpha1.Placement, error)
@@ -112,7 +112,7 @@ func (r *placementSchedulingReconciler) getAllValidSyncTargetsForPlacement(ctx c
 	}
 
 	// find all synctargets in the location workspace
-	syncTargets, err := r.listSyncTarget(logicalcluster.From(location))
+	syncTargets, err := r.listSyncTargets(logicalcluster.From(location))
 	if err != nil {
 		return nil, "", "", err
 	}

--- a/pkg/reconciler/workload/placement/placement_reconcile_scheduling_test.go
+++ b/pkg/reconciler/workload/placement/placement_reconcile_scheduling_test.go
@@ -129,7 +129,7 @@ func TestSchedulingReconcile(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			listSyncTarget := func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
+			listSyncTargets := func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
 				return testCase.syncTargets, nil
 			}
 			getLocation := func(clusterName logicalcluster.Path, name string) (*schedulingv1alpha1.Location, error) {
@@ -158,7 +158,7 @@ func TestSchedulingReconcile(t *testing.T) {
 				return testCase.apiBindings, nil
 			}
 			reconciler := &placementSchedulingReconciler{
-				listSyncTarget:          listSyncTarget,
+				listSyncTargets:         listSyncTargets,
 				getLocation:             getLocation,
 				patchPlacement:          patchPlacement,
 				listWorkloadAPIBindings: listWorkloadAPIBindings,
@@ -235,7 +235,7 @@ func TestReconcileStatusConditions(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			listSyncTarget := func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
+			listSyncTargets := func(clusterName logicalcluster.Name) ([]*workloadv1alpha1.SyncTarget, error) {
 				return testCase.syncTargets, nil
 			}
 			getLocation := func(clusterName logicalcluster.Path, name string) (*schedulingv1alpha1.Location, error) {
@@ -262,7 +262,7 @@ func TestReconcileStatusConditions(t *testing.T) {
 				return testCase.apiBindings, nil
 			}
 			reconciler := &placementSchedulingReconciler{
-				listSyncTarget:          listSyncTarget,
+				listSyncTargets:         listSyncTargets,
 				getLocation:             getLocation,
 				patchPlacement:          patchPlacement,
 				listWorkloadAPIBindings: listWorkloadAPIBindings,

--- a/tmc/pkg/server/controllers.go
+++ b/tmc/pkg/server/controllers.go
@@ -224,7 +224,9 @@ func (s *Server) installWorkloadPlacementScheduler(ctx context.Context, config *
 		kcpClusterClient,
 		s.Core.KcpSharedInformerFactory.Core().V1alpha1().LogicalClusters(),
 		s.Core.KcpSharedInformerFactory.Scheduling().V1alpha1().Locations(),
+		s.Core.CacheKcpSharedInformerFactory.Scheduling().V1alpha1().Locations(),
 		s.Core.KcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
+		s.Core.CacheKcpSharedInformerFactory.Workload().V1alpha1().SyncTargets(),
 		s.Core.KcpSharedInformerFactory.Scheduling().V1alpha1().Placements(),
 		s.Core.KcpSharedInformerFactory.Apis().V1alpha1().APIBindings(),
 	)


### PR DESCRIPTION
Signed-off-by: Nolan Brubaker <nolan@nbrubaker.com>

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Add cache informer for locations in placement controller.

## Related issue(s)

Part of #2900
